### PR TITLE
feat(ui): give steers their own settings section

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -409,6 +409,7 @@
   "settings_use_folder": "Diesen Ordner verwenden",
   "settings_tabs_aria": "Einstellungsbereiche",
   "settings_tab_workspace": "Arbeitsbereich",
+  "settings_tab_steers": "Steers",
   "settings_tab_session": "Sitzung",
   "settings_tab_device": "Gerät",
   "todopanel_title": "TO-DO · TODO.md",
@@ -3397,5 +3398,7 @@
   "feat_settings_redesign_title": "Einstellungen, neu gestaltet",
   "feat_settings_redesign_body": "Die Einstellungen öffnen sich jetzt als Cockpit: Sektionsleiste links (am Telefon eine Vollbild-Liste mit Detailseiten), ausgerichtete Einstellungszeilen und ein Suchfeld — mit / erreichbar —, das Sektionen filtert und Treffer hervorhebt. Änderungen gelten weiterhin sofort.",
   "feat_video_attachments_title": "Bildschirmaufnahmen anhängen",
-  "feat_video_attachments_body": "Das Upload-Limit liegt jetzt bei 250 MB – eine kommentierte Bildschirmaufnahme vom Smartphone passt damit bequem. Hänge Videos in „Neue Aufgabe“ an oder ziehe sie ins Terminal einer laufenden Session – der Agent bekommt einen Hinweis, wie er Frames und Ton extrahiert, um sie wirklich auszuwerten."
+  "feat_video_attachments_body": "Das Upload-Limit liegt jetzt bei 250 MB – eine kommentierte Bildschirmaufnahme vom Smartphone passt damit bequem. Hänge Videos in „Neue Aufgabe“ an oder ziehe sie ins Terminal einer laufenden Session – der Agent bekommt einen Hinweis, wie er Frames und Ton extrahiert, um sie wirklich auszuwerten.",
+  "feat_steers_settings_section_title": "Steers bekommen einen eigenen Einstellungsbereich",
+  "feat_steers_settings_section_body": "Gespeicherte Steers liegen jetzt unter Einstellungen → Steers. Die Sitzungssteuerung bleibt fokussiert, während Stift und Steer-Kontextmenü weiterhin denselben Editor öffnen und den ausgewählten Steer beibehalten."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -409,6 +409,7 @@
   "settings_use_folder": "Use this folder",
   "settings_tabs_aria": "Settings sections",
   "settings_tab_workspace": "Workspace",
+  "settings_tab_steers": "Steers",
   "settings_tab_session": "Session",
   "settings_tab_device": "Device",
   "todopanel_title": "TO-DO · TODO.md",
@@ -3397,5 +3398,7 @@
   "feat_settings_redesign_title": "Settings, redesigned",
   "feat_settings_redesign_body": "Settings now opens as a cockpit: a section rail on the left (a full-screen list with drill-in pages on phones), aligned setting rows, and a search field — press / to jump to it — that filters sections and highlights matches. Changes still apply immediately.",
   "feat_video_attachments_title": "Attach screen recordings",
-  "feat_video_attachments_body": "The upload limit is now 250 MB, so a narrated screen recording from your phone fits comfortably. Attach videos in New Task or drop them into a running session's terminal — the agent gets a hint on how to extract frames and audio to actually watch them."
+  "feat_video_attachments_body": "The upload limit is now 250 MB, so a narrated screen recording from your phone fits comfortably. Attach videos in New Task or drop them into a running session's terminal — the agent gets a hint on how to extract frames and audio to actually watch them.",
+  "feat_steers_settings_section_title": "Steers get their own settings section",
+  "feat_steers_settings_section_body": "Saved Steers now live under Settings → Steers. Session controls stay focused, while the pencil and steer context menu still open the same editor and preserve the selected steer."
 }

