### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs-site/src/content/docs/getting-started.md
+++ b/docs-site/src/content/docs/getting-started.md
@@ -117,7 +117,13 @@ Open <http://localhost:7330>. To expose it (e.g. via Tailscale), set
   Shepherd spawns on it through a CLI external-registration path (`tab create` →
   `pane run` → `report-agent`) rather than the legacy `agent start`. Any newer,
   untested version is refused: Shepherd warns at startup, blocks the in-app
-  updater, and refuses to spawn on it.
+  updater, and refuses to spawn on it. One known limitation on 0.7.5: a
+  **sandboxed** session is registered externally (herdr can't see through the
+  bwrap membrane) and herdr won't accept Shepherd's idle down-edge, so a resting
+  sandboxed agent reads *working* until it blocks or exits. Trusted sessions are
+  unaffected. If you depend on sandboxed sessions, the in-app herdr-update modal
+  raises a non-blocking advisory offering a one-click **downgrade to 0.7.4** —
+  the last version with full sandboxed-status fidelity.
 - The `claude` CLI, logged in with your Max/Pro subscription
 - Node.js — for the PTY helper subprocess
 

--- a/docs-site/src/content/docs/operating.md
+++ b/docs-site/src/content/docs/operating.md
@@ -85,7 +85,11 @@ details are in the
 
 ## Host tuning — tmpfs inodes
 
