### PR TITLE
feat(ui): show repository owners in picker

### DIFF
--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -446,6 +446,11 @@ export class GithubForge implements GitForge {
     return `https://github.com/${this.slug}`;
   }
 
+  /** The clone's `origin`: the fork in fork mode, otherwise this repository. */
+  get originSlug(): string {
+    return this.forkSlug ?? this.slug;
+  }
+
   /** Fork mode = a fork slug was supplied (`slug` is the upstream it forked from). */
   get isFork(): boolean {
     return !!this.forkSlug;

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -359,6 +359,9 @@ export interface OpenPrSnapshot {
 export interface GitForge {
   readonly kind: ForgeKind;
   readonly slug: string | null;
+  /** Repository identity from the clone's `origin` remote. In fork mode, `slug`
+   *  remains the upstream repository while this identifies the fork. */
+  readonly originSlug?: string | null;
   /** Default merge method for this host (from config; "squash" if unset). */
   readonly mergeMethod: MergeMethod;
   /** Configured deploy workflow filename, or null if redeploy is unavailable. */

--- a/src/server.ts
+++ b/src/server.ts
@@ -4577,16 +4577,21 @@ async function handleRepos({ req, parts, deps }: Ctx): Promise<Response | null> 
       // backlog payload) so a persisted hide matches its repo even under a symlinked root.
       // The picker (NewTask) hides these by default but reveals them on name search.
       const hiddenSet = reconcileRealPathsToRaw(deps.store.hiddenRepoPaths(), baseRepos);
-      const repos = baseRepos.map((r) => ({
-        ...r,
-        lastUsedAt: lastUsed[r.path],
-        recentAgentCount: recentCounts[r.path],
-        // Fork mode is derived from the (memoized) forge resolution, so the picker
-        // can offer "Sync fork" only on fork repos. resolveForge is cached per dir
-        // and shared with the backlog poller — no extra git shell on a warm cache.
-        isFork: deps.resolveForge?.(r.path)?.isFork ?? false,
-        hidden: hiddenSet.has(r.path),
-      }));
+      const repos = baseRepos.map((r) => {
+        // Fork mode and remote identity are derived from one (memoized) forge resolution,
+        // so the picker can offer "Sync fork" only on fork repos without repeating lookup.
+        const forge = deps.resolveForge?.(r.path) ?? null;
+        return {
+          ...r,
+          lastUsedAt: lastUsed[r.path],
+          recentAgentCount: recentCounts[r.path],
+          isFork: forge?.isFork ?? false,
+          // A fork's `slug` is its upstream; use the clone origin so callers identify
+          // the account that owns the fork. Undefined fields are omitted from JSON.
+          remoteSlug: forge?.originSlug ?? forge?.slug ?? undefined,
+          hidden: hiddenSet.has(r.path),
+        };
+      });
       // Return the window alongside the repos so the picker labels the count with
       // the exact day count it was computed over — single source of truth.
       return json({ repos, recentWindowDays: RECENT_WINDOW_DAYS });

--- a/test/forge/github-fork.test.ts
+++ b/test/forge/github-fork.test.ts
@@ -18,6 +18,19 @@ const FORK = "kai-osthoff/may";
 const FORK_OWNER = "kai-osthoff";
 const BRANCH = "shepherd/fix-thing";
 
+// ── originSlug: preserve the clone's origin identity in fork mode ──────────────
+
+test("fork mode originSlug is the fork while slug remains upstream", () => {
+  const forge = new GithubForge(UPSTREAM, {}, async () => "", FORK);
+  expect(forge.slug).toBe(UPSTREAM);
+  expect(forge.originSlug).toBe(FORK);
+});
+
+test("non-fork originSlug is the repository slug", () => {
+  const forge = new GithubForge("o/r", {}, async () => "");
+  expect(forge.originSlug).toBe("o/r");
+});
+
 /** Build a single gh `pr list` JSON entry (shape captured from a real cross-repo PR). */
 function prEntry(owner: string, extra: Record<string, unknown> = {}) {
   return {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1059,6 +1059,50 @@ test("GET /api/repos → 200 + { repos, recentWindowDays }", async () => {
   expect(typeof body.recentWindowDays).toBe("number");
 });
 
+test("GET /api/repos prefers originSlug, falls back to slug, and omits remoteSlug without a forge", async () => {
+  const noRemoteRoot = mkdtempSync(join(config.repoRoot, "shepherd-srv-no-remote-"));
+  const slugOnlyRoot = mkdtempSync(join(config.repoRoot, "shepherd-srv-slug-only-"));
+  const deps = makeDeps();
+  const calls = new Map<string, number>();
+  deps.resolveForge = (repoPath) => {
+    calls.set(repoPath, (calls.get(repoPath) ?? 0) + 1);
+    if (repoPath === tmpRoot) {
+      return {
+        slug: "upstream/project",
+        originSlug: "fork-account/project",
+        isFork: true,
+      } as GitForge;
+    }
+    if (repoPath === slugOnlyRoot) return { slug: "account/ordinary-project" } as GitForge;
+    return null;
+  };
+
+  try {
+    const res = await makeApp(deps).fetch(new Request("http://x/api/repos"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const forkRepo = body.repos.find((repo: { path: string }) => repo.path === tmpRoot);
+    const noRemoteRepo = body.repos.find((repo: { path: string }) => repo.path === noRemoteRoot);
+    const slugOnlyRepo = body.repos.find((repo: { path: string }) => repo.path === slugOnlyRoot);
+
+    expect(forkRepo).toMatchObject({
+      path: tmpRoot,
+      isFork: true,
+      remoteSlug: "fork-account/project",
+    });
+    expect(slugOnlyRepo).toMatchObject({
+      path: slugOnlyRoot,
+      remoteSlug: "account/ordinary-project",
+    });
+    expect(noRemoteRepo).toBeDefined();
+    expect(noRemoteRepo).not.toHaveProperty("remoteSlug");
+    expect([...calls.values()].every((count) => count === 1)).toBe(true);
+  } finally {
+    rmSync(noRemoteRoot, { recursive: true, force: true });
+    rmSync(slugOnlyRoot, { recursive: true, force: true });
+  }
+});
+
 test("GET /api/branches?repo=<validRepo> → 200 with branches + current", async () => {
   const app = harness();
   const res = await app.fetch(

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3374,5 +3374,7 @@
   "codexupdate_notes_loading": "Release-Notes werden geladen…",
   "codexupdate_notes_incomplete": "Der vollständige Release-Verlauf ist hier noch nicht verfügbar. Du kannst trotzdem jetzt aktualisieren oder die Quelle auf GitHub ansehen.",
   "feat_codex_release_notes_title": "Codex-Änderungen vor dem Update lesen",
-  "feat_codex_release_notes_body": "Das Codex-Update-Fenster zeigt jetzt die originalen GitHub-Release-Notes für jede auf npm veröffentlichte stabile Version in deinem Update-Bereich – neueste zuerst."
+  "feat_codex_release_notes_body": "Das Codex-Update-Fenster zeigt jetzt die originalen GitHub-Release-Notes für jede auf npm veröffentlichte stabile Version in deinem Update-Bereich – neueste zuerst.",
+  "feat_repo_owner_picker_title": "Das richtige Repository wählen",
+  "feat_repo_owner_picker_body": "Der Repository-Auswähler zeigt jetzt Owner und Repository und lässt nach Ownern suchen. Gleichnamige Repositories in verschiedenen Accounts lassen sich so leicht unterscheiden."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3374,5 +3374,7 @@
   "codexupdate_notes_loading": "Loading release notes…",
   "codexupdate_notes_incomplete": "The full release history is not available here yet. You can still update now or view the source on GitHub.",
   "feat_codex_release_notes_title": "Read Codex changes before updating",
-  "feat_codex_release_notes_body": "The Codex update dialog now shows the original GitHub release notes for every npm-published stable version in your update range, newest first."
+  "feat_codex_release_notes_body": "The Codex update dialog now shows the original GitHub release notes for every npm-published stable version in your update range, newest first.",
+  "feat_repo_owner_picker_title": "Pick the right repository",
+  "feat_repo_owner_picker_body": "The repository picker now shows each owner and repository, and lets you search by owner. Repositories with the same name in different accounts are easy to tell apart."
 }

--- a/ui/src/lib/components/RepoSelect.browser.test.ts
+++ b/ui/src/lib/components/RepoSelect.browser.test.ts
@@ -175,3 +175,83 @@ describe("RepoSelect — hideHidden", () => {
     await expect.element(page.getByRole("option", { name: /secret/ }).first()).toBeVisible();
   });
 });
+
+describe("RepoSelect — remote identity", () => {
+  const ownerRepos: RepoEntry[] = [
+    {
+      name: "api",
+      remoteSlug: "acme/api",
+      path: "/repos/acme-api",
+      display: "~/repos/acme-api",
+      realPath: "/repos/acme-api",
+    },
+    {
+      name: "api",
+      remoteSlug: "sibling/api",
+      path: "/repos/sibling-api",
+      display: "~/repos/sibling-api",
+      realPath: "/repos/sibling-api",
+    },
+  ];
+
+  it("shows owner-qualified slugs for duplicate local repo names", async () => {
+    render(RepoSelect, {
+      repos: ownerRepos,
+      value: "/repos/acme-api",
+      onchange: noop,
+      windowDays: 7,
+    });
+
+    await page.getByRole("button", { name: /acme\/api/ }).click();
+
+    await expect.element(page.getByRole("option", { name: /acme\/api/ })).toBeVisible();
+    await expect.element(page.getByRole("option", { name: /sibling\/api/ })).toBeVisible();
+  });
+
+  it("matches repositories by remote owner", async () => {
+    render(RepoSelect, {
+      repos: ownerRepos,
+      value: "/repos/acme-api",
+      onchange: noop,
+      windowDays: 7,
+    });
+
+    await page.getByRole("button", { name: /acme\/api/ }).click();
+    await page.getByPlaceholder(m.reposelect_filter_placeholder()).fill("sibling");
+
+    await expect.element(page.getByRole("option", { name: /sibling\/api/ })).toBeVisible();
+    expect(page.getByRole("option", { name: /acme\/api/ }).elements()).toHaveLength(0);
+  });
+
+  it("keeps the selected owner's identity in the closed trigger", async () => {
+    render(RepoSelect, {
+      repos: ownerRepos,
+      value: "/repos/sibling-api",
+      onchange: noop,
+      windowDays: 7,
+    });
+
+    await expect.element(page.getByRole("button", { name: /sibling\/api/ })).toBeVisible();
+  });
+
+  it("falls back to the local name when a remote slug is unavailable", async () => {
+    render(RepoSelect, {
+      repos: [
+        {
+          name: "local-api",
+          path: "/repos/local-api",
+          display: "~/repos/local-api",
+          realPath: "/repos/local-api",
+        },
+      ],
+      value: "/repos/local-api",
+      onchange: noop,
+      windowDays: 7,
+    });
+
+    const trigger = page.getByRole("button", { name: /local-api/ });
+    await expect.element(trigger).toBeVisible();
+    await trigger.click();
+    await expect.element(page.getByRole("option", { name: /local-api/ })).toBeVisible();
+  });
+});

--- a/ui/src/lib/components/RepoSelect.svelte
+++ b/ui/src/lib/components/RepoSelect.svelte
@@ -92,7 +92,11 @@
       // Hide flagged repos only while not searching; typing a name reveals them so a
       // hidden repo can still be picked to start a task.
       .filter((r) => !hideHidden || searching || !r.hidden)
-      .filter((r) => (r.name + " " + r.display).toLowerCase().includes(filter.toLowerCase())),
+      .filter((r) =>
+        ((r.remoteSlug ?? "") + " " + r.name + " " + r.display)
+          .toLowerCase()
+          .includes(filter.toLowerCase()),
+      ),
   );
 
   // The top few repos we've run the most agents on lately (desc by count, then by
@@ -220,7 +224,7 @@
   >
     {#if selected}
       <span class="rs-emoji" aria-hidden="true">{projectIcons.iconFor(selected.path) ?? "▣"}</span>
-      <b>{selected.name}</b>
+      <b>{selected.remoteSlug ?? selected.name}</b>
       <span class="dim">{selected.display}</span>
     {:else}
       <span class="placeholder">{m.reposelect_placeholder()}</span>
@@ -282,7 +286,7 @@
             >
               {projectIcons.iconFor(r.path) ?? "▣"}
             </button>
-            <b>{r.name}</b>
+            <b>{r.remoteSlug ?? r.name}</b>
             <span class="dim">{r.display}</span>
             {#if row.pinned}
               {@const label = recentAgentsLabel(r.recentAgentCount ?? 0)}

--- a/ui/src/lib/feature-announcements/entries/v1.45.0-repo-owner-picker.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.45.0-repo-owner-picker.ts
@@ -1,0 +1,11 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "repo-owner-picker",
+  sinceVersion: "1.45.0",
+  titleKey: "feat_repo_owner_picker_title",
+  bodyKey: "feat_repo_owner_picker_body",
+  targetId: "nt-repo",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -64,6 +64,8 @@ export interface EpicDraft {
 
 export interface RepoEntry {
   name: string;
+  /** Owner-qualified remote repository identity, when its forge remote is known. */
+  remoteSlug?: string;
   path: string;
   display: string;
   /** Most-recent session createdAt for this repo; undefined if never used. */


### PR DESCRIPTION
## Summary

- show the origin account as `owner/repo` in the New Task repository picker and keep the local path as secondary context
- preserve fork semantics so fork checkouts show the fork owner, while local-only repositories retain the existing name and path fallback
- search by owner, cover duplicate repository names, and announce the feature in EN and DE

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun test test/forge/github-fork.test.ts test/server.test.ts` — 153 passed, 1 skipped
- `cd ui && bun run check`
- `cd ui && bun run check:i18n`
- `cd ui && bun run test:browser src/lib/components/RepoSelect.browser.test.ts` — 10 passed
- `cd ui && bun run test` — 4,214 passed
- `bun run check:glossary`
- `bun run check:announcement-versions`
- `bash scripts/check-feature-catalog.sh`
- `bash scripts/check-branch-hygiene.sh`
- `bun run test` — 7,657 passed, 8 skipped, 1 environment-only failure in the unchanged PTY test because `node-pty` could not build in this worktree: the linker cannot find `-lgcc_s`

## Checklist

- [x] Conventional-commit PR title
- [x] Branch is linear off latest `main`
- [x] User-facing text is present in EN and DE with catalog parity
- [x] User-facing feature has a versioned feature-announcement entry
- [x] Existing design-system markup and tokens are reused
- [x] No public API, config, CLI, deployment, or manual operator step is required
