### PR TITLE
feat(usage): attribute Codex tokens by role

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,10 +644,7 @@ roadmap.
 
 Sessions are spawned with `claude --session-id <uuid>`, so each TASK maps deterministically to its
 `~/.claude/projects/<cwd>/<uuid>.jsonl`; the Viewport shows live per-session token counts parsed
-from it. Codex totals come from its local state database; Shepherd correlates new role spawns with
-their provider thread IDs and reconciles per-role usage to the authoritative per-model totals, with
-historically unattributable usage reported as Coding. The TopBar's 5h/weekly gauges are calibrated
-once a day by scraping `claude /usage` (driven
+from it. The TopBar's 5h/weekly gauges are calibrated once a day by scraping `claude /usage` (driven
 through an ephemeral interactive session — ToS-pure, no `-p`) to learn the plan ceilings, then the
 `%` is recomputed live from local JSONL between calibrations. No dollar figures (you're on a
 subscription); pricing is used only internally as relative weights for the limit math. Override the

--- a/README.md
+++ b/README.md
@@ -644,7 +644,10 @@ roadmap.
 
 Sessions are spawned with `claude --session-id <uuid>`, so each TASK maps deterministically to its
 `~/.claude/projects/<cwd>/<uuid>.jsonl`; the Viewport shows live per-session token counts parsed
-from it. The TopBar's 5h/weekly gauges are calibrated once a day by scraping `claude /usage` (driven
+from it. Codex totals come from its local state database; Shepherd correlates new role spawns with
+their provider thread IDs and reconciles per-role usage to the authoritative per-model totals, with
+historically unattributable usage reported as Coding. The TopBar's 5h/weekly gauges are calibrated
+once a day by scraping `claude /usage` (driven
 through an ephemeral interactive session — ToS-pure, no `-p`) to learn the plan ceilings, then the
 `%` is recomputed live from local JSONL between calibrations. No dollar figures (you're on a
 subscription); pricing is used only internally as relative weights for the limit math. Override the

