### PR TITLE
fix(herdr): pin the fresh-install path to the supported ceiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,10 +133,14 @@ enables the systemd user service. Idempotent — safe to re-run: it never clobbe
 
 This is third-party `curl|bash`: the script runs unconfined as your user _before_ any sandbox
 exists. It also invokes upstream installers it does not control — specifically: [bun.sh](https://bun.sh/install),
-[fnm.vercel.app](https://fnm.vercel.app) (Node via fnm), [herdr.dev](https://herdr.dev) (herdr), and
-[claude.ai](https://claude.ai/install.sh) (the `claude` CLI), plus your distro's package manager
-(`apt` / `apk` / `dnf` / `pacman`) for `git`, `unzip`, and the C/C++ build toolchain + `python3`
-(needed for the node-pty native build).
+[fnm.vercel.app](https://fnm.vercel.app) (Node via fnm) and [claude.ai](https://claude.ai/install.sh)
+(the `claude` CLI), plus your distro's package manager (`apt` / `apk` / `dnf` / `pacman`) for `git`,
+`unzip`, and the C/C++ build toolchain + `python3` (needed for the node-pty native build). herdr is
+**not** installed through `herdr.dev/install.sh` (which is latest-only): Shepherd downloads a
+**version-pinned** binary from
+[github.com/ogulcancelik/herdr/releases](https://github.com/ogulcancelik/herdr/releases) — the
+highest release Shepherd supports — verifies it reports that version, and installs it to
+`~/.local/bin`. That release binary is still third-party code fetched and executed on your machine.
 
 > **Shepherd supports herdr up to 0.7.5.** herdr 0.7.5 (protocol 17) reshaped `agent start`;
 > Shepherd drives it through a CLI external-registration path. Don't upgrade past 0.7.5 yet —
@@ -236,7 +240,8 @@ For the from-clone / development path, see [Quick start](#quick-start) below.
 
 - [Bun](https://bun.sh) — backend runtime + package manager
 - `herdr` on `PATH` — manages the interactive `claude` panes (owns the PTYs)
-  - On macOS, `herdr.dev/install.sh` installs to `~/.local/bin` by default — add it to your shell
+  - Shepherd installs a **version-pinned** herdr (the highest release it supports) into
+    `~/.local/bin`. On macOS that directory is not on `PATH` by default — add it to your shell
     profile before `bun run start`: `export PATH="$HOME/.local/bin:$PATH"`
 - The `claude` CLI, logged in with your Max/Pro subscription
 - Node.js — for the PTY helper subprocess

--- a/ci/onboarding-harness/run.ts
+++ b/ci/onboarding-harness/run.ts
@@ -18,6 +18,7 @@ import { assertDetection } from "./assert";
 import { buildGapReport, gateGapScenarios, statusDescription } from "./report";
 import { reportToGitHub, publishStatus } from "./issue";
 import { remediationsFor } from "../../src/remediations";
+import { HERDR_LAST_SUPPORTED_VERSION } from "../../src/herdr-capabilities";
 import { HERDR_MISSING_EXIT_CODE, HERDR_MISSING_MARKER } from "../../src/preflight";
 import type { DetectionResult, Scenario, ScenarioResult } from "./types";
 import type { DiagnosticsSnapshot } from "../../src/types";
@@ -40,6 +41,36 @@ type ScenarioBase = {
   gateEligible: boolean;
 };
 
+/** Assert the herdr the install path actually landed is the PINNED one (#1896).
+ *
+ *  `herdr: ok` is NOT enough: today HERDR_LAST_SUPPORTED_VERSION happens to equal herdr's latest
+ *  release, so an UNPINNED install (the very regression this guards) would satisfy the check and
+ *  the scenario would pass green. Reading the installed version is the only end-to-end evidence
+ *  that the pin is doing anything — and it becomes genuinely discriminating the day herdr ships
+ *  past the ceiling, which is exactly when a silent regression would otherwise reach users.
+ *
+ *  PATH is prepended because herdr installs to ~/.local/bin, which an `incus exec` non-login shell
+ *  does not have. Throws fail-closed: runScenario classifies it as a gating failure.
+ *
+ *  CALL IT ONLY WHEN THE herdr CHECK IS ALREADY `ok`. On a host where the install genuinely
+ *  failed, herdr is missing for an ordinary reason, and this would replace that scenario's own
+ *  diagnosis (`herdr want=ok got=error`, plus the install output) with a less useful message about
+ *  the pin. The pin is a question you can only ask once something IS installed. */
+async function assertPinnedHerdrInstalled(driver: IncusDriver, name: string): Promise<void> {
+  const r = await driver.exec(name, [
+    "sh",
+    "-c",
+    'export PATH="$HOME/.local/bin:$PATH"; "${HERDR_BIN:-herdr}" --version',
+  ]);
+  const version = /(\d+\.\d+\.\d+)/.exec(`${r.stdout}${r.stderr}`)?.[1];
+  if (version !== HERDR_LAST_SUPPORTED_VERSION) {
+    throw new Error(
+      `${name}: installed herdr is ${version ?? "unreadable"}, expected the pinned ` +
+        `${HERDR_LAST_SUPPORTED_VERSION} — the install path is not honouring the pin`,
+    );
+  }
+}
+
 /** Shared tail of BOTH install-e2e runners: probe the freshly-installed host, assert the
  *  target-ok set, and shape the result. `expect` is the target state (not a seeded defect),
  *  so `reachedGreen` is just whether detection saw every check reach `ok`. */
@@ -50,6 +81,9 @@ async function finishInstallE2E(
 ): Promise<ScenarioResult> {
   const after = await probeDiagnostics(driver, scenario.id);
   const detection = assertDetection(after, scenario.id, scenario.expect);
+  // Only once the target set (herdr included) is green: an install that failed outright keeps its
+  // own INSTALL GAP diagnosis rather than being re-labelled a pin failure.
+  if (detection.detected) await assertPinnedHerdrInstalled(driver, scenario.id);
   return {
     ...base,
     detection,
@@ -223,14 +257,17 @@ async function runHerdrPreflightE2E(
     throw new Error(`${scenario.id}: verbatim herdr remediation failed`);
   }
 
-  // Re-boot normally (herdr now present) and confirm the check recovered to ok.
+  // Re-boot normally (herdr now present) and confirm the check recovered to ok — AND, once it has,
+  // that the remediation installed the PINNED version rather than merely some herdr.
   await bootShepherd(driver, scenario.id);
   const after = await probeDiagnostics(driver, scenario.id);
+  const herdrOk = after.checks.find((c) => c.id === "herdr")?.state === "ok";
+  if (herdrOk) await assertPinnedHerdrInstalled(driver, scenario.id);
   return {
     ...base,
     detection: { scenarioId: scenario.id, detected: true, misses: [] },
     appliedVia: "verbatim",
-    reachedGreen: after.checks.find((c) => c.id === "herdr")?.state === "ok",
+    reachedGreen: herdrOk,
   };
 }
 

--- a/ci/onboarding-harness/scenarios.ts
+++ b/ci/onboarding-harness/scenarios.ts
@@ -97,9 +97,9 @@ export const SCENARIOS: Scenario[] = [
   {
     // A live-but-OUTDATED herdr: `herdr --version` reports below HERDR_MIN_VERSION → `warning`,
     // while the daemon still answers `agent list` (liveness ok) so it reads outdated, NOT
-    // offline. The baseline stub reports 99.99.99 (ok); this seed overwrites it to report an
-    // old version. Present-but-old passes the boot preflight (it fail-fasts only on a MISSING
-    // binary, src/preflight.ts), so the instance boots and self-diagnoses.
+    // offline. The baseline stub reports HERDR_LAST_SUPPORTED_VERSION (ok); this seed overwrites
+    // it to report an old version. Present-but-old passes the boot preflight (it fail-fasts only
+    // on a MISSING binary, src/preflight.ts), so the instance boots and self-diagnoses.
     //
     // DETECTION-ONLY: applies no remediation, so it exercises NONE of the #1578
     // `herdr update --handoff` remediation and largely duplicates the outdated→warning unit

--- a/ci/onboarding-harness/seed.ts
+++ b/ci/onboarding-harness/seed.ts
@@ -1,3 +1,4 @@
+import { HERDR_LAST_SUPPORTED_VERSION } from "../../src/herdr-capabilities";
 import type { IncusDriver } from "./incus";
 import type { Scenario } from "./types";
 
@@ -132,12 +133,19 @@ function ensureToolchain(): string {
  *  missing herdr fail-fasts (exit 78) BEFORE the HTTP server binds, so the 6
  *  non-herdr scenarios — which don't test herdr — just need preflight satisfied.
  *
+ *  The stub reports HERDR_LAST_SUPPORTED_VERSION, derived — never hardcoded. It used to
+ *  report `99.99.99`, which was fine until #1887 added the support CEILING: from then on the
+ *  baseline stub represented a herdr Shepherd REFUSES to drive, so every non-herdr scenario
+ *  booted with an `unsupported` herdr check and an UNSUPPORTED preflight banner. Harmless
+ *  (none of them expect `herdr: ok`) but a lie in the fixture, and it would confuse the next
+ *  scenario that does. Deriving it means a ceiling bump can never re-introduce the drift.
+ *
  *  The stub emits a single VALID JSON line for EVERY invocation. This is
  *  load-bearing, not decorative:
  *   - diagnostics' `herdrProbe` extracts a semver via `SEMVER_RE` from the output,
- *     so the JSON's `99.99.99` (≥ HERDR_MIN_VERSION) reads `ok`;
+ *     so the JSON's version (≥ HERDR_MIN_VERSION, ≤ the ceiling) reads `ok`;
  *   - on-loop `HerdrDriver.list()/tabs()/panes()` do an UNGUARDED `JSON.parse` then
- *     `parsed?.result?.… ?? []`. A plain-text `herdr 99.99.99` would throw a
+ *     `parsed?.result?.… ?? []`. A plain-text `herdr <version>` would throw a
  *     SyntaxError every tick (a different throw than the pre-#1313 ENOENT), so valid
  *     JSON is required — it parses cleanly to `[]` and never throws.
  *  A final `test -x` makes it a CHECKED step (fail-closes the baseline). */
@@ -146,7 +154,7 @@ function herdrStub(): string {
     'mkdir -p "$HOME/.local/bin"\n' +
     "cat > \"$HOME/.local/bin/herdr\" <<'HERDR_STUB'\n" +
     "#!/bin/sh\n" +
-    'echo \'{"version":"99.99.99"}\'\n' +
+    `echo '{"version":"${HERDR_LAST_SUPPORTED_VERSION}"}'\n` +
     "HERDR_STUB\n" +
     'chmod +x "$HOME/.local/bin/herdr"\n' +
     'test -x "$HOME/.local/bin/herdr"'

--- a/deploy/provision.ts
+++ b/deploy/provision.ts
@@ -20,7 +20,9 @@ import { homedir, totalmem } from "node:os";
 import { join } from "node:path";
 import { BUN_MIN_VERSION, NODE_MIN_VERSION, HERDR_MIN_VERSION } from "../src/config";
 import { compareSemver } from "../src/herdr-update";
-import { autoFixCommandFor, HERDR_INSTALL, HERDR_SERVE } from "../src/remediations";
+import { HERDR_LAST_SUPPORTED_VERSION } from "../src/herdr-capabilities";
+import { herdrPinnedInstallCommand } from "../src/herdr-install";
+import { autoFixCommandFor, HERDR_SERVE } from "../src/remediations";
 import { resolveBackupDir, backupConfiguredMarker } from "../src/backup-paths";
 
 // ── pure types + data ─────────────────────────────────────────────────────────
@@ -55,7 +57,15 @@ export const PREREQS: readonly Prereq[] = [
     // thrashes the unit while the orphan keeps serving. The check still reads `ok` (the orphan
     // answers), so the breakage would be invisible. On the service path the UNIT owns the
     // daemon; `buildOnly` (no systemd) starts it explicitly instead. #1574
-    installCommand: HERDR_INSTALL,
+    //
+    // It is also built with the UPSTREAM-COMPARABLE download budget rather than reusing
+    // `HERDR_INSTALL` verbatim (#1896): that constant is sized for the in-app Fix, whose child is
+    // SIGKILLed at REMEDIATION_TIMEOUT_MS, while nothing kills provision. This is the path where a
+    // failed herdr install genuinely strands an operator (`install.sh` aborts and the host is left
+    // with no herdr), so it gets the same bandwidth tolerance upstream's own installer allows.
+    installCommand: herdrPinnedInstallCommand(HERDR_LAST_SUPPORTED_VERSION, {
+      downloadBudget: "upstream",
+    }),
   },
   // claude is presence-only (no version floor), like diagnostics.
   { bin: "claude", hintKey: "diagnostics_hint_claude_missing" },

--- a/docs-site/src/content/docs/getting-started.md
+++ b/docs-site/src/content/docs/getting-started.md
@@ -26,10 +26,14 @@ state dir and never force-resets a dirty checkout.
 
 This is third-party `curl|bash`: the script runs unconfined as your user _before_
 any sandbox exists, and it invokes upstream installers it does not control —
-[bun.sh](https://bun.sh/install), [fnm](https://fnm.vercel.app) (Node),
-[herdr.dev](https://herdr.dev), and the [`claude` CLI](https://claude.ai/install.sh) —
-plus your distro's package manager for `git`, `unzip`, and the C/C++ build
-toolchain + `python3` (needed for the node-pty native build). In keeping with
+[bun.sh](https://bun.sh/install), [fnm](https://fnm.vercel.app) (Node), and the
+[`claude` CLI](https://claude.ai/install.sh) — plus your distro's package manager
+for `git`, `unzip`, and the C/C++ build toolchain + `python3` (needed for the
+node-pty native build). herdr is **not** installed via `herdr.dev/install.sh`
+(latest-only); Shepherd downloads a **version-pinned** release binary from
+[GitHub](https://github.com/ogulcancelik/herdr/releases), verifies the version it
+reports, and installs it to `~/.local/bin` — still third-party code fetched and
+executed on your machine. In keeping with
 Shepherd's radical-transparency posture the script echoes each third-party command
 before running it. Read it first:
 [deploy/install.sh](https://github.com/erwins-enkel/shepherd/blob/main/deploy/install.sh).

--- a/src/herdr-install.ts
+++ b/src/herdr-install.ts
@@ -1,0 +1,214 @@
+// Version-PINNED herdr installation (#1896).
+//
+// herdr.dev/install.sh is latest-only (verified live: it resolves latest.json's asset, downloads,
+// `mv`s it to ~/.local/bin, and does nothing else — no checksum, no signature, no version knob).
+// Shepherd refuses to drive a herdr above HERDR_LAST_SUPPORTED_VERSION, so installing "latest"
+// means every fresh onboarding breaks the day herdr ships past the ceiling — exactly the nightly
+// regression #1896 reported. This module builds the replacement: a version-addressable download of
+// the ceiling, so raising the ceiling propagates to every install path with no second edit.
+//
+// LEAF MODULE — imports nothing but the capability constant. src/preflight.ts is documented as
+// side-effect-free at import, and reaching these helpers through remediations.ts would drag
+// config.ts (which loads the forge config at import) into the boot preflight and its tests.
+// herdr-update.ts re-exports herdrAssetKey/herdrReleaseUrl from here, so existing importers are
+// unaffected.
+import { HERDR_LAST_SUPPORTED_VERSION } from "./herdr-capabilities";
+
+/** Versions are regex-captured (digits + dots) before they reach here, but they ultimately
+ *  originate from herdr.dev/latest.json — an external source. Strip anything that isn't a version
+ *  char before embedding in a shell program so a poisoned payload can never inject commands.
+ *  Empty → "unknown". */
+export function sanitizeVersion(v: string | null | undefined): string {
+  const clean = (v ?? "").replace(/[^0-9.]/g, "");
+  return clean || "unknown";
+}
+
+/** Map this host onto latest.json's asset key (`linux-x86_64`, `macos-aarch64`, …);
+ *  null when herdr publishes no binary for the platform. */
+export function herdrAssetKey(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): string | null {
+  const os = platform === "linux" ? "linux" : platform === "darwin" ? "macos" : null;
+  const cpu = arch === "x64" ? "x86_64" : arch === "arm64" ? "aarch64" : null;
+  return os && cpu ? `${os}-${cpu}` : null;
+}
+
+/** The GitHub release-tag page for a version — the manual-install pointer the loud failure
+ *  branches (and the preflight banner's no-asset fallback) hand the operator. */
+export function herdrReleaseTagUrl(version: string): string {
+  return `https://github.com/ogulcancelik/herdr/releases/tag/v${sanitizeVersion(version)}`;
+}
+
+/** The version-addressable release-asset URL, built from a HARDCODED template (the same GitHub
+ *  slug the modal's release-notes link uses). The DOWNGRADE flow (#1898) additionally cross-checks
+ *  this against latest.json's `releases` map before running — the template guarantees shape (no
+ *  injection), the manifest guarantees currency. The FRESH-INSTALL path below deliberately does
+ *  NOT: that cross-check protects a working install about to be swapped, whereas a fresh install
+ *  has nothing to protect, and a static remediation string (or a bare-host provision run, with no
+ *  Shepherd process) has no service to call. */
+export function herdrReleaseUrl(version: string, assetKey: string): string {
+  return `https://github.com/ogulcancelik/herdr/releases/download/v${sanitizeVersion(version)}/herdr-${assetKey}`;
+}
+
+/**
+ * `curl` transfer flags for the pinned download, sized to the CONSUMER's deadline.
+ *
+ * The artifact is ~20.3 MiB (measured: 21,315,048 bytes for v0.7.5 linux-x86_64, served via one
+ * 302 to release-assets.githubusercontent.com), so an attempt must cover connect + two TLS
+ * handshakes + the redirect + the body. That makes the cap a bandwidth floor, not a formality:
+ *
+ *  - `"upstream"` — `--max-time 120`, i.e. the same tolerance (≈1.4 Mbit/s) upstream's own
+ *    installer allows. Used where nothing kills the process: deploy/provision.ts (a fresh
+ *    install.sh) and the preflight banner's copy-pasteable line.
+ *  - `"in-app"` — must fit inside REMEDIATION_TIMEOUT_MS (120s), where defaultRunRemediation
+ *    SIGKILLs the whole process group, ALONGSIDE the HERDR_SERVE clause it is composed with
+ *    (≤22s: initial probe + spawn + its 10 × (probe + sleep 1) poll) and the local verify (~1s).
+ *    That leaves 90s for one attempt ⇒ a ≈1.9 Mbit/s floor, with 7s of slack against the
+ *    group-kill. See HERDR_IN_APP_DOWNLOAD_WORST_CASE_MS.
+ *
+ * The in-app path is deliberately the tight one: src/index.ts fail-fasts (exit 78) on a missing
+ * herdr, so the in-app `herdr_missing` fix is only reachable with Shepherd already running — the
+ * UI is up and a failed fix is visible and retryable. Nobody is stranded by the tighter cap.
+ */
+export type HerdrDownloadBudget = "upstream" | "in-app";
+
+/** Per-budget `curl` timing. `--retry-max-time` bars a NEW attempt after N seconds; an attempt
+ *  starting just under it still gets its full `--max-time`, so the worst case is
+ *  `retryMaxTime + maxTime` (and simply `maxTime` when retries are off).
+ *
+ *  The in-app budget deliberately runs a SINGLE attempt. When a hard deadline is the binding
+ *  constraint, splitting it into retries shrinks each attempt's cap and therefore RAISES the
+ *  bandwidth floor — the opposite of what a slow link needs. One 90s attempt admits ≈1.9 Mbit/s;
+ *  two 45s attempts would demand ≈3.8. Retrying the whole apply is the harness's job
+ *  (runWithRetry), and the operator can simply click Fix again. */
+const DOWNLOAD_BUDGETS = {
+  upstream: { connectTimeout: 10, maxTime: 120, retry: 1, retryDelay: 1, retryMaxTime: 121 },
+  "in-app": { connectTimeout: 5, maxTime: 90, retry: 0, retryDelay: 0, retryMaxTime: 0 },
+} as const satisfies Record<
+  HerdrDownloadBudget,
+  {
+    connectTimeout: number;
+    maxTime: number;
+    retry: number;
+    retryDelay: number;
+    retryMaxTime: number;
+  }
+>;
+
+/** Worst-case wall clock of the IN-APP pinned download, in ms. Exported so the budget arithmetic
+ *  is machine-checked against the real REMEDIATION_TIMEOUT_MS (see test/herdr-install.test.ts)
+ *  rather than asserted in prose — raising a timeout or adding a retry then fails the suite
+ *  instead of silently pushing the composed remediation past the group-kill. */
+export const HERDR_IN_APP_DOWNLOAD_WORST_CASE_MS =
+  (DOWNLOAD_BUDGETS["in-app"].retryMaxTime + DOWNLOAD_BUDGETS["in-app"].maxTime) * 1000;
+
+/** Worst case of the HERDR_SERVE clause the in-app remediation is composed with: initial probe
+ *  (1s) + spawn/`systemctl restart` (1s) + its poll loop of 10 × (probe 1s + `sleep 1`). Derived
+ *  from that loop's actual shape, not a round number chosen to fit. */
+export const HERDR_SERVE_WORST_CASE_MS = (1 + 1 + 10 * 2) * 1000;
+
+/** Local `--version` exec + atomic rename. */
+export const HERDR_VERIFY_WORST_CASE_MS = 1000;
+
+function curlFlags(budget: HerdrDownloadBudget): string {
+  const b = DOWNLOAD_BUDGETS[budget];
+  const retry = b.retry
+    ? ` --retry ${b.retry} --retry-delay ${b.retryDelay} --retry-max-time ${b.retryMaxTime}`
+    : "";
+  return `-fsSL${retry} --connect-timeout ${b.connectTimeout} --max-time ${b.maxTime}`;
+}
+
+/**
+ * The shell program that installs the PINNED herdr, as a single line.
+ *
+ * SINGLE LINE is load-bearing, not style: this string is carried on `check.remediation` and
+ * rendered verbatim by DiagnoseRows.svelte's confirm modal as `<code class="cmd">` with
+ * `white-space: pre` and only `overflow-x: auto`, inside a `.card` that has no desktop
+ * `max-height`/`overflow-y`. A long single line scrolls horizontally; a multi-line one grows the
+ * card past the viewport with no scrollbar and clips the CANCEL/RUN buttons.
+ *
+ * SUBSHELL-WRAPPED, also load-bearing: REMEDIATIONS composes this as
+ * `${HERDR_INSTALL} && (${HERDR_SERVE})`, and an unwrapped multi-statement program would let `&&`
+ * bind to only its LAST command — the exact trap remediations.ts already documents for
+ * HERDR_SERVE.
+ *
+ * Ordering mirrors buildDowngradeScript (download → verify → atomic swap), but its TIMEOUTS and
+ * TEMP PATH deliberately do not: that script has an existing binary to anchor a temp beside and
+ * never runs under defaultRunRemediation's group-kill.
+ *
+ * Failure policy — governing rule is NEVER WORSE THAN today's `curl | bash`, which performs no
+ * verification at all. Verification therefore BLOCKS only on positive evidence the artifact is
+ * wrong; everything else warns and proceeds exactly as today would:
+ *
+ *  - `uname` miss (either arm) ⇒ loud failure naming the release tag. No point deferring to
+ *    upstream: its installer has the identical `case` arms and fails the same way with less
+ *    information.
+ *  - download failure after the budgeted retries ⇒ loud failure, non-zero. Byte-parity with
+ *    today: provision's installPrereqs calls run() (NOT runWithRetry) and defaultRunner throws,
+ *    so a failed herdr install already aborts install.sh.
+ *  - cannot exec (126/127 — the glibc-asset-on-musl case; herdrAssetKey has no musl key, so
+ *    alpine gets the glibc asset exactly as upstream does) ⇒ WARN and swap anyway. A hard abort
+ *    here would kill install.sh on Alpine hosts that install fine today.
+ *  - exits 0 but the version is unparseable ⇒ WARN and swap anyway. That is evidence about our
+ *    PARSER (herdr emits JSON on some paths, and this pin is meant to propagate on a ceiling bump
+ *    with no second edit), not about the artifact.
+ *  - exits 0, parses, and differs from the pin ⇒ loud failure, temp removed, NO swap. The only
+ *    case with positive evidence the artifact is mislabeled.
+ *  - mkdir/chmod/mv failure ⇒ loud failure, non-zero, and NO success line.
+ *
+ * Two details that keep the above honest:
+ *  - the exec status is captured from the BINARY (`>"$OUT"; rc=$?`), never from a pipeline —
+ *    `V="$(… | head -n 1)"; rc=$?` would capture `head`'s status (always 0) and make the
+ *    exec-failure branch unreachable;
+ *  - the temp lives NEXT TO the install target, so `mv` is an atomic same-filesystem rename. A
+ *    /tmp temp would make it a copy+unlink, and on a `noexec` /tmp would make the `--version`
+ *    probe fail for reasons that have nothing to do with the artifact.
+ */
+export function herdrPinnedInstallCommand(
+  version: string = HERDR_LAST_SUPPORTED_VERSION,
+  opts: { downloadBudget?: HerdrDownloadBudget } = {},
+): string {
+  const v = sanitizeVersion(version);
+  const tag = herdrReleaseTagUrl(v);
+  // Asset key assembled by the shell from `uname`, NOT baked from process.platform: this string is
+  // built on the Shepherd host but can execute elsewhere (the harness applies it inside an Incus
+  // instance), and provision.ts runs it on hosts Shepherd has never introspected. The arms must
+  // agree with herdrAssetKey() — test/herdr-install.test.ts asserts that for every mapped pair.
+  const url = `https://github.com/ogulcancelik/herdr/releases/download/v${v}/herdr-$O-$A`;
+  return [
+    "(",
+    `case "$(uname -s)" in Linux) O=linux ;; Darwin) O=macos ;;`,
+    `*) echo "herdr: unsupported OS $(uname -s) — install herdr ${v} manually from ${tag}" >&2; exit 1 ;; esac;`,
+    `case "$(uname -m)" in x86_64|amd64) A=x86_64 ;; aarch64|arm64) A=aarch64 ;;`,
+    `*) echo "herdr: unsupported architecture $(uname -m) — install herdr ${v} manually from ${tag}" >&2; exit 1 ;; esac;`,
+    'D="${HERDR_INSTALL_DIR:-$HOME/.local/bin}";',
+    // && all the way through the swap: a failed mkdir/chmod/mv must short-circuit, never proceed.
+    'mkdir -p "$D" || { echo "herdr: cannot create $D" >&2; exit 1; };',
+    'T="$D/.herdr.$$"; OUT="$D/.herdr-version.$$";',
+    `curl ${curlFlags(opts.downloadBudget ?? "in-app")} -o "$T" "${url}" || ` +
+      `{ rm -f "$T"; echo "herdr: download failed for ${v} ($O-$A) — install manually from ${tag}" >&2; exit 1; };`,
+    'chmod +x "$T" || { rm -f "$T"; echo "herdr: cannot chmod $T" >&2; exit 1; };',
+    // rc is the BINARY's status; V is the parse. They are different questions with different
+    // answers, so they are captured separately.
+    '"$T" --version >"$OUT" 2>/dev/null; rc=$?;',
+    `V="$(grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+' "$OUT" 2>/dev/null | head -n 1)"; rm -f "$OUT";`,
+    'if [ "$rc" -ne 0 ]; then',
+    `echo "herdr: downloaded ${v} does not run here (exit $rc) — a musl host gets the glibc build; installing it anyway, as the upstream installer would" >&2;`,
+    'elif [ -z "$V" ]; then',
+    `echo "herdr: could not read a version from the downloaded ${v} binary — installing it anyway, as the upstream installer would" >&2;`,
+    `elif [ "$V" != "${v}" ]; then`,
+    `rm -f "$T"; echo "herdr: downloaded binary reports $V, expected ${v} — refusing to install it; get ${v} from ${tag}" >&2; exit 1;`,
+    "fi;",
+    'mv -f "$T" "$D/herdr" || { rm -f "$T"; echo "herdr: cannot install into $D" >&2; exit 1; };',
+    // Success is claimed only AFTER the swap is observed to have landed — `echo` exits 0, so an
+    // unguarded success line would report a healthy install on a host with no herdr.
+    // `-f` as well as `-x`: if `$D/herdr` were a DIRECTORY, `mv -f` would move the temp INSIDE it
+    // and exit 0, and a bare `-x` test passes on any traversable directory — reporting a healthy
+    // install with no herdr binary anywhere. The guard exists precisely to make the success line
+    // a verified fact, so it must not be satisfiable by the failure it guards against.
+    `[ -f "$D/herdr" ] && [ -x "$D/herdr" ] || { echo "herdr: $D/herdr is not an executable file after install" >&2; exit 1; };`,
+    `echo "herdr ${v} installed to $D/herdr";`,
+    ")",
+  ].join(" ");
+}

--- a/src/herdr-update.ts
+++ b/src/herdr-update.ts
@@ -9,6 +9,7 @@ import {
 } from "./herdr-capabilities";
 import { maintenance as sharedMaintenance } from "./maintenance";
 import { compareSemver } from "./semver";
+import { herdrAssetKey, herdrReleaseUrl, sanitizeVersion } from "./herdr-install";
 import { runScriptChild } from "./script-child";
 import { readInstalledVersion, readActualVersion } from "./version-probe";
 import type { HerdrUpdateStatus } from "./types";
@@ -18,6 +19,10 @@ export type { HerdrUpdateStatus };
 // `from "./herdr-update"` path; the implementation now lives in the leaf semver.ts (so
 // herdr-capabilities.ts can share it without an import cycle).
 export { compareSemver };
+// Same pattern for the release-artifact helpers: they moved to the leaf herdr-install.ts (so
+// preflight.ts can build a pinned install line without pulling config.ts into the boot path),
+// and are re-exported here for existing importers + test/herdr-downgrade.test.ts.
+export { herdrAssetKey, herdrReleaseUrl };
 
 const SEMVER_RE = /(\d+\.\d+\.\d+)/;
 const LATEST_URL = "https://herdr.dev/latest.json";
@@ -26,15 +31,6 @@ const LATEST_URL = "https://herdr.dev/latest.json";
  *  operator can `cat ~/.shepherd/herdr-update.log | grep '>>> herdr-update'` and
  *  read the exact sequence (and exit code) even after shepherd has restarted. */
 export const UPDATE_LOG_PREFIX = ">>> herdr-update:";
-
-/** Versions are regex-captured (digits + dots) before they reach here, but they
- *  ultimately originate from herdr.dev/latest.json — an external source. Strip
- *  anything that isn't a version char before embedding in the shell program so a
- *  poisoned payload can never inject commands. Empty → "unknown". */
-function sanitizeVersion(v: string | null | undefined): string {
-  const clean = (v ?? "").replace(/[^0-9.]/g, "");
-  return clean || "unknown";
-}
 
 // single-quote for the shell; a literal `'` inside (vanishingly unlikely in a
 // home path or binary path) is escaped via the classic '\'' close-reopen trick.
@@ -130,25 +126,6 @@ export function buildUpdateScript(
     "  fi",
     '} 2>&1 | tee -a "$LOG"',
   ].join("\n");
-}
-
-/** Map this host onto latest.json's asset key (`linux-x86_64`, `macos-aarch64`, …);
- *  null when herdr publishes no binary for the platform. */
-export function herdrAssetKey(
-  platform: NodeJS.Platform = process.platform,
-  arch: string = process.arch,
-): string | null {
-  const os = platform === "linux" ? "linux" : platform === "darwin" ? "macos" : null;
-  const cpu = arch === "x64" ? "x86_64" : arch === "arm64" ? "aarch64" : null;
-  return os && cpu ? `${os}-${cpu}` : null;
-}
-
-/** The version-addressable release-asset URL, built from a HARDCODED template (the
- *  same GitHub slug the modal's release-notes link uses). The downgrade flow (#1898)
- *  cross-checks this against latest.json's `releases` map before running — the
- *  template guarantees shape (no injection), the manifest guarantees currency. */
-export function herdrReleaseUrl(version: string, assetKey: string): string {
-  return `https://github.com/ogulcancelik/herdr/releases/download/v${sanitizeVersion(version)}/herdr-${assetKey}`;
 }
 
 /**

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -2,7 +2,12 @@
 // resolvable on PATH, instead of letting Shepherd spew stack traces trying to use it.
 //
 // Pure/side-effect-free at import time — the caller (src/index.ts) injects runVersion/
-// log/exit so this module stays testable with fakes.
+// log/exit so this module stays testable with fakes. Its only imports are LEAF modules
+// (herdr-capabilities / herdr-install); pulling in remediations.ts would drag config.ts, which
+// loads the forge config at import, into the boot preflight and its tests.
+
+import { HERDR_LAST_SUPPORTED_VERSION } from "./herdr-capabilities";
+import { herdrAssetKey, herdrReleaseTagUrl, herdrReleaseUrl } from "./herdr-install";
 
 export const HERDR_MISSING_EXIT_CODE = 78; // EX_CONFIG
 
@@ -11,12 +16,27 @@ export const HERDR_MISSING_EXIT_CODE = 78; // EX_CONFIG
 // copy that a future reword would break silently.
 export const HERDR_MISSING_MARKER = "herdr not found on PATH";
 
-const BANNER = `⚠  ${HERDR_MISSING_MARKER} — Shepherd cannot run.
+/** The fail-fast banner. A FUNCTION, not a const, so both platform branches are testable and
+ *  neither can render `undefined`.
+ *
+ *  The install line is PINNED to the highest herdr Shepherd can drive (#1896) — pointing an
+ *  operator at `herdr.dev/install.sh` would hand them whatever is newest, and on a herdr above the
+ *  ceiling the driver refuses every agent spawn. Because preflight runs on the very host it is
+ *  instructing, the platform is baked in for a short copy-pasteable line; when herdr publishes no
+ *  binary for this platform (`assetKey` null — Windows, or an unsupported arch) it falls back to
+ *  the release-tag page rather than printing a URL that cannot exist. */
+export function herdrMissingBanner(assetKey: string | null = herdrAssetKey()): string {
+  const install = assetKey
+    ? `mkdir -p ~/.local/bin && curl -fsSL -o ~/.local/bin/herdr ${herdrReleaseUrl(HERDR_LAST_SUPPORTED_VERSION, assetKey)} && chmod +x ~/.local/bin/herdr`
+    : `download herdr ${HERDR_LAST_SUPPORTED_VERSION} for your platform from ${herdrReleaseTagUrl(HERDR_LAST_SUPPORTED_VERSION)}`;
+  return `⚠  ${HERDR_MISSING_MARKER} — Shepherd cannot run.
    herdr owns the interactive claude PTYs; nothing works without it.
-   Install:  curl -fsSL https://herdr.dev/install.sh | bash
+   Shepherd supports herdr <= ${HERDR_LAST_SUPPORTED_VERSION}; newer releases break agent spawning.
+   Install:  ${install}
    It installs to ~/.local/bin — ensure that's on PATH:
        export PATH="$HOME/.local/bin:$PATH"   (add to your shell profile)
    Then re-run: bun run start`;
+}
 
 // Defensively inspects an unknown error for the two shapes a missing binary throws as:
 // Node's spawn/execFileSync ENOENT (`err.code === "ENOENT"`), and Bun's thrown
@@ -44,7 +64,7 @@ export function preflightHerdr(deps: {
     return runVersion();
   } catch (err) {
     if (isBinaryMissingError(err)) {
-      log(BANNER);
+      log(herdrMissingBanner());
       exit(HERDR_MISSING_EXIT_CODE);
     }
     // Present but broken (e.g. permission error) — not our call to make; fail open.

--- a/src/remediations.ts
+++ b/src/remediations.ts
@@ -1,4 +1,6 @@
 import { config } from "./config";
+import { HERDR_LAST_SUPPORTED_VERSION } from "./herdr-capabilities";
+import { herdrPinnedInstallCommand } from "./herdr-install";
 import { buildUpdateScript } from "./herdr-update";
 import type { DiagnosticsSnapshot } from "./types";
 
@@ -20,7 +22,18 @@ const NODE_INSTALL =
   'mkdir -p "$HOME/.local/bin" && ' +
   'ln -sf "$("$FNM" exec --using=lts-latest node -e \'console.log(process.execPath)\')" ' +
   '"$HOME/.local/bin/node"';
-export const HERDR_INSTALL = "curl -fsSL https://herdr.dev/install.sh | bash";
+// PINNED to HERDR_LAST_SUPPORTED_VERSION (#1896), not `curl -fsSL https://herdr.dev/install.sh |
+// bash`. The upstream installer is latest-only, and Shepherd's driver refuses to spawn on a herdr
+// above the ceiling — so installing "latest" strands every fresh host the day herdr ships past it.
+// One constant drives every install path: raise the ceiling and this follows.
+//
+// The IN-APP budget is the default because this constant's primary consumer is the diagnostics Fix
+// endpoint, whose child is SIGKILLed at REMEDIATION_TIMEOUT_MS. deploy/provision.ts passes the
+// upstream-comparable budget instead — it has no deadline, and it is the path where a failed
+// install actually strands someone.
+export const HERDR_INSTALL = herdrPinnedInstallCommand(HERDR_LAST_SUPPORTED_VERSION, {
+  downloadBudget: "in-app",
+});
 
 /** Bring the herdr daemon up and PROVE it answers. herdr 0.7.3 does NOT auto-spawn its
  *  server on a CLI call (verified in a clean instance, #1574) — a host that never ran

--- a/test/herdr-install.test.ts
+++ b/test/herdr-install.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, it } from "bun:test";
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { REMEDIATION_TIMEOUT_MS } from "../src/config";
+import { HERDR_LAST_SUPPORTED_VERSION } from "../src/herdr-capabilities";
+import {
+  HERDR_IN_APP_DOWNLOAD_WORST_CASE_MS,
+  HERDR_SERVE_WORST_CASE_MS,
+  HERDR_VERIFY_WORST_CASE_MS,
+  herdrAssetKey,
+  herdrPinnedInstallCommand,
+  herdrReleaseTagUrl,
+  herdrReleaseUrl,
+  sanitizeVersion,
+} from "../src/herdr-install";
+
+const PIN = HERDR_LAST_SUPPORTED_VERSION;
+
+// ── shape / property assertions ───────────────────────────────────────────────
+
+describe("herdrPinnedInstallCommand: shape", () => {
+  const cmd = herdrPinnedInstallCommand();
+
+  it("pins the supported ceiling and never reaches the latest-only upstream installer", () => {
+    expect(cmd).toContain(`/releases/download/v${PIN}/herdr-`);
+    // The whole point of #1896: `herdr.dev/install.sh` resolves latest.json and installs
+    // whatever is newest, which is what put an above-ceiling herdr on every fresh host.
+    expect(cmd).not.toContain("herdr.dev/install.sh");
+  });
+
+  it("is a subshell so `${HERDR_INSTALL} && (${HERDR_SERVE})` gates on the WHOLE program", () => {
+    expect(cmd.startsWith("(")).toBe(true);
+    expect(cmd.trimEnd().endsWith(")")).toBe(true);
+  });
+
+  it("emits a single line — DiagnoseRows renders it `white-space: pre` in a card with no desktop max-height", () => {
+    expect(cmd).not.toContain("\n");
+  });
+
+  it("downloads into the install dir, never /tmp, so the swap is an atomic same-fs rename", () => {
+    expect(cmd).toContain('D="${HERDR_INSTALL_DIR:-$HOME/.local/bin}"');
+    expect(cmd).toContain('T="$D/.herdr.$$"');
+    expect(cmd).not.toContain("/tmp/");
+  });
+
+  it("claims success only behind a post-swap executable check", () => {
+    const guard = cmd.indexOf('[ -x "$D/herdr" ]');
+    const claim = cmd.indexOf(`echo "herdr ${PIN} installed`);
+    expect(guard).toBeGreaterThan(-1);
+    expect(claim).toBeGreaterThan(guard);
+  });
+
+  it("sizes the download per consumer: upstream-comparable vs the in-app deadline", () => {
+    expect(herdrPinnedInstallCommand(PIN, { downloadBudget: "upstream" })).toContain(
+      "--max-time 120",
+    );
+    expect(herdrPinnedInstallCommand(PIN, { downloadBudget: "in-app" })).toContain("--max-time 90");
+    // Default is the tight one: REMEDIATIONS is the default consumer, and an accidentally-loose
+    // in-app command would be SIGKILLed mid-download by defaultRunRemediation.
+    expect(cmd).toContain("--max-time 90");
+  });
+
+  it("keeps the in-app budget inside the remediation group-kill, with every term declared", () => {
+    // Not `REMEDIATION_TIMEOUT_MS - download - serve`: a residual makes this tautological and it
+    // would keep passing when the download budget is raised — the exact regression it guards.
+    const worstCase =
+      HERDR_IN_APP_DOWNLOAD_WORST_CASE_MS + HERDR_VERIFY_WORST_CASE_MS + HERDR_SERVE_WORST_CASE_MS;
+    expect(worstCase).toBeLessThanOrEqual(REMEDIATION_TIMEOUT_MS);
+  });
+
+  it("strips shell metacharacters out of the version", () => {
+    const evil = herdrPinnedInstallCommand('0.7.5"; rm -rf ~ #');
+    expect(evil).toContain("/releases/download/v0.7.5/herdr-");
+    expect(evil).not.toContain("rm -rf ~");
+  });
+});
+
+describe("herdrReleaseTagUrl", () => {
+  it("points at the pinned release tag and sanitizes", () => {
+    expect(herdrReleaseTagUrl("0.7.5")).toBe(
+      "https://github.com/ogulcancelik/herdr/releases/tag/v0.7.5",
+    );
+    expect(herdrReleaseTagUrl("0.7.5; rm -rf ~")).toBe(
+      "https://github.com/ogulcancelik/herdr/releases/tag/v0.7.5",
+    );
+  });
+});
+
+describe("sanitizeVersion", () => {
+  it("keeps version chars, drops the rest, and never returns empty", () => {
+    expect(sanitizeVersion("0.7.5")).toBe("0.7.5");
+    expect(sanitizeVersion("herdr 0.7.5\n")).toBe("0.7.5");
+    expect(sanitizeVersion("")).toBe("unknown");
+    expect(sanitizeVersion(null)).toBe("unknown");
+  });
+});
+
+// ── PATH-shim harness: run the REAL program with fake `uname` / `curl` ────────
+//
+// Every branch below executes the production string. Fakes are on PATH (and `$HOME` contains a
+// SPACE, so a missing quote fails here rather than on a user's machine); nothing touches the
+// network and nothing touches the real ~/.local/bin.
+
+interface Shim {
+  dir: string;
+  home: string;
+  installDir: string;
+  curlLog: string;
+}
+
+function makeShim(opts: {
+  unameS?: string;
+  unameM?: string;
+  /** what the fake `curl` does: succeed writing a stub, or fail */
+  curl:
+    | { mode: "fail" }
+    | { mode: "stub"; version?: string; executable?: boolean; versionExit?: number };
+}): Shim {
+  const dir = mkdtempSync(join(tmpdir(), "herdr-install-"));
+  const home = join(dir, "home dir"); // deliberate space
+  const bin = join(dir, "bin");
+  const installDir = join(home, ".local", "bin");
+  const curlLog = join(dir, "curl.log");
+  mkdirSync(bin, { recursive: true });
+  mkdirSync(home, { recursive: true });
+
+  const write = (name: string, body: string) => {
+    const p = join(bin, name);
+    writeFileSync(p, body);
+    chmodSync(p, 0o755);
+  };
+
+  write(
+    "uname",
+    `#!/bin/sh\ncase "$1" in -s) echo '${opts.unameS ?? "Linux"}' ;; -m) echo '${opts.unameM ?? "x86_64"}' ;; *) echo '${opts.unameS ?? "Linux"}' ;; esac\n`,
+  );
+
+  if (opts.curl.mode === "fail") {
+    write("curl", `#!/bin/sh\nprintf '%s\\n' "$*" >> '${curlLog}'\nexit 22\n`);
+  } else {
+    const version = opts.curl.version ?? PIN;
+    const versionExit = opts.curl.versionExit ?? 0;
+    // The artifact the fake curl "downloads". Written from Node (never interpolated into shell
+    // quoting) so the payload's own quotes can't corrupt the shim. `executable: false` writes a
+    // blob the shell cannot exec — the glibc-asset-on-musl shape.
+    const payload = join(dir, "payload");
+    writeFileSync(
+      payload,
+      opts.curl.executable === false
+        ? "\u007fELF not runnable here\n"
+        : `#!/bin/sh\necho "herdr ${version}"\nexit ${versionExit}\n`,
+    );
+    write(
+      "curl",
+      `#!/bin/sh\nprintf '%s\\n' "$*" >> '${curlLog}'\n` +
+        // mimic `curl -o <path> <url>`: find the -o argument
+        `out=""\nwhile [ $# -gt 0 ]; do if [ "$1" = "-o" ]; then out="$2"; fi; shift; done\n` +
+        `cp '${payload}' "$out"\n`,
+    );
+  }
+
+  return { dir, home, installDir, curlLog };
+}
+
+function runProgram(
+  shim: Shim,
+  cmd: string = herdrPinnedInstallCommand(),
+): { code: number; stdout: string; stderr: string } {
+  const r = spawnSync("sh", ["-c", cmd], {
+    env: {
+      PATH: `${join(shim.dir, "bin")}:/usr/bin:/bin`,
+      HOME: shim.home,
+    },
+    encoding: "utf8",
+  });
+  return { code: r.status ?? -1, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+function curlCalls(shim: Shim): string {
+  return existsSync(shim.curlLog) ? execFileSync("cat", [shim.curlLog], { encoding: "utf8" }) : "";
+}
+
+/** Leftover temp files in the install dir — the program must clean up on every path. */
+function strays(shim: Shim): string[] {
+  if (!existsSync(shim.installDir)) return [];
+  return readdirSync(shim.installDir).filter((f) => f.startsWith(".herdr"));
+}
+
+describe("herdrPinnedInstallCommand: execution branches", () => {
+  const cleanup = (shim: Shim) => rmSync(shim.dir, { recursive: true, force: true });
+
+  it("success: installs an executable herdr reporting the pin, leaves no temp behind", () => {
+    const shim = makeShim({ curl: { mode: "stub" } });
+    try {
+      const r = runProgram(shim);
+      expect(r.code).toBe(0);
+      const installed = join(shim.installDir, "herdr");
+      expect(existsSync(installed)).toBe(true);
+      expect(execFileSync(installed, ["--version"], { encoding: "utf8" })).toContain(PIN);
+      expect(strays(shim)).toEqual([]);
+      // The temp was written INSIDE the install dir (same filesystem ⇒ atomic rename), not /tmp.
+      expect(curlCalls(shim)).toContain(join(shim.installDir, ".herdr."));
+      expect(r.stdout).toContain(`herdr ${PIN} installed`);
+    } finally {
+      cleanup(shim);
+    }
+  });
+
+  it("unmapped OS: fails loudly naming the release tag, without downloading anything", () => {
+    const shim = makeShim({ unameS: "SunOS", curl: { mode: "stub" } });
+    try {
+      const r = runProgram(shim);
+      expect(r.code).not.toBe(0);
+      expect(r.stderr).toContain(herdrReleaseTagUrl(PIN));
+      expect(curlCalls(shim)).toBe("");
+    } finally {
+      cleanup(shim);
+    }
+  });
+
+  it("unmapped architecture: fails loudly naming the release tag, without downloading anything", () => {
+    const shim = makeShim({ unameM: "armv7l", curl: { mode: "stub" } });
+    try {
+      const r = runProgram(shim);
+      expect(r.code).not.toBe(0);
+      expect(r.stderr).toContain(herdrReleaseTagUrl(PIN));
+      expect(curlCalls(shim)).toBe("");
+    } finally {
+      cleanup(shim);
+    }
+  });
+
+  it("download failure: fails loudly, installs nothing, leaves no temp", () => {
+    const shim = makeShim({ curl: { mode: "fail" } });
+    try {
+      const r = runProgram(shim);
+      expect(r.code).not.toBe(0);
+      expect(r.stderr).toContain("download failed");
+      expect(existsSync(join(shim.installDir, "herdr"))).toBe(false);
+      expect(strays(shim)).toEqual([]);
+    } finally {
+      cleanup(shim);
+    }
+  });
+
+  it("cannot exec (musl/glibc): warns but installs anyway — a hard abort would kill install.sh on Alpine", () => {
+    const shim = makeShim({ curl: { mode: "stub", executable: false } });
+    try {
+      const r = runProgram(shim);
+      expect(r.code).toBe(0);
+      expect(r.stderr).toContain("does not run here");
+      expect(existsSync(join(shim.installDir, "herdr"))).toBe(true);
+      expect(strays(shim)).toEqual([]);
+    } finally {
+      cleanup(shim);
+    }
+  });
+
+  it("exit 0 with an unparseable version: warns but installs anyway — that is our parser, not a bad artifact", () => {
+    const shim = makeShim({ curl: { mode: "stub", version: "unreleased-build" } });
+    try {
+      const r = runProgram(shim);
+      expect(r.code).toBe(0);
+      expect(r.stderr).toContain("could not read a version");
+      expect(existsSync(join(shim.installDir, "herdr"))).toBe(true);
+    } finally {
+      cleanup(shim);
+    }
+  });
+
+  it("version mismatch: refuses to install — the one case with positive evidence the artifact is wrong", () => {
+    const shim = makeShim({ curl: { mode: "stub", version: "9.9.9" } });
+    try {
+      const r = runProgram(shim);
+      expect(r.code).not.toBe(0);
+      expect(r.stderr).toContain("reports 9.9.9");
+      expect(existsSync(join(shim.installDir, "herdr"))).toBe(false);
+      expect(strays(shim)).toEqual([]);
+    } finally {
+      cleanup(shim);
+    }
+  });
+
+  it("refuses to claim success when $D/herdr is a directory (mv would move INTO it)", () => {
+    const shim = makeShim({ curl: { mode: "stub" } });
+    try {
+      mkdirSync(join(shim.installDir, "herdr"), { recursive: true });
+      const r = runProgram(shim);
+      expect(r.code).not.toBe(0);
+      // A bare `-x` test passes on a traversable directory, so this is the case that would
+      // otherwise report a healthy install with no herdr binary anywhere.
+      expect(r.stdout).not.toContain("installed to");
+    } finally {
+      cleanup(shim);
+    }
+  });
+
+  it("unwritable install dir: fails non-zero and never claims success", () => {
+    const shim = makeShim({ curl: { mode: "stub" } });
+    try {
+      mkdirSync(shim.installDir, { recursive: true });
+      chmodSync(shim.installDir, 0o500); // read+execute, not writable
+      const r = runProgram(shim);
+      expect(r.code).not.toBe(0);
+      // `echo` exits 0, so an unguarded success line would report a healthy install on a host
+      // with no herdr — and provision's runner (which throws only on non-zero) would sail on.
+      expect(r.stdout).not.toContain("installed to");
+      expect(existsSync(join(shim.installDir, "herdr"))).toBe(false);
+    } finally {
+      chmodSync(shim.installDir, 0o700);
+      cleanup(shim);
+    }
+  });
+});
+
+// ── the two platform mappings must agree ─────────────────────────────────────
+//
+// herdrAssetKey (TypeScript: the preflight banner + #1902's downgrade) and the shell `case` arms
+// (every real install) are independent tables that can silently diverge. No harness scenario runs
+// macOS, so this is the only seam that can catch the Darwin arms at all.
+
+describe("TS herdrAssetKey and the shell uname mapping agree", () => {
+  const pairs: Array<{ platform: NodeJS.Platform; arch: string; s: string; m: string }> = [
+    { platform: "linux", arch: "x64", s: "Linux", m: "x86_64" },
+    { platform: "linux", arch: "arm64", s: "Linux", m: "aarch64" },
+    { platform: "darwin", arch: "x64", s: "Darwin", m: "x86_64" },
+    { platform: "darwin", arch: "arm64", s: "Darwin", m: "aarch64" },
+    // Shell-only aliases the TS table never sees, asserted against the same canonical URL.
+    { platform: "linux", arch: "x64", s: "Linux", m: "amd64" },
+    { platform: "darwin", arch: "arm64", s: "Darwin", m: "arm64" },
+  ];
+
+  for (const { platform, arch, s, m } of pairs) {
+    it(`${s}/${m} downloads ${herdrAssetKey(platform, arch)}`, () => {
+      const shim = makeShim({ unameS: s, unameM: m, curl: { mode: "stub" } });
+      try {
+        runProgram(shim);
+        expect(curlCalls(shim)).toContain(herdrReleaseUrl(PIN, herdrAssetKey(platform, arch)!));
+      } finally {
+        rmSync(shim.dir, { recursive: true, force: true });
+      }
+    });
+  }
+});

--- a/test/onboarding-harness/herdr-preflight.test.ts
+++ b/test/onboarding-harness/herdr-preflight.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { IncusDriver } from "../../ci/onboarding-harness/incus";
 import { runScenario } from "../../ci/onboarding-harness/run";
 import { SCENARIOS } from "../../ci/onboarding-harness/scenarios";
+import { HERDR_LAST_SUPPORTED_VERSION } from "../../src/herdr-capabilities";
 import { HERDR_MISSING_EXIT_CODE, HERDR_MISSING_MARKER } from "../../src/preflight";
 import type { IncusExec } from "../../ci/onboarding-harness/types";
 import type { DiagnosticsSnapshot } from "../../src/types";
@@ -29,11 +30,21 @@ const isFailFastBoot = (joined: string): boolean =>
 
 /** Recorder: fail-fast boot returns the given exit code + banner output; the
  *  diagnostics probe returns `snapshot`; everything else succeeds (code 0). */
-function recorder(failFastCode: number, snapshot: DiagnosticsSnapshot) {
+function recorder(
+  failFastCode: number,
+  snapshot: DiagnosticsSnapshot,
+  installedHerdr: string = HERDR_LAST_SUPPORTED_VERSION,
+) {
   const calls: string[][] = [];
   const run = async (args: string[]): Promise<IncusExec> => {
     calls.push(args);
     const joined = args.join(" ");
+    if (joined.includes("--version")) {
+      // The installed-version assertion (#1896): the harness demands the PINNED herdr, not merely
+      // a working one, so the fake answers as a correctly-pinned host would — unless a test
+      // overrides it to prove the assertion actually bites.
+      return { stdout: `herdr ${installedHerdr}\n`, stderr: "", code: 0 };
+    }
     if (isFailFastBoot(joined)) {
       const output = failFastCode === HERDR_MISSING_EXIT_CODE ? `⚠  ${HERDR_MISSING_MARKER}\n` : "";
       return { stdout: output, stderr: "", code: failFastCode };
@@ -65,7 +76,9 @@ describe("herdr-missing runScenario (fail-fast preflight path)", () => {
     // Foreground fail-fast boot happened (timeout guard, no setsid/token).
     expect(flat.some((c) => isFailFastBoot(c))).toBe(true);
     // The REAL verbatim remediation ran (production REMEDIATIONS → herdr.dev install).
-    expect(flat.some((c) => c.includes("herdr.dev/install.sh"))).toBe(true);
+    expect(
+      flat.some((c) => c.includes(`/releases/download/v${HERDR_LAST_SUPPORTED_VERSION}/herdr-`)),
+    ).toBe(true);
     // Re-boot used the normal detached launch (setsid) + probed diagnostics.
     expect(flat.some((c) => c.includes("src/index.ts") && c.includes("setsid"))).toBe(true);
     expect(flat.some((c) => c.includes("/api/diagnostics?refresh=1"))).toBe(true);
@@ -76,6 +89,20 @@ describe("herdr-missing runScenario (fail-fast preflight path)", () => {
     expect(result.gateEligible).toBe(true);
     // Teardown ran (finally → delete).
     expect(calls.some((c) => c[0] === "delete")).toBe(true);
+  });
+
+  it("fail-closes when the install lands an UNPINNED herdr, even though the check reads ok", async () => {
+    // The teeth behind the pin (#1896). `herdr: ok` alone cannot catch an unpinned install while
+    // HERDR_LAST_SUPPORTED_VERSION happens to equal herdr's latest release — so the scenario reads
+    // the installed version and refuses anything but the pin. Without this, the day herdr ships
+    // past the ceiling a silently-unpinned install would sail through green.
+    const { run } = recorder(HERDR_MISSING_EXIT_CODE, greenAfterFix(), "9.9.9");
+    const d = new IncusDriver(run, "shep-onb-");
+    const result = await runScenario(d, herdrMissing, "/tmp/shepherd.tar");
+
+    expect(result.reachedGreen).toBe(false);
+    expect(result.error).toContain("9.9.9");
+    expect(result.error).toContain(HERDR_LAST_SUPPORTED_VERSION);
   });
 
   it("fail-closes (gating BOOT CRASH) when boot does NOT fail-fast — a timeout kill (124) is never a pass", async () => {
@@ -91,9 +118,11 @@ describe("herdr-missing runScenario (fail-fast preflight path)", () => {
     expect(result.installE2E).toBeUndefined();
     expect(result.error).toContain("expected herdr fail-fast");
     // Never proceeded to the remediation after a non-78 boot.
-    expect(calls.map((c) => c.join(" ")).some((c) => c.includes("herdr.dev/install.sh"))).toBe(
-      false,
-    );
+    expect(
+      calls
+        .map((c) => c.join(" "))
+        .some((c) => c.includes(`/releases/download/v${HERDR_LAST_SUPPORTED_VERSION}/herdr-`)),
+    ).toBe(false);
     // Still torn down.
     expect(calls.some((c) => c[0] === "delete")).toBe(true);
   });

--- a/test/onboarding-harness/install-e2e.test.ts
+++ b/test/onboarding-harness/install-e2e.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { HERDR_LAST_SUPPORTED_VERSION } from "../../src/herdr-capabilities";
 import { IncusDriver } from "../../ci/onboarding-harness/incus";
 import { seedInstance } from "../../ci/onboarding-harness/seed";
 import { runScenario } from "../../ci/onboarding-harness/run";
@@ -33,6 +34,11 @@ function recorder(snapshot: DiagnosticsSnapshot) {
   const run = async (args: string[]): Promise<IncusExec> => {
     calls.push(args);
     const joined = args.join(" ");
+    if (joined.includes("--version")) {
+      // The installed-version assertion (#1896): the harness demands the PINNED herdr, not merely
+      // a working one, so the fake must answer as a correctly-pinned host would.
+      return { stdout: `herdr ${HERDR_LAST_SUPPORTED_VERSION}\n`, stderr: "", code: 0 };
+    }
     if (joined.includes("/api/diagnostics?refresh=1")) {
       return { stdout: JSON.stringify(snapshot), stderr: "", code: 0 };
     }

--- a/test/onboarding-harness/install-lifecycle.test.ts
+++ b/test/onboarding-harness/install-lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { HERDR_LAST_SUPPORTED_VERSION } from "../../src/herdr-capabilities";
 import { IncusDriver } from "../../ci/onboarding-harness/incus";
 import { runScenario } from "../../ci/onboarding-harness/run";
 import { SCENARIOS } from "../../ci/onboarding-harness/scenarios";
@@ -33,6 +34,11 @@ function recorder(snapshot: DiagnosticsSnapshot, deadUnit?: "herdr" | "shepherd"
   const run = async (args: string[]): Promise<IncusExec> => {
     calls.push(args);
     const joined = args.join(" ");
+    if (joined.includes("--version")) {
+      // The installed-version assertion (#1896): the harness demands the PINNED herdr, not merely
+      // a working one, so the fake must answer as a correctly-pinned host would.
+      return { stdout: `herdr ${HERDR_LAST_SUPPORTED_VERSION}\n`, stderr: "", code: 0 };
+    }
     if (joined.includes("/api/diagnostics?refresh=1")) {
       return { stdout: JSON.stringify(snapshot), stderr: "", code: 0 };
     }

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -1,9 +1,11 @@
+import { HERDR_LAST_SUPPORTED_VERSION } from "../src/herdr-capabilities";
 import { test, expect } from "bun:test";
 import {
   HERDR_MISSING_EXIT_CODE,
   HERDR_MISSING_MARKER,
   isBinaryMissingError,
   preflightHerdr,
+  herdrMissingBanner,
 } from "../src/preflight";
 
 // ── isBinaryMissingError ─────────────────────────────────────────────────────
@@ -70,7 +72,27 @@ test("preflightHerdr: missing binary → logs one banner and exits 78", () => {
   expect(calls).toEqual([HERDR_MISSING_EXIT_CODE]);
   expect(logs).toHaveLength(1);
   expect(logs[0]).toContain("herdr not found on PATH");
-  expect(logs[0]).toContain("https://herdr.dev/install.sh");
+  // PINNED, not the latest-only upstream installer (#1896): an operator following the banner must
+  // land on a herdr Shepherd can actually drive.
+  expect(logs[0]).toContain(`/releases/download/v${HERDR_LAST_SUPPORTED_VERSION}/herdr-`);
+  expect(logs[0]).not.toContain("herdr.dev/install.sh");
+  expect(logs[0]).toContain(`supports herdr <= ${HERDR_LAST_SUPPORTED_VERSION}`);
+});
+
+test("banner falls back to the release-tag page when herdr publishes no binary for the platform", () => {
+  // assetKey null (Windows, or an unsupported arch) must never render `undefined` into a URL.
+  const banner = herdrMissingBanner(null);
+  expect(banner).toContain(`/releases/tag/v${HERDR_LAST_SUPPORTED_VERSION}`);
+  expect(banner).not.toContain("undefined");
+  expect(banner).not.toContain("/releases/download/");
+});
+
+test("banner renders a pinned, copy-pasteable install line for a mapped platform", () => {
+  const banner = herdrMissingBanner("linux-x86_64");
+  expect(banner).toContain(
+    `curl -fsSL -o ~/.local/bin/herdr https://github.com/ogulcancelik/herdr/releases/download/v${HERDR_LAST_SUPPORTED_VERSION}/herdr-linux-x86_64`,
+  );
+  expect(banner).not.toContain("undefined");
 });
 
 test("emitted banner contains the exported HERDR_MISSING_MARKER (no drift for out-of-tree matchers)", () => {

--- a/test/provision.test.ts
+++ b/test/provision.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, spyOn, beforeEach, afterEach } from "bun:test";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { readFileSync } from "node:fs";
+import { HERDR_LAST_SUPPORTED_VERSION } from "../src/herdr-capabilities";
 import {
   PREREQS,
   provision,
@@ -69,7 +70,8 @@ describe("selectPrereqCommand", () => {
   it("selects an install for a below-floor herdr", () => {
     const herdr = PREREQS.find((p) => p.bin === "herdr")!;
     const cmd = selectPrereqCommand(herdr, { version: "0.1.0" });
-    expect(cmd).toContain("herdr.dev/install.sh");
+    expect(cmd).toContain(`/releases/download/v${HERDR_LAST_SUPPORTED_VERSION}/herdr-`);
+    expect(cmd).not.toContain("herdr.dev/install.sh");
   });
 
   it("never selects tailscale (guidance-only) — it is not a prereq", () => {
@@ -196,7 +198,7 @@ describe("provision orchestration (injected runner, no real installs)", () => {
     });
     const flat = calls.map((c) => c.join(" "));
     expect(flat.some((c) => c.includes("bun.sh/install"))).toBe(false);
-    expect(flat.some((c) => c.includes("herdr.dev/install"))).toBe(false);
+    expect(flat.some((c) => c.includes("/releases/download/v"))).toBe(false);
     expect(flat.some((c) => c.includes("tailscale.com/install"))).toBe(false);
   });
 
@@ -206,7 +208,7 @@ describe("provision orchestration (injected runner, no real installs)", () => {
     const probe = (bin: string) => (bin === "herdr" ? "0.1.0" : "999.0.0");
     provision({ run, probe, platform: "linux", env: { SHEPHERD_NO_SERVICE: "1" }, repo: "/repo" });
     const flat = calls.map((c) => c.join(" "));
-    expect(flat.some((c) => c.includes("herdr.dev/install"))).toBe(true);
+    expect(flat.some((c) => c.includes("/releases/download/v"))).toBe(true);
   });
 
   it("always lays the node-gyp safety net", () => {
@@ -333,7 +335,7 @@ describe("extracted helpers (direct)", () => {
     const probe = (bin: string) => (bin === "herdr" ? "0.1.0" : "999.0.0");
     installPrereqs(probe, run, { FOO: "bar" });
     const flat = calls.map((c) => c.join(" "));
-    expect(flat.some((c) => c.includes("herdr.dev/install"))).toBe(true);
+    expect(flat.some((c) => c.includes("/releases/download/v"))).toBe(true);
     expect(flat.some((c) => c.includes("bun.sh/install"))).toBe(false);
   });
 
@@ -505,7 +507,8 @@ describe("extracted helpers (direct)", () => {
     // orphan kept serving (check reads `ok`, breakage invisible). The UNIT must own the daemon.
     const herdr = PREREQS.find((p) => p.bin === "herdr")!;
     const cmd = selectPrereqCommand(herdr, { version: null })!;
-    expect(cmd).toContain("herdr.dev/install.sh");
+    expect(cmd).toContain(`/releases/download/v${HERDR_LAST_SUPPORTED_VERSION}/herdr-`);
+    expect(cmd).not.toContain("herdr.dev/install.sh");
     expect(cmd).not.toContain("server");
     expect(cmd).not.toContain("agent list");
   });

--- a/test/remediations.test.ts
+++ b/test/remediations.test.ts
@@ -1,3 +1,4 @@
+import { HERDR_LAST_SUPPORTED_VERSION } from "../src/herdr-capabilities";
 import { describe, expect, it } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -152,7 +153,9 @@ describe("herdr offline remediation (#1574)", () => {
 
   it("herdr_missing installs AND starts, so the single-apply preflight scenario reaches green", () => {
     const cmd = REMEDIATIONS.diagnostics_hint_herdr_missing!;
-    expect(cmd).toContain("herdr.dev/install.sh");
+    // PINNED install (#1896), never the latest-only upstream installer.
+    expect(cmd).toContain(`/releases/download/v${HERDR_LAST_SUPPORTED_VERSION}/herdr-`);
+    expect(cmd).not.toContain("herdr.dev/install.sh");
     expect(cmd).toContain('"$H" server');
   });
 
@@ -192,6 +195,22 @@ describe("herdr_missing composition is behaviorally gated, not just shaped right
     writeStub(`#!/bin/sh\necho "$@" >> "${logPath}"\nexit 0\n`);
     try {
       const result = runInSandbox(composed("false"), dir);
+      expect(result.status).not.toBe(0);
+      expect(existsSync(logPath)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("gates on a MULTI-STATEMENT failing install too — the shape HERDR_INSTALL now has (#1896)", () => {
+    // The `false` case above cannot catch the real regression risk any more: HERDR_INSTALL is now
+    // a multi-statement program, so if it ever lost its own subshell wrapper, `&&` would bind to
+    // only its LAST statement and the install's failure would stop gating. Substituting a
+    // multi-statement clause reproduces exactly that shape and proves the composition still gates.
+    const { dir, logPath, writeStub } = makeSandbox();
+    writeStub(`#!/bin/sh\necho "$@" >> "${logPath}"\nexit 0\n`);
+    try {
+      const result = runInSandbox(composed("( echo installing >/dev/null; false )"), dir);
       expect(result.status).not.toBe(0);
       expect(existsSync(logPath)).toBe(false);
     } finally {


### PR DESCRIPTION
Fixes #1896.

## The regression, and why it is already gone

The Jul 22 nightly ran on `39a6631` (#1887), which pinned the herdr support ceiling to **0.7.4** while `herdr.dev` served **0.7.5**. Every Shepherd install path used `curl -fsSL https://herdr.dev/install.sh | bash`, which is **latest-only**, so all three real-install scenarios landed a herdr above the ceiling and reported `herdr want=ok got=error`. #1901 later raised the ceiling to 0.7.5, and re-running the three failing scenarios on unmodified `main` confirmed the proximate cause was already resolved:

| Scenario | Jul 22 nightly (`39a6631`) | Re-run on `633dea48` | With this PR |
| --- | --- | --- | --- |
| `herdr-missing` | ADVICE GAP | PASS | **PASS** |
| `install-e2e` | INSTALL GAP — `herdr want=ok got=error` | PASS | **PASS** |
| `install-e2e-service` | INSTALL GAP — `herdr want=ok got=error` | PASS | **PASS** |

## What this PR actually fixes

The **durable** hole the incident exposed: the pin was one-sided. Shepherd's driver refuses to spawn on a herdr above `HERDR_LAST_SUPPORTED_VERSION`, but every install path fetched *latest* — so the day herdr ships 0.7.6, every fresh onboarding breaks again, for a reason no Shepherd change caused.

Installs now fetch the **version-addressable release asset for the ceiling**. One constant drives every path: raise the ceiling and installs follow, with no second edit.

## Design notes worth reviewing

**The download budget is a parameter, not a constant.** `defaultRunRemediation`'s 120s group-kill binds only the in-app Fix — and that is *not* the path where being herdr-less strands anyone, since `preflightHerdr` exits 78 before the server binds, so the in-app `herdr_missing` Fix is reachable only with Shepherd already running and its UI up. `provision.ts` (a fresh `install.sh`) and the preflight banner therefore get **upstream-comparable** tolerance (`--max-time 120`, ≈1.4 Mbit/s for the measured 20.3 MiB artifact); the in-app entry gets a budget that provably fits alongside `HERDR_SERVE`, asserted in a unit test against the real `REMEDIATION_TIMEOUT_MS` with every term declared (never a residual, which would make the check tautological).

**Verification blocks only on positive evidence the artifact is wrong.** Governing rule throughout: never worse than today's unverifying `curl | bash`.

| Branch | Behaviour |
| --- | --- |
| `uname` miss (OS *or* arch) | fail loudly, naming the release tag |
| download failure | fail loudly — parity with today, where `defaultRunner` already aborts `install.sh` |
| cannot `exec` (glibc asset on musl) | **warn, install anyway** — a hard abort would kill `install.sh` on Alpine hosts that install fine today |
| `--version` unparseable | **warn, install anyway** — that is evidence about our parser, not the artifact |
| parses, but differs from the pin | fail loudly, no swap |
| `mkdir`/`chmod`/`mv` failure | fail loudly, non-zero, no success line |

**The success line is a verified fact, not an intention.** `echo` exits 0, so an unguarded success message would report a healthy install on a host with no herdr — and provision's runner (which throws only on non-zero) would sail on. The claim sits behind a post-swap `[ -f ] && [ -x ]` check; `-f` matters because if `~/.local/bin/herdr` were a directory, `mv -f` moves the temp *inside* it and a bare `-x` passes.

**The harness assertion has teeth.** `herdr: ok` cannot distinguish a pinned install from an unpinned one while the ceiling equals latest, so all three real-install scenarios now assert the **installed** `herdr --version` equals the pin. A unit test proves it bites (a `9.9.9` install fails the scenario even though the check reads ok).

**Deliberately not pinned:** `herdr update --handoff` (verified: no version argument, so pinning means abandoning `--handoff` and killing live agent panes) and provision's skip-when-adequate (making it ceiling-aware would silently downgrade an operator's own binary). Both are already covered *with consent* by #1887's banner and #1902's one-click downgrade. The rule: **pin what we install; never silently rewrite what the operator already has.**

## Verification

- `bun run lint` clean; `bun run test` 7655 pass / 0 fail.
- Empirical acceptance on the real Incus host, with the pin in place: `herdr-missing` (Arch, in-app remediation path), `install-e2e` and `install-e2e-service` (Ubuntu, provision + systemd-unit paths) — **all PASS**, each also asserting the installed version equals the pin.
- New `test/herdr-install.test.ts` executes the real shell program under a `PATH` shim (fake `uname`/`curl`, and a `$HOME` containing a space so a missing quote fails in CI rather than on a user's machine): all six failure branches plus the success path, and a mapping-agreement table proving the TypeScript `herdrAssetKey` and the shell `case` arms cannot drift — including the macOS arms, which no harness scenario can reach.

## Trade-offs recorded

- The pin removes an *accidental* early-warning signal (the nightly used to redden when herdr outran the ceiling). It was a destructive detector — it blocked the release gate on an upstream event Shepherd could not fix, which is exactly what #1896 was. Follow-up #1905 tracks a non-gating replacement advisory.
- In-app, a 1.42–1.76 Mbit/s link can now fail the Fix where upstream's looser timeout would have squeezed through. Non-catastrophic by construction: that path only exists with Shepherd already running, so the operator sees the failure and can retry.
- The `latest.json` `releases` cross-check that the downgrade flow performs is **not** reproduced here — it protects a working install about to be swapped, and a fresh install has nothing to protect. Upstream performs no integrity check we lose: it does `curl` → `mv` → `chmod +x` with no checksum or signature, so this path is strictly *more* verified than today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)