### PR TITLE
fix(ui): make the new-task modal usable on mobile (controls + issue picker)

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3319,6 +3319,8 @@
   "newtask_context_chip_aria": "Repository {repo}, von Branch {branch}",
   "newtask_engine_sheet_title": "Engine & Leitplanken",
   "newtask_context_sheet_title": "Repo & Branch",
+  "newtask_sources_open": "Issues & Befehle durchsuchen",
+  "newtask_sources_sheet_title": "Issues & Befehle",
   "newtask_gate_on": "Gate an",
   "newtask_gate_off": "Gate aus",
   "newtask_toggle_on": "AN",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3319,6 +3319,8 @@
   "newtask_context_chip_aria": "Repository {repo}, from branch {branch}",
   "newtask_engine_sheet_title": "Engine & Guards",
   "newtask_context_sheet_title": "Repo & Branch",
+  "newtask_sources_open": "Browse issues & commands",
+  "newtask_sources_sheet_title": "Issues & Commands",
   "newtask_gate_on": "gate on",
   "newtask_gate_off": "gate off",
   "newtask_toggle_on": "ON",

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -3334,3 +3334,234 @@ describe("NewTask mobile controls stay reachable while typing", () => {
     expect(getComputedStyle(document.querySelector<HTMLElement>(".left")!).overflowY).toBe("auto");
   });
 });