--- a/ui/src/lib/components/Settings.browser.test.ts
+++ b/ui/src/lib/components/Settings.browser.test.ts
@@ -22,6 +22,8 @@ vi.mock("$lib/api", async (importOriginal) => {
     ...actual,
     getSettings: vi.fn(),
     listDirs: vi.fn(async () => ({ path: "/repo", display: "/repo", parent: null, entries: [] })),
+    getSteers: vi.fn(async () => []),
+    getCommands: vi.fn(async () => ({ commands: [] })),
     getDiagnostics: vi.fn(async () => ({ checks: [] })),
     fixDiagnostic: vi.fn(),
     verifyApiKey: vi.fn(),
@@ -544,6 +546,26 @@ describe("Settings responsive navigation", () => {
       .element(page.getByRole("tabpanel", { name: m.settings_tab_workspace() }))
       .toBeInTheDocument();
   });
+
+  it("renders Steers between Coding CLI and Plugins in its own panel", async () => {
+    await page.viewport(1280, 900);
+    render(Settings, { initialTab: "steers", onclose: noop, onsaved: noop });
+
+    const tabs = [...document.querySelectorAll<HTMLElement>('[role="tab"]')];
+    const labels = tabs.map((tab) => tab.querySelector(".ilabel")?.textContent?.trim());
+    expect(labels.indexOf(m.settings_tab_steers())).toBe(
+      labels.indexOf(m.settings_tab_coding_agents()) + 1,
+    );
+    expect(labels.indexOf(m.settings_tab_plugins())).toBe(
+      labels.indexOf(m.settings_tab_steers()) + 1,
+    );
+
+    const steersPanel = document.querySelector<HTMLElement>("#settings-panel-steers");
+    const sessionPanel = document.querySelector<HTMLElement>("#settings-panel-session");
+    expect(steersPanel?.getAttribute("role")).toBe("tabpanel");
+    expect(steersPanel?.querySelector(".editor")).not.toBeNull();
+    expect(sessionPanel?.querySelector(".editor")).toBeNull();
+  });
 });
 
 describe("Settings dialog layout stability", () => {
@@ -662,6 +684,28 @@ describe("Settings search", () => {
     const devicePanel = document.querySelector<HTMLElement>("#settings-panel-device");
     expect(devicePanel).not.toBeNull();
     await expect.poll(() => devicePanel!.querySelectorAll("mark").length).toBeGreaterThan(0);
+  });
+
+  it("counts and highlights matches in the Steers section", async () => {
+    await page.viewport(1280, 900);
+    await mountCodingAgents();
+
+    const { matchCount, sectionSearchRows } = await import("$lib/settings-search");
+    const query = "saved";
+    const expected = matchCount(sectionSearchRows({ provider: "claude" }).steers, query);
+    expect(expected).toBeGreaterThan(0);
+
+    await searchInput().fill(query);
+
+    const steersTab = page
+      .getByRole("tab", { name: m.settings_tab_steers(), exact: false })
+      .element() as HTMLElement;
+    await expect.poll(() => steersTab.textContent).toContain(String(expected));
+
+    await page.getByRole("tab", { name: m.settings_tab_steers(), exact: false }).click();
+    const steersPanel = document.querySelector<HTMLElement>("#settings-panel-steers");
+    expect(steersPanel).not.toBeNull();
+    await expect.poll(() => steersPanel!.querySelectorAll("mark").length).toBeGreaterThan(0);
   });
 
   it("`/` focuses the search field; Esc clears the query, second Esc closes", async () => {

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -32,6 +32,7 @@
   import SettingsDevicePanel from "$lib/components/settings/SettingsDevicePanel.svelte";
   import SettingsDiagnosePanel from "$lib/components/settings/SettingsDiagnosePanel.svelte";
   import SettingsPluginsPanel from "$lib/components/settings/SettingsPluginsPanel.svelte";
+  import SteersEditor from "$lib/components/SteersEditor.svelte";
   import { dialog } from "$lib/a11yDialog";
   import { openFeedback } from "$lib/feedback-dialog.svelte";
   import type { FeedbackKind } from "$lib/feedback-link";
@@ -314,6 +315,8 @@
         return m.settings_tab_workspace();
       case "codingAgents":
         return m.settings_tab_coding_agents();
+      case "steers":
+        return m.settings_tab_steers();
       case "plugins":
         return m.settings_tab_plugins();
       case "session":
@@ -418,7 +421,7 @@
         {/each}
       {/snippet}
 
-      <!-- All six panels stay mounted and toggle via `hidden`: every
+      <!-- All seven panels stay mounted and toggle via `hidden`: every
            settings-panel-* id resolves for the rail's aria-controls, and the
            steers editor keeps any in-progress draft across section switches
            instead of remounting and resyncing from the store. -->
@@ -437,6 +440,16 @@
           {onclose}
           {query}
         />
+      </div>
+
+      <div
+        class="panel"
+        use:panelShape={isNarrow}
+        id="settings-panel-steers"
+        aria-label={m.settings_tab_steers()}
+        hidden={active !== "steers"}
+      >
+        <SteersEditor {focusSteerId} {query} />
       </div>
 
       <div
@@ -492,7 +505,6 @@
           {fableAvailable}
           {fableAvailableBusy}
           onToggleFable={toggleFableAvailable}
-          {focusSteerId}
         />
       </div>
 

--- a/ui/src/lib/components/SteersEditor.browser.test.ts
+++ b/ui/src/lib/components/SteersEditor.browser.test.ts
@@ -75,3 +75,13 @@ describe("SteersEditor focusSteerId", () => {
     expect(editing.length).toBe(0);
   });
 });
+
+describe("SteersEditor settings search", () => {
+  it("highlights a matching substring in its settings chrome", async () => {
+    render(SteersEditor, { query: "saved" });
+    await tick();
+
+    const mark = document.querySelector(".editor mark");
+    expect(mark?.textContent.toLowerCase()).toBe("saved");
+  });
+});

--- a/ui/src/lib/components/SteersEditor.svelte
+++ b/ui/src/lib/components/SteersEditor.svelte
@@ -18,11 +18,15 @@
     commandProviders,
   } from "$lib/slash";
   import type { Steer, SlashCommand } from "$lib/types";
+  import HighlightText from "$lib/components/settings/HighlightText.svelte";
   import { m } from "$lib/paraglide/messages";
 
   // Steer to expand + focus on open (from a steer chip's right-click → "Edit"). The
   // editor lists every steer; this jumps straight to the one the operator picked.
-  let { focusSteerId = null }: { focusSteerId?: string | null } = $props();
+  let {
+    focusSteerId = null,
+    query = "",
+  }: { focusSteerId?: string | null; query?: string } = $props();
 
   const flipDurationMs = 150;
 
@@ -276,8 +280,8 @@
 </script>
 
 <div class="editor" bind:this={rootEl}>
-  <span class="micro">{m.steerseditor_title()}</span>
-  <p class="hint">{m.steerseditor_hint()}</p>
+  <span class="micro"><HighlightText text={m.steerseditor_title()} {query} /></span>
+  <p class="hint"><HighlightText text={m.steerseditor_hint()} {query} /></p>
   <div
     class="rows"
     class:focusing={editingId !== null}

--- a/ui/src/lib/components/SteersEditor.svelte
+++ b/ui/src/lib/components/SteersEditor.svelte
@@ -23,10 +23,8 @@
 
   // Steer to expand + focus on open (from a steer chip's right-click → "Edit"). The
   // editor lists every steer; this jumps straight to the one the operator picked.
-  let {
-    focusSteerId = null,
-    query = "",
-  }: { focusSteerId?: string | null; query?: string } = $props();
+  let { focusSteerId = null, query = "" }: { focusSteerId?: string | null; query?: string } =
+    $props();
 
   const flipDurationMs = 150;
 

--- a/ui/src/lib/components/page/AppOverlays.browser.test.ts
+++ b/ui/src/lib/components/page/AppOverlays.browser.test.ts
@@ -1,15 +1,24 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../../app.css";
 import AppOverlays from "./AppOverlays.svelte";
 import type { HerdStore } from "$lib/store.svelte";
-import type { AgentProvider, DiagnosticsSnapshot, HerdrUpdateStatus } from "$lib/types";
+import type { AgentProvider, DiagnosticsSnapshot, HerdrUpdateStatus, Steer } from "$lib/types";
+import { steers } from "$lib/steers.svelte";
+import { repos } from "$lib/repos.svelte";
+import { steersSettingsOpen } from "../../../routes/steers-settings-open";
+import { m } from "$lib/paraglide/messages";
 
 // The redesigned NewTask is responsive (rail vs. mobile sheet); vitest-browser's
 // default viewport is mobile-width, so pin desktop for these desktop-DOM suites.
 beforeEach(async () => {
   await page.viewport(1280, 900);
+});
+afterEach(() => {
+  steers.list = [];
+  steers.loaded = false;
+  repos.loaded = false;
 });
 
 // NewTask calls listRepos() on mount; stub it so the dialog mounts without a server.
@@ -146,6 +155,45 @@ function baseProps(): Props {
     onstarresolve: vi.fn(),
   };
 }