-Shepherd keeps spawned agents' Node compile cache **off** the `/tmp` tmpfs and runs
+Shepherd points spawned **trusted** agents at a disk-backed `TMPDIR`
+(`~/.cache/shepherd/tmp`) and keeps their Node compile cache **off** the `/tmp`
+tmpfs, so an agent's scratch tree, git worktrees, dependency installs, and tool
+caches no longer eat tmpfs inodes. Sandboxed agents are unaffected — the membrane
+gives them their own ephemeral `/tmp`. It also runs
 an inode-guard sweep on **startup + daily** that, once `/tmp` inode use crosses a
 threshold, drops the compile cache and stale regenerable tool caches (but never a
 live session's scratch). As a host-level belt on long-uptime hosts, raise `/tmp`'s
@@ -95,8 +99,9 @@ live session's scratch). As a host-level belt on long-uptime hosts, raise `/tmp`
 tmpfs /tmp tmpfs nr_inodes=4194304 0 0
 ```
 
-The relevant override env vars (`SHEPHERD_NODE_COMPILE_CACHE`,
-`SHEPHERD_TMP_INODE_PCT`, `SHEPHERD_TMP_STALE_HOURS`, `SHEPHERD_TMP_SWEEP_DIR`) are
+The relevant override env vars (`SHEPHERD_AGENT_TMPDIR`,
+`SHEPHERD_NODE_COMPILE_CACHE`, `SHEPHERD_TMP_INODE_PCT`,
+`SHEPHERD_TMP_STALE_HOURS`, `SHEPHERD_TMP_SWEEP_DIR`) are
 listed in [Configuration](/reference/configuration/).
 
 The **Temp filesystem inodes** row in Settings → Diagnose surfaces this live: it warns

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -52,6 +52,7 @@ lines), read by the systemd unit if present.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
+| `SHEPHERD_AGENT_TMPDIR` | `~/.cache/shepherd/tmp` | Disk-backed `TMPDIR` handed to spawned **trusted** agents, so their scratch tree, git worktrees, dependency installs, and bare-`$TMPDIR` tool caches land on a real filesystem instead of exhausting the `/tmp` tmpfs inode table. Sandboxed spawns are unaffected — the membrane's `--clearenv` wipes the shim and its own `--tmpfs /tmp` is ephemeral. Set it to the **empty string** to disable the redirect and inherit the tmpfs again ([#1875](https://github.com/erwins-enkel/shepherd/issues/1875)) |
 | `SHEPHERD_NODE_COMPILE_CACHE` | _(disk dir)_ | Node compile-cache dir (kept off the `/tmp` tmpfs) |
 | `SHEPHERD_TMP_INODE_PCT` | `80` | Inode-sweep threshold (% of `/tmp` inodes) — also the warning band of the **Temp filesystem inodes** Diagnose row (row bands stay ordered: >95 raises the error band too; outside `(0, 100]` the row falls back to 80, the sweep still honours it) |
 | `SHEPHERD_TMP_STALE_HOURS` | `24` | Scratch staleness cutoff |

--- a/docs/sandbox-security.md
+++ b/docs/sandbox-security.md
@@ -30,6 +30,15 @@ The membrane keeps two token surfaces readable to any in-membrane tool call:
 …), re-setting only HOME/PATH/TERM + non-secret locale vars — so these two
 **bound files** are the only token surfaces left inside the membrane.
 
+In **api-key** auth mode the first surface changes shape rather than
+disappearing (`maskCredentials`): `~/.claude` is bound per-child with
+`.credentials.json` **omitted**, so the OAuth token is genuinely absent inside
+the membrane (`maskedClaudeDirBinds`, `src/sandbox.ts:397-405`) — but the
+`apiKeyHelper` script is bound **RO** at its own path so the `--settings` entry
+resolves (`src/sandbox.ts:541-547`), and that script emits the API key on
+demand. The count of readable token surfaces is therefore the same in either
+mode; only which Anthropic credential it is changes.
+
 **Why accepted.** A single-uid `bwrap` membrane has no privilege boundary
 between `claude` and its own tool calls: any file `claude` reads to authenticate,
 an injected tool call can also read. So the tokens the session legitimately needs
@@ -51,7 +60,7 @@ secrets out of the membrane entirely.
 
 Egress confinement is keyed to the autonomous **profile**, not to whether a human
 is watching (`willEgressConfine`, `src/sandbox.ts:693-698`; applied at
-`src/service.ts:1879`): the wrap applies iff the autonomous profile resolves
+`src/service.ts:2161`): the wrap applies iff the autonomous profile resolves
 **and** the fs + egress backends are present, independent of `ctx.auto`.
 Consequences:
 
@@ -108,7 +117,7 @@ Write --permission-mode dontAsk` (`src/transient-agent-argv.ts`,
   `buildTransientAgentArgv("reviewer", …)`).
 - **Research is the deliberately egress-UNCONFINED surface.** A research session
   that would resolve to `autonomous` is **downgraded to `standard`**
-  (`src/service.ts` `researchSafeProfileOverride`, ~L2708, warns once),
+  (`src/service.ts` `researchSafeProfileOverride`, ~L2804, warns once),
   because research needs **open** web egress (search/fetch + sub-agents) that the
   autonomous firewall would block. The same downgrade applies to an
   **epic-authoring** session (`input.epicAuthoring`, #1507), which likewise needs
@@ -117,14 +126,14 @@ Write --permission-mode dontAsk` (`src/transient-agent-argv.ts`,
   route materializes the draft. It is operator-_created_ (cannot be
   auto-drained — `standard` refuses auto-spawn) but **autopilot-steerable, so it
   runs unattended in practice** (`RESEARCH_PROCEED_STEER`,
-  `src/autopilot.ts:42-47`, dispatched at L335). It ingests **untrusted web**
+  `src/autopilot.ts:44-49`, dispatched at L356). It ingests **untrusted web**
   content on `trusted`/`standard` with the **network open**, and can
   `gh pr create` / open issues via the bound gh token — so a hijacked research
   agent has **both** readable tokens **and** open egress.
 
   **Compensating factors:** the downgrade is explicit and warns once; research
   delivers a **report PR or GitHub issue only, never a code PR**
-  (`src/autopilot.ts:40-45`). The residual is **accepted**.
+  (`src/autopilot.ts:42-43`). The residual is **accepted**.
 
 ## See also
 


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc sync — stale prose vs. current source

Baseline: the last doc sync on `main` was `c99d09248` (2026-07-17). Everything below is
grounded in a source file or a commit that landed after it.

## Changes

- **`docs-site/src/content/docs/reference/configuration.md`** — added a
  `SHEPHERD_AGENT_TMPDIR` row to the **Host tuning (tmpfs inodes)** table (default
  `~/.cache/shepherd/tmp`, empty string disables, trusted spawns only).
  Source: `src/tmp-sweep.ts:71-86` (`agentTmpDir()`), `src/herdr.ts:488-513`
  (`buildWrappedArgv` emits `env -u CLAUDE_CODE_TMPDIR TMPDIR=<disk>`; the outer shim is
  wiped by `bwrap --clearenv` for sandboxed spawns), commit `4588a739f`
  (*fix(tmp): point trusted agents at a disk-backed TMPDIR (#1875) (#1882)*). The section
  is a closed enumeration of that feature's knobs, and it was missing the newest one.

- **`docs-site/src/content/docs/operating.md`** — the *Host tuning — tmpfs inodes* section
  claimed only that Shepherd keeps the **Node compile cache** off the tmpfs. Reworded the
  opening paragraph to state the structural change (trusted agents now get a disk-backed
  `TMPDIR`; sandboxed agents unaffected because the membrane gives them their own ephemeral
  `/tmp`), and added `SHEPHERD_AGENT_TMPDIR` to the list of "the relevant override env
  vars" this page hands off to Configuration. Same source as above.

- **`docs-site/src/content/docs/getting-started.md`** — the herdr requirement bullet stated
  0.7.5 support but omitted the known 0.7.5 limitation that landed in the *same* PR, after
  its doc commit. Added: a **sandboxed** session is externally registered, herdr refuses the
  client's idle down-edge, so a resting sandboxed agent reads `working`; trusted sessions
  unaffected; the herdr-update modal offers a one-click downgrade to 0.7.4.
  Source: `src/herdr-capabilities.ts:31-38` (`HERDR_LAST_FULL_SANDBOX_STATUS_VERSION = "0.7.4"`),
  `src/herdr-update.ts:234-238` (`sandboxIdleRegressed` / `sandboxDowngradeTarget`),
  `src/server.ts:4219-4235` (`POST /api/herdr-update/downgrade/sandbox`), commit `633dea484`.

- **`docs/sandbox-security.md`** — two kinds of fix:
  1. Corrected drifted source line references. `willEgressConfine` application site
     `src/service.ts:1879` → `:2161`; `researchSafeProfileOverride` `~L2708` → `~L2804`;
     `RESEARCH_PROCEED_STEER` `src/autopilot.ts:42-47` → `:44-49`, dispatched `L335` → `L356`;
     the "report PR or issue, never a code PR" comment `src/autopilot.ts:40-45` → `:42-43`.
     (Verified against the current files; the `src/sandbox.ts` references — 397-405, 429-431,
     436-438, 539, 564, 623, 682, 693-698 — were re-checked and are all still correct.)
  2. **R3** described the `~/.claude/.credentials.json` RW bind as unconditional. In
     **api-key** auth mode `maskCredentials` binds `~/.claude` per-child with
     `.credentials.json` omitted (`maskedClaudeDirBinds`, `src/sandbox.ts:397-405`), while the
     `apiKeyHelper` script is bound RO instead (`src/sandbox.ts:541-547`) — so the residual is
     the same size but a different credential. Added a paragraph saying exactly that,
     after the `--clearenv` paragraph so its "these two bound files" referent is unbroken.

Unchanged: `docs/external-task-api.md`, `docs/token-usage-analysis.md`,
`docs-site/src/content/docs/index.md`, `docs-site/src/content/docs/reference/glossary.md`.

## Uncertain / needs human judgment

- **`docs/external-task-api.md` — request-schema table is a subset of `ALLOWED_KEYS`.**
  `validateCreate` (`src/validate.ts:42-60`) also accepts `issueRef`, `attachmentNames`,
  `launchUiState`, `planGateEnabled`, `autopilotEnabled`, `sandboxProfile`, `research`,
  `epicAuthoring`, and `mergeTrainPrs`. The documented seven look like a deliberate
  "minimum useful external-submitter surface" rather than an accidental omission (most of
  those keys long predate the doc's last edit), so I did not expand the table. If the intent
  is a complete schema mirror, someone should decide which of those to expose — especially
  `sandboxProfile`, which has security consequences for an unattended submitter.

- **`docs-site/.../reference/configuration.md` frontmatter says "Every environment
  variable", but the page is a curated subset.** Undocumented and read in `src/`:
  the whole `SHEPHERD_LEARNINGS_*` family (`src/learnings-lifecycle.ts`, ~15 vars), the
  per-role `*_CLI` / `*_MODEL` / `*_EFFORT` triples for critic / planner / recap / rundown /
  namer / autopilot / distiller / optimizer / merge-suggest, `SHEPHERD_SANDBOX_EXTRA_HOSTS`
  (referenced in this page's own prose as "operator extras" but never given a row),
  `SHEPHERD_LLM_NAMING`, `SHEPHERD_AUTOPILOT_STEP_CAP`, `SHEPHERD_REVIEW_CYCLES_CAP`,
  `SHEPHERD_PLAN_REVIEW_CYCLES_CAP`, `SHEPHERD_HOUSE_RULES_BUDGET_CHARS`,
  `SHEPHERD_SESSION_HOUSEKEEPING`, `SHEPHERD_EXTRA_CREDITS_DRAIN_CEILING`,
  `SHEPHERD_AUTOMERGE_REBASE_CAP`, `SHEPHERD_AUTH_MODE`, `SHEPHERD_FABLE_AVAILABLE`,
  `SHEPHERD_DEFAULT_*`, `SHEPHERD_PROFILE_LOOP`, and the `*_UPDATE_LOG` paths. This is a
  scope decision (curate vs. exhaustive), not something I should settle unilaterally — so I
  changed nothing beyond the tmpfs section, whose table is a closed per-feature enumeration.

- **`SHEPHERD_HERDR_SOCKET` description vs. the 0.7.5 socket driver.** The entry says the
  socket path covers the async read + write surface and only `list`/`read`/`tabs`/`panes`
  still shell out. `#1899` rebuilt the socket driver's spawn/write surface for protocol 17
  (`tab.create` → `pane.send_text` → `report_agent`, no `pane-run` RPC). I could not
  convince myself whether the existing prose is still accurate for both the ≤0.7.4 and 0.7.5
  branches, so I left it alone. Someone who knows the driver should re-read that cell.

- **`docs/token-usage-analysis.md`** is a dated measurement report (TASK-286…295), not a
  living reference. Its cost-proxy weights still match `src/pricing.ts` (Opus 5/25,
  Sonnet 3/15, Haiku 1/5, Fable 10/50), so nothing was touched. It is progressively less
  representative of current behavior, but re-running `scripts/usage-report.ts` is a human
  call, not a doc edit.