### PR TITLE
test(ui): epsilon-tolerant a11y-floor geometry assertions

### DIFF
--- a/ui/src/lib/components/EpicDraftModal.browser.test.ts
+++ b/ui/src/lib/components/EpicDraftModal.browser.test.ts
@@ -5,6 +5,7 @@ import { userEvent } from "vitest/browser";
 import "../../app.css";
 import type { EpicDraft } from "$lib/types";
 import { epicDrafts } from "$lib/epic-draft.svelte";
+import { expectMinPx } from "$lib/test-support/geometry";
 import EpicDraftModal from "./EpicDraftModal.svelte";
 
 function longDraft(sessionId: string): EpicDraft {
@@ -76,8 +77,8 @@ describe.each([
     expect(getComputedStyle(list).overflowY).not.toBe("auto");
 
     // a11y sizing floor on the actions that commit or discard a whole epic.
-    expect(approve.getBoundingClientRect().height).toBeGreaterThanOrEqual(44);
-    expect(abort.getBoundingClientRect().height).toBeGreaterThanOrEqual(44);
+    expectMinPx(approve.getBoundingClientRect().height, 44, "approve tap-target");
+    expectMinPx(abort.getBoundingClientRect().height, 44, "abort tap-target");
 
     // Pinned means pinned: reachable at the top of the draft AND at the very bottom of it.
     expect(hitTestable(approve), "approve clickable at scroll-top").toBe(true);
@@ -125,11 +126,11 @@ describe.each([
     }
 
     expect(parseFloat(getComputedStyle(input).fontSize)).toBeGreaterThanOrEqual(bodyFontSize);
-    expect(input.getBoundingClientRect().height).toBeGreaterThanOrEqual(44);
+    expectMinPx(input.getBoundingClientRect().height, 44, "input tap-target");
     expect(buttons.length).toBeGreaterThan(0);
     for (const button of buttons) {
       expect(parseFloat(getComputedStyle(button).fontSize)).toBe(bodyFontSize);
-      expect(button.getBoundingClientRect().height).toBeGreaterThanOrEqual(44);
+      expectMinPx(button.getBoundingClientRect().height, 44, "button tap-target");
     }
 
     unmount();

--- a/ui/src/lib/components/EpicDraftPanel.browser.test.ts
+++ b/ui/src/lib/components/EpicDraftPanel.browser.test.ts
@@ -3,6 +3,7 @@ import { render } from "vitest-browser-svelte";
 import "../../app.css";
 import type { EpicDraft } from "$lib/types";
 import { epicDrafts } from "$lib/epic-draft.svelte";
+import { expectMinPx } from "$lib/test-support/geometry";
 import EpicDraftPanel from "./EpicDraftPanel.svelte";
 
 function longDraft(sessionId: string): EpicDraft {
@@ -125,7 +126,7 @@ describe("EpicDraftPanel bar — behavior", () => {
     const cta = container.querySelector<HTMLButtonElement>(".edp-cta");
     expect(cta, "awaiting draft should offer a review CTA").not.toBeNull();
     // a11y sizing floor — this is the only way into the review surface.
-    expect(cta!.getBoundingClientRect().height).toBeGreaterThanOrEqual(44);
+    expectMinPx(cta!.getBoundingClientRect().height, 44, "review CTA tap-target");
 
     cta!.click();
     expect(onreview).toHaveBeenCalledTimes(1);

--- a/ui/src/lib/components/Herd.browser.test.ts
+++ b/ui/src/lib/components/Herd.browser.test.ts
@@ -8,6 +8,7 @@ import { GROUP_KEY_BY_STAGE } from "./herd-partition";
 import { isReworkRunning } from "./rework-running";
 import { reviews, planGates } from "$lib/reviews.svelte";
 import { postMergeSteps } from "$lib/post-merge-steps.svelte";
+import { expectMinPx } from "$lib/test-support/geometry";
 import type { Session, GitState, Epic, EpicChild, PostMergeSteps, ReviewVerdict } from "$lib/types";
 
 function session(partial: Partial<Session> & { id: string }): Session {
@@ -221,7 +222,7 @@ describe("Herd mobile lifecycle accordion", () => {
     await expect.element(page.getByText("review session")).not.toBeInTheDocument();
 
     const reviewToggleHeight = (reviewing.element() as HTMLElement).getBoundingClientRect().height;
-    expect(reviewToggleHeight).toBeGreaterThanOrEqual(44);
+    expectMinPx(reviewToggleHeight, 44, "review toggle tap-target");
   });
 
   it("opens only the tapped group and lets a second tap close it", async () => {
@@ -406,8 +407,10 @@ describe("Herd desktop lifecycle group collapse", () => {
     for (const name of [/Ready to merge \(1\)/i, "Merge train", "Decommission all"] as const) {
       const el = page.getByRole("button", { name });
       await expect.element(el).toBeInTheDocument();
-      expect((el.element() as HTMLElement).getBoundingClientRect().height).toBeGreaterThanOrEqual(
+      expectMinPx(
+        (el.element() as HTMLElement).getBoundingClientRect().height,
         44,
+        `${name} tap-target`,
       );
     }
   });

--- a/ui/src/lib/components/IssuesPanel.browser.test.ts
+++ b/ui/src/lib/components/IssuesPanel.browser.test.ts
@@ -5,6 +5,7 @@ import "../../app.css";
 import type { Issue, EpicSummary, Epic, Steer } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
 import { listIssues, getEpics, getEpic } from "$lib/api";
+import { expectMinPx } from "$lib/test-support/geometry";
 import { steers } from "$lib/steers.svelte";
 import { issuesFilter } from "$lib/issues-filter.svelte";
 import { backlogRefresh } from "$lib/backlog-refresh.svelte";
@@ -221,8 +222,8 @@ describe("IssuesPanel compact issue rows", () => {
       );
       for (const selector of [".issue-num", ".issue-title"]) {
         const rect = document.querySelector<HTMLElement>(selector)!.getBoundingClientRect();
-        expect(rect.height).toBeGreaterThanOrEqual(hitSize);
-        expect(rect.width).toBeGreaterThanOrEqual(hitSize);
+        expectMinPx(rect.height, hitSize, `${selector} hit-target height`);
+        expectMinPx(rect.width, hitSize, `${selector} hit-target width`);
       }
     } finally {
       steers.list = previousSteers;

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -7,6 +7,7 @@ import type { Issue, RepoConfig, RepoEntry, SlashCommand, Steer } from "$lib/typ
 import { m } from "$lib/paraglide/messages";
 import { steers } from "$lib/steers.svelte";
 import { viewerCache } from "$lib/viewer-cache.svelte";
+import { expectMinPx } from "$lib/test-support/geometry";
 import {
   listIssues,
   getEpics,
@@ -2623,9 +2624,11 @@ describe("NewTask geometry (measurable handoff criteria)", () => {
       Math.round(document.querySelector<HTMLElement>(".rail")!.getBoundingClientRect().width),
     ).toBe(300);
     // Prompt hero ≥132px; toolbar buttons 28×28.
-    expect(
+    expectMinPx(
       document.querySelector<HTMLElement>("#nt-prompt")!.getBoundingClientRect().height,
-    ).toBeGreaterThanOrEqual(132);
+      132,
+      "prompt hero min-height",
+    );
     const tool = document.querySelector<HTMLElement>(".tool-btn")!.getBoundingClientRect();
     expect(Math.round(tool.width)).toBe(28);
     expect(Math.round(tool.height)).toBe(28);
@@ -2697,18 +2700,26 @@ describe("NewTask geometry (measurable handoff criteria)", () => {
     });
     expect(sheet).toBe(true);
     // 44px targets: toolbar buttons, close ✕, mode segments, CTA; 16px prompt.
-    expect(
+    expectMinPx(
       document.querySelector<HTMLElement>(".tool-btn")!.getBoundingClientRect().height,
-    ).toBeGreaterThanOrEqual(44);
-    expect(
+      44,
+      "toolbar button tap-target",
+    );
+    expectMinPx(
       document.querySelector<HTMLElement>(".x")!.getBoundingClientRect().height,
-    ).toBeGreaterThanOrEqual(44);
-    expect(
+      44,
+      "close ✕ tap-target",
+    );
+    expectMinPx(
       document.querySelector<HTMLElement>(".seg-btn")!.getBoundingClientRect().height,
-    ).toBeGreaterThanOrEqual(44);
-    expect(
+      44,
+      "mode segment tap-target",
+    );
+    expectMinPx(
       document.querySelector<HTMLElement>("button.run")!.getBoundingClientRect().height,
-    ).toBeGreaterThanOrEqual(44);
+      44,
+      "CTA tap-target",
+    );
     expect(getComputedStyle(document.querySelector("#nt-prompt")!).fontSize).toBe("16px");
     expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(390);
   });

--- a/ui/src/lib/components/PromptSources.browser.test.ts
+++ b/ui/src/lib/components/PromptSources.browser.test.ts
@@ -5,6 +5,7 @@ import "../../app.css";
 import type { Issue, SlashCommand } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
 import { listIssues, getCommands } from "$lib/api";
+import { expectMinPx } from "$lib/test-support/geometry";
 import { issuesFilter } from "$lib/issues-filter.svelte";
 
 // Mock the API so no network fires; each test seeds the data it needs.
@@ -384,9 +385,11 @@ describe("PromptSources label chips (responsive 1↔2 cap)", () => {
     const hitSize = parseFloat(
       getComputedStyle(document.documentElement).getPropertyValue("--mobile-actionbar-hit"),
     );
-    expect(
+    expectMinPx(
       document.querySelector<HTMLElement>(".issue-source-row")!.getBoundingClientRect().height,
-    ).toBeGreaterThanOrEqual(hitSize);
+      hitSize,
+      "issue source row hit-target",
+    );
   });
 });
 

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -6,6 +6,7 @@ import type { Session, UsageLimits, UpdateStatus, HerdrUpdateStatus, HeldTask } 
 import { m } from "$lib/paraglide/messages";
 import { REPO_URL, DOCS_URL, version } from "$lib/build-info";
 import { formatTokenLabel } from "$lib/format";
+import { expectMinPx } from "$lib/test-support/geometry";
 
 // Mock api so the manual /usage refresh path never fires a real network call —
 // individual tests stub refreshUsage's resolution/rejection per case.
@@ -933,15 +934,15 @@ describe("TopBarHeldBadge — mobile held-task dialog", () => {
 
     const close = page.getByRole("button", { name: m.common_close() });
     const closeBox = (close.element() as HTMLElement).getBoundingClientRect();
-    expect(closeBox?.width).toBeGreaterThanOrEqual(44);
-    expect(closeBox?.height).toBeGreaterThanOrEqual(44);
+    expectMinPx(closeBox?.width, 44, "close tap-target width");
+    expectMinPx(closeBox?.height, 44, "close tap-target height");
 
     const spawn = page.getByRole("button", { name: m.topbar_held_spawn_now() });
     const discard = page.getByRole("button", { name: m.topbar_held_discard() });
     const spawnBox = (spawn.element() as HTMLElement).getBoundingClientRect();
     const discardBox = (discard.element() as HTMLElement).getBoundingClientRect();
-    expect(spawnBox?.height).toBeGreaterThanOrEqual(44);
-    expect(discardBox?.height).toBeGreaterThanOrEqual(44);
+    expectMinPx(spawnBox?.height, 44, "spawn tap-target height");
+    expectMinPx(discardBox?.height, 44, "discard tap-target height");
     expect(spawnBox?.width).toBeGreaterThan(150);
     expect(discardBox?.width).toBeGreaterThan(150);
 
@@ -2424,13 +2425,13 @@ describe("TopBar — telemetry menu visual/geometry path", () => {
     expect(Math.abs(r.width - window.innerWidth)).toBeLessThanOrEqual(1);
     // Touch tiers: Halt 52 / workspace+plugin 48 / support 44.
     const hero = page.getByRole("button", { name: m.halt_all_aria({ count: 1 }) }).element();
-    expect(hero.getBoundingClientRect().height).toBeGreaterThanOrEqual(52);
+    expectMinPx(hero.getBoundingClientRect().height, 52, "halt hero tier");
     const settingsRow = page.getByRole("button", { name: m.settings_title() }).element();
-    expect(settingsRow.getBoundingClientRect().height).toBeGreaterThanOrEqual(48);
+    expectMinPx(settingsRow.getBoundingClientRect().height, 48, "settings row tier");
     const pluginRow = page.getByRole("button", { name: "Plugin One" }).element();
-    expect(pluginRow.getBoundingClientRect().height).toBeGreaterThanOrEqual(48);
+    expectMinPx(pluginRow.getBoundingClientRect().height, 48, "plugin row tier");
     const supportRow = page.getByRole("button", { name: m.feedback_dialog_title_bug() }).element();
-    expect(supportRow.getBoundingClientRect().height).toBeGreaterThanOrEqual(44);
+    expectMinPx(supportRow.getBoundingClientRect().height, 44, "support row tier");
   });
 });
 

--- a/ui/src/lib/components/UpNextPanel.browser.test.ts
+++ b/ui/src/lib/components/UpNextPanel.browser.test.ts
@@ -11,6 +11,7 @@ import type {
 } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
 import { upNext } from "$lib/up-next.svelte";
+import { expectMinPx } from "$lib/test-support/geometry";
 import { getUpNext, startUpNext } from "$lib/api";
 
 // Mock the API so mounting (which kicks upNext.load()) makes no real network call.
@@ -272,9 +273,11 @@ describe("UpNextPanel compact issue rows", () => {
 
     // Checkbox + link remain the 44px touch targets…
     for (const selector of [".un-check", ".un-link"]) {
-      expect(
+      expectMinPx(
         row.querySelector<HTMLElement>(selector)!.getBoundingClientRect().height,
-      ).toBeGreaterThanOrEqual(hitSize);
+        hitSize,
+        `${selector} tap-target`,
+      );
     }
     // …but the per-row Start is hidden entirely (out of the layout + a11y tree).
     // Starting one issue goes through the checkbox → sticky batch bar instead.

--- a/ui/src/lib/test-support/geometry.test.ts
+++ b/ui/src/lib/test-support/geometry.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { expectMinPx, GEOMETRY_EPSILON } from "./geometry";
+
+describe("expectMinPx — a11y floor with sub-pixel slack", () => {
+  it("passes when the value carries only sub-pixel ULP noise under the floor", () => {
+    // The exact flake shape: a 52px tier measured as 51.99998… (transform-mapped float).
+    expect(() => expectMinPx(51.99998474121094, 52)).not.toThrow();
+    expect(() => expectMinPx(44 - 1.5e-5, 44)).not.toThrow();
+  });
+
+  it("passes exactly at the floor and above", () => {
+    expect(() => expectMinPx(52, 52)).not.toThrow();
+    expect(() => expectMinPx(60, 52)).not.toThrow();
+  });
+
+  it("fails on a real regression a full pixel (or more) below the floor", () => {
+    // A failing inner expect throws, so the sub-floor case is asserted via toThrow.
+    expect(() => expectMinPx(51, 52)).toThrow();
+    expect(() => expectMinPx(48, 52)).toThrow();
+  });
+
+  it("keeps the epsilon far below one pixel so it cannot mask a real regression", () => {
+    expect(GEOMETRY_EPSILON).toBeLessThan(1);
+    // Just under the floor by more than epsilon must fail.
+    expect(() => expectMinPx(52 - GEOMETRY_EPSILON - 0.01, 52)).toThrow();
+  });
+});

--- a/ui/src/lib/test-support/geometry.ts
+++ b/ui/src/lib/test-support/geometry.ts
@@ -1,0 +1,28 @@
+import { expect } from "vitest";
+
+/**
+ * Sub-pixel slack for a11y geometry floors.
+ *
+ * `getBoundingClientRect()` returns the transform-mapped border box as floats, so a box
+ * whose CSS `min-height` is exactly a tier can measure a few float32 ULPs under it
+ * (~1.5e-5px) when an ancestor carries an animating transform (e.g. a Svelte `fly` sheet).
+ * That is imperceptible float noise, not a real geometry regression — but `51.99998… >= 52`
+ * is false, so it flakes the gate.
+ *
+ * 0.05px is ~3000× the observed ULP noise yet ~20× below the smallest real regression (1px);
+ * the a11y tiers are ≥4px apart, so this epsilon can never let a genuine floor regression pass.
+ */
+export const GEOMETRY_EPSILON = 0.05;
+
+/**
+ * Assert a measured px dimension meets an a11y sizing floor, tolerant of the sub-pixel float
+ * noise transform-mapped `getBoundingClientRect()` values carry.
+ *
+ * @param value   Measured dimension (e.g. `el.getBoundingClientRect().height`). `undefined`
+ *                is accepted for optional-chained call sites and still fails, unchanged.
+ * @param floorPx The floor to meet — an integer tier or a runtime value (e.g. a parsed CSS var).
+ * @param label   Optional context surfaced in the failure message (the raw call sites carry one).
+ */
+export function expectMinPx(value: number | undefined, floorPx: number, label?: string): void {
+  expect(value, label).toBeGreaterThanOrEqual(floorPx - GEOMETRY_EPSILON);
+}


### PR DESCRIPTION
Closes #1907.

## Problem

The pre-push `ui` lane flakes intermittently on unrelated PRs (most recently #1906, a server-only change) with:

```
AssertionError: expected 51.99998474121094 to be greater than or equal to 52
  TopBar — telemetry menu visual/geometry path
  > mobile: 12px-top-radius full-bleed sheet with the 52/48/44px row tiers
```

Re-running the identical push goes green. The retry became folklore ("ui lane fails, push again") — and a gate people are trained to re-run on red stops being a gate.

## Root cause

The a11y tap-target tiers are asserted by comparing a `getBoundingClientRect()` dimension — a **transform-mapped float** — against an **exact integer** with `>=`. The mobile gear sheet opens with a Svelte `fly` transition, so an ancestor carries an animating `transform` while the assertions run; mapping a box through a transform matrix costs a few float32 ULPs (~1.5e-5px) even for a pure translate. `.height` is translate-invariant, so this is imperceptible float noise — not a real regression (`GearHaltHero.svelte` sets `min-height: 52px`) — but `51.99998… >= 52` is false, and whether the race reads the ULP-dirty value is machine-load dependent.

## Fix

A single shared, epsilon-tolerant helper — `ui/src/lib/test-support/geometry.ts` → `expectMinPx(value, floorPx, label?)` with `GEOMETRY_EPSILON = 0.05` — applied to **all 24** a11y size-floor assertions across **8** browser-test files (inline, two-line-wrapped, and variable-stored `rect`/dimension forms, incl. loop bodies and `hitSize` variable floors).

`0.05px` is ~3000× the observed ULP noise yet ~20× below the smallest real regression (1px); the tiers are ≥4px apart, so it can never let a genuine floor regression pass. A contract test (`geometry.test.ts`) locks this: it passes at `floor − 1.5e-5` and asserts `expect(() => expectMinPx(floor − 1, floor)).toThrow()`.

| File | Migrated | Floors |
| --- | --- | --- |
| TopBar | 8 | 52 / 48 / 44 (+44 width) |
| NewTask | 5 | 132 / 44 |
| EpicDraftModal | 4 | 44 |
| IssuesPanel | 2 | hitSize (h+w) |
| Herd | 2 | 44 |
| EpicDraftPanel | 1 | 44 |
| PromptSources | 1 | hitSize |
| UpNextPanel | 1 | hitSize |

## Out of scope (deliberate)

- Positional `.left`/`.right`/`.top`/`.bottom` containment bounds (different concern; several already carry ±slack).
- Computed-style font/ratio floors (read `getComputedStyle`, not transform-mapped rects).
- `Viewport.browser.test.ts:804` already bakes in a 0.5px epsilon — left as-is.
- The sheet's `vi.waitFor` settle gate — height is translate-invariant, so measuring mid-fly is fine once epsilon absorbs the ULP.

## Verification

- `cd ui && bun run check` — 0 errors.
- Full UI suite: **274 files, 4208 tests pass**; targeted contract + 8 migrated files green.
- Prettier + ESLint clean; pre-push all 7 lanes green (ui lane included).

Test-only change: no production code, no i18n/feature-catalog/glossary impact.