+
+const steer = (p: Partial<Steer>): Steer => ({
+  id: "b",
+  label: "Bravo",
+  text: "do bravo",
+  inSteerBar: true,
+  onIssues: false,
+  ...p,
+});
+
+const frames = (n = 2) =>
+  new Promise<void>((resolve) => {
+    let i = 0;
+    const step = () => (++i >= n ? resolve() : requestAnimationFrame(step));
+    requestAnimationFrame(step);
+  });
+
+describe("Settings deep links", () => {
+  it("forwards the Steers request into the mobile detail and focused editor row", async () => {
+    await page.viewport(360, 900);
+    steers.list = [steer({})];
+    steers.loaded = true;
+    repos.loaded = true;
+
+    render(AppOverlays, { ...baseProps(), ...steersSettingsOpen("b") });
+    await frames();
+
+    await expect
+      .element(page.getByRole("region", { name: m.settings_tab_steers() }))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByRole("button", { name: m.settings_tab_workspace(), exact: false }))
+      .not.toBeInTheDocument();
+
+    const row = document.querySelector<HTMLElement>('.srow[data-steer-id="b"]');
+    expect(row?.classList.contains("editing")).toBe(true);
+    expect(document.activeElement).toBe(row?.querySelector("textarea.text"));
+  });
+});
 
 function diagnostics(states: Record<AgentProvider, "ok" | "optional">): DiagnosticsSnapshot {
   return {

--- a/ui/src/lib/components/settings/SettingsSessionPanel.svelte
+++ b/ui/src/lib/components/settings/SettingsSessionPanel.svelte
@@ -20,7 +20,6 @@
   import { MODELS, type Settings } from "$lib/types";
   import { modelGuidanceAlias, modelOptionLabel } from "$lib/model-guidance";
   import ModelGuidance from "$lib/components/ModelGuidance.svelte";
-  import SteersEditor from "$lib/components/SteersEditor.svelte";
   import RestartShepherdDialog from "$lib/components/RestartShepherdDialog.svelte";
   import SettingRow from "./SettingRow.svelte";
   import SettingToggle from "./SettingToggle.svelte";
@@ -38,14 +37,12 @@
     fableAvailable,
     fableAvailableBusy,
     onToggleFable,
-    focusSteerId = null,
   }: {
     payload: Settings | null;
     query?: string;
     fableAvailable: boolean;
     fableAvailableBusy: boolean;
     onToggleFable: () => void;
-    focusSteerId?: string | null;
   } = $props();
 
   let remoteControl = $state(false); // Claude Code Remote Control auto-start in sessions
@@ -697,8 +694,6 @@
   {/snippet}
 </SettingRow>
 
-<div class="steers"><SteersEditor {focusSteerId} /></div>
-
 {#if restartOpen}
   <RestartShepherdDialog onclose={() => (restartOpen = false)} />
 {/if}
@@ -707,10 +702,5 @@
   .unavailable {
     color: var(--color-faint);
     font-size: var(--fs-meta);
-  }
-  .steers {
-    margin-top: 12px;
-    border-top: 1px solid var(--color-line);
-    padding-top: 4px;
   }
 </style>

--- a/ui/src/lib/feature-announcements/entries/v1.46.0-steers-settings-section.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.46.0-steers-settings-section.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "steers-settings-section",
+  sinceVersion: "1.46.0",
+  titleKey: "feat_steers_settings_section_title",
+  bodyKey: "feat_steers_settings_section_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/settings-search.ts
+++ b/ui/src/lib/settings-search.ts
@@ -211,10 +211,7 @@ export function sectionSearchRows(ctx: {
       ...cli.codex,
       ...cli.roles,
     ],
-    steers: [
-      [m.settings_tab_steers()],
-      [m.steerseditor_title(), m.steerseditor_hint()],
-    ],
+    steers: [[m.settings_tab_steers()], [m.steerseditor_title(), m.steerseditor_hint()]],
     plugins: [[m.settings_tab_plugins()], [m.plugins_check_updates()]],
     session: [[m.settings_tab_session()], ...sessionRows(ctx.session ?? {})],
     device: [

--- a/ui/src/lib/settings-search.ts
+++ b/ui/src/lib/settings-search.ts
@@ -3,6 +3,7 @@ import { m } from "$lib/paraglide/messages";
 export const SETTINGS_SECTION_IDS = [
   "workspace",
   "codingAgents",
+  "steers",
   "plugins",
   "session",
   "device",
@@ -14,6 +15,7 @@ export type SettingsSectionId = (typeof SETTINGS_SECTION_IDS)[number];
 export const SECTION_GLYPHS: Record<SettingsSectionId, string> = {
   workspace: "▦",
   codingAgents: "⌁",
+  steers: "⇥",
   plugins: "✦",
   session: "⌖",
   device: "◫",
@@ -208,6 +210,10 @@ export function sectionSearchRows(ctx: {
       ...cli.claude,
       ...cli.codex,
       ...cli.roles,
+    ],
+    steers: [
+      [m.settings_tab_steers()],
+      [m.steerseditor_title(), m.steerseditor_hint()],
     ],
     plugins: [[m.settings_tab_plugins()], [m.plugins_check_updates()]],
     session: [[m.settings_tab_session()], ...sessionRows(ctx.session ?? {})],

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -146,6 +146,7 @@
   // Side-effect-free (no top-level DOM/timer work) — tree-shakes out of non-demo
   // builds along with every other __DEMO__-guarded reference below.
   import { commandBarShowcase } from "$lib/demo/showcase";
+  import { steersSettingsOpen } from "./steers-settings-open";
 
   const store = new HerdStore();
 
@@ -778,10 +779,11 @@
   // right-click → "Edit") expands + focuses that row; omitted for the plain pencil.
   // Defined here, not inline, so the nullish branch stays out of the route template.
   function openSteersEditor(id?: string) {
-    settingsTab = "session";
-    focusSteerId = id ?? null;
-    settingsDeepLink = true;
-    showSettings = true;
+    const target = steersSettingsOpen(id);
+    settingsTab = target.settingsTab;
+    focusSteerId = target.focusSteerId;
+    settingsDeepLink = target.settingsMobileView === "detail";
+    showSettings = target.showSettings;
   }
 
   function loadSettings() {

--- a/ui/src/routes/steers-settings-open.test.ts
+++ b/ui/src/routes/steers-settings-open.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { steersSettingsOpen } from "./steers-settings-open";
+
+describe("steersSettingsOpen", () => {
+  it("routes a targeted edit into the mobile Steers detail", () => {
+    expect(steersSettingsOpen("b")).toEqual({
+      showSettings: true,
+      settingsTab: "steers",
+      settingsMobileView: "detail",
+      focusSteerId: "b",
+    });
+  });
+
+  it("opens the same detail without targeting a steer", () => {
+    expect(steersSettingsOpen()).toEqual({
+      showSettings: true,
+      settingsTab: "steers",
+      settingsMobileView: "detail",
+      focusSteerId: null,
+    });
+  });
+});

--- a/ui/src/routes/steers-settings-open.ts
+++ b/ui/src/routes/steers-settings-open.ts
@@ -1,0 +1,15 @@
+export interface SteersSettingsOpen {
+  showSettings: true;
+  settingsTab: "steers";
+  settingsMobileView: "detail";
+  focusSteerId: string | null;
+}
+
+export function steersSettingsOpen(id?: string): SteersSettingsOpen {
+  return {
+    showSettings: true,
+    settingsTab: "steers",
+    settingsMobileView: "detail",
+    focusSteerId: id ?? null,
+  };
+}


### PR DESCRIPTION
## Summary

- move Saved Steers out of Session into a dedicated Settings → Steers section
- preserve pencil/context-menu deep links, mobile detail routing, and targeted steer focus
- add settings search coverage, EN/DE copy, and the v1.46.0 feature announcement

## Validation

- `cd ui && bun run check`
- `cd ui && bun run check:i18n`
- `cd ui && bun run test` (277 files, 4,269 tests)
- `node scripts/check-announcement-versions.mjs`
- `scripts/check-feature-catalog.sh`
- `scripts/check-branch-hygiene.sh`

## Test runner note

The repository-instruction literal `cd ui && bun test` invokes Bun’s native runner and incorrectly collects Vitest browser specs as Node tests on unchanged `main`. The package-defined Vitest suite, `bun run test`, is green and is the authoritative UI test run.