### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -38,6 +38,20 @@ lines), read by the systemd unit if present.
 | `SHEPHERD_USAGE_DOWNGRADE_PCT` | `70` | Downgrade threshold: when the higher of the 5-hour / weekly usage window reaches this percent, new spawns are downgraded. Range `0`–`100`; default `70` is deliberately **below** `SHEPHERD_USAGE_HOLD_PCT` (`80`) so usage downgrades first and only later holds |
 | `SHEPHERD_USAGE_DOWNGRADE_MODEL` | `haiku` | Model the downgrade routes spawns to while active — a default-model setting (`auto` / `default` / `<alias>`) |
 
+## Review loops (PR critic + plan gate)
+
+The two cycle caps bound how many times a rejected head is sent back for rework
+before Shepherd escalates to a human; both are UI-configurable and persisted in the
+SQLite `settings` table, so the env var only seeds a fresh DB. The timeout is
+**env-only** — a machine-speed / PR-size escape hatch rather than a product knob.
+Out-of-range values are snapped into the stated range rather than rejected.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `SHEPHERD_REVIEW_CYCLES_CAP` | `3` | Max PR-critic auto-address rounds before escalating to a human. Range `1`–`8`. Seeds a fresh DB; persisted + UI-configurable |
+| `SHEPHERD_PLAN_REVIEW_CYCLES_CAP` | `5` | Max plan-gate adversarial-review rounds before escalating to a human. Range `1`–`12`. Seeds a fresh DB; persisted + UI-configurable |
+| `SHEPHERD_REVIEW_TIMEOUT_MS` | `600000` (10 min) | Hard deadline for a single critic run — both the session critic and the standalone PR critic — before it is abandoned and finalized as an `error` verdict. Clamped to `60000` (1 min)–`3600000` (60 min). Raise it for a repo whose PRs genuinely outgrow the default: a critic restarts from scratch on every retry, so a PR that can't finish inside the deadline stays permanently un-reviewable rather than being reviewed slowly. A run that hits the wall now also logs a `[review] no-verdict` diagnostic (cause, elapsed vs deadline, provider/model/effort, redacted pane tail) instead of failing silently |
+
 ## Live preview
 
 | Variable | Default | Purpose |


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc update summary

## Changes

- **`docs-site/src/content/docs/reference/configuration.md`** — added a new
  **"Review loops (PR critic + plan gate)"** section documenting three env vars that
  the page (whose stated scope is "every environment variable") did not list:
  - `SHEPHERD_REVIEW_TIMEOUT_MS` (default `600000`, clamped to 1–60 min) — introduced in
    `bcbfda109` *fix(review): stop silent critic timeouts; make the deadline configurable (#1946)*;
    grounded in `src/config.ts` (`reviewTimeoutMs`, `REVIEW_TIMEOUT_MS_MIN/MAX/DEFAULT`). The same
    commit added the `[review] no-verdict` diagnostic log, also noted.
  - `SHEPHERD_REVIEW_CYCLES_CAP` (default `3`, range 1–8) and
    `SHEPHERD_PLAN_REVIEW_CYCLES_CAP` (default `5`, range 1–12) — grounded in
    `src/config.ts:801-826` (`prReviewCyclesCap` / `planReviewCyclesCap`, and the
    `PR_REVIEW_CYCLES_MIN/MAX`, `PLAN_REVIEW_CYCLES_MIN/MAX` constants at `src/config.ts:62-65`).
    Included because they are the immediate neighbours of the new timeout knob and were equally
    undocumented; the "seeds a fresh DB / persisted + UI-configurable" wording mirrors the
    in-source comments.

No other in-scope page was changed. Checked and found current:
`docs/external-task-api.md` (model list matches `CLAUDE_MODELS` in `src/types.ts:316-323`,
already refreshed by `aecf69694`), `docs/sandbox-security.md` (reviewer allowlist still matches
`READONLY_GIT` + the reviewer preset in `src/transient-agent-argv.ts`),
`docs/token-usage-analysis.md` (a dated report, not a live reference),
`docs-site/.../index.md`, `getting-started.md` (herdr 0.7.5 ceiling still current),
`operating.md`, `reference/glossary.md`.

## Uncertain / needs human judgment

- **Oversized-prompt clamp/refusal (`ce6e71d80`, #1944).** A large plan or prompt is now clamped —
  or the critic/plan-gate spawn is refused outright — with a `spawn_notices` sidecar surfaced in the
  HUD (`src/prompt-fit.ts`, `src/argv-limit.ts`, `CriticSpawnFailure.svelte`). This is clearly
  operator-facing, but it has **no env var** and no existing section in the in-scope pages that it
  obviously belongs to (`configuration.md` is env-only; `operating.md` covers host tuning). I did not
  invent a new section for it. A human may want a short "why a critic refused to run" note in
  `operating.md` or the glossary.
- **`tui:"default"` unattended-pane kill-switch (`922eddd88`).** `docs/sandbox-security.md` quotes the
  transient-reviewer invocation as a flag list; the new `--settings` `tui` key (and the
  `src/critic-stuck.ts` stuck-pane detector) is not reflected there. The quoted list is about the
  *permission* posture, not the settings blob, so I left it alone rather than expanding its scope.
- **Per-role env vars generally.** `SHEPHERD_CRITIC_*`, `SHEPHERD_PLANNER_*`, `SHEPHERD_RECAP_*`,
  `SHEPHERD_RUNDOWN_*`, `SHEPHERD_NAMER_*`, `SHEPHERD_AUTOPILOT_*`, `SHEPHERD_SANDBOX_EXTRA_HOSTS`,
  and several others exist in `src/config.ts` but appear nowhere in `configuration.md`. They are
  long-standing rather than newly stale, so documenting the whole matrix felt out of scope for a
  sync pass — but the page does claim to list every variable, so this gap is real.