--- a/src/codex-session-id.ts
+++ b/src/codex-session-id.ts
@@ -12,8 +12,9 @@
  *    canonical (Shepherd's `safeRepoDir` realpath-resolves repoPath and the worktree joins from it)
  *    and which Codex records canonically. No `realpath` is performed on the candidate cwd — this runs
  *    BEFORE the worktree is re-created at restore time, so the path may not exist on disk.
- *  - `source === "cli"` excludes headless `codex exec` ROLE spawns (recap/critic/reviewer) that can
- *    share a worktree cwd; resuming one of those instead of the interactive session would be wrong.
+ *  - Interactive discovery requires `source === "cli"`. Reviewer discovery explicitly selects
+ *    `source === "exec"` and also requires the row-specific correlation marker in a user message,
+ *    so concurrent role spawns in the same cwd cannot be confused.
  */
 import { closeSync, openSync, readSync } from "node:fs";
 import { normalize } from "node:path";
@@ -26,26 +27,103 @@ interface SessionMetaHeader {
   source: string | null;
 }
 
+export interface CodexSessionDiscoveryOptions {
+  source?: "cli" | "exec";
+  correlationMarker?: string;
+}
+
+export function codexReviewerCorrelationMarker(reviewerSessionId: string): string {
+  return `[SHEPHERD_REVIEWER_SPAWN_ID:${reviewerSessionId}]`;
+}
+
 /**
- * The newest interactive (`source === "cli"`) rollout whose recorded cwd equals `worktreePath`,
- * among rollouts modified at/after `notBeforeMs`; null if none. The scan is UNBOUNDED over that
- * mtime window (callers must not cap it) so a busy machine can't push the target rollout out of view.
+ * The newest rollout with the requested source whose recorded cwd equals `worktreePath`, among
+ * rollouts modified at/after `notBeforeMs`; exec discovery additionally requires its correlation
+ * marker. The scan is UNBOUNDED over that mtime window (callers must not cap it) so a busy machine
+ * can't push the target rollout out of view.
  */
 export function findCodexSessionId(
   worktreePath: string,
   notBeforeMs: number,
   home = codexHome(),
+  options: CodexSessionDiscoveryOptions = {},
 ): string | null {
   const target = normalize(worktreePath);
+  const source = options.source ?? "cli";
+  if (source === "exec" && !options.correlationMarker) return null;
   // listRolloutFiles is newest-first by mtime, so the first cwd+cli match is the newest one — and the
   // first file older than the window means every remaining file is too: stop rather than scan the tail.
   for (const { path, mtimeMs } of listRolloutFiles(home)) {
     if (mtimeMs < notBeforeMs) break;
     const meta = readSessionMeta(path);
-    if (!meta || meta.source !== "cli" || !meta.id) continue;
-    if (normalize(meta.cwd) === target) return meta.id;
+    if (!meta || meta.source !== source || !meta.id) continue;
+    if (normalize(meta.cwd) !== target) continue;
+    if (source === "exec" && !hasMarkedUserMessage(path, options.correlationMarker as string))
+      continue;
+    return meta.id;
   }
   return null;
+}
+
+/** Match the marker only at the start of a user-authored record. Codex may inject its own user
+ *  prelude before the positional exec prompt, so scan user records rather than stopping at the
+ *  first one; assistant/tool output can never satisfy the match. */
+function hasMarkedUserMessage(path: string, marker: string): boolean {
+  const content = readPrefix(path, 1024 * 1024);
+  if (!content) return false;
+  for (const line of content.split("\n").slice(1)) {
+    if (!line) continue;
+    const record = parseRolloutRecord(line);
+    if (record && userMessageText(record)?.startsWith(marker)) return true;
+  }
+  return false;
+}
+
+interface RolloutRecord {
+  type?: unknown;
+  payload?: unknown;
+}
+
+interface RolloutPayload {
+  type?: unknown;
+  role?: unknown;
+  content?: unknown;
+  message?: unknown;
+  text?: unknown;
+}
+
+function parseRolloutRecord(line: string): RolloutRecord | null {
+  try {
+    const record: unknown = JSON.parse(line);
+    return record && typeof record === "object" ? (record as RolloutRecord) : null;
+  } catch {
+    return null;
+  }
+}
+
+function userMessageText(record: RolloutRecord): string | null {
+  if (!record.payload || typeof record.payload !== "object") return null;
+  const payload = record.payload as RolloutPayload;
+  return responseItemUserText(record.type, payload) ?? eventUserText(record.type, payload);
+}
+
+function responseItemUserText(recordType: unknown, payload: RolloutPayload): string | null {
+  if (recordType !== "response_item" || payload.type !== "message" || payload.role !== "user")
+    return null;
+  if (!Array.isArray(payload.content)) return null;
+  return payload.content.map(contentPartText).join("");
+}
+
+function contentPartText(part: unknown): string {
+  if (!part || typeof part !== "object") return "";
+  const text = (part as { text?: unknown }).text;
+  return typeof text === "string" ? text : "";
+}
+
+function eventUserText(recordType: unknown, payload: RolloutPayload): string | null {
+  if (recordType !== "event_msg" || payload.type !== "user_message") return null;
+  if (typeof payload.message === "string") return payload.message;
+  return typeof payload.text === "string" ? payload.text : null;
 }
 
 /** Parse line 1 of a rollout jsonl (the `session_meta` record). Tolerant: null on any read/parse
@@ -76,14 +154,19 @@ function readSessionMeta(path: string): SessionMetaHeader | null {
  *  of KB. One bounded read (512 KiB) covers any realistic header; a header larger than that, or with
  *  no newline in the buffer, yields a truncated string that simply fails to JSON-parse (→ skipped). */
 function readFirstLine(path: string): string | null {
+  const text = readPrefix(path, 512 * 1024);
+  if (text === null) return null;
+  const nl = text.indexOf("\n");
+  return nl === -1 ? text : text.slice(0, nl);
+}
+
+function readPrefix(path: string, maxBytes: number): string | null {
   let fd: number | null = null;
   try {
     fd = openSync(path, "r");
-    const buf = Buffer.alloc(512 * 1024);
+    const buf = Buffer.alloc(maxBytes);
     const n = readSync(fd, buf, 0, buf.length, 0);
-    const text = buf.toString("utf8", 0, n);
-    const nl = text.indexOf("\n");
-    return nl === -1 ? text : text.slice(0, nl);
+    return buf.toString("utf8", 0, n);
   } catch {
     return null;
   } finally {

--- a/src/codex-usage.ts
+++ b/src/codex-usage.ts
@@ -240,6 +240,42 @@ export function readCodexModelUsage(dbPath: string | null, cutoff: number): Reco
   }
 }
 
+/** Read the authoritative token total for one provider-native Codex thread. */
+export function readCodexThreadUsage(
+  dbPath: string | null,
+  threadId: string,
+): { model: string; totalTokens: number } | null {
+  if (!dbPath || !existsSync(dbPath)) return null;
+  let db: Database | null = null;
+  try {
+    db = new Database(dbPath, { readonly: true });
+    const columns = db.query(`PRAGMA table_info(threads)`).all() as { name: string }[];
+    const hasModel = columns.some((column) => column.name === "model");
+    if (hasModel) {
+      const row = db
+        .query<{ model: string; totalTokens: number }, [string]>(
+          `SELECT COALESCE(NULLIF(model, ''), 'unknown') AS model, tokens_used AS totalTokens
+           FROM threads
+           WHERE id = ? AND model_provider = 'openai'`,
+        )
+        .get(threadId);
+      return row ? { model: row.model, totalTokens: row.totalTokens } : null;
+    }
+    const row = db
+      .query<{ totalTokens: number }, [string]>(
+        `SELECT tokens_used AS totalTokens
+         FROM threads
+         WHERE id = ? AND model_provider = 'openai'`,
+      )
+      .get(threadId);
+    return row ? { model: "unknown", totalTokens: row.totalTokens } : null;
+  } catch {
+    return null;
+  } finally {
+    db?.close();
+  }
+}
+
 /** One rollout's `rate_limits.primary`/`.secondary` shape (Codex CLI session log). */
 interface RolloutLimitWindow {
   used_percent?: number;

--- a/src/critic-core.ts
+++ b/src/critic-core.ts
@@ -528,7 +528,7 @@ export function shouldSkipForPatchId(
  *  Individually guarded — a transcript-read failure must never strand the caller. */
 export async function captureUsage(
   readUsage: (worktreePath: string, criticSessionId: string) => Promise<SessionUsage | null>,
-  completeReviewerSpawn: (criticSessionId: string, usage: SessionUsage, now: number) => void,
+  completeReviewerSpawn: (criticSessionId: string, usage: SessionUsage | null, now: number) => void,
   worktreePath: string,
   criticSessionId: string,
   now: number,
@@ -536,7 +536,7 @@ export async function captureUsage(
 ): Promise<void> {
   try {
     const usage = await readUsage(worktreePath, criticSessionId);
-    if (usage) completeReviewerSpawn(criticSessionId, usage, now);
+    completeReviewerSpawn(criticSessionId, usage, now);
   } catch (err) {
     console.warn(`[review] usage capture failed for ${logLabel}:`, err);
   }

--- a/src/doc-agent.ts
+++ b/src/doc-agent.ts
@@ -666,7 +666,7 @@ export class DocAgentService {
       this.deps.worktree.remove(wt.worktreePath);
       return { ok: false, result: { status: "error", reason: "spawn failed" } };
     }
-    const { terminalId, spawnSessionId } = spawned;
+    const { terminalId, spawnSessionId, reviewerProvider, model, reviewerEffort } = spawned;
     const startedAt = this.now();
     this.inflight.set(repoPath, {
       repoPath,
@@ -688,7 +688,9 @@ export class DocAgentService {
       taskSessionId: repoPath,
       kind: "doc_agent",
       worktreePath: wt.worktreePath,
-      model: this.deps.env?.().model ?? null,
+      reviewerProvider,
+      model,
+      reviewerEffort,
       spawnedAt: startedAt,
     });
     return { ok: true };
@@ -761,7 +763,17 @@ export class DocAgentService {
     agentName: string,
     base: string,
     promptCtx?: RetargetPromptCtx,
-  ): Promise<{ terminalId: string; spawnSessionId: string } | null | "aborted"> {
+  ): Promise<
+    | {
+        terminalId: string;
+        spawnSessionId: string;
+        reviewerProvider: RoleEnvironment["provider"];
+        model: string | null;
+        reviewerEffort: string | null;
+      }
+    | null
+    | "aborted"
+  > {
     const env = this.deps.env?.() ?? { provider: "claude" as const, model: null };
     const { argv, sessionId } = buildTransientAgentArgv("doc", {
       provider: env.provider,
@@ -781,7 +793,7 @@ export class DocAgentService {
       descriptor: {
         sessionId,
         kind: "doc",
-        model: this.deps.env?.().model ?? null,
+        model: env.model,
       },
     });
     if ("aborted" in aux) {
@@ -792,7 +804,13 @@ export class DocAgentService {
       const terminalId = (
         await this.deps.herdr.start(agentName, worktreePath, aux.wrapped, aux.spawnEnv)
       ).terminalId;
-      return { terminalId, spawnSessionId: sessionId };
+      return {
+        terminalId,
+        spawnSessionId: sessionId,
+        reviewerProvider: env.provider,
+        model: env.model,
+        reviewerEffort: env.effort ?? null,
+      };
     } catch (err) {
       if (err instanceof HerdrUnavailableError) {
         console.warn(`[doc-agent] herdr unavailable for ${repoPath}:`, err);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2365,9 +2365,13 @@ const timerTask = (label: string, fn: () => Promise<unknown>) => () =>
 // double-spawns it (or errors with agent_name_taken). Mirrors the `calibrating` flag below.
 let releasingHeld = false;
 deferredStarts.push(() => {
+  timerTask("usage", async () => {
+    store.retryPendingCodexReviewerUsage(latestCodexStateDb());
+  })();
   setInterval(
     timerTask("usage", async () => {
       await accountIndex.refresh(Date.now());
+      store.retryPendingCodexReviewerUsage(latestCodexStateDb());
       events.emit("usage:limits", usageLimits.limits(Date.now()));
       if (releasingHeld) return; // prior release still draining — skip this tick's release
       releasingHeld = true;

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -897,7 +897,7 @@ export class RecapService {
       // Best-effort usage capture.
       try {
         const u = await this._readUsage(r.cwd, r.spawnSessionId);
-        if (u) this.deps.store.completeReviewerSpawn(r.spawnSessionId, u, t);
+        this.deps.store.completeReviewerSpawn(r.spawnSessionId, u, t);
       } catch (err) {
         console.warn(`[recap] usage capture failed for ${r.sessionId}:`, err);
       }

--- a/src/review.ts
+++ b/src/review.ts
@@ -340,7 +340,8 @@ export class ReviewService {
     // Fail closed: api-key mode without a configured key must NOT bill the subscription.
     // Checked AFTER the worktree allocation + the post-await re-check so the worktree cleanup
     // here has wt.worktreePath — but BEFORE membrane/backend construction so we skip that work.
-    if (apiKeyFailClosed(this.deps.env?.().provider ?? "claude")) {
+    const reviewerEnv = this.deps.env?.() ?? { provider: "claude" as const, model: null };
+    if (apiKeyFailClosed(reviewerEnv.provider)) {
       console.warn(
         "[review] api-key mode enabled but no API key configured — skipping (fail closed, not billing subscription)",
       );
@@ -353,6 +354,7 @@ export class ReviewService {
       prior?.findings ?? [],
       authorNotes,
       issueBody,
+      reviewerEnv,
     );
     // Fire plugin onSpawn hooks for this reviewer-style spawn (issue #1205) and bind any patched
     // env THROUGH the membrane (apiKeyPassthroughEnv handled inside). A hook that calls abortSpawn
@@ -367,7 +369,7 @@ export class ReviewService {
         sessionId: criticSessionId,
         kind: "review",
         parentSessionId: session.id,
-        model: this.deps.env?.().model ?? null,
+        model: reviewerEnv.model,
       },
     });
     if ("aborted" in aux) {
@@ -418,7 +420,9 @@ export class ReviewService {
       taskSessionId: session.id,
       kind: "review",
       worktreePath: wt.worktreePath,
-      model: this.deps.env?.().model ?? null,
+      reviewerProvider: reviewerEnv.provider,
+      model: reviewerEnv.model,
+      reviewerEffort: reviewerEnv.effort ?? null,
       spawnedAt: this.now(),
     });
     this.deps.onReviewing?.(session.id, true);
@@ -572,13 +576,13 @@ export class ReviewService {
     priorFindings: string[],
     authorNotes: string[],
     issueBody: string | null,
+    env: RoleEnvironment,
   ): { argv: string[]; sessionId: string } {
     // Shared with the plan reviewer: same read-only injection-contained sandbox (the PR diff is
     // UNTRUSTED). The prompt is the only critic-specific part. `diffBase` is the resolved base
     // commit (SHA) threaded from rebaseSkip, NOT session.baseBranch — so the review diffs the
     // identical fresh base the fingerprint used (no stale-local-main fold-in). `issueBody` is the
     // originating issue's body, fetched in begin() and injected as UNTRUSTED context.
-    const env = this.deps.env?.() ?? { provider: "claude" as const, model: null };
     return buildTransientAgentArgv("reviewer", {
       provider: env.provider,
       model: env.model,

--- a/src/standalone-critic.ts
+++ b/src/standalone-critic.ts
@@ -405,14 +405,14 @@ export class StandalonePrCriticService {
       priorReviewedPatchIds: string[];
     },
   ): Promise<void> {
-    if (apiKeyFailClosed(this.deps.env?.().provider ?? "claude")) {
+    const env = this.deps.env?.() ?? { provider: "claude" as const, model: null };
+    if (apiKeyFailClosed(env.provider)) {
       this.log(
         `[pr-critic] ${repoPath}#${pr.number} api-key mode enabled but no API key configured — skipping (fail closed, not billing subscription)`,
       );
       this.deps.worktree.remove(worktreePath);
       return;
     }
-    const env = this.deps.env?.() ?? { provider: "claude" as const, model: null };
     const { argv, sessionId: criticSessionId } = buildTransientAgentArgv("reviewer", {
       provider: env.provider,
       model: env.model,
@@ -430,7 +430,7 @@ export class StandalonePrCriticService {
       descriptor: {
         sessionId: criticSessionId,
         kind: "review",
-        model: this.deps.env?.().model ?? null,
+        model: env.model,
       },
     });
     if ("aborted" in aux) {
@@ -478,7 +478,9 @@ export class StandalonePrCriticService {
       taskSessionId: `pr:${repoPath}#${pr.number}`,
       kind: "review",
       worktreePath,
-      model: this.deps.env?.().model ?? null,
+      reviewerProvider: env.provider,
+      model: env.model,
+      reviewerEffort: env.effort ?? null,
       spawnedAt: this.now(),
     });
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -55,6 +55,8 @@ import { dominantModel, type SessionUsage } from "./usage";
 import { type SandboxProfile, isSandboxProfile } from "./sandbox";
 import { normalizeRepoDefaultModelSetting } from "./default-model";
 import { normalizeRepoDefaultEffortSetting } from "./default-effort";
+import { codexReviewerCorrelationMarker, findCodexSessionId } from "./codex-session-id";
+import { latestCodexStateDb, readCodexThreadUsage } from "./codex-usage";
 import { sanitizeScopeGlobs } from "./house-rules";
 import type { EpicRun } from "./epic-core";
 import type { EpicLandingState } from "./completed-epic";
@@ -1047,6 +1049,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       reviewerProvider  TEXT,
       model             TEXT,
       reviewerEffort    TEXT,
+      providerThreadId  TEXT,
       spawnedAt         INTEGER NOT NULL,
       completedAt       INTEGER,
       inputTokens       INTEGER,
@@ -3081,9 +3084,47 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     );
   }
 
-  /** Fill a spawn's token totals + completedAt once its transcript is read. No-op when the
+  /** Complete a spawn and capture provider-native token usage when available. No-op when the
    *  reviewerSessionId is unknown (the WHERE simply matches nothing). */
-  completeReviewerSpawn(reviewerSessionId: string, u: SessionUsage, completedAt: number): void {
+  completeReviewerSpawn(
+    reviewerSessionId: string,
+    u: SessionUsage | null,
+    completedAt: number,
+  ): void {
+    const row = this.db
+      .query<
+        {
+          reviewerProvider: AgentProvider | null;
+          worktreePath: string;
+          spawnedAt: number;
+          providerThreadId: string | null;
+        },
+        [string]
+      >(
+        `SELECT reviewerProvider, worktreePath, spawnedAt, providerThreadId
+         FROM reviewer_spawns WHERE reviewerSessionId = ?`,
+      )
+      .get(reviewerSessionId);
+    if (!row) return;
+
+    if (row.reviewerProvider === "codex") {
+      const providerThreadId =
+        row.providerThreadId ??
+        findCodexSessionId(row.worktreePath, row.spawnedAt - 5 * 60_000, undefined, {
+          source: "exec",
+          correlationMarker: codexReviewerCorrelationMarker(reviewerSessionId),
+        });
+      this.db.run(
+        `UPDATE reviewer_spawns
+         SET completedAt = ?, providerThreadId = COALESCE(providerThreadId, ?)
+         WHERE reviewerSessionId = ?`,
+        [completedAt, providerThreadId, reviewerSessionId],
+      );
+      if (providerThreadId) this.retryPendingCodexReviewerUsage(latestCodexStateDb());
+      return;
+    }
+
+    if (!u) return;
     // Backfill the TRUE model from the transcript: the spawn-time `model` column held the
     // configured override, which is null when auto-resolved — but the transcript names the model
     // that actually ran. A reviewer spawn is one model, so `dominantModel(u)` is it. It returns
@@ -3106,6 +3147,33 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
         reviewerSessionId,
       ],
     );
+  }
+
+  /** Fill delayed Codex usage only for rows already bound to an exact provider thread. */
+  retryPendingCodexReviewerUsage(dbPath: string | null): number {
+    const pending = this.db
+      .query<{ reviewerSessionId: string; providerThreadId: string }, []>(
+        `SELECT reviewerSessionId, providerThreadId
+         FROM reviewer_spawns
+         WHERE reviewerProvider = 'codex'
+           AND completedAt IS NOT NULL
+           AND providerThreadId IS NOT NULL
+           AND totalTokens IS NULL
+         ORDER BY spawnedAt`,
+      )
+      .all();
+    let completed = 0;
+    for (const row of pending) {
+      const usage = readCodexThreadUsage(dbPath, row.providerThreadId);
+      if (!usage) continue;
+      this.db.run(
+        `UPDATE reviewer_spawns SET model = ?, totalTokens = ?
+         WHERE reviewerSessionId = ? AND totalTokens IS NULL`,
+        [usage.model, usage.totalTokens, row.reviewerSessionId],
+      );
+      completed++;
+    }
+    return completed;
   }
 
   /** All reviewer-spawn rows, oldest-spawned first. Column names already match the
@@ -3518,6 +3586,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     };
     add("reviewerProvider", `reviewerProvider TEXT`);
     add("reviewerEffort", `reviewerEffort TEXT`);
+    add("providerThreadId", `providerThreadId TEXT`);
   }
 
   // ── learnings ─────────────────────────────────────────────────────────────

--- a/src/transient-agent-argv.ts
+++ b/src/transient-agent-argv.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { apiKeySettingsFragment } from "./spawn-auth";
 import { codexRoleArgv } from "./codex-role-argv";
 import { effortForSpawn } from "./default-effort";
+import { codexReviewerCorrelationMarker } from "./codex-session-id";
 import type { AgentProvider } from "./types";
 
 /**
@@ -147,10 +148,14 @@ export function buildTransientAgentArgv(
   // Codex CLI path: a headless, workspace-write-sandboxed `codex exec` runs the same prompt (which
   // writes the kind's result/verdict file). None of the Claude-only flags (--settings, --safe-mode,
   // --allowedTools) have a Codex equivalent; the sandbox shape is enforced by
-  // `--sandbox workspace-write`. sessionId is returned for shape but unused (no Claude transcript).
+  // `--sandbox workspace-write`. The returned sessionId also correlates the rollout to its spawn.
   if (opts.provider === "codex")
     return {
-      argv: codexRoleArgv(opts.model, sanitizePromptArg(opts.prompt), opts.effort ?? null),
+      argv: codexRoleArgv(
+        opts.model,
+        `${codexReviewerCorrelationMarker(sessionId)}\n${sanitizePromptArg(opts.prompt)}`,
+        opts.effort ?? null,
+      ),
       sessionId,
     };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -731,6 +731,7 @@ export interface ReviewerSpawnRow {
   reviewerProvider: AgentProvider | null;
   model: string | null;
   reviewerEffort: string | null;
+  providerThreadId: string | null;
   spawnedAt: number;
   completedAt: number | null;
   inputTokens: number | null;

--- a/src/usage-breakdown.ts
+++ b/src/usage-breakdown.ts
@@ -303,6 +303,51 @@ function claudeUsageByRole(
   return byRole;
 }
 
+interface CodexRoleAllocation {
+  role: ReturnType<SessionStore["listReviewerSpawns"]>[number]["kind"];
+  model: string;
+  tokens: number;
+}
+
+function codexRoleAllocation(
+  sp: ReturnType<SessionStore["listReviewerSpawns"]>[number],
+  cutoff: number,
+  remaining: Record<string, number>,
+): CodexRoleAllocation | null {
+  if (sp.reviewerProvider !== "codex" || !sp.providerThreadId) return null;
+  if (sp.completedAt == null || sp.completedAt < cutoff) return null;
+  if (sp.totalTokens == null || sp.totalTokens <= 0) return null;
+  const model = usableModel(sp.model);
+  if (!model) return null;
+  const tokens = Math.min(sp.totalTokens, remaining[model] ?? 0);
+  return tokens > 0 ? { role: sp.kind, model, tokens } : null;
+}
+
+/** Attribute captured Codex role spawns from the authoritative per-model thread totals. */
+function codexUsageByRole(
+  spawns: ReturnType<SessionStore["listReviewerSpawns"]>,
+  cutoff: number,
+  byModel: Record<string, number>,
+): UsageByRole {
+  const remaining = Object.fromEntries(
+    Object.entries(byModel).map(([model, tokens]) => [model, Math.max(0, tokens)]),
+  );
+  const byRole: UsageByRole = {};
+
+  for (const sp of spawns) {
+    const allocation = codexRoleAllocation(sp, cutoff, remaining);
+    if (!allocation) continue;
+    const role = byRole[allocation.role] ?? {};
+    role[allocation.model] = (role[allocation.model] ?? 0) + allocation.tokens;
+    byRole[allocation.role] = role;
+    remaining[allocation.model] = (remaining[allocation.model] ?? 0) - allocation.tokens;
+  }
+
+  const coding = Object.fromEntries(Object.entries(remaining).filter(([, tokens]) => tokens > 0));
+  if (Object.keys(coding).length > 0) byRole.coding = coding;
+  return byRole;
+}
+
 function foldModels(byRole: UsageByRole): Record<string, number> {
   const byModel: Record<string, number> = {};
   for (const models of Object.values(byRole)) {
@@ -531,6 +576,7 @@ export async function buildUsageBreakdown(opts: {
   const claudeByRole = claudeUsageByRole(taskMap, spawns, cutoff);
   const claudeByModel = foldModels(claudeByRole);
   const codexByModel = opts.codexModelUsage?.(cutoff) ?? {};
+  const codexByRole = codexUsageByRole(spawns, cutoff, codexByModel);
   const modelBreakdown = (byModel: Record<string, number>, byRole: UsageByRole = {}) => ({
     totalTokens: Object.values(byModel).reduce((sum, tokens) => sum + tokens, 0),
     byModel,
@@ -545,7 +591,7 @@ export async function buildUsageBreakdown(opts: {
     dollars: apiKey ? totals.totalUnits : null,
     models: {
       claude: modelBreakdown(claudeByModel, claudeByRole),
-      codex: modelBreakdown(codexByModel),
+      codex: modelBreakdown(codexByModel, codexByRole),
     },
     repos,
   };

--- a/test/autopilot-llm.test.ts
+++ b/test/autopilot-llm.test.ts
@@ -280,7 +280,7 @@ for (const failingStage of ["stop", "record", "complete", "cleanup"] as const) {
         },
         completeReviewerSpawn: (_sessionId, usage) => {
           order.push("complete");
-          completedUsages.push(usage);
+          if (usage) completedUsages.push(usage);
           if (failingStage === "complete") throw new Error("complete failed");
         },
       },

--- a/test/codex-session-id.test.ts
+++ b/test/codex-session-id.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { findCodexSessionId } from "../src/codex-session-id";
+import { codexReviewerCorrelationMarker, findCodexSessionId } from "../src/codex-session-id";
 
 let home: string;
 let sessionsDir: string;
@@ -34,6 +34,17 @@ function writeRollout(
 
 const CWD = "/home/u/.shepherd-worktrees/repo-feature";
 
+function userMessage(text: string): string {
+  return JSON.stringify({
+    type: "response_item",
+    payload: {
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text }],
+    },
+  });
+}
+
 test("returns the session id of an interactive (source=cli) rollout matching the cwd", () => {
   writeRollout("rollout-1.jsonl", { session_id: "uuid-A", cwd: CWD, source: "cli" }, 1000);
   expect(findCodexSessionId(CWD, 0, home)).toBe("uuid-A");
@@ -55,6 +66,49 @@ test("ignores source=exec (headless role) rollouts sharing the cwd", () => {
   writeRollout("rollout-exec.jsonl", { session_id: "uuid-exec", cwd: CWD, source: "exec" }, 3000);
   writeRollout("rollout-cli.jsonl", { session_id: "uuid-cli", cwd: CWD, source: "cli" }, 2000);
   expect(findCodexSessionId(CWD, 0, home)).toBe("uuid-cli");
+});
+
+test("binds an exec rollout to its reviewer spawn even when a later exec shares the cwd", () => {
+  const targetMarker = codexReviewerCorrelationMarker("spawn-target");
+  const competitorMarker = codexReviewerCorrelationMarker("spawn-competitor");
+  writeRollout(
+    "rollout-target.jsonl",
+    { session_id: "uuid-target", cwd: CWD, source: "exec" },
+    2000,
+    [
+      userMessage("<recommended_plugins>preloaded by Codex</recommended_plugins>"),
+      userMessage(`${targetMarker}\nReview target`),
+    ],
+  );
+  writeRollout(
+    "rollout-competitor.jsonl",
+    { session_id: "uuid-competitor", cwd: CWD, source: "exec" },
+    3000,
+    [userMessage(`${competitorMarker}\nReview competitor`)],
+  );
+
+  expect(
+    findCodexSessionId(CWD, 0, home, {
+      source: "exec",
+      correlationMarker: targetMarker,
+    }),
+  ).toBe("uuid-target");
+});
+
+test("does not fall back to the newest exec rollout when no marker matches", () => {
+  writeRollout(
+    "rollout-competitor.jsonl",
+    { session_id: "uuid-competitor", cwd: CWD, source: "exec" },
+    3000,
+    [userMessage(`${codexReviewerCorrelationMarker("spawn-competitor")}\nReview competitor`)],
+  );
+
+  expect(
+    findCodexSessionId(CWD, 0, home, {
+      source: "exec",
+      correlationMarker: codexReviewerCorrelationMarker("spawn-missing"),
+    }),
+  ).toBeNull();
 });
 
 test("skips rollouts older than notBeforeMs", () => {

--- a/test/codex-usage.test.ts
+++ b/test/codex-usage.test.ts
@@ -10,6 +10,7 @@ import {
   recentCodexRolloutPaths,
   readCodexRateLimits,
   readCodexModelUsage,
+  readCodexThreadUsage,
   readCodexTokenUsage,
 } from "../src/codex-usage";
 
@@ -139,6 +140,81 @@ test("readCodexModelUsage uses one unknown bucket when the model column is absen
   db.close();
 
   expect(readCodexModelUsage(path, NOW - 5 * H)).toEqual({ unknown: 1000 });
+});
+
+test("readCodexThreadUsage reads one exact OpenAI thread with its model", () => {
+  const dir = tempDir();
+  const path = join(dir, "state_5.sqlite");
+  const db = new Database(path);
+  db.exec(`
+    CREATE TABLE threads (
+      id TEXT PRIMARY KEY,
+      model_provider TEXT NOT NULL,
+      model TEXT,
+      tokens_used INTEGER NOT NULL DEFAULT 0,
+      updated_at_ms INTEGER NOT NULL
+    )
+  `);
+  const insert = db.query(
+    "INSERT INTO threads (id, model_provider, model, tokens_used, updated_at_ms) VALUES (?, ?, ?, ?, ?)",
+  );
+  insert.run("target", "openai", "gpt-5.6", 4321, NOW);
+  insert.run("other", "openai", "gpt-5.5", 9999, NOW);
+  db.close();
+
+  expect(readCodexThreadUsage(path, "target")).toEqual({ model: "gpt-5.6", totalTokens: 4321 });
+});
+
+test("readCodexThreadUsage normalizes an empty model and rejects non-OpenAI threads", () => {
+  const dir = tempDir();
+  const path = join(dir, "state_5.sqlite");
+  const db = new Database(path);
+  db.exec(`
+    CREATE TABLE threads (
+      id TEXT PRIMARY KEY,
+      model_provider TEXT NOT NULL,
+      model TEXT,
+      tokens_used INTEGER NOT NULL DEFAULT 0,
+      updated_at_ms INTEGER NOT NULL
+    )
+  `);
+  const insert = db.query(
+    "INSERT INTO threads (id, model_provider, model, tokens_used, updated_at_ms) VALUES (?, ?, ?, ?, ?)",
+  );
+  insert.run("unknown", "openai", "", 0, NOW);
+  insert.run("local", "ollama", "llama", 9999, NOW);
+  db.close();
+
+  expect(readCodexThreadUsage(path, "unknown")).toEqual({ model: "unknown", totalTokens: 0 });
+  expect(readCodexThreadUsage(path, "local")).toBeNull();
+});
+
+test("readCodexThreadUsage uses unknown when the model column is absent", () => {
+  const dir = tempDir();
+  const path = join(dir, "state_5.sqlite");
+  const db = createStateDb(path);
+  db.query(
+    "INSERT INTO threads (id, model_provider, tokens_used, updated_at_ms) VALUES (?, ?, ?, ?)",
+  ).run("target", "openai", 777, NOW);
+  db.close();
+
+  expect(readCodexThreadUsage(path, "target")).toEqual({ model: "unknown", totalTokens: 777 });
+});
+
+test("readCodexThreadUsage fails closed when required state schema is unavailable", () => {
+  const dir = tempDir();
+  for (const [name, schema] of [
+    ["missing-table", "CREATE TABLE unrelated (id TEXT)"],
+    ["missing-provider", "CREATE TABLE threads (id TEXT PRIMARY KEY, tokens_used INTEGER)"],
+    ["missing-tokens", "CREATE TABLE threads (id TEXT PRIMARY KEY, model_provider TEXT)"],
+  ] as const) {
+    const path = join(dir, `${name}.sqlite`);
+    const db = new Database(path);
+    db.exec(schema);
+    db.close();
+
+    expect(readCodexThreadUsage(path, "target")).toBeNull();
+  }
 });
 
 /** A Codex rollout `token_count` line carrying a rate-limit reading. */

--- a/test/doc-agent.test.ts
+++ b/test/doc-agent.test.ts
@@ -210,6 +210,9 @@ function mkHarness(opts?: {
   runSpawnHooks?: (d: unknown) => Promise<unknown>;
   /** Per-role reasoning-effort override threaded into the spawn env (issue #1418). */
   effort?: string | null;
+  provider?: "claude" | "codex";
+  model?: string | null;
+  usageUnavailable?: boolean;
 }): Harness {
   const o = {
     forgeKind: "github" as "github" | "local" | null,
@@ -240,6 +243,8 @@ function mkHarness(opts?: {
     editPrThrows: false,
     noEditPr: false,
     effort: null as string | null,
+    provider: "claude" as "claude" | "codex",
+    model: null as string | null,
     ...opts,
   };
 
@@ -453,7 +458,7 @@ function mkHarness(opts?: {
     repos: () => o.repos,
     store: store as any,
     nightlyHour: o.nightlyHour,
-    env: () => ({ provider: "claude", model: null, effort: o.effort }),
+    env: () => ({ provider: o.provider, model: o.model, effort: o.effort }),
     act: o.act,
     onChange: (f) => finalizes.push(f),
     now: o.now,
@@ -477,18 +482,21 @@ function mkHarness(opts?: {
       markers.set(p, c);
     },
     readMarker: (p: string) => markers.get(p) ?? null,
-    readUsage: async () => ({
-      input: 5,
-      output: 7,
-      cacheRead: 0,
-      cacheWrite: 0,
-      total: 12,
-      messageCount: 1,
-      lastActivity: null,
-      byModel: {},
-      fullRecaches: 0,
-      sidechainCount: 0,
-    }),
+    readUsage: async () =>
+      o.usageUnavailable
+        ? null
+        : {
+            input: 5,
+            output: 7,
+            cacheRead: 0,
+            cacheWrite: 0,
+            total: 12,
+            messageCount: 1,
+            lastActivity: null,
+            byModel: {},
+            fullRecaches: 0,
+            sidechainCount: 0,
+          },
   });
 
   return {
@@ -1058,6 +1066,28 @@ test("row completed at finalize: act path completes the spawn row", async () => 
   await h.svc.tick();
   expect(h.completedRows).toHaveLength(1);
   expect(h.completedRows[0]!.reviewerSessionId).toBe(h.spawnRows[0]!.reviewerSessionId);
+});
+
+test("Claude doc row uses zero usage when its transcript is unavailable", async () => {
+  const h = mkHarness({ provider: "claude", usageUnavailable: true });
+  await h.svc.consider("/repo");
+  await h.svc.tick();
+
+  expect(h.completedRows).toHaveLength(1);
+  expect(h.completedRows[0]!.total).toBe(0);
+  expect(h.spawnRows[0]!.completedAt).not.toBeNull();
+});
+
+test("Codex doc agent persists the provider environment used for its spawn", async () => {
+  const h = mkHarness({ provider: "codex", model: "gpt-5.6", effort: "high" });
+  await h.svc.consider("/repo");
+  expect(h.spawnRows[0]).toMatchObject({
+    reviewerProvider: "codex",
+    model: "gpt-5.6",
+    reviewerEffort: "high",
+  });
+  await h.svc.tick();
+  expect(h.completedRows).toHaveLength(1);
 });
 
 // ── prettier pre-format (fix: doc-agent auto-PRs fail CI lint gate) ─────────────

--- a/test/namer-llm.test.ts
+++ b/test/namer-llm.test.ts
@@ -34,6 +34,10 @@ function stripFenceNonce(s: string): string {
   return s.replace(/⟦(\/?)UNTRUSTED:([^:⟧]+):[^⟧]*⟧/g, "⟦$1UNTRUSTED:$2⟧");
 }
 
+function stripReviewerCorrelationMarker(s: string): string {
+  return s.replace(/^\[SHEPHERD_REVIEWER_SPAWN_ID:[^\]]+\]\n/, "");
+}
+
 function makeDeps(over: Partial<import("../src/namer-llm").LlmNamerDeps> = {}) {
   const calls: any = { started: null, stopped: false, cleaned: false };
   const base = {
@@ -110,7 +114,9 @@ test("llmName: codex provider spawns headless `codex exec` (no claude flags)", a
     readName: () => "mobile footer",
   });
   await llmName("the mobile footer needs settings", deps, "l");
-  expect(calls.started.argv.map(stripFenceNonce)).toEqual(
+  expect(
+    calls.started.argv.map((arg: string) => stripFenceNonce(stripReviewerCorrelationMarker(arg))),
+  ).toEqual(
     [
       "codex",
       "exec",

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -530,6 +530,28 @@ test("tick: generating row + valid verdict → state 'ready' + usage + stop + cl
   expect(cleaned).toContain("/tmp/recap-s1");
 });
 
+test("tick completes a Codex recap even when no Claude usage transcript exists", async () => {
+  const rec = makeRecap({
+    state: "generating",
+    cwd: "/tmp/recap-codex",
+    spawnSessionId: "sp-codex",
+    spawnedAt: 100_000,
+  });
+  const store = makeStore([], [rec]);
+  const svc = buildSvc({
+    store,
+    herdr: makeHerdr([{ cwd: rec.cwd, terminalId: "t-codex" }]),
+    nowFn: () => 200_000,
+    timeoutMs: 300_000,
+    verdictJson: VALID_VERDICT_JSON,
+    readUsage: async () => null,
+  });
+
+  await svc.tick();
+
+  expect(store.completedSpawns).toEqual([{ id: "sp-codex", u: null, at: 200_000 }]);
+});
+
 // TASK-561 follow-up: the #822 failsafe still left recap generation failing on retry. A chatty
 // agent wraps the JSON in prose, jsonrepair rescues it into an ARRAY (["Here is the recap:", {…}]),
 // and the OLD finalize → parseRecapVerdict rejected arrays → `failed`. The fix unwraps the recap

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -416,6 +416,29 @@ test("completes the spawn's token total on finalize (issue #502)", async () => {
   expect(completedSpawns[0]!.id).toBe(recordedSpawns[0]!.reviewerSessionId);
 });
 
+test("Codex review records its resolved provider and completes without Claude usage", async () => {
+  const env = { provider: "codex" as const, model: "gpt-5.6", effort: "high" };
+  const {
+    deps: d,
+    recordedSpawns,
+    completedSpawns,
+  } = makeDeps({
+    env: () => env,
+    readUsage: async () => null,
+  });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+
+  expect(recordedSpawns[0]).toMatchObject({
+    reviewerProvider: "codex",
+    model: "gpt-5.6",
+    reviewerEffort: "high",
+  });
+  expect(completedSpawns).toHaveLength(1);
+  expect(completedSpawns[0]!.u).toBeNull();
+});
+
 test("onReviewing fires true on spawn and false on finalize", async () => {
   const events: { id: string; reviewing: boolean }[] = [];
   const { deps: d } = makeDeps({

--- a/test/server-usage-breakdown.test.ts
+++ b/test/server-usage-breakdown.test.ts
@@ -142,7 +142,40 @@ test("GET /api/usage/breakdown forwards cutoff to the Codex model dependency", a
   expect(body.models.codex).toEqual({
     totalTokens: 1000,
     byModel: { "gpt-5.5": 700, unknown: 300 },
-    byRole: {},
+    byRole: { coding: { "gpt-5.5": 700, unknown: 300 } },
+  });
+});
+
+test("GET /api/usage/breakdown returns attributed Codex roles plus the exact coding remainder", async () => {
+  const { app, store } = harness({ codexModelUsage: () => ({ "gpt-5.6": 1_000 }) });
+  // @ts-expect-error accessing internal db for focused endpoint setup
+  store.db.run(
+    `INSERT INTO reviewer_spawns
+       (reviewerSessionId, taskSessionId, kind, worktreePath, reviewerProvider, model,
+        providerThreadId, spawnedAt, completedAt, totalTokens)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      "codex-review",
+      "task",
+      "review",
+      "/wt/codex-review",
+      "codex",
+      "gpt-5.6",
+      "thread-review",
+      NOW - 2_000,
+      NOW - 1_000,
+      250,
+    ],
+  );
+
+  const body = await (await app.fetch(new Request("http://x/api/usage/breakdown?range=7d"))).json();
+  expect(body.models.codex).toEqual({
+    totalTokens: 1_000,
+    byModel: { "gpt-5.6": 1_000 },
+    byRole: {
+      review: { "gpt-5.6": 250 },
+      coding: { "gpt-5.6": 750 },
+    },
   });
 });
 

--- a/test/standalone-critic.test.ts
+++ b/test/standalone-critic.test.ts
@@ -256,6 +256,24 @@ test("reviews a fresh open green regular session-less PR", async () => {
   expect(settings.env).toBeUndefined();
 });
 
+test("Codex critic records its resolved provider and completes without Claude usage", async () => {
+  const { deps, spies } = makeDeps({
+    env: () => ({ provider: "codex", model: "gpt-5.6", effort: "high" }),
+    readUsage: async () => null,
+  });
+  const svc = new StandalonePrCriticService(deps as any);
+  await svc.sweep();
+  await svc.tick();
+
+  expect(spies.recordedSpawns[0]).toMatchObject({
+    reviewerProvider: "codex",
+    model: "gpt-5.6",
+    reviewerEffort: "high",
+  });
+  expect(spies.completedSpawns).toHaveLength(1);
+  expect(spies.completedSpawns[0]!.u).toBeNull();
+});
+
 test("reviews a REST-enumerated green PR while GraphQL backoff is active", async () => {
   graphRateLimit.noteLimitError(60);
   let metaCalls = 0;

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1,9 +1,10 @@
 import { test, expect } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
 import { SessionStore } from "../src/store";
+import { codexReviewerCorrelationMarker } from "../src/codex-session-id";
 import type { PrReview, Recap, ReviewVerdict, SessionLaunchMetadata } from "../src/types";
 import type { SessionUsage } from "../src/usage";
 
@@ -1282,6 +1283,7 @@ test("recordReviewerSpawn then listReviewerSpawns returns the row with NULL toke
     reviewerProvider: null,
     model: null,
     reviewerEffort: null,
+    providerThreadId: null,
     spawnedAt: 1000,
     completedAt: null,
     inputTokens: null,
@@ -1309,6 +1311,146 @@ test("recordReviewerSpawn persists reviewer provider and effort", () => {
     model: "gpt-5.5",
     reviewerEffort: "high",
   });
+});
+
+test("legacy reviewer_spawns schema migrates providerThreadId as null", () => {
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-store-reviewer-migration-"));
+  const path = join(dir, "store.sqlite");
+  try {
+    const raw = new Database(path);
+    raw.exec(`CREATE TABLE reviewer_spawns (
+      reviewerSessionId TEXT PRIMARY KEY,
+      taskSessionId TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      worktreePath TEXT NOT NULL,
+      model TEXT,
+      spawnedAt INTEGER NOT NULL,
+      completedAt INTEGER,
+      inputTokens INTEGER,
+      outputTokens INTEGER,
+      cacheReadTokens INTEGER,
+      cacheWriteTokens INTEGER,
+      totalTokens INTEGER
+    )`);
+    raw
+      .query(
+        `INSERT INTO reviewer_spawns
+       (reviewerSessionId, taskSessionId, kind, worktreePath, model, spawnedAt)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run("legacy", "task", "review", "/legacy", "gpt-5.5", 1);
+    raw.close();
+
+    const store = new SessionStore(path);
+    expect(store.listReviewerSpawns()[0]?.providerThreadId).toBeNull();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("Codex completion persists the exact rollout and retries delayed thread usage after reopen", () => {
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-store-codex-reviewer-"));
+  const storePath = join(dir, "store.sqlite");
+  const codexHome = join(dir, "codex");
+  const sessions = join(codexHome, "sessions");
+  mkdirSync(sessions, { recursive: true });
+  const previousCodexHome = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = codexHome;
+
+  const writeExecRollout = (name: string, id: string, marker: string, mtimeSec: number) => {
+    const path = join(sessions, name);
+    writeFileSync(
+      path,
+      [
+        JSON.stringify({
+          type: "session_meta",
+          payload: { session_id: id, cwd: "/review-wt", source: "exec" },
+        }),
+        JSON.stringify({
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: `${marker}\nReview` }],
+          },
+        }),
+      ].join("\n") + "\n",
+    );
+    utimesSync(path, mtimeSec, mtimeSec);
+  };
+
+  try {
+    writeExecRollout(
+      "rollout-target.jsonl",
+      "thread-target",
+      codexReviewerCorrelationMarker("spawn-target"),
+      2,
+    );
+    writeExecRollout(
+      "rollout-competitor.jsonl",
+      "thread-competitor",
+      codexReviewerCorrelationMarker("spawn-competitor"),
+      3,
+    );
+
+    const first = new SessionStore(storePath);
+    first.recordReviewerSpawn({
+      reviewerSessionId: "spawn-target",
+      taskSessionId: "task",
+      kind: "review",
+      worktreePath: "/review-wt",
+      reviewerProvider: "codex",
+      model: null,
+      spawnedAt: 1_000,
+    });
+    first.completeReviewerSpawn("spawn-target", null, 4_000);
+    expect(first.listReviewerSpawns()[0]).toMatchObject({
+      completedAt: 4_000,
+      providerThreadId: "thread-target",
+      totalTokens: null,
+    });
+    (first as unknown as { db: Database }).db.close();
+
+    const statePath = join(codexHome, "state_5.sqlite");
+    const state = new Database(statePath);
+    state.exec(`CREATE TABLE threads (
+      id TEXT PRIMARY KEY,
+      model_provider TEXT NOT NULL,
+      model TEXT,
+      tokens_used INTEGER NOT NULL DEFAULT 0,
+      updated_at_ms INTEGER NOT NULL
+    )`);
+    const insert = state.query(
+      `INSERT INTO threads (id, model_provider, model, tokens_used, updated_at_ms)
+       VALUES (?, 'openai', ?, ?, ?)`,
+    );
+    insert.run("thread-target", "gpt-5.6", 4321, 5_000);
+    insert.run("thread-competitor", "gpt-5.5", 9999, 5_000);
+    state.close();
+
+    const reopened = new SessionStore(storePath);
+    reopened.recordReviewerSpawn({
+      reviewerSessionId: "legacy-no-thread-id",
+      taskSessionId: "task",
+      kind: "review",
+      worktreePath: "/review-wt",
+      reviewerProvider: "codex",
+      model: "gpt-5.5",
+      spawnedAt: 2_000,
+    });
+    expect(reopened.retryPendingCodexReviewerUsage(statePath)).toBe(1);
+    expect(reopened.listReviewerSpawns()[0]).toMatchObject({
+      providerThreadId: "thread-target",
+      model: "gpt-5.6",
+      totalTokens: 4321,
+    });
+    expect(reopened.listReviewerSpawns()[1]?.totalTokens).toBeNull();
+    expect(reopened.retryPendingCodexReviewerUsage(statePath)).toBe(0);
+  } finally {
+    if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousCodexHome;
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("completeReviewerSpawn fills token totals + completedAt", () => {

--- a/test/transient-agent-argv.test.ts
+++ b/test/transient-agent-argv.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import { buildTransientAgentArgv, type TransientAgentKind } from "../src/transient-agent-argv";
+import { codexReviewerCorrelationMarker } from "../src/codex-session-id";
 import { config } from "../src/config";
 
 // Temporarily set config auth fields, always restoring them.
@@ -64,6 +65,27 @@ test("Codex effort routes to -c model_reasoning_effort with xhigh → high clamp
   expect(cIdx).toBeGreaterThan(-1);
   expect(argv[cIdx + 1]).toBe("model_reasoning_effort=high");
   expect(argv).not.toContain("--effort"); // Codex uses the -c surface, not --effort
+});
+
+test("Codex prompts carry the spawn's unique reviewer correlation marker", () => {
+  const first = buildTransientAgentArgv("reviewer", {
+    provider: "codex",
+    model: "gpt-5.5",
+    prompt: "Review this change",
+  });
+  const second = buildTransientAgentArgv("reviewer", {
+    provider: "codex",
+    model: "gpt-5.5",
+    prompt: "Review this change",
+  });
+
+  expect(first.argv.at(-1)).toBe(
+    `${codexReviewerCorrelationMarker(first.sessionId)}\nReview this change`,
+  );
+  expect(second.argv.at(-1)).toBe(
+    `${codexReviewerCorrelationMarker(second.sessionId)}\nReview this change`,
+  );
+  expect(first.argv.at(-1)).not.toBe(second.argv.at(-1));
 });
 
 // ── Mechanical invariant: flag order (the variadic --allowedTools trap) ─────────────────────────
@@ -137,13 +159,13 @@ test("multiple NULs are each escaped", () => {
 });
 
 test("Codex prompts escape NULs with the same argv contract as Claude", () => {
-  const { argv } = buildTransientAgentArgv("writer-only", {
+  const { argv, sessionId } = buildTransientAgentArgv("writer-only", {
     provider: "codex",
     model: "gpt-5.3-codex",
     prompt: "a\0b",
   });
   expect(argv.slice(0, 4)).toEqual(["codex", "exec", "--sandbox", "workspace-write"]);
-  expect(argv[argv.length - 1]).toBe("a\\0b");
+  expect(argv[argv.length - 1]).toBe(`${codexReviewerCorrelationMarker(sessionId)}\na\\0b`);
   for (const arg of argv) expect(arg.includes("\0")).toBe(false);
 });
 
@@ -321,11 +343,12 @@ test("writer-only + model 'haiku' reproduces verify-key's historical argv shape"
 
 test("codex provider: every kind → `codex exec --sandbox workspace-write [-m <model>] <prompt>`", () => {
   for (const kind of ALL_KINDS) {
-    const withModel = buildTransientAgentArgv(kind, {
+    const withModelSpawn = buildTransientAgentArgv(kind, {
       provider: "codex",
       model: "gpt-5.5",
       prompt: "DO_IT",
-    }).argv;
+    });
+    const withModel = withModelSpawn.argv;
     expect(withModel).toEqual([
       "codex",
       "exec",
@@ -333,7 +356,7 @@ test("codex provider: every kind → `codex exec --sandbox workspace-write [-m <
       "workspace-write",
       "-m",
       "gpt-5.5",
-      "DO_IT",
+      `${codexReviewerCorrelationMarker(withModelSpawn.sessionId)}\nDO_IT`,
     ]);
     // No Claude flags leak in.
     for (const flag of [
@@ -345,12 +368,18 @@ test("codex provider: every kind → `codex exec --sandbox workspace-write [-m <
       expect(withModel).not.toContain(flag);
     }
     // No model → no -m flag, prompt still trailing.
-    const noModel = buildTransientAgentArgv(kind, {
+    const noModelSpawn = buildTransientAgentArgv(kind, {
       provider: "codex",
       model: null,
       prompt: "DO_IT",
-    }).argv;
-    expect(noModel).toEqual(["codex", "exec", "--sandbox", "workspace-write", "DO_IT"]);
+    });
+    expect(noModelSpawn.argv).toEqual([
+      "codex",
+      "exec",
+      "--sandbox",
+      "workspace-write",
+      `${codexReviewerCorrelationMarker(noModelSpawn.sessionId)}\nDO_IT`,
+    ]);
   }
 });
 

--- a/test/usage-breakdown.test.ts
+++ b/test/usage-breakdown.test.ts
@@ -125,6 +125,8 @@ function seedRoleSpawn(
     output?: number;
     cacheRead?: number;
     cacheWrite?: number;
+    providerThreadId?: string | null;
+    totalTokens?: number | null;
   },
 ): void {
   const input = r.input ?? 0;
@@ -136,8 +138,8 @@ function seedRoleSpawn(
     `INSERT INTO reviewer_spawns
        (reviewerSessionId, taskSessionId, kind, worktreePath, reviewerProvider, model,
         spawnedAt, completedAt, inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens,
-        totalTokens)
-     VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+        totalTokens, providerThreadId)
+     VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
     [
       r.id,
       "task-a",
@@ -151,7 +153,8 @@ function seedRoleSpawn(
       output,
       cacheRead,
       cacheWrite,
-      input + output + cacheRead + cacheWrite,
+      r.totalTokens === undefined ? input + output + cacheRead + cacheWrite : r.totalTokens,
+      r.providerThreadId ?? null,
     ],
   );
 }
@@ -308,6 +311,102 @@ test("legacy null-provider Claude classifier is anchored and range-filtered", as
     recap: Object.fromEntries(accepted.map((model) => [model, 1])),
   });
   expect(bd.models.claude.totalTokens).toBe(accepted.length);
+});
+
+test("Codex roles reconcile to authoritative per-model totals with legacy usage in coding", async () => {
+  const store = new SessionStore(":memory:");
+  seedRoleSpawn(store, {
+    id: "review",
+    kind: "review",
+    provider: "codex",
+    model: "gpt-5.6",
+    providerThreadId: "thread-review",
+    totalTokens: 200,
+  });
+  seedRoleSpawn(store, {
+    id: "plan",
+    kind: "plan_gate",
+    provider: "codex",
+    model: "gpt-5.6",
+    providerThreadId: "thread-plan",
+    totalTokens: 100,
+  });
+  seedRoleSpawn(store, {
+    id: "legacy",
+    kind: "recap",
+    provider: "codex",
+    model: "gpt-5.6",
+    totalTokens: 999,
+  });
+  seedRoleSpawn(store, {
+    id: "old",
+    kind: "review",
+    provider: "codex",
+    model: "gpt-5.6",
+    providerThreadId: "thread-old",
+    completedAt: NOW - 2 * H24,
+    totalTokens: 500,
+  });
+  seedRoleSpawn(store, {
+    id: "unfinished",
+    kind: "review",
+    provider: "codex",
+    model: "gpt-5.6",
+    providerThreadId: "thread-unfinished",
+    completedAt: null,
+    totalTokens: 500,
+  });
+
+  const bd = await buildUsageBreakdown({
+    store,
+    range: "24h",
+    now: NOW,
+    apiKey: false,
+    codexModelUsage: () => ({ "gpt-5.6": 1_000, unknown: 300 }),
+  });
+
+  expect(bd.models.codex).toEqual({
+    totalTokens: 1_300,
+    byModel: { "gpt-5.6": 1_000, unknown: 300 },
+    byRole: {
+      review: { "gpt-5.6": 200 },
+      plan_gate: { "gpt-5.6": 100 },
+      coding: { "gpt-5.6": 700, unknown: 300 },
+    },
+  });
+});
+
+test("Codex role attribution is capped by each authoritative model budget", async () => {
+  const store = new SessionStore(":memory:");
+  seedRoleSpawn(store, {
+    id: "review",
+    kind: "review",
+    provider: "codex",
+    model: "gpt-5.6",
+    providerThreadId: "thread-review",
+    totalTokens: 200,
+  });
+  seedRoleSpawn(store, {
+    id: "plan",
+    kind: "plan_gate",
+    provider: "codex",
+    model: "gpt-5.6",
+    providerThreadId: "thread-plan",
+    totalTokens: 200,
+  });
+
+  const bd = await buildUsageBreakdown({
+    store,
+    range: "all",
+    now: NOW,
+    apiKey: false,
+    codexModelUsage: () => ({ "gpt-5.6": 250 }),
+  });
+
+  expect(bd.models.codex.byRole).toEqual({
+    review: { "gpt-5.6": 200 },
+    plan_gate: { "gpt-5.6": 50 },
+  });
 });
 
 test("repo→task grouping, sorting, field mapping", async () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3123,5 +3123,7 @@
   "feat_build_queue_progress_toggle_title": "Build-Queue direkt öffnen",
   "feat_build_queue_progress_toggle_body": "Klicke auf das Fortschritts-Badge einer Session, um sie auszuwählen und ihre Build-Queue über dem Terminal zu öffnen. Klicke erneut auf das Badge der ausgewählten Session, um die Queue ein- oder auszuklappen.",
   "feat_usage_role_model_breakdown_title": "Claude-Verbrauch nach Rolle und Modell erkennen",
-  "feat_usage_role_model_breakdown_body": "Klappe Coding, Review, Plan Gate und weitere Claude-Rollen unter Nutzung → Modelle auf, um das verwendete Modell, seine Tokens und den jeweiligen Anteil zu sehen."
+  "feat_usage_role_model_breakdown_body": "Klappe Coding, Review, Plan Gate und weitere Claude-Rollen unter Nutzung → Modelle auf, um das verwendete Modell, seine Tokens und den jeweiligen Anteil zu sehen.",
+  "feat_codex_role_usage_title": "Codex-Verbrauch nach Rolle erkennen",
+  "feat_codex_role_usage_body": "Klappe Coding, Review, Plan Gate und weitere Codex-Rollen unter Nutzung → Modelle auf, um zu sehen, wohin die Tokens der einzelnen Modelle geflossen sind."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3123,5 +3123,7 @@
   "feat_build_queue_progress_toggle_title": "Open the build queue from progress",
   "feat_build_queue_progress_toggle_body": "Click a session's progress badge to select it and open its build queue above the terminal. Click the selected session's badge again to collapse or expand the queue.",
   "feat_usage_role_model_breakdown_title": "See Claude usage by role and model",
-  "feat_usage_role_model_breakdown_body": "Expand Coding, Review, Plan gate, and other Claude roles in Usage → Models to see which model consumed their tokens and what share it represents."
+  "feat_usage_role_model_breakdown_body": "Expand Coding, Review, Plan gate, and other Claude roles in Usage → Models to see which model consumed their tokens and what share it represents.",
+  "feat_codex_role_usage_title": "See Codex usage by role",
+  "feat_codex_role_usage_body": "Expand Coding, Review, Plan gate, and other Codex roles in Usage → Models to see where each model's tokens went."
 }

--- a/ui/src/lib/components/usage/ModelsLens.browser.test.ts
+++ b/ui/src/lib/components/usage/ModelsLens.browser.test.ts
@@ -158,4 +158,32 @@ describe("ModelsLens", () => {
     expect(modelRow.textContent).toContain("100.0%");
     expect(modelRow.textContent).toContain(formatTokenLabel(100));
   });
+
+  it("expands Codex roles in canonical order and hides the unavailable badge", () => {
+    render(ModelsLens, {
+      models: {
+        claude: { totalTokens: 0, byModel: {}, byRole: {} },
+        codex: {
+          totalTokens: 1000,
+          byModel: { "gpt-5.6": 750, "gpt-5.5": 250 },
+          byRole: {
+            coding: { "gpt-5.6": 600 },
+            review: { "gpt-5.6": 150 },
+            plan_gate: { "gpt-5.5": 250 },
+          },
+        },
+      },
+    });
+
+    const codex = document.querySelector<HTMLElement>('[data-provider="codex"]')!;
+    expect(codex.querySelector(".role-unavailable")).toBeNull();
+    const roles = codex.querySelectorAll<HTMLDetailsElement>(".role-detail");
+    expect([...roles].map((role) => role.dataset.role)).toEqual(["coding", "review", "plan_gate"]);
+    expect(roles[0]!.querySelector("summary")?.textContent).toContain("60.0%");
+    expect(roles[1]!.querySelector("summary")?.textContent).toContain("15.0%");
+    expect(roles[2]!.querySelector("summary")?.textContent).toContain("25.0%");
+    roles[2]!.querySelector<HTMLElement>("summary")!.click();
+    expect(roles[2]!.textContent).toContain("GPT-5.5");
+    expect(roles[2]!.textContent).toContain("100.0%");
+  });
 });

--- a/ui/src/lib/components/usage/ModelsLens.svelte
+++ b/ui/src/lib/components/usage/ModelsLens.svelte
@@ -140,7 +140,7 @@
           <span
             >{m.usage_models_total({ tokens: formatTokenLabel(provider.data.totalTokens) })}</span
           >
-          {#if provider.id === "codex"}
+          {#if provider.id === "codex" && roleRows.length === 0}
             <span class="role-unavailable">{m.usage_models_codex_roles_unavailable()}</span>
           {/if}
         </div>
@@ -175,7 +175,7 @@
         <p class="empty">{m.usage_models_empty()}</p>
       {/if}
 
-      {#if provider.id === "claude" && roleRows.length > 0}
+      {#if roleRows.length > 0}
         <div class="role-breakdown">
           <h3>{m.usage_models_by_role()}</h3>
           {#each roleRows as role (role.id)}

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-codex-role-usage.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-codex-role-usage.ts
@@ -1,0 +1,8 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+export default {
+  id: "codex-role-usage",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_codex_role_usage_title",
+  bodyKey: "feat_codex_role_usage_body",
+} satisfies FeatureAnnouncement;


### PR DESCRIPTION
## Summary

- correlate each new Codex role spawn with its exact provider rollout/thread ID and retry delayed state-database usage across restarts
- reconcile attributed role totals against authoritative Codex per-model totals, assigning the remainder and legacy data to Coding
- render Codex role breakdowns in Usage → Models and remove the unavailable badge when role data exists

## Verification

- bun run lint
- bun run typecheck
- bun run test (6964 passed, 8 skipped)
- cd ui && bun run check
- cd ui && bun run check:i18n
- cd ui && bun run test (3663 passed)
- pre-push gates including extension check, feature/i18n/glossary/announcement checks, and fallow audit

Closes #1728