### PR TITLE
fix: hydrate persisted session card state

### DIFF
--- a/src/pr-poller.ts
+++ b/src/pr-poller.ts
@@ -423,8 +423,7 @@ export class PrPoller implements PrCache {
     // login, so the herd can show "waiting on scoop" instead of "your turn".
     const git = annotateHandoff(raw, s.repoPath, me, prev);
     this.trackTransient(s.id, git);
-    if (gitStateChanged(prev, git)) {
-      this.set(s.id, git);
+    if (gitStateChanged(prev, git) && this.set(s.id, git)) {
       this.onChange(s.id, git);
     }
   }
@@ -567,9 +566,14 @@ export class PrPoller implements PrCache {
   get(id: string): GitState | undefined {
     return this.cache.get(id);
   }
-  set(id: string, git: GitState): void {
-    this.store.putSessionGitCache(id, git);
+  set(id: string, git: GitState): boolean {
+    if (!this.store.putSessionGitCache(id, git)) {
+      this.cache.delete(id);
+      this.transientSince.delete(id);
+      return false;
+    }
     this.cache.set(id, git);
+    return true;
   }
   drop(id: string): void {
     this.store.deleteSessionGitCache(id);

--- a/src/pr-poller.ts
+++ b/src/pr-poller.ts
@@ -4,6 +4,11 @@ import type { GitForge, GitState, PrStatus } from "./forge/types";
 import { annotateHandoff } from "./repo-roles";
 import type { OpenPrSnapshotService } from "./open-pr-snapshot";
 
+type PrPollerStore = Pick<
+  SessionStore,
+  "list" | "get" | "listSessionGitCache" | "putSessionGitCache" | "deleteSessionGitCache"
+>;
+
 /** Read/write handle the HTTP layer uses to serve snapshots and apply instant
  *  updates from PR actions. `PrPoller` implements it. */
 export interface PrCache {
@@ -180,7 +185,7 @@ export class PrPoller implements PrCache {
   }
 
   constructor(
-    private store: Pick<SessionStore, "list" | "get">,
+    private store: PrPollerStore,
     private resolveForge: (repoPath: string) => GitForge | null,
     private onChange: (id: string, git: GitState) => void,
     private intervalMs = 120_000,
@@ -227,7 +232,9 @@ export class PrPoller implements PrCache {
      *  from it (`refresh`, always-fresh) so the PRs tab reuses the poller's fetch; when absent
      *  (older test wiring), the batch falls back to the forge's direct `listOpenPrStatuses`. */
     private snapshotSvc?: OpenPrSnapshotService,
-  ) {}
+  ) {
+    this.cache = new Map(Object.entries(this.store.listSessionGitCache()));
+  }
 
   /** Epoch-ms of the last full sweep that actually ran — gates the cold-path
    *  throttle in `tick`. */
@@ -258,8 +265,7 @@ export class PrPoller implements PrCache {
       }
       for (const id of [...this.cache.keys()]) {
         if (!active.has(id)) {
-          this.cache.delete(id);
-          this.transientSince.delete(id);
+          this.drop(id);
         }
       }
     } finally {
@@ -418,7 +424,7 @@ export class PrPoller implements PrCache {
     const git = annotateHandoff(raw, s.repoPath, me, prev);
     this.trackTransient(s.id, git);
     if (gitStateChanged(prev, git)) {
-      this.cache.set(s.id, git);
+      this.set(s.id, git);
       this.onChange(s.id, git);
     }
   }
@@ -562,9 +568,11 @@ export class PrPoller implements PrCache {
     return this.cache.get(id);
   }
   set(id: string, git: GitState): void {
+    this.store.putSessionGitCache(id, git);
     this.cache.set(id, git);
   }
   drop(id: string): void {
+    this.store.deleteSessionGitCache(id);
     this.cache.delete(id);
     this.transientSince.delete(id);
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -2376,11 +2376,16 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     })();
   }
 
-  putSessionGitCache(sessionId: string, state: GitState): void {
-    this.db.run(
-      `INSERT INTO session_git_cache (sessionId, gitJson, updatedAt) VALUES (?, ?, ?)
+  putSessionGitCache(sessionId: string, state: GitState): boolean {
+    return (
+      this.db.run(
+        `INSERT INTO session_git_cache (sessionId, gitJson, updatedAt)
+       SELECT ?, ?, ? WHERE EXISTS (
+         SELECT 1 FROM sessions WHERE id = ? AND status != 'archived'
+       )
        ON CONFLICT(sessionId) DO UPDATE SET gitJson=excluded.gitJson, updatedAt=excluded.updatedAt`,
-      [sessionId, JSON.stringify(state), Date.now()],
+        [sessionId, JSON.stringify(state), Date.now(), sessionId],
+      ).changes > 0
     );
   }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -61,6 +61,7 @@ import { sanitizeScopeGlobs } from "./house-rules";
 import type { EpicRun } from "./epic-core";
 import type { EpicLandingState } from "./completed-epic";
 import { normalizeRule } from "./learning-rule";
+import type { GitState } from "./forge/types";
 
 /** Tolerantly parse a persisted JSON column, falling back to `fallback` on any error. */
 function safeJsonParse<T>(raw: string | null | undefined, fallback: T): T {
@@ -76,6 +77,40 @@ function safeJsonParse<T>(raw: string | null | undefined, fallback: T): T {
 function safeJsonArray(raw: string | null | undefined): string[] {
   const v = safeJsonParse<unknown>(raw, []);
   return Array.isArray(v) ? v.filter((s): s is string => typeof s === "string") : [];
+}
+
+function parsePersistedGitState(raw: string): GitState | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const state = value as Record<string, unknown>;
+  if (state.kind !== "github" && state.kind !== "gitea" && state.kind !== "local") return null;
+  if (
+    state.state !== "none" &&
+    state.state !== "open" &&
+    state.state !== "merged" &&
+    state.state !== "closed"
+  )
+    return null;
+  if (
+    state.checks !== "none" &&
+    state.checks !== "pending" &&
+    state.checks !== "success" &&
+    state.checks !== "failure"
+  )
+    return null;
+  if (typeof state.deployConfigured !== "boolean") return null;
+  if (state.state === "none") {
+    if (state.number !== undefined) return null;
+  } else if (!Number.isInteger(state.number) || (state.number as number) <= 0) {
+    return null;
+  }
+  if (state.headSha !== undefined && typeof state.headSha !== "string") return null;
+  return state as unknown as GitState;
 }
 
 /** Tolerantly parse the persisted findings JSON back to a string[] (never throws). */
@@ -903,6 +938,10 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       auto INTEGER NOT NULL DEFAULT 0, issueNumber INTEGER,
       createdAt INTEGER NOT NULL, updatedAt INTEGER NOT NULL, archivedAt INTEGER)`);
     this.migrateSessionColumns();
+    this.db.run(`CREATE TABLE IF NOT EXISTS session_git_cache (
+      sessionId TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+      gitJson TEXT NOT NULL,
+      updatedAt INTEGER NOT NULL)`);
     this.db.run(`CREATE TABLE IF NOT EXISTS task_seq (
       id INTEGER PRIMARY KEY CHECK (id = 1), next INTEGER NOT NULL)`);
     // Seed once from the high-water mark of existing desigs (TASK-NN) + 1, or 1 on a fresh DB.
@@ -2336,10 +2375,48 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
 
   archive(id: string, reason: SessionArchiveReason = "operator") {
     const now = Date.now();
+    this.db.transaction(() => {
+      this.db.run(
+        `UPDATE sessions SET status='archived', archivedAt=?, archiveReason=?, updatedAt=? WHERE id=? AND status!='archived'`,
+        [now, reason, now, id],
+      );
+      this.deleteSessionGitCache(id);
+    })();
+  }
+
+  putSessionGitCache(sessionId: string, state: GitState): void {
     this.db.run(
-      `UPDATE sessions SET status='archived', archivedAt=?, archiveReason=?, updatedAt=? WHERE id=? AND status!='archived'`,
-      [now, reason, now, id],
+      `INSERT INTO session_git_cache (sessionId, gitJson, updatedAt) VALUES (?, ?, ?)
+       ON CONFLICT(sessionId) DO UPDATE SET gitJson=excluded.gitJson, updatedAt=excluded.updatedAt`,
+      [sessionId, JSON.stringify(state), Date.now()],
     );
+  }
+
+  listSessionGitCache(): Record<string, GitState> {
+    const rows = this.db
+      .query(
+        `SELECT c.sessionId, c.gitJson, s.status
+         FROM session_git_cache c JOIN sessions s ON s.id = c.sessionId`,
+      )
+      .all() as { sessionId: string; gitJson: string; status: string }[];
+    const result: Record<string, GitState> = {};
+    const invalid: string[] = [];
+    for (const row of rows) {
+      const state = parsePersistedGitState(row.gitJson);
+      if (row.status === "archived" || !state) invalid.push(row.sessionId);
+      else result[row.sessionId] = state;
+    }
+    if (invalid.length > 0) {
+      const remove = this.db.query(`DELETE FROM session_git_cache WHERE sessionId = ?`);
+      this.db.transaction(() => {
+        for (const sessionId of invalid) remove.run(sessionId);
+      })();
+    }
+    return result;
+  }
+
+  deleteSessionGitCache(sessionId: string): void {
+    this.db.run(`DELETE FROM session_git_cache WHERE sessionId = ?`, [sessionId]);
   }
 
   unarchive(id: string) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -79,6 +79,10 @@ function safeJsonArray(raw: string | null | undefined): string[] {
   return Array.isArray(v) ? v.filter((s): s is string => typeof s === "string") : [];
 }
 
+const PERSISTED_GIT_KINDS = new Set<unknown>(["github", "gitea", "local"]);
+const PERSISTED_PR_STATES = new Set<unknown>(["none", "open", "merged", "closed"]);
+const PERSISTED_CHECK_STATES = new Set<unknown>(["none", "pending", "success", "failure"]);
+
 function parsePersistedGitState(raw: string): GitState | null {
   let value: unknown;
   try {
@@ -88,21 +92,9 @@ function parsePersistedGitState(raw: string): GitState | null {
   }
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   const state = value as Record<string, unknown>;
-  if (state.kind !== "github" && state.kind !== "gitea" && state.kind !== "local") return null;
-  if (
-    state.state !== "none" &&
-    state.state !== "open" &&
-    state.state !== "merged" &&
-    state.state !== "closed"
-  )
-    return null;
-  if (
-    state.checks !== "none" &&
-    state.checks !== "pending" &&
-    state.checks !== "success" &&
-    state.checks !== "failure"
-  )
-    return null;
+  if (!PERSISTED_GIT_KINDS.has(state.kind)) return null;
+  if (!PERSISTED_PR_STATES.has(state.state)) return null;
+  if (!PERSISTED_CHECK_STATES.has(state.checks)) return null;
   if (typeof state.deployConfigured !== "boolean") return null;
   if (state.state === "none") {
     if (state.number !== undefined) return null;

--- a/src/store.ts
+++ b/src/store.ts
@@ -82,16 +82,118 @@ function safeJsonArray(raw: string | null | undefined): string[] {
 const PERSISTED_GIT_KINDS = new Set<unknown>(["github", "gitea", "local"]);
 const PERSISTED_PR_STATES = new Set<unknown>(["none", "open", "merged", "closed"]);
 const PERSISTED_CHECK_STATES = new Set<unknown>(["none", "pending", "success", "failure"]);
+const PERSISTED_MERGE_STATES = new Set<unknown>([
+  "behind",
+  "blocked",
+  "clean",
+  "dirty",
+  "draft",
+  "has_hooks",
+  "unknown",
+  "unstable",
+]);
+const PERSISTED_REVIEW_STATES = new Set<unknown>(["approved", "changes_requested", "commented"]);
 
-function parsePersistedGitState(raw: string): GitState | null {
-  let value: unknown;
+type FlatOptionalGitField = Exclude<
+  keyof GitState,
+  | "kind"
+  | "state"
+  | "checks"
+  | "deployConfigured"
+  | "number"
+  | "latestReview"
+  | "reviewerStates"
+  | "reviewBlock"
+>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function isWebUrl(value: unknown): value is string {
+  if (typeof value !== "string") return false;
   try {
-    value = JSON.parse(raw);
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
   } catch {
-    return null;
+    return false;
   }
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  const state = value as Record<string, unknown>;
+}
+
+const FLAT_OPTIONAL_GIT_FIELDS = {
+  url: isWebUrl,
+  title: (value: unknown) => typeof value === "string",
+  createdAt: isFiniteNumber,
+  mergeable: (value: unknown) => value === null || typeof value === "boolean",
+  runningChecks: isStringArray,
+  headSha: (value: unknown) => typeof value === "string",
+  requestedReviewers: isStringArray,
+  isDraft: (value: unknown) => typeof value === "boolean",
+  mergeStateStatus: (value: unknown) => PERSISTED_MERGE_STATES.has(value),
+  baseRefName: (value: unknown) => typeof value === "string",
+  noCi: (value: unknown) => typeof value === "boolean",
+  handoff: (value: unknown) => value === "reviewer" || value === "merger",
+  handoffWho: (value: unknown) => typeof value === "string",
+  handoffInferred: (value: unknown) => typeof value === "boolean",
+  issueUrl: isWebUrl,
+} satisfies Record<FlatOptionalGitField, (value: unknown) => boolean>;
+
+function parsePersistedLatestReview(value: unknown): GitState["latestReview"] | null {
+  if (
+    !isRecord(value) ||
+    !PERSISTED_REVIEW_STATES.has(value.state) ||
+    typeof value.author !== "string" ||
+    !isFiniteNumber(value.submittedAt)
+  )
+    return null;
+  return {
+    state: value.state as NonNullable<GitState["latestReview"]>["state"],
+    author: value.author,
+    submittedAt: value.submittedAt,
+  };
+}
+
+function parsePersistedReviewerStates(value: unknown): GitState["reviewerStates"] | null {
+  if (!isRecord(value)) return null;
+  const reviewers: Array<[string, NonNullable<GitState["reviewerStates"]>[string]]> = [];
+  for (const [reviewer, review] of Object.entries(value)) {
+    if (
+      !isRecord(review) ||
+      !PERSISTED_REVIEW_STATES.has(review.state) ||
+      (review.latestAt !== null && !isFiniteNumber(review.latestAt))
+    )
+      return null;
+    reviewers.push([
+      reviewer,
+      {
+        state: review.state as NonNullable<GitState["reviewerStates"]>[string]["state"],
+        latestAt: review.latestAt,
+      },
+    ]);
+  }
+  return Object.fromEntries(reviewers);
+}
+
+function parsePersistedReviewBlock(value: unknown): GitState["reviewBlock"] | null {
+  if (
+    !isRecord(value) ||
+    typeof value.reviewer !== "string" ||
+    value.state !== "changes_requested" ||
+    (value.latestAt !== null && !isFiniteNumber(value.latestAt))
+  )
+    return null;
+  return { reviewer: value.reviewer, state: "changes_requested", latestAt: value.latestAt };
+}
+
+function parsePersistedGitCore(state: Record<string, unknown>): GitState | null {
   if (!PERSISTED_GIT_KINDS.has(state.kind)) return null;
   if (!PERSISTED_PR_STATES.has(state.state)) return null;
   if (!PERSISTED_CHECK_STATES.has(state.checks)) return null;
@@ -101,8 +203,57 @@ function parsePersistedGitState(raw: string): GitState | null {
   } else if (!Number.isInteger(state.number) || (state.number as number) <= 0) {
     return null;
   }
-  if (state.headSha !== undefined && typeof state.headSha !== "string") return null;
-  return state as unknown as GitState;
+  const result: GitState = {
+    kind: state.kind as GitState["kind"],
+    state: state.state as GitState["state"],
+    checks: state.checks as GitState["checks"],
+    deployConfigured: state.deployConfigured,
+  };
+  if (state.number !== undefined) result.number = state.number as number;
+  return result;
+}
+
+function applyPersistedFlatGitFields(state: Record<string, unknown>, result: GitState): boolean {
+  for (const field of Object.keys(FLAT_OPTIONAL_GIT_FIELDS) as FlatOptionalGitField[]) {
+    const fieldValue = state[field];
+    if (fieldValue === undefined) continue;
+    if (!FLAT_OPTIONAL_GIT_FIELDS[field](fieldValue)) return false;
+    Object.assign(result, { [field]: fieldValue });
+  }
+  return true;
+}
+
+function parsePersistedGitState(raw: string): GitState | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!isRecord(value)) return null;
+  const state = value;
+  const result = parsePersistedGitCore(state);
+  if (!result || !applyPersistedFlatGitFields(state, result)) return null;
+
+  if (state.latestReview !== undefined) {
+    const latestReview = parsePersistedLatestReview(state.latestReview);
+    if (!latestReview) return null;
+    result.latestReview = latestReview;
+  }
+
+  if (state.reviewerStates !== undefined) {
+    const reviewerStates = parsePersistedReviewerStates(state.reviewerStates);
+    if (!reviewerStates) return null;
+    result.reviewerStates = reviewerStates;
+  }
+
+  if (state.reviewBlock !== undefined) {
+    const reviewBlock = parsePersistedReviewBlock(state.reviewBlock);
+    if (!reviewBlock) return null;
+    result.reviewBlock = reviewBlock;
+  }
+
+  return result;
 }
 
 /** Tolerantly parse the persisted findings JSON back to a string[] (never throws). */

--- a/test/pr-poller.test.ts
+++ b/test/pr-poller.test.ts
@@ -170,8 +170,46 @@ test("snapshot/set/drop manage the cache", async () => {
 
   poller.set(s.id, { ...NONE, kind: "github" });
   expect(poller.snapshot()[s.id]?.state).toBe("none");
+  expect(store.listSessionGitCache()[s.id]?.state).toBe("none");
   poller.drop(s.id);
   expect(poller.snapshot()[s.id]).toBeUndefined();
+  expect(store.listSessionGitCache()[s.id]).toBeUndefined();
+});
+
+test("restart hydrates prior PR identity and accepts its unreachable terminal transition", async () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  let cur: PrStatus = OPEN;
+  const beforeRestart = new PrPoller(
+    store,
+    () => forgeReturning(() => cur),
+    () => {},
+  );
+  await beforeRestart.tick();
+  expect(store.listSessionGitCache()[s.id]?.state).toBe("open");
+
+  cur = {
+    state: "merged",
+    number: 7,
+    checks: "success",
+    headSha: "remote-final-head",
+    deployConfigured: false,
+  };
+  const afterRestart = new PrPoller(
+    store,
+    () => forgeReturning(() => cur),
+    () => {},
+    120_000,
+    1000,
+    () => null,
+    15_000,
+    () => false,
+  );
+
+  expect(afterRestart.snapshot()[s.id]?.state).toBe("open");
+  await afterRestart.tick();
+  expect(afterRestart.snapshot()[s.id]).toMatchObject({ state: "merged", number: 7 });
+  expect(store.listSessionGitCache()[s.id]).toMatchObject({ state: "merged", number: 7 });
 });
 
 test("re-emits when checks or head SHA change on the same PR", async () => {

--- a/test/pr-poller.test.ts
+++ b/test/pr-poller.test.ts
@@ -159,6 +159,36 @@ test("keeps the last cached value when prStatus throws", async () => {
   expect(poller.snapshot()[s.id]?.state).toBe("open");
 });
 
+test("does not restore or emit git state when a session is archived during its poll", async () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  let markStarted!: () => void;
+  let resolveStatus!: (status: PrStatus) => void;
+  const started = new Promise<void>((resolve) => (markStarted = resolve));
+  const status = new Promise<PrStatus>((resolve) => (resolveStatus = resolve));
+  const forge = forgeReturning(() => OPEN);
+  forge.prStatus = async () => {
+    markStarted();
+    return status;
+  };
+  const emitted: GitState[] = [];
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    (_id, git) => emitted.push(git),
+  );
+
+  const tick = poller.tick();
+  await started;
+  store.archive(s.id);
+  resolveStatus(OPEN);
+  await tick;
+
+  expect(store.listSessionGitCache()[s.id]).toBeUndefined();
+  expect(poller.snapshot()[s.id]).toBeUndefined();
+  expect(emitted).toEqual([]);
+});
+
 test("snapshot/set/drop manage the cache", async () => {
   const store = new SessionStore(":memory:");
   const s = store.create(baseSession);

--- a/test/server-git.test.ts
+++ b/test/server-git.test.ts
@@ -1,12 +1,12 @@
 import { test, expect } from "bun:test";
 import { makeApp, type AppDeps } from "../src/server";
-import type { SessionStore } from "../src/store";
+import { SessionStore } from "../src/store";
 import type { SessionService } from "../src/service";
 import type { EventHub } from "../src/events";
 import type { Session } from "../src/types";
 import type { GitForge, GitState, MergeMethod, PrStatus } from "../src/forge/types";
 import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
-import type { PrCache } from "../src/pr-poller";
+import { PrPoller, type PrCache } from "../src/pr-poller";
 
 const ORIGIN = "http://localhost";
 
@@ -506,6 +506,46 @@ test("GET /api/git returns the prCache snapshot", async () => {
   const res = await app.fetch(new Request("http://localhost/api/git"));
   expect(res.status).toBe(200);
   expect(await res.json()).toEqual({});
+});
+
+test("GET /api/git returns the startup-hydrated persisted snapshot without forge calls", async () => {
+  const store = new SessionStore(":memory:");
+  const session = store.create({
+    name: "cached",
+    prompt: "cached git state",
+    repoPath: "/repo",
+    baseBranch: "main",
+    branch: "shepherd/cached",
+    worktreePath: "/wt/cached",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "cached-agent",
+  });
+  const cached: GitState = {
+    kind: "github",
+    state: "open",
+    number: 7,
+    checks: "pending",
+    deployConfigured: false,
+  };
+  store.putSessionGitCache(session.id, cached);
+  let forgeCalls = 0;
+  const poller = new PrPoller(
+    store,
+    () => {
+      forgeCalls++;
+      return fakeForge();
+    },
+    () => {},
+  );
+  const deps = Object.assign(makeDeps(fakeForge()), { store, prCache: poller });
+  const app = makeApp(deps);
+
+  const res = await app.fetch(new Request("http://localhost/api/git"));
+
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ [session.id]: cached });
+  expect(forgeCalls).toBe(0);
 });
 
 test("GET git trusts a merged PR when cache already showed it open (signal b)", async () => {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -6669,9 +6669,9 @@ test("relaunch tears down the just-created session if a post-create step throws 
     expect(store.get(replacementId)?.status).toBe("archived");
     const db = new Database(path);
     expect(
-      db.query(`SELECT COUNT(*) AS count FROM session_git_cache WHERE sessionId = ?`).get(
-        replacementId,
-      ),
+      db
+        .query(`SELECT COUNT(*) AS count FROM session_git_cache WHERE sessionId = ?`)
+        .get(replacementId),
     ).toEqual({ count: 0 });
     db.close();
     // the new agent was stopped during teardown

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -10,6 +10,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Database } from "bun:sqlite";
 import { shepherdRuntimeDir } from "../src/runtime-dir";
 import { SessionStore } from "../src/store";
 import {
@@ -6030,8 +6031,9 @@ function relaunchHarness(
     failStart = true;
   };
   // Make the post-create override step throw (called only after seeding the original).
-  const breakOverride = () => {
-    store.setAutopilotState = () => {
+  const breakOverride = (beforeThrow?: (sessionId: string) => void) => {
+    store.setAutopilotState = (sessionId: string) => {
+      beforeThrow?.(sessionId);
       throw new Error("override write failed");
     };
   };
@@ -6639,21 +6641,45 @@ test("replaceAgent re-attaches existing uploads without copying them back into t
 });
 
 test("relaunch tears down the just-created session if a post-create step throws (no orphan)", async () => {
-  const store = new SessionStore(":memory:");
-  const { service, calls, breakOverride } = relaunchHarness(store);
-  const orig = originalSession(store);
-  const before = store.list().length;
-  breakOverride();
+  const dir = mkdtempSync(join(tmpdir(), "relaunch-cleanup-"));
+  const path = join(dir, "state.db");
+  try {
+    const store = new SessionStore(path);
+    const { service, calls, breakOverride } = relaunchHarness(store);
+    const orig = originalSession(store);
+    const before = store.list().length;
+    let replacementId = "";
+    breakOverride((sessionId) => {
+      replacementId = sessionId;
+      store.putSessionGitCache(sessionId, {
+        kind: "github",
+        state: "open",
+        number: 7,
+        checks: "pending",
+        deployConfigured: false,
+      });
+    });
 
-  await expect(service.relaunch(orig.id)).rejects.toThrow("override write failed");
+    await expect(service.relaunch(orig.id)).rejects.toThrow("override write failed");
 
-  // no orphaned new session left active in the store (only the original remains)
-  const active = store.list().filter((s) => s.status !== "archived");
-  expect(active.map((s) => s.id)).toEqual([orig.id]);
-  expect(store.list().length).toBe(before + 1); // the new row exists but is archived
-  // the new agent was stopped during teardown
-  expect(calls.stopped).toHaveLength(1);
-  expect(calls.stopped[0]).not.toBe("term_orig");
+    // no orphaned new session left active in the store (only the original remains)
+    const active = store.list().filter((s) => s.status !== "archived");
+    expect(active.map((s) => s.id)).toEqual([orig.id]);
+    expect(store.list().length).toBe(before + 1); // the new row exists but is archived
+    expect(store.get(replacementId)?.status).toBe("archived");
+    const db = new Database(path);
+    expect(
+      db.query(`SELECT COUNT(*) AS count FROM session_git_cache WHERE sessionId = ?`).get(
+        replacementId,
+      ),
+    ).toEqual({ count: 0 });
+    db.close();
+    // the new agent was stopped during teardown
+    expect(calls.stopped).toHaveLength(1);
+    expect(calls.stopped[0]).not.toBe("term_orig");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("relaunch overrides apply repo/baseBranch/prompt/model/plan-gate/Autopilot over the original", async () => {

--- a/test/session-git-cache.test.ts
+++ b/test/session-git-cache.test.ts
@@ -83,6 +83,104 @@ test("session git cache rejects and deletes structurally invalid JSON objects", 
   });
 });
 
+test("session git cache validates every optional GitState field before hydration", () => {
+  withFileStore((store, path) => {
+    const invalidFields: Array<[string, unknown]> = [
+      ["url", "javascript:alert(1)"],
+      ["title", 7],
+      ["createdAt", "now"],
+      ["mergeable", "yes"],
+      ["runningChecks", ["verify", 7]],
+      ["headSha", 7],
+      ["latestReview", { state: "approved", author: "scoop", submittedAt: "now" }],
+      ["reviewerStates", { scoop: { state: "approved", latestAt: "now" } }],
+      ["requestedReviewers", ["scoop", 7]],
+      ["isDraft", "yes"],
+      ["mergeStateStatus", "ready"],
+      ["baseRefName", 7],
+      ["noCi", "yes"],
+      ["handoff", "operator"],
+      ["handoffWho", 7],
+      ["handoffInferred", "yes"],
+      ["reviewBlock", { reviewer: "scoop", state: "approved", latestAt: 1 }],
+      ["issueUrl", "data:text/html,bad"],
+    ];
+    const db = new Database(path);
+    for (const [index, [field, invalidValue]] of invalidFields.entries()) {
+      const session = store.create({
+        ...base,
+        name: `invalid-${field}`,
+        branch: `shepherd/invalid-${index}`,
+        herdrAgentId: `term_invalid_${index}`,
+      });
+      db.run(`INSERT INTO session_git_cache (sessionId, gitJson, updatedAt) VALUES (?, ?, ?)`, [
+        session.id,
+        JSON.stringify({
+          kind: "github",
+          state: "open",
+          number: 7,
+          checks: "pending",
+          deployConfigured: false,
+          [field]: invalidValue,
+        }),
+        Date.now(),
+      ]);
+    }
+
+    expect(store.listSessionGitCache()).toEqual({});
+    expect(db.query(`SELECT COUNT(*) AS count FROM session_git_cache`).get()).toEqual({ count: 0 });
+    db.close();
+  });
+});
+
+test("session git cache preserves valid optional fields and strips unknown fields", () => {
+  withFileStore((store, path) => {
+    const session = store.create(base);
+    const db = new Database(path);
+    const expected: GitState = {
+      kind: "github",
+      state: "open",
+      number: 7,
+      url: "https://github.com/acme/repo/pull/7",
+      title: "Persisted PR",
+      createdAt: 1,
+      mergeable: null,
+      checks: "pending",
+      runningChecks: ["verify"],
+      headSha: "abc123",
+      latestReview: { state: "approved", author: "scoop", submittedAt: 2 },
+      reviewerStates: { scoop: { state: "changes_requested", latestAt: null } },
+      requestedReviewers: ["scoop"],
+      isDraft: true,
+      mergeStateStatus: "blocked",
+      baseRefName: "main",
+      deployConfigured: true,
+      noCi: false,
+      handoff: "reviewer",
+      handoffWho: "scoop",
+      handoffInferred: true,
+      reviewBlock: { reviewer: "scoop", state: "changes_requested", latestAt: 3 },
+      issueUrl: "http://gitea.local/acme/repo/issues/9",
+    };
+    db.run(`INSERT INTO session_git_cache (sessionId, gitJson, updatedAt) VALUES (?, ?, ?)`, [
+      session.id,
+      JSON.stringify({
+        ...expected,
+        latestReview: { ...expected.latestReview, unknown: "discard me" },
+        reviewerStates: {
+          scoop: { ...expected.reviewerStates?.scoop, unknown: "discard me" },
+        },
+        reviewBlock: { ...expected.reviewBlock, unknown: "discard me" },
+        unknown: "discard me",
+      }),
+      Date.now(),
+    ]);
+
+    expect(store.listSessionGitCache()).toEqual({ [session.id]: expected });
+    db.close();
+  });
+});
+
 test("archive atomically removes the session git cache row", () => {
   withFileStore((store, path) => {
     const session = store.create(base);

--- a/test/session-git-cache.test.ts
+++ b/test/session-git-cache.test.ts
@@ -1,0 +1,113 @@
+import { expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { GitState } from "../src/forge/types";
+import { SessionStore } from "../src/store";
+
+const base = {
+  name: "cached-git",
+  prompt: "persist git state",
+  repoPath: "/repo",
+  baseBranch: "main",
+  branch: "shepherd/cached-git",
+  worktreePath: "/repo-wt",
+  isolated: true,
+  herdrSession: "default",
+  herdrAgentId: "term_git_cache",
+};
+
+function withFileStore(run: (store: SessionStore, path: string) => void): void {
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-git-cache-"));
+  const path = join(dir, "state.db");
+  try {
+    run(new SessionStore(path), path);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("session git cache round-trips open and none states", () => {
+  withFileStore((store, path) => {
+    const openSession = store.create(base);
+    const noneSession = store.create({
+      ...base,
+      name: "no-pr",
+      branch: "shepherd/no-pr",
+      herdrAgentId: "term_no_pr",
+    });
+    const open: GitState = {
+      kind: "github",
+      state: "open",
+      number: 7,
+      checks: "pending",
+      deployConfigured: false,
+      headSha: "abc123",
+    };
+    const none: GitState = {
+      kind: "github",
+      state: "none",
+      checks: "none",
+      deployConfigured: false,
+    };
+
+    store.putSessionGitCache(openSession.id, open);
+    store.putSessionGitCache(noneSession.id, none);
+
+    const reopened = new SessionStore(path);
+    expect(reopened.listSessionGitCache()).toEqual({
+      [openSession.id]: open,
+      [noneSession.id]: none,
+    });
+  });
+});
+
+test("session git cache rejects and deletes structurally invalid JSON objects", () => {
+  withFileStore((store, path) => {
+    const session = store.create(base);
+    const db = new Database(path);
+    db.run(
+      `INSERT INTO session_git_cache (sessionId, gitJson, updatedAt) VALUES (?, ?, ?)`,
+      [
+        session.id,
+        JSON.stringify({ kind: "github", number: 7, checks: "success", deployConfigured: false }),
+        Date.now(),
+      ],
+    );
+
+    expect(store.listSessionGitCache()).toEqual({});
+    expect(
+      db.query(`SELECT COUNT(*) AS count FROM session_git_cache WHERE sessionId = ?`).get(
+        session.id,
+      ),
+    ).toEqual({ count: 0 });
+    db.close();
+  });
+});
+
+test("archive atomically removes the session git cache row", () => {
+  withFileStore((store, path) => {
+    const session = store.create(base);
+    store.putSessionGitCache(session.id, {
+      kind: "github",
+      state: "open",
+      number: 7,
+      checks: "success",
+      deployConfigured: false,
+    });
+
+    store.archive(session.id);
+
+    expect(store.get(session.id)?.status).toBe("archived");
+    expect(store.pruneArchivedSessions({ maxAgeMs: -1, keepNewest: 0 })).toBe(1);
+    expect(store.get(session.id)).toBeNull();
+    const db = new Database(path);
+    expect(
+      db.query(`SELECT COUNT(*) AS count FROM session_git_cache WHERE sessionId = ?`).get(
+        session.id,
+      ),
+    ).toEqual({ count: 0 });
+    db.close();
+  });
+});

--- a/test/session-git-cache.test.ts
+++ b/test/session-git-cache.test.ts
@@ -67,20 +67,17 @@ test("session git cache rejects and deletes structurally invalid JSON objects", 
   withFileStore((store, path) => {
     const session = store.create(base);
     const db = new Database(path);
-    db.run(
-      `INSERT INTO session_git_cache (sessionId, gitJson, updatedAt) VALUES (?, ?, ?)`,
-      [
-        session.id,
-        JSON.stringify({ kind: "github", number: 7, checks: "success", deployConfigured: false }),
-        Date.now(),
-      ],
-    );
+    db.run(`INSERT INTO session_git_cache (sessionId, gitJson, updatedAt) VALUES (?, ?, ?)`, [
+      session.id,
+      JSON.stringify({ kind: "github", number: 7, checks: "success", deployConfigured: false }),
+      Date.now(),
+    ]);
 
     expect(store.listSessionGitCache()).toEqual({});
     expect(
-      db.query(`SELECT COUNT(*) AS count FROM session_git_cache WHERE sessionId = ?`).get(
-        session.id,
-      ),
+      db
+        .query(`SELECT COUNT(*) AS count FROM session_git_cache WHERE sessionId = ?`)
+        .get(session.id),
     ).toEqual({ count: 0 });
     db.close();
   });
@@ -104,9 +101,9 @@ test("archive atomically removes the session git cache row", () => {
     expect(store.get(session.id)).toBeNull();
     const db = new Database(path);
     expect(
-      db.query(`SELECT COUNT(*) AS count FROM session_git_cache WHERE sessionId = ?`).get(
-        session.id,
-      ),
+      db
+        .query(`SELECT COUNT(*) AS count FROM session_git_cache WHERE sessionId = ?`)
+        .get(session.id),
     ).toEqual({ count: 0 });
     db.close();
   });

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -1,9 +1,27 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { fetchCodexReleaseNotes, getCommands } from "./api";
+import { fetchCodexReleaseNotes, getBuildQueues, getCommands } from "./api";
 
 vi.mock("$lib/auth.svelte", () => ({
   auth: { unauthenticated: false, checked: false },
 }));
+
+describe("getBuildQueues", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("requests the bulk queue snapshot", async () => {
+    const queues = { s1: { sessionId: "s1", approved: true, steps: [] } };
+    const fetchMock = vi.fn(async () => Response.json(queues));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(getBuildQueues()).resolves.toEqual(queues);
+    expect(fetchMock).toHaveBeenCalledWith("/api/queues");
+  });
+});
 
 describe("getCommands", () => {
   const originalFetch = globalThis.fetch;

--- a/ui/src/lib/build-queue-bootstrap.test.ts
+++ b/ui/src/lib/build-queue-bootstrap.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { bootstrapBuildQueues } from "./build-queue-bootstrap";
+import { buildQueues } from "./buildQueues.svelte";
+import { HerdStore } from "./store.svelte";
+import type { BuildQueue } from "./types";
+
+const queue: BuildQueue = {
+  sessionId: "s1",
+  approved: true,
+  steps: [{ id: "s1", title: "Done", status: "done", position: 0 }],
+};
+
+afterEach(() => {
+  buildQueues.map = {};
+  vi.restoreAllMocks();
+});
+
+it("hydrates the HerdStore and badge singleton from the cold queue snapshot", async () => {
+  const store = new HerdStore();
+  const snapshot = { s1: queue };
+  const getBuildQueues = vi.fn(async () => snapshot);
+  const setBuildQueues = vi.spyOn(store, "setBuildQueues");
+
+  await bootstrapBuildQueues({
+    getBuildQueues,
+    setBuildQueues: (queues) => store.setBuildQueues(queues),
+  });
+
+  expect(getBuildQueues).toHaveBeenCalledOnce();
+  expect(setBuildQueues).toHaveBeenCalledWith(snapshot);
+  expect(store.buildQueues).toEqual(snapshot);
+  expect(buildQueues.map).toEqual(snapshot);
+});

--- a/ui/src/lib/build-queue-bootstrap.test.ts
+++ b/ui/src/lib/build-queue-bootstrap.test.ts
@@ -23,11 +23,41 @@ it("hydrates the HerdStore and badge singleton from the cold queue snapshot", as
 
   await bootstrapBuildQueues({
     getBuildQueues,
-    setBuildQueues: (queues) => store.setBuildQueues(queues),
+    getBuildQueueRevision: () => store.getBuildQueueRevision(),
+    setBuildQueues: (queues, revision) => store.setBuildQueues(queues, revision),
   });
 
   expect(getBuildQueues).toHaveBeenCalledOnce();
-  expect(setBuildQueues).toHaveBeenCalledWith(snapshot);
+  expect(setBuildQueues).toHaveBeenCalledWith(snapshot, 0);
   expect(store.buildQueues).toEqual(snapshot);
   expect(buildQueues.map).toEqual(snapshot);
+});
+
+it("preserves a live queue update received while the snapshot is in flight", async () => {
+  const store = new HerdStore();
+  const staleQueue = { ...queue, approved: false };
+  const liveQueue = {
+    ...queue,
+    steps: [{ ...queue.steps[0]!, title: "Live", status: "active" as const }],
+  };
+  const otherQueue = { ...queue, sessionId: "s2" };
+  let resolveSnapshot!: (snapshot: Record<string, BuildQueue>) => void;
+  const getBuildQueues = vi.fn(
+    () =>
+      new Promise<Record<string, BuildQueue>>((resolve) => {
+        resolveSnapshot = resolve;
+      }),
+  );
+
+  const hydration = bootstrapBuildQueues({
+    getBuildQueues,
+    getBuildQueueRevision: () => store.getBuildQueueRevision(),
+    setBuildQueues: (snapshot, revision) => store.setBuildQueues(snapshot, revision),
+  });
+  store.setBuildQueue(liveQueue);
+  resolveSnapshot({ s1: staleQueue, s2: otherQueue });
+  await hydration;
+
+  expect(store.buildQueues).toEqual({ s1: liveQueue, s2: otherQueue });
+  expect(buildQueues.map).toEqual({ s1: liveQueue, s2: otherQueue });
 });

--- a/ui/src/lib/build-queue-bootstrap.ts
+++ b/ui/src/lib/build-queue-bootstrap.ts
@@ -1,0 +1,10 @@
+import type { BuildQueue } from "./types";
+
+interface BuildQueueBootstrapDeps {
+  getBuildQueues: () => Promise<Record<string, BuildQueue>>;
+  setBuildQueues: (queues: Record<string, BuildQueue>) => void;
+}
+
+export async function bootstrapBuildQueues(deps: BuildQueueBootstrapDeps): Promise<void> {
+  deps.setBuildQueues(await deps.getBuildQueues());
+}

--- a/ui/src/lib/build-queue-bootstrap.ts
+++ b/ui/src/lib/build-queue-bootstrap.ts
@@ -2,9 +2,11 @@ import type { BuildQueue } from "./types";
 
 interface BuildQueueBootstrapDeps {
   getBuildQueues: () => Promise<Record<string, BuildQueue>>;
-  setBuildQueues: (queues: Record<string, BuildQueue>) => void;
+  getBuildQueueRevision: () => number;
+  setBuildQueues: (queues: Record<string, BuildQueue>, preserveAfterRevision: number) => void;
 }
 
 export async function bootstrapBuildQueues(deps: BuildQueueBootstrapDeps): Promise<void> {
-  deps.setBuildQueues(await deps.getBuildQueues());
+  const revision = deps.getBuildQueueRevision();
+  deps.setBuildQueues(await deps.getBuildQueues(), revision);
 }

--- a/ui/src/lib/buildQueues.svelte.ts
+++ b/ui/src/lib/buildQueues.svelte.ts
@@ -4,7 +4,7 @@ import { setKey } from "./safe-keys";
 /** Module-level reactive build-queue map keyed by sessionId.
  *  Driven by two sources:
  *  - WS `queue:update` events (via HerdStore.apply → upsertBuildQueue)
- *  - The resync bootstrap GET /api/queues (via seedBuildQueues)
+ *  - Cold-start and resync GET /api/queues snapshots (via seed)
  *  Components (e.g. BuildQueueBadge) read from this directly by sessionId
  *  without needing the page-local HerdStore instance as a prop. */
 class BuildQueuesStore {

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -153,6 +153,8 @@ export class HerdStore {
   /** Live build queue keyed by sessionId; bootstrapped via GET /api/sessions/:id/queue,
    *  updated in real-time by the `queue:update` WS event. */
   buildQueues = $state<Record<string, BuildQueue>>({});
+  private buildQueueRevision = 0;
+  private buildQueueRevisions = new SvelteMap<string, number>();
   /** Live epic state keyed by `${repoPath}#${parentIssueNumber}`;
    *  updated in real-time by the `epic:update` WS event. */
   epics = $state<Record<string, Epic>>({});
@@ -271,15 +273,30 @@ export class HerdStore {
   }
   /** Seed (or replace) the build queue for a session — called after a bootstrap GET. */
   setBuildQueue(q: BuildQueue) {
-    // Guarded even though CodeQL flags only the `queue:update` twin below: same map, same key
-    // shape, same form — leaving this open would be a bypass sitting beside the guard.
+    if (!SAFE_ID.test(q.sessionId)) return;
+    this.buildQueueRevision++;
+    this.buildQueueRevisions.set(q.sessionId, this.buildQueueRevision);
     this.buildQueues = setKey(this.buildQueues, q.sessionId, q);
     buildQueuesStore.upsert(q);
   }
-  /** Bulk-replace the build queue map — called after a bootstrap GET /api/queues. */
-  setBuildQueues(map: Record<string, BuildQueue>) {
-    this.buildQueues = map;
-    buildQueuesStore.seed(map);
+  getBuildQueueRevision(): number {
+    return this.buildQueueRevision;
+  }
+  /** Replace the queue snapshot while retaining per-session updates newer than the request. */
+  setBuildQueues(map: Record<string, BuildQueue>, preserveAfterRevision = this.buildQueueRevision) {
+    let next = map;
+    for (const [sessionId, revision] of this.buildQueueRevisions) {
+      const current = this.buildQueues[sessionId];
+      if (revision > preserveAfterRevision && current) next = setKey(next, sessionId, current);
+    }
+    this.buildQueues = next;
+    this.buildQueueRevisions = new SvelteMap(
+      Object.keys(next).map((sessionId) => [
+        sessionId,
+        Math.max(preserveAfterRevision, this.buildQueueRevisions.get(sessionId) ?? 0),
+      ]),
+    );
+    buildQueuesStore.seed(next);
   }
   /** Upsert an epic — called after GET/PUT /api/epic or on `epic:update` WS push.
    *  FINISHED epics (idle + every child merged — the drain's own auto-complete
@@ -865,8 +882,7 @@ export class HerdStore {
         this.autoMerge = setPathKey(this.autoMerge, ev.data.repoPath, ev.data);
         break;
       case "queue:update":
-        this.buildQueues = setKey(this.buildQueues, ev.data.sessionId, ev.data);
-        buildQueuesStore.upsert(ev.data);
+        this.setBuildQueue(ev.data);
         break;
       case "session:epic-draft":
         epicDraftsStore.upsert(ev.data);

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -276,7 +276,7 @@ export class HerdStore {
     this.buildQueues = setKey(this.buildQueues, q.sessionId, q);
     buildQueuesStore.upsert(q);
   }
-  /** Bulk-replace the build queue map — called after a resync GET /api/queues. */
+  /** Bulk-replace the build queue map — called after a bootstrap GET /api/queues. */
   setBuildQueues(map: Record<string, BuildQueue>) {
     this.buildQueues = map;
     buildQueuesStore.seed(map);

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -6,6 +6,7 @@
   import { onMount, tick, untrack } from "svelte";
   import { MediaQuery, SvelteSet } from "svelte/reactivity";
   import { HerdStore } from "$lib/store.svelte";
+  import { bootstrapBuildQueues } from "$lib/build-queue-bootstrap";
   import type { SettingsSectionId } from "$lib/settings-search";
   import { createTabSignal, deriveTabState } from "$lib/tab-signal.svelte";
   import { tabTicker } from "$lib/tab-ticker.svelte";
@@ -844,6 +845,13 @@
       .catch(() => {});
   }
 
+  function refreshBuildQueues() {
+    bootstrapBuildQueues({
+      getBuildQueues,
+      setBuildQueues: (queues) => store.setBuildQueues(queues),
+    }).catch(() => {});
+  }
+
   // Wake + socket-reopen typically coincide (a frozen tab kills the socket), which
   // would fire resync() twice back-to-back. The guard swallows the duplicate on the
   // visibility/pageshow path only; the socket-open caller passes force:true and must
@@ -893,9 +901,7 @@
     getBacklog()
       .then((p) => (backlog = p))
       .catch(() => {});
-    getBuildQueues()
-      .then((m) => store.setBuildQueues(m))
-      .catch(() => {});
+    refreshBuildQueues();
     // Re-seed completed epics: the epic:completed WS payload carries the bare row WITHOUT the
     // GET-only live landing-gate fields (landingReady/landingChecks/landingMergeable/landingStranded),
     // so only a fetch repopulates them — without this, the "Land epic" CTA reads disabled on wake.
@@ -1732,6 +1738,7 @@
     gitStates()
       .then((m) => store.setGit(m))
       .catch(() => {});
+    refreshBuildQueues();
     activityStates()
       .then((m) => store.setActivity(m))
       .catch(() => {});

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -848,7 +848,8 @@
   function refreshBuildQueues() {
     bootstrapBuildQueues({
       getBuildQueues,
-      setBuildQueues: (queues) => store.setBuildQueues(queues),
+      getBuildQueueRevision: () => store.getBuildQueueRevision(),
+      setBuildQueues: (queues, revision) => store.setBuildQueues(queues, revision),
     }).catch(() => {});
   }
 


### PR DESCRIPTION
## Summary

- hydrate persisted build queues during the initial dashboard bootstrap
- persist structurally validated per-session Git state and seed the PR poller at startup
- invalidate durable Git identity atomically on archive while preserving reused-branch collision protection
- cover restart hydration, archive lifecycle, malformed cache rows, and UI queue bootstrap behavior

## Verification

- bun run lint
- bun run test
- cd ui && bun run check
- cd ui && CI=true bun run test

Closes #1770