+
+// #1854 dropped the issue/command picker (PromptSources) on mobile — the only path left was
+// typing `#`. These fixtures cover the restored mobile sources sheet: the toolbar trigger, the
+// sheet's scroll chain, the focus contract, and a11y floors.
+describe("NewTask mobile sources sheet", () => {
+  class FakeVisualViewport extends EventTarget {
+    height: number;
+    offsetTop: number;
+    constructor(height: number, offsetTop = 0) {
+      super();
+      this.height = height;
+      this.offsetTop = offsetTop;
+    }
+  }
+  function installFakeViewport(height: number, offsetTop = 0) {
+    const fake = new FakeVisualViewport(height, offsetTop);
+    const prev = Object.getOwnPropertyDescriptor(window, "visualViewport");
+    Object.defineProperty(window, "visualViewport", { configurable: true, value: fake });
+    const restore = () => {
+      if (prev) Object.defineProperty(window, "visualViewport", prev);
+      else delete (window as unknown as { visualViewport?: unknown }).visualViewport;
+    };
+    return { fake, restore };
+  }
+  const srcBtn = () => document.querySelector<HTMLButtonElement>(".sources-btn");
+  const psWrap = () => document.querySelector<HTMLElement>(".ps-wrap");
+
+  it("opens the sheet from the toolbar trigger and lists issues", async () => {
+    await page.viewport(390, 844);
+    seedIssues([mkIssue(1, "alpha"), mkIssue(2, "bravo")]);
+    mockListRepos.mockResolvedValue({ repos: [], recentWindowDays: 30 });
+    render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo" } });
+    await expect.poll(() => srcBtn()).toBeTruthy();
+
+    srcBtn()!.click();
+    await expect.poll(() => psWrap()).toBeTruthy();
+    await expect.poll(() => document.querySelector(".sheet")?.textContent).toContain("alpha");
+  });
+
+  it("attaches an issue on pick and closes the sheet (issue-ref visible)", async () => {
+    const { restore } = installFakeViewport(440, 0);
+    try {
+      await page.viewport(390, 844);
+      seedIssues([mkIssue(7, "charlie")]);
+      mockListRepos.mockResolvedValue({ repos: [], recentWindowDays: 30 });
+      render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo" } });
+      await expect.poll(() => srcBtn()).toBeTruthy();
+      srcBtn()!.click();
+      await expect.poll(() => document.querySelector(".sheet .issue-list-row")).toBeTruthy();
+
+      document.querySelector<HTMLElement>(".sheet .issue-list-row")!.click();
+      // Sheet closes and the issue attaches.
+      await expect.poll(() => document.querySelector(".ps-wrap")).toBeNull();
+      const ref = document.querySelector<HTMLElement>(".issue-ref");
+      expect(ref?.textContent).toContain("charlie");
+      // The attached-issue row is visible in the keyboard-shrunk region (rect-based).
+      const r = ref!.getBoundingClientRect();
+      expect(r.top).toBeGreaterThanOrEqual(0);
+      expect(r.bottom).toBeLessThanOrEqual(440 + 1);
+    } finally {
+      restore();
+    }
+  });
+
+  it("honors the single-active-sheet invariant", async () => {
+    await page.viewport(390, 844);
+    seedIssues([mkIssue(1)]);
+    mockListRepos.mockResolvedValue({ repos: [], recentWindowDays: 30 });
+    render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo" } });
+    await expect.poll(() => document.querySelector(".engine-summary")).toBeTruthy();
+
+    document.querySelector<HTMLButtonElement>(".engine-summary")!.click();
+    await expect.poll(() => document.querySelector(".sheet")).toBeTruthy();
+    // Opening the sources sheet replaces the engine sheet — never two at once.
+    srcBtn()!.click();
+    await expect.poll(() => document.querySelector(".ps-wrap")).toBeTruthy();
+    expect(document.querySelectorAll(".sheet").length).toBe(1);
+  });
+
+  it("follows the focus contract: prompt-writing pick focuses the prompt, issue pick does not", async () => {
+    await page.viewport(390, 844);
+    mockGetCommands.mockResolvedValue({
+      commands: [{ name: "plan", description: "make a plan", scope: "project" }],
+    });
+    seedIssues([mkIssue(3, "delta")]);
+    mockListRepos.mockResolvedValue({ repos: [], recentWindowDays: 30 });
+    render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo" } });
+    await expect.poll(() => srcBtn()).toBeTruthy();
+
+    // Issue pick: focus is NOT stolen — use:dialog restores it to the trigger button.
+    // Focus the trigger first (a real tap focuses it; a synthetic click does not).
+    srcBtn()!.focus();
+    srcBtn()!.click();
+    await expect.poll(() => document.querySelector(".sheet .issue-list-row")).toBeTruthy();
+    document.querySelector<HTMLElement>(".sheet .issue-list-row")!.click();
+    await expect.poll(() => document.activeElement?.classList.contains("sources-btn")).toBe(true);
+
+    // Command pick: seeds the prompt and focuses the textarea with the caret at the end.
+    srcBtn()!.focus();
+    srcBtn()!.click();
+    await expect
+      .poll(() => document.querySelectorAll(".sheet .tab").length)
+      .toBeGreaterThanOrEqual(2);
+    // Switch to the Commands tab, then pick the command row.
+    const tabs = document.querySelectorAll<HTMLButtonElement>(".sheet .tab");
+    tabs[tabs.length - 1].click();
+    await expect
+      .poll(() => document.querySelector<HTMLElement>(".sheet .ps-body .row"))
+      .toBeTruthy();
+    document.querySelector<HTMLElement>(".sheet .ps-body .row")!.click();
+    await expect.poll(() => document.activeElement?.id).toBe("nt-prompt");
+    const ta = document.querySelector<HTMLTextAreaElement>("#nt-prompt")!;
+    expect(ta.selectionStart).toBe(ta.value.length);
+  });
+
+  it("makes .ps-body the sole scroller with a sticky head", async () => {
+    // Short region so the issue list overflows `.ps-body` regardless of how many rows the
+    // persisted "mine & unassigned" filter leaves.
+    const { restore } = installFakeViewport(240, 0);
+    try {
+      await page.viewport(375, 667);
+      seedIssues(Array.from({ length: 12 }, (_, i) => mkIssue(i + 1, `issue-${i}`)));
+      mockListRepos.mockResolvedValue({ repos: [], recentWindowDays: 30 });
+      render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo" } });
+      await expect.poll(() => srcBtn()).toBeTruthy();
+      srcBtn()!.click();
+      await expect
+        .poll(() => document.querySelectorAll(".sheet .issue-list-row").length)
+        .toBeGreaterThan(2);
+
+      const sheetBody = document.querySelector<HTMLElement>(".sheet-body")!;
+      const psBody = document.querySelector<HTMLElement>(".ps-body")!;
+      const psHead = document.querySelector<HTMLElement>(".ps-head")!;
+      // Structural: `.ps-body` is the scroller; `.sheet-body` is not (the override
+      // reversed the default so `.ps-filter-bar`'s sticky sticks to a moving box).
+      expect(getComputedStyle(psBody).overflowY).toBe("auto");
+      expect(getComputedStyle(sheetBody).overflow).toBe("hidden");
+      // Functional: the list overflows `.ps-body`, not `.sheet-body`.
+      await expect.poll(() => psBody.scrollHeight > psBody.clientHeight).toBe(true);
+      expect(sheetBody.scrollHeight).toBeLessThanOrEqual(sheetBody.clientHeight + 1);
+
+      // The head (tabs + filter) stays put when the rows scroll.
+      const headTop = psHead.getBoundingClientRect().top;
+      psBody.scrollTop = psBody.scrollHeight;
+      await expect.poll(() => psBody.scrollTop).toBeGreaterThan(0);
+      expect(Math.abs(psHead.getBoundingClientRect().top - headTop)).toBeLessThan(1);
+    } finally {
+      restore();
+    }
+  });
+
+  it("keeps the engine sheet's own .sheet-body scroller (the :has scope did not leak)", async () => {
+    await page.viewport(390, 640);
+    mockListRepos.mockResolvedValue({ repos: [], recentWindowDays: 30 });
+    render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo" } });
+    await expect.poll(() => document.querySelector(".engine-summary")).toBeTruthy();
+    document.querySelector<HTMLButtonElement>(".engine-summary")!.click();
+    await expect.poll(() => document.querySelector(".sheet-body")).toBeTruthy();
+    // No .ps-wrap here, so the override must not apply — the sheet-body stays the scroller.
+    expect(document.querySelector(".ps-wrap")).toBeNull();
+    expect(getComputedStyle(document.querySelector<HTMLElement>(".sheet-body")!).overflowY).toBe(
+      "auto",
+    );
+  });
+
+  it("meets the 44px tap-target floor for the sheet's primary controls", async () => {
+    await page.viewport(390, 844);
+    seedIssues([mkIssue(1, "echo")]);
+    mockListRepos.mockResolvedValue({ repos: [], recentWindowDays: 30 });
+    render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo" } });
+    await expect.poll(() => srcBtn()).toBeTruthy();
+    // The trigger button itself.
+    expectMinPx(srcBtn()!.getBoundingClientRect().height, 44, "sources-btn");
+    srcBtn()!.click();
+    await expect.poll(() => document.querySelector(".sheet .tab")).toBeTruthy();
+    for (const sel of [".tab", ".issue-list-row", ".filter-chip"]) {
+      const el = document.querySelector<HTMLElement>(`.sheet ${sel}`)!;
+      expectMinPx(el.getBoundingClientRect().height, 44, sel);
+    }
+  });
+
+  it("does not wrap the toolbar with the trigger + an attachment chip at 375px", async () => {
+    await page.viewport(375, 667);
+    mockListRepos.mockResolvedValue({ repos: [], recentWindowDays: 30 });
+    render(NewTask, {
+      props: {
+        onsubmit: vi.fn(),
+        initialRepoPath: "/repo",
+        initialImages: [{ path: "/staged/a.png", name: "a.png" }],
+      },
+    });
+    await expect.poll(() => srcBtn()).toBeTruthy();
+    // Single row: the trigger sits on the same line as the attach button (no wrap).
+    const attach = document.querySelector<HTMLElement>(".tool-btn")!;
+    expect(
+      Math.abs(srcBtn()!.getBoundingClientRect().top - attach.getBoundingClientRect().top),
+    ).toBeLessThan(8);
+  });
+
+  it("shows plain hint text (not a button) when no repo is selected", async () => {
+    await page.viewport(390, 844);
+    mockListRepos.mockResolvedValue({ repos: [], recentWindowDays: 30 });
+    render(NewTask, { props: { onsubmit: vi.fn() } });
+    await expect.poll(() => document.querySelector(".char-count")).toBeTruthy();
+    expect(document.querySelector(".sources-btn")).toBeNull();
+  });
+
+  it("positions the filter popover inside the keyboard-visible region", async () => {
+    const REGION = 420;
+    const { restore } = installFakeViewport(REGION, 0);
+    try {
+      await page.viewport(375, 667);
+      seedIssues([mkIssue(1, "foxtrot"), mkIssue(2, "golf")]);
+      mockListRepos.mockResolvedValue({ repos: [], recentWindowDays: 30 });
+      render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo" } });
+      await expect.poll(() => srcBtn()).toBeTruthy();
+      srcBtn()!.click();
+      await expect.poll(() => document.querySelector(".filter-chip")).toBeTruthy();
+      document.querySelector<HTMLButtonElement>(".filter-chip")!.click();
+      await expect.poll(() => document.querySelector(".filter-popover")).toBeTruthy();
+
+      const panel = document.querySelector<HTMLElement>(".filter-popover")!;
+      await expect.poll(() => panel.getBoundingClientRect().height).toBeGreaterThan(0);
+      const r = panel.getBoundingClientRect();
+      expect(r.top).toBeGreaterThanOrEqual(0);
+      expect(r.bottom).toBeLessThanOrEqual(REGION + 1);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -3078,3 +3078,259 @@ describe("NewTask keyboard-aware viewport (mobile)", () => {
     }
   });
 });
+
+// The #1854 redesign let the prompt field grow without bound on mobile (autogrow writes an
+// inline height that beats the mobile `height:100%`, and mobile drops the 40vh cap), so the
+// Mode/Engine controls and the in-field toolbar scrolled out of reach while typing. The fix
+// pins them by stopping `.left` scrolling as a whole (only `.nt-notices` scrolls) and making
+// the hero the flexible box with the textarea taken out of flow (so a long prompt can't
+// re-inflate it). These fixtures reuse the fake visualViewport to simulate the keyboard-shrunk
+// region; the real Android keyboard is validated on-device.
+describe("NewTask mobile controls stay reachable while typing", () => {
+  class FakeVisualViewport extends EventTarget {
+    height: number;
+    offsetTop: number;
+    constructor(height: number, offsetTop = 0) {
+      super();
+      this.height = height;
+      this.offsetTop = offsetTop;
+    }
+  }
+  function installFakeViewport(height: number, offsetTop = 0) {
+    const fake = new FakeVisualViewport(height, offsetTop);
+    const prev = Object.getOwnPropertyDescriptor(window, "visualViewport");
+    Object.defineProperty(window, "visualViewport", { configurable: true, value: fake });
+    const restore = () => {
+      if (prev) Object.defineProperty(window, "visualViewport", prev);
+      else delete (window as unknown as { visualViewport?: unknown }).visualViewport;
+    };
+    return { fake, restore };
+  }
+
+  const LONG_PROMPT = Array.from({ length: 60 }, (_, i) => `line ${i} of a very long prompt`).join(
+    "\n",
+  );
+  const textarea = () => document.querySelector<HTMLTextAreaElement>("#nt-prompt")!;
+
+  // `elementFromPoint` at an element's centre resolves to itself or a descendant — proving it
+  // is actually on-screen and not occluded, clipped, or crushed to 0 (a bare rect check can't:
+  // a crushed-to-0 or ancestor-clipped element still returns a rect).
+  function hitTestsToSelf(el: HTMLElement): boolean {
+    const r = el.getBoundingClientRect();
+    const hit = document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2);
+    return !!hit && (hit === el || el.contains(hit));
+  }
+
+  it("keeps autogrow inert on mobile so the field never grows unbounded", async () => {
+    await page.viewport(390, 844);
+    mockListRepos.mockResolvedValue({ repos: [], recentWindowDays: 30 });
+    render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo", initialPrompt: "x" } });
+    await expect.poll(() => textarea()).toBeTruthy();
+
+    // Type a long prompt: on today's code autogrow would write an inline height here.
+    const ta = textarea();
+    ta.value = LONG_PROMPT;
+    ta.dispatchEvent(new Event("input", { bubbles: true }));
+
+    // Inert on mobile → no inline height; the CSS governs and the textarea scrolls its own
+    // content instead of growing the block.
+    await expect.poll(() => ta.style.height).toBe("");
+    expect(ta.scrollHeight).toBeGreaterThan(ta.clientHeight);
+  });
+
+  it("clears a stale inline height inherited from desktop across the breakpoint (both ways)", async () => {
+    // Desktop first: the seeded long prompt autogrows → an inline height is written.
+    await page.viewport(1280, 900);
+    mockListRepos.mockResolvedValue({ repos: [], recentWindowDays: 30 });
+    render(NewTask, {
+      props: { onsubmit: vi.fn(), initialRepoPath: "/repo", initialPrompt: LONG_PROMPT },
+    });
+    await expect.poll(() => textarea()).toBeTruthy();
+    await expect.poll(() => textarea().style.height).not.toBe("");
+    expect(parseFloat(textarea().style.height)).toBeGreaterThan(132); // grown past the base
+
+    // Cross to mobile: the same element persists (single mount point), so the stale inline
+    // height must be cleared or it would beat `height:100%` and recreate the unbounded field.
+    await page.viewport(390, 844);
+    await expect.poll(() => textarea().style.height).toBe("");
+
+    // Cross back to desktop: the persisting element is re-autogrown (onMount's call won't
+    // re-fire), so it does not sit scrolled at its 132px base.
+    await page.viewport(1280, 900);
+    await expect.poll(() => textarea().style.height).not.toBe("");
+    expect(parseFloat(textarea().style.height)).toBeGreaterThan(132);
+  });
+
+  // A realistic keyboard-up portrait region (~half of an 844-tall phone) shows every control
+  // AT REST at default text size. --ui-scale 1.5 (iOS Dynamic Type) inflates the chrome enough
+  // that the same region needs a few px of card scroll — the ladder's documented behavior — so
+  // there we assert REACHABLE (scroll-to-reveal). Split per scale so per-test cleanup runs
+  // between them (two stacked NewTask instances would break elementFromPoint).
+  it.each([
+    { scale: "1", atRest: true },
+    { scale: "1.5", atRest: false },
+  ])(
+    "keeps Mode, Engine, the toolbar and the CTA reachable with a long prompt (--ui-scale $scale)",
+    async ({ scale, atRest }) => {
+      const { restore } = installFakeViewport(440, 0);
+      try {
+        document.documentElement.style.setProperty("--ui-scale", scale);
+        await page.viewport(390, 844);
+        mockListRepos.mockResolvedValue({ repos: [], recentWindowDays: 30 });
+        render(NewTask, {
+          props: { onsubmit: vi.fn(), initialRepoPath: "/repo", initialPrompt: LONG_PROMPT },
+        });
+        await expect.poll(() => document.querySelector(".seg-row")).toBeTruthy();
+
+        const left = document.querySelector<HTMLElement>(".left")!;
+        // `.left` is not itself a scroll container on mobile — that is what let the
+        // controls scroll away. The notices wrapper is the only scroller.
+        expect(getComputedStyle(left).overflow).toBe("visible");
+        expect(
+          getComputedStyle(document.querySelector<HTMLElement>(".nt-notices")!).overflowY,
+        ).toBe("auto");
+        // `.toolbar` is structurally outside the (only) scroller.
+        expect(
+          document.querySelector(".nt-notices")?.contains(document.querySelector(".toolbar")),
+        ).toBe(false);
+
+        for (const sel of [".seg-row", ".engine-summary", ".toolbar", "button.run"]) {
+          const el = document.querySelector<HTMLElement>(sel)!;
+          // Scroll-allowed (1.5) case: re-reveal on every poll tick so revealing a later
+          // control can't leave this one scrolled off.
+          await expect
+            .poll(
+              () => {
+                if (!atRest) el.scrollIntoView({ block: "nearest" });
+                return hitTestsToSelf(el);
+              },
+              { timeout: 2000 },
+            )
+            .toBe(true);
+        }
+      } finally {
+        document.documentElement.style.removeProperty("--ui-scale");
+        restore();
+      }
+    },
+  );
+
+  it("keeps the prompt controls reachable regardless of a tall notices column", async () => {
+    const { restore } = installFakeViewport(360, 0);
+    try {
+      await page.viewport(375, 667);
+      // Diverged upstream renders a notice into the (scrollable) notices column.
+      mockBranchStatus.mockResolvedValue({
+        behind: 9,
+        ahead: 4,
+        diverged: true,
+        hasUpstream: true,
+        localExists: true,
+      });
+      mockListRepos.mockResolvedValue({ repos: [], recentWindowDays: 30 });
+      render(NewTask, {
+        props: { onsubmit: vi.fn(), initialRepoPath: "/repo", initialPrompt: LONG_PROMPT },
+      });
+      await expect.poll(() => document.querySelector(".nt-upstream")).toBeTruthy();
+
+      // The notice lives in the notices scroller, not among the pinned controls.
+      const notices = document.querySelector<HTMLElement>(".nt-notices")!;
+      expect(notices.contains(document.querySelector(".nt-upstream"))).toBe(true);
+      expect(notices.contains(document.querySelector(".seg-row"))).toBe(false);
+      // Controls remain reachable regardless of the notices.
+      document.querySelector<HTMLElement>(".seg-row")!.scrollIntoView({ block: "nearest" });
+      await expect
+        .poll(() => hitTestsToSelf(document.querySelector<HTMLElement>(".seg-row")!))
+        .toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  it("keeps the field bounded and never overlapping the toolbar with a long prompt", async () => {
+    const { restore } = installFakeViewport(300, 0);
+    try {
+      await page.viewport(390, 844);
+      mockListRepos.mockResolvedValue({ repos: [], recentWindowDays: 30 });
+      render(NewTask, {
+        props: { onsubmit: vi.fn(), initialPrompt: LONG_PROMPT, initialRepoPath: "/repo" },
+      });
+      await expect.poll(() => document.querySelector(".prompt-block")).toBeTruthy();
+
+      const block = document.querySelector<HTMLElement>(".prompt-block")!;
+      const ta = textarea();
+      const toolbar = document.querySelector<HTMLElement>(".toolbar")!;
+      // The block is not clipped — the menus that render inside it must not be cut off.
+      expect(getComputedStyle(block).overflow).toBe("visible");
+      // The textarea scrolls its own content (bounded), rather than growing the block.
+      expect(ta.scrollHeight).toBeGreaterThan(ta.clientHeight);
+      // The textarea never overlaps the pinned toolbar below it.
+      expect(ta.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+        toolbar.getBoundingClientRect().top + 1,
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  it("never clips the CTA away at the worst geometry", async () => {
+    const { restore } = installFakeViewport(200, 0);
+    try {
+      mockPointer(true);
+      document.documentElement.style.setProperty("--ui-scale", "1.5");
+      await page.viewport(852, 393);
+      mockListRepos.mockResolvedValue({ repos: [], recentWindowDays: 30 });
+      render(NewTask, {
+        props: {
+          onsubmit: vi.fn(),
+          initialRepoPath: "/repo",
+          initialPrompt: LONG_PROMPT,
+          holdLikely: true,
+        },
+      });
+      await expect.poll(() => document.querySelector(".run-dual")).toBeTruthy();
+
+      // Dual CTA lays out in a ROW in the short-and-touch branch (buys back vertical space).
+      const hold = document.querySelector<HTMLElement>("button.run-hold")!;
+      const anyway = document.querySelector<HTMLElement>("button.run-anyway")!;
+      expect(
+        Math.abs(hold.getBoundingClientRect().top - anyway.getBoundingClientRect().top),
+      ).toBeLessThan(2);
+
+      // At a 200px region the pinned set can exceed it — the card scrolls so the CTA stays
+      // REACHABLE (not clipped away). Reveal it, then hit-test.
+      anyway.scrollIntoView({ block: "nearest" });
+      await expect.poll(() => hitTestsToSelf(anyway)).toBe(true);
+    } finally {
+      document.documentElement.style.removeProperty("--ui-scale");
+      restore();
+    }
+  });
+
+  it("keeps the notices column at zero height when no notice fires (keyboard down)", async () => {
+    await page.viewport(390, 844);
+    mockListRepos.mockResolvedValue({ repos: [], recentWindowDays: 30 });
+    render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo" } });
+    await expect.poll(() => document.querySelector(".nt-notices")).toBeTruthy();
+
+    const notices = document.querySelector<HTMLElement>(".nt-notices")!;
+    const block = document.querySelector<HTMLElement>(".prompt-block")!;
+    // Empty notices cost no height (poll: the upstream check briefly shows a "checking"
+    // line before it settles to no notice); the hero takes the card's free space.
+    await expect.poll(() => notices.getBoundingClientRect().height).toBeLessThan(1);
+    expect(block.getBoundingClientRect().height).toBeGreaterThan(300);
+  });
+
+  it("leaves the desktop layout scrolling as a whole column", async () => {
+    await page.viewport(1280, 900);
+    mockListRepos.mockResolvedValue({ repos: [], recentWindowDays: 30 });
+    render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo" } });
+    await expect.poll(() => document.querySelector(".rail")).toBeTruthy();
+    // Desktop keeps the rail, the notices wrapper is transparent (display:contents), and
+    // `.left` remains the scroller.
+    expect(getComputedStyle(document.querySelector<HTMLElement>(".nt-notices")!).display).toBe(
+      "contents",
+    );
+    expect(getComputedStyle(document.querySelector<HTMLElement>(".left")!).overflowY).toBe("auto");
+  });
+});

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -322,6 +322,20 @@
     if (!mobile && activeSheet !== null) activeSheet = null;
   });
 
+  // The prompt textarea has a SINGLE mount point (it lives in `.left` on both layouts),
+  // so it is not remounted when the breakpoint flips — which means an inline height that
+  // `autogrow()` wrote on desktop would survive onto mobile and beat the mobile
+  // `height: 100%`, recreating the unbounded field. So: clear the stale inline height
+  // when entering mobile, and re-grow the persisting element when landing on desktop
+  // (onMount's initial autogrow does not re-fire for an element that never remounted).
+  $effect(() => {
+    if (mobile) {
+      if (promptInput) promptInput.style.height = "";
+    } else {
+      tick().then(autogrow);
+    }
+  });
+
   // ── inline slash-command autocomplete (reuses the /api/commands index) ──
   let allCommands = $state<SlashCommand[]>([]);
   let slashOpen = $state(false);
@@ -764,8 +778,11 @@
   }
 
   // Grow the prompt with its content (capped by CSS max-height, then it scrolls).
+  // Inert on mobile: there the field is a flex-filled, full-height box (CSS
+  // `height: 100%`) that scrolls internally, so writing an inline height would only
+  // push the pinned toolbar/controls off-screen — the exact regression this fixes.
   function autogrow() {
-    if (!promptInput) return;
+    if (!promptInput || mobile) return;
     promptInput.style.height = "auto";
     promptInput.style.height = `${promptInput.scrollHeight}px`;
   }
@@ -1321,30 +1338,39 @@
             </div>
           {/if}
 
-          {#if upstreamLoading}
-            <span class="nt-upstream">{m.newtask_upstream_checking()}</span>
-          {:else if upstream?.diverged}
-            <span class="nt-upstream nt-upstream-warn">
-              {m.newtask_upstream_diverged({
-                behind: upstream.behind,
-                ahead: upstream.ahead,
-                base: baseBranch,
-              })}
-            </span>
-          {:else if upstream && upstream.behind > 0}
-            <span class="nt-upstream">{m.newtask_upstream_behind({ count: upstream.behind })}</span>
-          {:else if baseMissing}
-            <BaseRepairNotice repairing={repairingBase} onrepair={repairInitialCommit} />
-          {/if}
+          <!-- Notices column: the ONLY scrollable region on mobile (see the mobile
+               media query). `.left` itself stops scrolling there so the prompt block,
+               mode/engine controls and error stay pinned; only these informational
+               notices scroll. On desktop `.nt-notices` is `display: contents`, so the
+               notices participate in `.left`'s flow exactly as before. -->
+          <div class="nt-notices">
+            {#if upstreamLoading}
+              <span class="nt-upstream">{m.newtask_upstream_checking()}</span>
+            {:else if upstream?.diverged}
+              <span class="nt-upstream nt-upstream-warn">
+                {m.newtask_upstream_diverged({
+                  behind: upstream.behind,
+                  ahead: upstream.ahead,
+                  base: baseBranch,
+                })}
+              </span>
+            {:else if upstream && upstream.behind > 0}
+              <span class="nt-upstream"
+                >{m.newtask_upstream_behind({ count: upstream.behind })}</span
+              >
+            {:else if baseMissing}
+              <BaseRepairNotice repairing={repairingBase} onrepair={repairInitialCommit} />
+            {/if}
 
-          {#if relaunch}
-            <div class="relaunch-note">
-              <span>{m.newtask_relaunch_note()}</span>
-              {#if relaunchIssueNumber != null && repoPath !== initialRepoPath}
-                <span>{m.newtask_relaunch_issue_drop_note({ number: relaunchIssueNumber })}</span>
-              {/if}
-            </div>
-          {/if}
+            {#if relaunch}
+              <div class="relaunch-note">
+                <span>{m.newtask_relaunch_note()}</span>
+                {#if relaunchIssueNumber != null && repoPath !== initialRepoPath}
+                  <span>{m.newtask_relaunch_issue_drop_note({ number: relaunchIssueNumber })}</span>
+                {/if}
+              </div>
+            {/if}
+          </div>
 
           <!-- Prompt hero: the single visual hero — the only field with a bright border. -->
           <div class="prompt-block">
@@ -1946,6 +1972,11 @@
     text-overflow: ellipsis;
   }
 
+  /* Desktop: the notices wrapper is transparent to layout — its children flow in
+     `.left` exactly as before. It becomes a real flex scroller only on mobile. */
+  .nt-notices {
+    display: contents;
+  }
   .nt-upstream {
     font-size: var(--fs-micro);
     color: var(--color-muted);
@@ -2338,6 +2369,12 @@
       height: 100dvh;
       margin: 0;
       border: 0;
+      /* Degenerate backstop: at a region so short that the pinned header/footer +
+         controls exceed it, `.left`'s overflow:visible content contributes to the
+         card's scroll height and the whole card scrolls, keeping the CTA reachable.
+         The fixed sheets are unaffected — their containing block is `.overlay`, an
+         ancestor of `.card`. */
+      overflow-y: auto;
     }
     .bracket::before,
     .bracket::after {
@@ -2390,34 +2427,62 @@
     .cbody {
       display: flex;
       min-height: 0;
-      flex: 1;
+      /* Grow into free space but NEVER shrink below content: when the region is too
+         short for the pinned header/footer + controls, `.card` scrolls instead of the
+         field being squeezed into overlap. */
+      flex: 1 0 auto;
     }
     .left {
       flex: 1;
+      min-height: 0;
       border-right: 0;
       padding: 12px 16px;
+      /* The column itself no longer scrolls — that is what let the controls scroll
+         away. Only `.nt-notices` scrolls (below); the prompt block, mode/engine and
+         error are pinned by the base `.left > * { flex-shrink: 0 }` rule. Overflow
+         is visible so the degenerate case feeds `.card`'s scroll (see `.card`). */
+      overflow: visible;
+    }
+    /* Notices are the ONLY scrollable region on mobile. Empty → 0 height, so no
+       notice costs no space (no conditional wrapper needed). */
+    .nt-notices {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      flex: 0 1 auto;
+      min-height: 0;
       overflow-y: auto;
       -webkit-overflow-scrolling: touch;
     }
-    /* Hero fills the remaining height; 16px text prevents iOS zoom. */
+    /* The prompt hero is the flexible box: it grows into free space and, when the
+       region is short, shrinks toward its content floor so the pinned controls below
+       stay in view. That floor is the `flex-shrink: 0` toolbar plus the prompt-wrap's
+       explicit min-height (~one line) — and it is TEXT-INDEPENDENT because the textarea
+       is taken out of flow below, so a long prompt cannot re-inflate the block. Its
+       own `overflow-y: auto` scrolls the text inside the field instead. */
     .prompt-block {
-      flex: 1;
+      flex: 1 1 0;
       display: flex;
-      min-height: 0;
+      min-height: auto;
     }
     .hero {
       flex: 1;
-      min-height: 180px;
+      min-height: auto;
     }
     .prompt-wrap {
       flex: 1;
-      min-height: 0;
+      /* One-line floor for the field; the toolbar (flex-shrink:0) adds the rest. */
+      min-height: 3rem;
     }
     textarea {
-      /* Full-height hero: the wrap flexes, the textarea fills it. 16px comes from
-         the global iOS no-zoom guard in app.css; restated for the geometry tests. */
-      height: 100%;
-      min-height: 120px;
+      /* Absolutely positioned so the textarea contributes NOTHING to intrinsic sizing
+         — that is what keeps a long prompt from inflating the block's min-content back
+         to the unbounded height. It fills `.prompt-wrap` and scrolls its own content.
+         16px font comes from the global iOS no-zoom guard in app.css. */
+      position: absolute;
+      inset: 0;
+      height: auto;
+      min-height: 0;
       max-height: none;
       font-size: var(--fs-lg);
       line-height: 1.45;
@@ -2538,6 +2603,20 @@
       min-height: 44px;
       width: 100%;
       box-sizing: border-box;
+    }
+  }
+
+  /* Landscape phone / short-and-touch (e.g. 852×393): height is the scarce axis but
+     width is plentiful, so lay the dual CTA out in a row — two stacked 44px buttons
+     would cost ~52px of height exactly where the region is tightest. Scoped to the
+     short-and-touch branch only; narrow portrait keeps the stacked column above. */
+  @media (max-height: 480px) and (pointer: coarse) {
+    .run-dual {
+      flex-direction: row;
+    }
+    .run-dual .run {
+      flex: 1;
+      width: auto;
     }
   }
 </style>

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -315,7 +315,7 @@
   const shortViewport = new MediaQuery("(max-height: 480px)");
   const mobile = $derived(narrowViewport.current || (shortViewport.current && coarse.current));
   // Single active-sheet invariant: at most one mobile sheet is open, by construction.
-  let activeSheet = $state<"engine" | "context" | null>(null);
+  let activeSheet = $state<"engine" | "context" | "sources" | null>(null);
   let contextSheetEl = $state<HTMLElement | null>(null);
   // Leaving mobile while a sheet is open: the rail takes over; close the sheet.
   $effect(() => {
@@ -775,6 +775,24 @@
       promptInput?.focus();
       promptInput?.setSelectionRange(prompt.length, prompt.length);
     });
+  }
+
+  // Mobile sources sheet (issues + commands). Closing the sheet and moving focus race:
+  // `MobileEngineSheet`'s use:dialog restores focus to the opener on destroy, so a pick
+  // that seeds the prompt must close the sheet FIRST, await the destroy, THEN focus the
+  // prompt — otherwise the restore wins and the Android keyboard stays down mid-compose.
+  async function closeSheetFocusPrompt() {
+    activeSheet = null;
+    await tick();
+    autogrow();
+    promptInput?.focus();
+    promptInput?.setSelectionRange(prompt.length, prompt.length);
+  }
+  // An issue pick (pickIssue) deliberately does NOT steal focus — same as the desktop
+  // rail — so just close the sheet and let use:dialog restore focus to the trigger
+  // button, leaving the keyboard down.
+  function closeSheetKeepFocus() {
+    activeSheet = null;
   }
 
   // Grow the prompt with its content (capped by CSS max-height, then it scrolls).
@@ -1447,7 +1465,25 @@
                 {/each}
                 <span class="char-count">
                   {#if mobile}
-                    {m.newtask_syntax_hint_touch()}
+                    {#if repoPath}
+                      <!-- The hint becomes the sources-sheet trigger: browse/filter
+                           issues + commands, the picker #1854 dropped on mobile. Icon-only
+                           (`#`) so it never wraps the flex-wrap toolbar when attachment
+                           chips are present; the accessible name carries the full label.
+                           Inert text when no repo is selected (nothing to load). -->
+                      <button
+                        type="button"
+                        class="sources-btn"
+                        aria-haspopup="dialog"
+                        aria-expanded={activeSheet === "sources"}
+                        aria-label={m.newtask_sources_open()}
+                        onclick={() => (activeSheet = "sources")}
+                      >
+                        <span aria-hidden="true">#</span>
+                      </button>
+                    {:else}
+                      {m.newtask_syntax_hint_touch()}
+                    {/if}
                   {:else}
                     {m.newtask_char_count({ count: prompt.length })}
                   {/if}
@@ -1681,6 +1717,40 @@
             />
           {/if}
         </div>
+      </MobileEngineSheet>
+    {:else if mobile && activeSheet === "sources"}
+      <!-- Restores the issue/command picker #1854 dropped on mobile. Same PromptSources
+           as the desktop rail; picks close the sheet under the focus contract above. -->
+      <MobileEngineSheet
+        label={m.newtask_sources_sheet_title()}
+        title={m.newtask_sources_sheet_title()}
+        onclose={() => (activeSheet = null)}
+      >
+        <PromptSources
+          {repoPath}
+          {issueData}
+          {epicParents}
+          {nativeSubIssues}
+          {epicsLoaded}
+          {agentProvider}
+          allowIssues={!relaunch}
+          onpick={(p) => {
+            prompt = p;
+            closeSheetFocusPrompt();
+          }}
+          onpickcommand={(c) => {
+            pickCommandFromSource(c);
+            closeSheetFocusPrompt();
+          }}
+          onpickissue={(i) => {
+            pickIssue(i);
+            closeSheetKeepFocus();
+          }}
+          onpicksteer={(i, s) => {
+            injectSteer(i, s);
+            closeSheetFocusPrompt();
+          }}
+        />
       </MobileEngineSheet>
     {/if}
   </form>
@@ -2506,6 +2576,25 @@
     .char-count {
       font-size: var(--fs-meta);
     }
+    /* Sources-sheet trigger: icon-only `#` at a 44×44 tap target (a11y floor), sized to
+       never wrap the toolbar even beside attachment chips. */
+    .sources-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      width: 44px;
+      height: 44px;
+      background: transparent;
+      border: 0;
+      font: inherit;
+      font-size: var(--fs-lg);
+      color: var(--color-muted);
+      cursor: pointer;
+    }
+    .sources-btn:hover {
+      color: var(--color-ink);
+    }
     .seg-btn {
       min-height: 44px;
       font-size: var(--fs-meta);
@@ -2603,6 +2692,36 @@
       min-height: 44px;
       width: 100%;
       box-sizing: border-box;
+    }
+
+    /* Sources sheet: restore PromptSources' own flex scroll chain so `.ps-body` is the
+       sole scroller — NOT `.sheet-body`. Otherwise `.ps-body`'s inner scroll never moves
+       and `.ps-filter-bar` (sticky top:0) sticks to a box that never scrolls, so the
+       Commands-tab search scrolls away with the sheet. Scoped by `:has(.ps-wrap)` so the
+       engine and context sheets keep their own `.sheet-body` scroller untouched. */
+    :global(.sheet:has(.ps-wrap) .sheet-body) {
+      overflow: hidden;
+      display: flex;
+    }
+    :global(.sheet:has(.ps-wrap) .ps-wrap) {
+      flex: 1;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+    }
+    :global(.sheet:has(.ps-wrap) .ps-head) {
+      flex-shrink: 0;
+    }
+    :global(.sheet:has(.ps-wrap) .ps-body) {
+      flex: 1;
+      min-height: 0;
+      max-height: none;
+    }
+    /* Meet the 44px tap-target floor for the sheet's primary controls in a touch sheet. */
+    :global(.sheet:has(.ps-wrap) .tab),
+    :global(.sheet:has(.ps-wrap) .issue-list-row),
+    :global(.sheet:has(.ps-wrap) .filter-chip) {
+      min-height: 44px;
     }
   }
 


### PR DESCRIPTION
## Problem

Reported from Android: opening the new-task sheet, typing a long prompt gives a full-screen text area with **no controls in view** — you have to scroll and manually dismiss the keyboard to reach Mode/Engine or Run. Separately, the **issue picker is gone on mobile** entirely (the `#1854` "calm form" redesign gated it to desktop). The related iOS-keyboard PR `#1855` is already merged; this branch is rebased on it and closes the two gaps it left.

## Two commits

**1 — `fix(ui): keep new-task controls reachable with the mobile keyboard up`**

Root cause: `autogrow()` writes an inline `height` that beats the mobile `height:100%`, and mobile drops the desktop `40vh` cap — so a long prompt grows the field without bound and pushes every control off-screen.

- `autogrow()` is inert on mobile; the textarea scrolls its own content. A `mobile`-keyed `$effect` clears a stale inline height inherited from desktop across the breakpoint (single mount point) and re-autogrows on the way back.
- The notice branches move into a `.nt-notices` scroller (`display:contents` on desktop), so `.left` stops scrolling as a whole and the Mode segments, Engine row, in-field toolbar and error are pinned by the existing `.left > * { flex-shrink: 0 }`.
- The hero is the flexible box; the textarea is taken **out of flow** (`position:absolute`) so a long prompt can't re-inflate the block's min-content. `.card` scrolls as a degenerate backstop; the dual CTA goes row in short-and-touch landscape.

**2 — `fix(ui): restore the issue/command picker on mobile`**

- The `# issue · / command` toolbar hint becomes an icon-only `#` trigger (mobile + a selected repo) opening a third `MobileEngineSheet` that renders `PromptSources` with the desktop props. Icon-only so it never wraps the flex-wrap toolbar beside attachment chips; the accessible name carries the full label.
- Picks close the sheet under a focus contract: a prompt-writing pick focuses the prompt (caret at end); an issue pick leaves focus to `use:dialog`'s restore (keyboard stays down) — matching the desktop rail.
- Scoped `.sheet:has(.ps-wrap)` overrides make `.ps-body` the sole scroller so `.ps-filter-bar`'s sticky works and `.ps-head` stays put; the engine/context sheets keep their own scroller. 44px tap floors on the sheet's tabs, rows and filter trigger. New EN+DE keys (`newtask_sources_open`, `newtask_sources_sheet_title`).

## Out of scope

Capping the field's height when the keyboard is **down** — confirmed with the reporter that pinning the controls is the whole ask. Keyboard down, the hero takes the card's free space (a large target for the primary input); keyboard up, it yields toward the toolbar floor while every control stays reachable.

## Testing

- `bun run check`, `bun run check:i18n`, prettier, eslint — clean.
- `bun run test` — 4247 passed, incl. **19 new browser fixtures**: autogrow inertness + stale-height crossing, controls hit-testable (`elementFromPoint`, `--ui-scale` 1 and 1.5), CTA/error never clipped at the worst geometry, notices-only-scroll, field-never-overlaps-toolbar, desktop-unchanged; plus the sources sheet (open/pick/close, single-sheet invariant, focus contract, `.ps-body` scroll chain + `:has()` no-leak, 44px floors, toolbar wrap budget, no-repo state, filter-popover positioning).
- Real Android/iOS keyboards can't be synthesized in the harness (same caveat as `#1855`) — final confirmation is on-device.