### PR TITLE
feat(uploads): accept 250 MB screen-recording video attachments

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -110,7 +110,7 @@ import {
 } from "./preview-launch";
 import { sessionActivity } from "./activity";
 import { firstRun } from "./first-run";
-import { handleUpload, parseUploadFile, MAX_UPLOAD_BYTES } from "./uploads";
+import { handleUpload, parseUploadFile, MAX_UPLOAD_BYTES, MAX_REQUEST_BODY_BYTES } from "./uploads";
 import type { UsageLimits, UsageLimitsService } from "./usage-limits";
 import type { UpdateService } from "./update";
 import type { HerdrUpdateService } from "./herdr-update";
@@ -259,6 +259,9 @@ export interface AppDeps {
   store: SessionStore;
   service: SessionService;
   events: EventHub;
+  /** Test seam: overrides MAX_UPLOAD_BYTES for the scratchpad upload route so the 413
+   *  path is testable without allocating limit-sized fixtures. Production never sets it. */
+  maxUploadBytes?: number;
   /** Live Codex auth mode; optional for tests and read on demand in production. */
   readCodexAuthMode?: () => CodexAuthMode;
   /** Anonymous product telemetry (Aptabase). `event()` itself no-ops unless consent is
@@ -2396,7 +2399,8 @@ async function handleSessionScratchpadUpload({
   const file = await parseUploadFile(req);
   if (file instanceof Response) return file;
 
-  if (file.size > MAX_UPLOAD_BYTES) return json({ error: "file too large" }, 413);
+  if (file.size > (deps.maxUploadBytes ?? MAX_UPLOAD_BYTES))
+    return json({ error: "file too large" }, 413);
 
   const rel = url.searchParams.get("path") ?? "";
   const dir = await resolveScratchpadUploadDir(s.worktreePath, s.claudeSessionId, rel);
@@ -4484,7 +4488,11 @@ async function runStarPromptAction(
 function handleUploads({ req, parts, deps }: Ctx): Promise<Response> | null {
   if (parts[0] === "api" && parts[1] === "uploads" && !parts[2]) {
     if (req.method === "POST") {
-      return handleUpload(req, { store: deps.store, repoRoot: config.repoRoot });
+      return handleUpload(req, {
+        store: deps.store,
+        repoRoot: config.repoRoot,
+        maxUploadBytes: deps.maxUploadBytes,
+      });
     }
   }
   return null;
@@ -7665,11 +7673,16 @@ export function pickTerminalBridgeKind(opts: {
  *    one native sub-issue link each + buildEpic — ~25 sequential round-trips for a 12-child epic,
  *    which blows past 10s. Bun then severs the socket while the handler keeps running to completion,
  *    so the operator saw a bogus failure for an approve that had actually succeeded. 255 is Bun's
- *    ceiling for both `idleTimeout` and `server.timeout`. */
+ *    ceiling for both `idleTimeout` and `server.timeout`.
+ *  - the upload routes carry attachments up to MAX_UPLOAD_BYTES (screen recordings) from phones
+ *    over Tailscale/LTE; a network switch or backgrounded app can stall the stream past 10s and
+ *    kill an otherwise-healthy upload, so they get a 120s idle budget. */
 export const slowRequestTimeoutSec = (req: Request, url: URL): number | null => {
   if (req.method !== "POST") return null;
   if (url.pathname === "/api/usage/refresh") return 60;
   if (/^\/api\/sessions\/[^/]+\/epic-draft\/approve$/.test(url.pathname)) return 255;
+  if (url.pathname === "/api/uploads") return 120;
+  if (/^\/api\/sessions\/[^/]+\/scratchpad\/upload$/.test(url.pathname)) return 120;
   return null;
 };
 
@@ -7687,6 +7700,9 @@ export function serve(deps: AppDeps, port: number) {
   return Bun.serve<WsData>({
     port,
     hostname: config.host,
+    // Bun's 128 MiB default would reject screen-recording uploads at the transport
+    // layer, before the app-level MAX_UPLOAD_BYTES check ever runs.
+    maxRequestBodySize: MAX_REQUEST_BODY_BYTES,
     fetch(req, server) {
       const authErr = checkAuth(req);
       if (authErr) return authErr;

--- a/src/service.ts
+++ b/src/service.ts
@@ -147,6 +147,9 @@ export const MERGE_STALE_MS = 30 * 60_000;
  *  reclaim a genuinely dead train, never one still landing PRs. */
 export const TRAIN_TRACKER_MAX_MS = 24 * 60 * 60_000;
 
+/** Attachment extensions that get the video-consumption note in the launch prompt. */
+const VIDEO_EXT_RE = /\.(mp4|mov|m4v|webm|mkv)$/i;
+
 export interface ServiceDeps {
   store: SessionStore;
   worktree: Pick<
@@ -1891,14 +1894,26 @@ export class SessionService {
     const dropped = input.images.length - copiedPaths.length;
     const attachedBlock =
       copiedPaths.length > 0 ? `Attached files:\n${copiedPaths.join("\n")}` : "";
-    if (dropped === 0) return { promptBlock: attachedBlock, dropped, attachments };
+    // Agents can't watch a video; without this nudge a screen recording just sits in the
+    // worktree unused. Phrasing kept aligned with ui/src/lib/attachment-paste.ts.
+    const videoNames = copiedPaths.filter((p) => VIDEO_EXT_RE.test(p)).map((p) => basename(p));
+    const videoNote =
+      videoNames.length > 0
+        ? `[Note: video attachment(s) (screen recording): ${videoNames.join(", ")}. You cannot view a video directly — if ffmpeg is available, extract keyframes (e.g. 1 fps stills) and the audio track, read the stills with the Read tool, and transcribe the audio if a transcription tool is available.]`
+        : "";
+    if (dropped === 0)
+      return {
+        promptBlock: [attachedBlock, videoNote].filter(Boolean).join("\n\n"),
+        dropped,
+        attachments,
+      };
 
     console.warn(
       `[uploads] ${dropped}/${input.images.length} staged file(s) missing at spawn; proceeding without them`,
     );
     const droppedNote = `[Note: ${dropped} attached file(s) could not be restored — the upload expired and is unavailable for this session.]`;
     return {
-      promptBlock: [attachedBlock, droppedNote].filter(Boolean).join("\n\n"),
+      promptBlock: [attachedBlock, videoNote, droppedNote].filter(Boolean).join("\n\n"),
       dropped,
       attachments,
     };

--- a/src/uploads.ts
+++ b/src/uploads.ts
@@ -3,10 +3,23 @@ import { mkdirSync, copyFileSync, rmSync, readdirSync, statSync, existsSync } fr
 import { join, basename } from "node:path";
 import type { SessionStore } from "./store";
 
-export const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+/** Sized for smartphone screen recordings (~0.63 MB/s HEVC → ≈6–7 min), uniform across
+ *  all upload endpoints (New Task staging, in-session attach, scratchpad). */
+export const MAX_UPLOAD_BYTES = 250 * 1024 * 1024;
+
+/** Transport cap for the main Bun.serve — MUST stay above MAX_UPLOAD_BYTES (headroom for
+ *  multipart framing), else Bun rejects bodies before the app-level 413 can fire. */
+export const MAX_REQUEST_BODY_BYTES = MAX_UPLOAD_BYTES + 1024 * 1024;
 
 /** Age after which an abandoned staged upload (New Task or relaunch carry) is reclaimed. */
 export const STAGING_TTL_MS = 24 * 60 * 60 * 1000;
+
+const VIDEO_MIME_EXT: Record<string, string> = {
+  "video/mp4": "mp4",
+  "video/quicktime": "mov",
+  "video/webm": "webm",
+  "video/x-m4v": "m4v",
+};
 
 const MIME_EXT: Record<string, string> = {
   "image/png": "png",
@@ -16,6 +29,7 @@ const MIME_EXT: Record<string, string> = {
   "application/pdf": "pdf",
   "text/markdown": "md",
   "text/plain": "txt",
+  ...VIDEO_MIME_EXT,
 };
 
 const IMAGE_MIME_EXT: Record<string, string> = {
@@ -23,6 +37,12 @@ const IMAGE_MIME_EXT: Record<string, string> = {
   "image/jpeg": "jpg",
   "image/gif": "gif",
   "image/webp": "webp",
+};
+
+/** In-session attach accepts images and videos (screen recordings), nothing else. */
+const SESSION_ATTACH_MIME_EXT: Record<string, string> = {
+  ...IMAGE_MIME_EXT,
+  ...VIDEO_MIME_EXT,
 };
 
 const SAFE_EXT_RE = /^[a-z0-9]{1,16}$/;
@@ -35,6 +55,11 @@ export function extForMime(mime: string): string | null {
 /** Extension for a supported live terminal image MIME, or null if unsupported. */
 export function imageExtForMime(mime: string): string | null {
   return IMAGE_MIME_EXT[mime.toLowerCase().split(";", 1)[0] ?? ""] ?? null;
+}
+
+/** Extension for a supported in-session attachment MIME (image or video), or null. */
+export function sessionAttachExtForMime(mime: string): string | null {
+  return SESSION_ATTACH_MIME_EXT[mime.toLowerCase().split(";", 1)[0] ?? ""] ?? null;
 }
 
 function safeExt(ext: string | null | undefined): string | null {
@@ -130,6 +155,9 @@ const j = (body: unknown, status = 200): Response =>
 export interface UploadDeps {
   store: Pick<SessionStore, "get">;
   repoRoot: string;
+  /** Test seam: overrides MAX_UPLOAD_BYTES so the 413 path is testable without
+   *  allocating limit-sized fixtures. Production never sets this. */
+  maxUploadBytes?: number;
 }
 
 /**
@@ -149,7 +177,8 @@ export async function handleUpload(req: Request, deps: UploadDeps): Promise<Resp
   const file = await parseUploadFile(req);
   if (file instanceof Response) return file;
 
-  if (file.size > MAX_UPLOAD_BYTES) return j({ error: "file too large" }, 413);
+  if (file.size > (deps.maxUploadBytes ?? MAX_UPLOAD_BYTES))
+    return j({ error: "file too large" }, 413);
 
   const sessionId = new URL(req.url).searchParams.get("session");
   let ext: string;
@@ -157,9 +186,9 @@ export async function handleUpload(req: Request, deps: UploadDeps): Promise<Resp
   if (sessionId) {
     const s = deps.store.get(sessionId);
     if (!s) return j({ error: "unknown session" }, 404);
-    const imageExt = imageExtForMime(file.type);
-    if (!imageExt) return j({ error: "unsupported image type" }, 415);
-    ext = imageExt;
+    const attachExt = sessionAttachExtForMime(file.type);
+    if (!attachExt) return j({ error: "unsupported attachment type" }, 415);
+    ext = attachExt;
     destDir = worktreeUploadsDir(s.worktreePath);
   } else {
     ext = uploadExtension(file);

--- a/test/epic-draft-api.test.ts
+++ b/test/epic-draft-api.test.ts
@@ -213,8 +213,15 @@ test("slowRequestTimeoutSec budgets the known-slow routes and leaves others on t
   expect(sec("POST", "/api/sessions/abc-123/epic-draft/approve")).toBe(255); // Bun's ceiling
   expect(sec("POST", "/api/usage/refresh")).toBe(60); // pre-existing budget, unchanged
 
+  // Screen-recording-sized uploads from phones can stall past 10s (network switch,
+  // backgrounded app) — both upload routes get the 120s idle budget.
+  expect(sec("POST", "/api/uploads")).toBe(120);
+  expect(sec("POST", "/api/sessions/abc-123/scratchpad/upload")).toBe(120);
+
   // Everything else keeps the 10s default — including the draft's other verbs and near-miss paths.
   expect(sec("GET", "/api/sessions/abc-123/epic-draft/approve")).toBeNull();
+  expect(sec("GET", "/api/uploads")).toBeNull();
+  expect(sec("POST", "/api/sessions/abc-123/scratchpad/upload/extra")).toBeNull();
   expect(sec("POST", "/api/sessions/abc-123/epic-draft")).toBeNull();
   expect(sec("POST", "/api/sessions/abc-123/epic-draft/approve/extra")).toBeNull();
   expect(sec("POST", "/api/sessions")).toBeNull();

--- a/test/scratchpad-upload.test.ts
+++ b/test/scratchpad-upload.test.ts
@@ -6,7 +6,6 @@ import { SessionStore } from "../src/store";
 import { EventHub } from "../src/events";
 import { config } from "../src/config";
 import { sessionScratchpadDir } from "../src/tmp-sweep";
-import { MAX_UPLOAD_BYTES } from "../src/uploads";
 
 let tmpRoot: string;
 let repoDir: string;
@@ -29,7 +28,7 @@ afterEach(() => {
   else process.env.SHEPHERD_TMP_SWEEP_DIR = prevEnv;
 });
 
-function harness() {
+function harness(maxUploadBytes?: number) {
   const store = new SessionStore(":memory:");
   const hub = new EventHub();
   const deps: AppDeps = {
@@ -37,6 +36,7 @@ function harness() {
     service: {} as any,
     events: hub,
     usageLimits: { limits: () => ({}) } as any,
+    maxUploadBytes,
   };
   return { app: makeApp(deps), store };
 }
@@ -159,15 +159,20 @@ test("POST upload: ?path pointing at existing file → 404", async () => {
 
 // ── Oversize → 413 ──────────────────────────────────────────────────────────
 
-test("POST upload: oversize file → 413", async () => {
-  const { app, store } = harness();
+// Runs against an injected tiny limit (maxUploadBytes seam) instead of allocating a
+// MAX_UPLOAD_BYTES-sized fixture (250 MiB); a boundary-sized file also proves the check
+// is strictly-greater-than.
+test("POST upload: oversize file → 413, at-limit file accepted", async () => {
+  const { app, store } = harness(8);
   const s = makeSession(store);
   const root = sessionScratchpadDir(repoDir, SID);
   mkdirSync(root, { recursive: true });
 
-  const bigData = new Uint8Array(MAX_UPLOAD_BYTES + 1);
-  const file = new File([bigData], "big.bin", { type: "application/octet-stream" });
-  const res = await app.fetch(makeUploadRequest(s.id, file));
+  const atLimit = new File(["A".repeat(8)], "ok.bin", { type: "application/octet-stream" });
+  expect((await app.fetch(makeUploadRequest(s.id, atLimit))).status).toBe(200);
+
+  const over = new File(["A".repeat(9)], "big.bin", { type: "application/octet-stream" });
+  const res = await app.fetch(makeUploadRequest(s.id, over));
   expect(res.status).toBe(413);
 });
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1200,6 +1200,36 @@ test("POST /api/uploads saves a staged attachment and returns its path", async (
   rmSync(body.path, { force: true });
 });
 
+// The single deliberately-large upload in the suite (~130 MiB buffer + Bun's server-side
+// buffering, ~300 MB transient): a 200 through the REAL serve() is only possible if
+// maxRequestBodySize is actually wired into Bun.serve — under Bun's 128 MiB default the
+// transport rejects this body before the handler runs. Direct handleUpload() tests bypass
+// transport entirely, so don't shrink this below 128 MiB or it proves nothing.
+test("serve() accepts a >128 MiB screen-recording upload end-to-end", async () => {
+  const server = serve(makeDeps(), 0);
+  let stagedPath: string | null = null;
+  try {
+    const fd = new FormData();
+    const bytes = 130 * 1024 * 1024;
+    fd.append("file", new File([new Uint8Array(bytes).fill(65)], "rec.mp4", { type: "video/mp4" }));
+    const res = await fetch(`http://localhost:${server.port}/api/uploads`, {
+      method: "POST",
+      body: fd,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    stagedPath = body.path;
+    // Staging lives under config.repoRoot — OUTSIDE this suite's tmpRoot teardown — so the
+    // prefix assertion proves the finally-cleanup below targets the staged fixture.
+    expect(body.path.startsWith(stagingDir(config.repoRoot) + "/")).toBe(true);
+    expect(body.path.endsWith(".mp4")).toBe(true);
+    expect(Bun.file(body.path).size).toBe(bytes);
+  } finally {
+    if (stagedPath) rmSync(stagedPath, { force: true });
+    server.stop();
+  }
+});
+
 test("POST /api/uploads?session rejects a non-image for the live terminal image workflow", async () => {
   const app = makeApp(makeDeps(["term_x"]));
   const created = await (

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1461,12 +1461,65 @@ test("createSession: copies attachments into worktree and appends paths to the p
     images: ["/stage/a.png", "/stage/notes.md"],
   });
 
-  // prompt argv (last element) carries the user text + the copied attachment paths
+  // prompt argv (last element) carries the user text + the copied attachment paths;
+  // exact match doubles as the image-only case for the video note (none appended)
   expect(calls.argv[calls.argv.length - 1]).toBe(
     "look at this\n\nAttached files:\n/wt/repo-x/.shepherd-uploads/a.png\n/wt/repo-x/.shepherd-uploads/notes.md",
   );
   // stored prompt stays the clean user text
   expect(store.get(s.id)?.prompt).toBe("look at this");
+});
+
+test("createSession: a video attachment appends the ffmpeg consumption note", async () => {
+  const store = new SessionStore(":memory:");
+  const calls: any = {};
+  const service = new SessionService({
+    store,
+    namer: async () => "repo-x",
+    worktree: {
+      ensureBaseRef: async () => {},
+      branchExists: () => false,
+      create: () => ({ worktreePath: "/wt/repo-x", branch: "shepherd/repo-x", isolated: true }),
+      remove: () => {},
+    } as any,
+    herdr: {
+      start: async (name: string, cwd: string, argv: string[]) => {
+        calls.argv = argv;
+        return {
+          terminalId: "term_y",
+          cwd,
+          agent: "claude",
+          agentStatus: "working",
+          paneId: "p",
+          tabId: "t",
+          workspaceId: "w",
+        };
+      },
+      list: () => [],
+    } as any,
+    copyUploads: (uploads: string[], worktreePath: string) =>
+      uploads.map((i) => ({
+        src: i,
+        copiedPath: `${worktreePath}/.shepherd-uploads/${i.split("/").pop()}`,
+      })),
+  });
+
+  await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "watch this",
+    model: null,
+    images: ["/stage/rec.mp4", "/stage/shot.png"],
+  });
+
+  const prompt = calls.argv[calls.argv.length - 1] as string;
+  expect(prompt).toContain(
+    "Attached files:\n/wt/repo-x/.shepherd-uploads/rec.mp4\n/wt/repo-x/.shepherd-uploads/shot.png",
+  );
+  // the note names only the video, not the image, and points at ffmpeg extraction
+  expect(prompt).toContain("[Note: video attachment(s) (screen recording): rec.mp4.");
+  expect(prompt).toContain("extract keyframes");
+  expect(prompt).not.toContain("shot.png.");
 });
 
 test("createSession: a dropped (swept) attachment still spawns, notes the loss, emits a toast event", async () => {

--- a/test/uploads.test.ts
+++ b/test/uploads.test.ts
@@ -13,7 +13,9 @@ import { join } from "node:path";
 import {
   extForMime,
   imageExtForMime,
+  sessionAttachExtForMime,
   MAX_UPLOAD_BYTES,
+  MAX_REQUEST_BODY_BYTES,
   stagingDir,
   worktreeUploadsDir,
   copyStagedIntoWorktree,
@@ -33,6 +35,10 @@ test("extForMime maps supported staged upload types", () => {
   expect(extForMime("application/pdf")).toBe("pdf");
   expect(extForMime("text/markdown")).toBe("md");
   expect(extForMime("text/plain")).toBe("txt");
+  expect(extForMime("video/mp4")).toBe("mp4");
+  expect(extForMime("video/quicktime")).toBe("mov");
+  expect(extForMime("video/webm")).toBe("webm");
+  expect(extForMime("video/x-m4v")).toBe("m4v");
   expect(extForMime("")).toBeNull();
 });
 
@@ -41,10 +47,23 @@ test("imageExtForMime remains image-only for live terminal uploads", () => {
   expect(imageExtForMime("image/jpeg")).toBe("jpg");
   expect(imageExtForMime("application/pdf")).toBeNull();
   expect(imageExtForMime("text/plain")).toBeNull();
+  expect(imageExtForMime("video/mp4")).toBeNull();
 });
 
-test("MAX_UPLOAD_BYTES is 10 MB", () => {
-  expect(MAX_UPLOAD_BYTES).toBe(10 * 1024 * 1024);
+test("sessionAttachExtForMime accepts images and videos, nothing else", () => {
+  expect(sessionAttachExtForMime("image/png")).toBe("png");
+  expect(sessionAttachExtForMime("video/mp4")).toBe("mp4");
+  expect(sessionAttachExtForMime("video/quicktime")).toBe("mov");
+  expect(sessionAttachExtForMime("application/pdf")).toBeNull();
+  expect(sessionAttachExtForMime("text/plain")).toBeNull();
+});
+
+test("MAX_UPLOAD_BYTES is 250 MB", () => {
+  expect(MAX_UPLOAD_BYTES).toBe(250 * 1024 * 1024);
+});
+
+test("transport cap stays above the app limit so the app-level 413 is reachable", () => {
+  expect(MAX_REQUEST_BODY_BYTES).toBeGreaterThan(MAX_UPLOAD_BYTES);
 });
 
 test("stagingDir / worktreeUploadsDir build the expected paths", () => {
@@ -124,6 +143,10 @@ test("sweepStaging is a no-op when staging dir is absent", () => {
 
 test("uploadExtension derives bounded safe extensions for staged attachments", () => {
   expect(uploadExtension(new File(["x"], "report.pdf", { type: "application/pdf" }))).toBe("pdf");
+  // MIME fallback for a nameless video — unit-level only: Bun's multipart round-trip
+  // re-infers the part type from the filename extension, so this can't be exercised
+  // through handleUpload with an extension-less name.
+  expect(uploadExtension(new File(["x"], "clip", { type: "video/mp4" }))).toBe("mp4");
   expect(uploadExtension(new File(["x"], "notes.md", { type: "" }))).toBe("md");
   expect(uploadExtension(new File(["x"], "todo", { type: "text/plain" }))).toBe("txt");
   expect(uploadExtension(new File(["x"], "noext", { type: "" }))).toBe("bin");
@@ -180,8 +203,9 @@ test("handleUpload saves staged non-image attachments when no session given", as
     new File([new Uint8Array([3])], "readme.txt", { type: "text/plain" }),
     new File([new Uint8Array([4])], "noext", { type: "" }),
     new File([new Uint8Array([5])], "unsafe." + "x".repeat(40), { type: "" }),
+    new File([new Uint8Array([6])], "ScreenRecording.mov", { type: "video/quicktime" }),
   ];
-  const endings = [".pdf", ".md", ".txt", ".bin", ".bin"];
+  const endings = [".pdf", ".md", ".txt", ".bin", ".bin", ".mov"];
   for (let i = 0; i < cases.length; i++) {
     const res = await handleUpload(uploadReq(cases[i]!), { store, repoRoot: root });
     expect(res.status).toBe(200);
@@ -217,7 +241,39 @@ test("handleUpload saves into the session worktree when ?session= is valid", asy
   expect(existsSync(body.path)).toBe(true);
 });
 
-test("handleUpload keeps ?session= uploads image-only", async () => {
+test("handleUpload accepts video uploads on the ?session= path", async () => {
+  const store = new SessionStore(":memory:");
+  const wt = join(root, "wt-sess");
+  mkdirSync(wt);
+  const s = store.create({
+    name: "n",
+    prompt: "p",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/n",
+    worktreePath: wt,
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_a",
+    claudeSessionId: "00000000-0000-0000-0000-000000000000",
+    model: null,
+  });
+  const cases: Array<[string, string, string]> = [
+    ["rec.mp4", "video/mp4", ".mp4"],
+    ["rec.mov", "video/quicktime", ".mov"],
+  ];
+  for (const [name, type, ending] of cases) {
+    const file = new File([new Uint8Array([9])], name, { type });
+    const res = await handleUpload(uploadReq(file, `?session=${s.id}`), { store, repoRoot: root });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.path.startsWith(worktreeUploadsDir(wt) + "/")).toBe(true);
+    expect(body.path.endsWith(ending)).toBe(true);
+    expect(existsSync(body.path)).toBe(true);
+  }
+});
+
+test("handleUpload keeps ?session= uploads image/video-only", async () => {
   const store = new SessionStore(":memory:");
   const wt = join(root, "wt-sess");
   mkdirSync(wt);
@@ -267,10 +323,49 @@ test("handleUpload accepts an empty MIME file and falls back for extensionless n
   expect(existsSync(body.path)).toBe(true);
 });
 
-test("handleUpload 413s a file over the size cap", async () => {
+// The 413 boundary runs against an injected tiny limit (maxUploadBytes seam) so no test
+// allocates limit-sized fixtures; the real-server transport test in server.test.ts is the
+// single deliberately-large upload in the suite. Fixture contents are ASCII: Bun's
+// multipart round-trip corrupts parts whose bytes are all NUL (name lost, size 0).
+test("handleUpload 413s a file over the size cap, accepts one exactly at it", async () => {
   const store = new SessionStore(":memory:");
-  const big = new File([new Uint8Array(MAX_UPLOAD_BYTES + 1)], "x.png", { type: "image/png" });
-  const res = await handleUpload(uploadReq(big), { store, repoRoot: root });
+  const atLimit = new File(["A".repeat(8)], "ok.png", { type: "image/png" });
+  const okRes = await handleUpload(uploadReq(atLimit), {
+    store,
+    repoRoot: root,
+    maxUploadBytes: 8,
+  });
+  expect(okRes.status).toBe(200);
+
+  const over = new File(["A".repeat(9)], "big.png", { type: "image/png" });
+  const res = await handleUpload(uploadReq(over), { store, repoRoot: root, maxUploadBytes: 8 });
+  expect(res.status).toBe(413);
+  expect((await res.json()).error).toBe("file too large");
+});
+
+test("handleUpload 413s an over-limit upload on the ?session= path too", async () => {
+  const store = new SessionStore(":memory:");
+  const wt = join(root, "wt-sess");
+  mkdirSync(wt);
+  const s = store.create({
+    name: "n",
+    prompt: "p",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/n",
+    worktreePath: wt,
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_a",
+    claudeSessionId: "00000000-0000-0000-0000-000000000000",
+    model: null,
+  });
+  const over = new File(["A".repeat(9)], "rec.mp4", { type: "video/mp4" });
+  const res = await handleUpload(uploadReq(over, `?session=${s.id}`), {
+    store,
+    repoRoot: root,
+    maxUploadBytes: 8,
+  });
   expect(res.status).toBe(413);
 });
 

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -699,7 +699,7 @@
   "clearmerged_leftovers": "{count} Hintergrundprozesse dieser Sessions werden ebenfalls beendet.",
   "clearmerged_confirm": "{count} stilllegen",
   "viewport_upload_failed": "Upload fehlgeschlagen. Zum Wiederholen tippen",
-  "viewport_attach_image": "Bild anhängen",
+  "viewport_attach_image": "Bild/Video anhängen",
   "viewport_notes_aria": "Notiz hinzufügen: {key} drücken",
   "viewport_type_steer_hint": "⌁ tippen zum Steuern",
   "viewport_detach_hint": "⇥ trennen",
@@ -2542,7 +2542,7 @@
   "files_upload_drop_hint": "Dateien zum Hochladen hierher ziehen",
   "files_uploading": "{name} wird hochgeladen…",
   "files_upload_done": "{name} hochgeladen",
-  "files_upload_too_large": "{name} ist zu groß (max. 10 MB)",
+  "files_upload_too_large": "{name} ist zu groß (max. 250 MB)",
   "files_upload_failed": "{name} konnte nicht hochgeladen werden",
   "feat_scratchpad_upload_title": "Dateien ins Scratchpad hochladen",
   "feat_scratchpad_upload_body": "Du kannst jetzt direkt aus dem Dateien-Tab Dateien in das Scratchpad einer Session laden - per Klick auf Hochladen oder per Drag-and-drop. Der Agent kann alles lesen, was du dort ablegst.",
@@ -3393,5 +3393,7 @@
   "settings_diag_issues": "{count} Probleme",
   "settings_plugins_installed_summary": "{count} installiert",
   "feat_settings_redesign_title": "Einstellungen, neu gestaltet",
-  "feat_settings_redesign_body": "Die Einstellungen öffnen sich jetzt als Cockpit: Sektionsleiste links (am Telefon eine Vollbild-Liste mit Detailseiten), ausgerichtete Einstellungszeilen und ein Suchfeld — mit / erreichbar —, das Sektionen filtert und Treffer hervorhebt. Änderungen gelten weiterhin sofort."
+  "feat_settings_redesign_body": "Die Einstellungen öffnen sich jetzt als Cockpit: Sektionsleiste links (am Telefon eine Vollbild-Liste mit Detailseiten), ausgerichtete Einstellungszeilen und ein Suchfeld — mit / erreichbar —, das Sektionen filtert und Treffer hervorhebt. Änderungen gelten weiterhin sofort.",
+  "feat_video_attachments_title": "Bildschirmaufnahmen anhängen",
+  "feat_video_attachments_body": "Das Upload-Limit liegt jetzt bei 250 MB – eine kommentierte Bildschirmaufnahme vom Smartphone passt damit bequem. Hänge Videos in „Neue Aufgabe“ an oder ziehe sie ins Terminal einer laufenden Session – der Agent bekommt einen Hinweis, wie er Frames und Ton extrahiert, um sie wirklich auszuwerten."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -699,7 +699,7 @@
   "clearmerged_leftovers": "{count} background processes from these sessions will also be terminated.",
   "clearmerged_confirm": "Decommission {count}",
   "viewport_upload_failed": "Upload failed. Tap to retry",
-  "viewport_attach_image": "Attach image",
+  "viewport_attach_image": "Attach image/video",
   "viewport_notes_aria": "Add notes: press {key}",
   "viewport_type_steer_hint": "⌁ type to steer",
   "viewport_detach_hint": "⇥ detach",
@@ -2542,7 +2542,7 @@
   "files_upload_drop_hint": "Drop files to upload",
   "files_uploading": "Uploading {name}…",
   "files_upload_done": "{name} uploaded",
-  "files_upload_too_large": "{name} is too large (max 10 MB)",
+  "files_upload_too_large": "{name} is too large (max 250 MB)",
   "files_upload_failed": "Upload of {name} failed",
   "feat_scratchpad_upload_title": "Upload files to the scratchpad",
   "feat_scratchpad_upload_body": "You can now upload files directly into a session's scratchpad from the Files tab — click Upload or drag-and-drop files onto the list. The agent can read anything you drop there.",
@@ -3393,5 +3393,7 @@
   "settings_diag_issues": "{count} issues",
   "settings_plugins_installed_summary": "{count} installed",
   "feat_settings_redesign_title": "Settings, redesigned",
-  "feat_settings_redesign_body": "Settings now opens as a cockpit: a section rail on the left (a full-screen list with drill-in pages on phones), aligned setting rows, and a search field — press / to jump to it — that filters sections and highlights matches. Changes still apply immediately."
+  "feat_settings_redesign_body": "Settings now opens as a cockpit: a section rail on the left (a full-screen list with drill-in pages on phones), aligned setting rows, and a search field — press / to jump to it — that filters sections and highlights matches. Changes still apply immediately.",
+  "feat_video_attachments_title": "Attach screen recordings",
+  "feat_video_attachments_body": "The upload limit is now 250 MB, so a narrated screen recording from your phone fits comfortably. Attach videos in New Task or drop them into a running session's terminal — the agent gets a hint on how to extract frames and audio to actually watch them."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -725,7 +725,7 @@ export function worktreeDownloadUrl(id: string, path: string): string {
 }
 
 /** Upload one arbitrary file into a session's scratchpad dir (#1258). Returns the root-relative path.
- *  Throws an ApiError so callers can branch on status (e.g. 413 = too large, max 10 MB). */
+ *  Throws an ApiError so callers can branch on status (e.g. 413 = too large, max 250 MB). */
 export async function uploadScratchpadFile(
   id: string,
   file: File,

--- a/ui/src/lib/attachment-paste.test.ts
+++ b/ui/src/lib/attachment-paste.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { attachmentPastePayload } from "./attachment-paste";
+
+describe("attachmentPastePayload", () => {
+  it("keeps image payloads byte-identical to the bare path", () => {
+    expect(attachmentPastePayload("/wt/.shepherd-uploads/a.png", "image/png")).toBe(
+      "/wt/.shepherd-uploads/a.png",
+    );
+    expect(attachmentPastePayload("/wt/.shepherd-uploads/b.jpg", "image/jpeg")).toBe(
+      "/wt/.shepherd-uploads/b.jpg",
+    );
+  });
+
+  it("appends the ffmpeg hint for video MIMEs", () => {
+    for (const mime of ["video/mp4", "video/quicktime", "VIDEO/MP4"]) {
+      expect(attachmentPastePayload("/wt/.shepherd-uploads/rec.mp4", mime)).toBe(
+        "/wt/.shepherd-uploads/rec.mp4 (screen-recording video — extract keyframes/audio with ffmpeg to view)",
+      );
+    }
+  });
+});

--- a/ui/src/lib/attachment-paste.ts
+++ b/ui/src/lib/attachment-paste.ts
@@ -1,0 +1,8 @@
+/** In-session attachments are delivered by bracket-pasting their worktree path into the
+ *  agent's PTY. A video needs a nudge the path alone doesn't give: agents can't watch it,
+ *  so without the hint a screen recording just sits in the worktree unused. Phrasing kept
+ *  aligned with the launch-prompt note in src/service.ts (composeUploadPrompt). */
+export function attachmentPastePayload(path: string, mime: string): string {
+  if (!mime.toLowerCase().startsWith("video/")) return path;
+  return `${path} (screen-recording video — extract keyframes/audio with ffmpeg to view)`;
+}

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -32,6 +32,7 @@
   import { uiScale } from "$lib/ui-scale.svelte";
   import { tick, untrack } from "svelte";
   import { SvelteMap } from "svelte/reactivity";
+  import { attachmentPastePayload } from "$lib/attachment-paste";
   import {
     getSessionUsage,
     getTodo,
@@ -1380,13 +1381,15 @@
     await handleStopPreview();
   }
 
-  // upload image(s) into this session's worktree, then inject their paths into
+  // upload image(s)/video(s) into this session's worktree, then inject their paths into
   // the PTY — the user adds wording and presses Enter themselves. The path is
   // wrapped in bracketed-paste markers (ESC[200~ … ESC[201~) so the TUI ingests
   // it as one atomic paste; injecting it as a fast raw-keystroke burst drops
   // characters (notably on mobile, racing with resize events).
   async function attachImages(files: FileList | File[]) {
-    const imgs = Array.from(files).filter((f) => f.type.startsWith("image/"));
+    const imgs = Array.from(files).filter(
+      (f) => f.type.startsWith("image/") || f.type.startsWith("video/"),
+    );
     if (imgs.length === 0 || !conn) return;
     uploading = true;
     uploadFailed = false;
@@ -1397,7 +1400,7 @@
         // stopImmediatePropagation()s, so xterm's textarea never sees this paste —
         // count it here or a pasted screenshot would never escalate the banner.
         bumpOperatorInput();
-        conn.send(` \x1b[200~${path}\x1b[201~ `);
+        conn.send(` \x1b[200~${attachmentPastePayload(path, f.type)}\x1b[201~ `);
       }
     } catch {
       // surface failure on the button; never inject into the PTY (would pollute the prompt)

--- a/ui/src/lib/components/viewport/ViewportTermControls.svelte
+++ b/ui/src/lib/components/viewport/ViewportTermControls.svelte
@@ -157,7 +157,7 @@
   <input
     bind:this={fileInput}
     type="file"
-    accept="image/*"
+    accept="image/*,video/*"
     multiple
     hidden
     onchange={(e) => {

--- a/ui/src/lib/feature-announcements/entries/v1.45.0-video-attachments.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.45.0-video-attachments.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "video-attachments",
+  sinceVersion: "1.45.0",
+  titleKey: "feat_video_attachments_title",
+  bodyKey: "feat_video_attachments_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
## Why

Attaching a ~97 MB HEVC screen recording (2:34, narrated) from a phone failed with 413 "file too large" — the app-level cap was 10 MiB. Narrated screen recordings are a high-bandwidth way to describe UI issues, so the limit must not block a 2–3 minute video.

## What

**Server**
- `MAX_UPLOAD_BYTES` 10 MiB → **250 MB**, uniform across New Task staging, in-session attach, and scratchpad uploads (~6–7 min of iPhone screen recording at the observed ~0.63 MB/s bitrate).
- In-session attach (`?session=`) now accepts video MIMEs (mp4/mov/webm/m4v) — was image-only 415.
- `Bun.serve` gets `maxRequestBodySize` wired above the app limit (Bun's 128 MiB default rejected big bodies before the handler); invariant test keeps transport > app cap.
- Both upload routes get a **120 s idle budget** via `slowRequestTimeoutSec` so phone uploads survive brief network stalls (Bun default: 10 s).
- Launch prompt appends an ffmpeg extraction note for video attachments — agents can't watch a video, so without the nudge it would sit unused.

**UI**
- In-session picker/drag-drop accept `video/*`; the PTY paste payload carries a short inline ffmpeg hint for videos (new pure helper `attachment-paste.ts`; image payloads stay byte-identical).
- EN/DE copy updated (attach label, 250 MB error text); What's-New entry `v1.45.0-video-attachments`.

## Testing

- Oversize (413) boundaries run against an injected `maxUploadBytes` seam — no more `MAX_UPLOAD_BYTES + 1` giant allocations (both `uploads.test.ts` and `scratchpad-upload.test.ts`).
- The single deliberately-large test POSTs ~130 MiB through the **real** `serve()` — only passes if `maxRequestBodySize` is actually wired; cleans up its staged fixture in a `finally` (staging lives outside the suite's tmpRoot teardown).
- Root suite: 7671 pass, 1 fail = known node-pty native-module issue in Shepherd worktrees (unrelated; nothing pty-touched). UI: 4222 pass, `check`/`check:i18n`/catalog/version/glossary/branch-hygiene gates green, prettier clean.

Plan reviewed via plan gate (3 review rounds); decisions (250 MB, hint-only, in-session included, uniform limit) confirmed by operator.