### PR TITLE
feat(usage): add model and role breakdowns for Claude and Codex

### DIFF
--- a/src/autopilot-llm.ts
+++ b/src/autopilot-llm.ts
@@ -11,7 +11,8 @@ import type { AutopilotVerdict, AgentProvider } from "./types";
 import type { OperatorLanguage } from "./operator-language";
 import { apiKeyFailClosed, apiKeyPassthroughEnv } from "./spawn-auth";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
-import { readSessionUsage, type SessionUsage } from "./usage";
+import type { SessionUsage } from "./usage";
+import { readReviewerSpawnUsage } from "./reviewer-usage";
 import {
   VERDICT_FILE,
   SURFACE,
@@ -29,7 +30,13 @@ export type { RawVerdict } from "./autopilot-classify-core";
 
 export interface ClassifierDeps {
   herdr: Pick<HerdrDriver, "start" | "stop">;
-  store: Pick<SessionStore, "recordReviewerSpawn" | "completeReviewerSpawn">;
+  store: Pick<
+    SessionStore,
+    | "recordReviewerSpawn"
+    | "completeReviewerSpawn"
+    | "listReviewerSpawns"
+    | "setReviewerSpawnProviderSessionId"
+  >;
   taskSessionId: string;
   makeTmpDir?: () => string;
   readVerdict?: (cwd: string) => RawVerdict | null;
@@ -168,12 +175,6 @@ async function teardownClassifier(
     }
 
     if (!cwd || !sessionId) return;
-    let usage = ZEROED_USAGE;
-    try {
-      usage = (await deps.readUsage(cwd, sessionId, spawnAccountDir)) ?? ZEROED_USAGE;
-    } catch (err) {
-      deps.reportFailure("[autopilot] classifier usage read failed:", err);
-    }
 
     try {
       deps.store.recordReviewerSpawn({
@@ -191,6 +192,13 @@ async function teardownClassifier(
       return;
     }
 
+    let usage: SessionUsage | null = deps.provider === "codex" ? null : ZEROED_USAGE;
+    try {
+      usage = (await deps.readUsage(cwd, sessionId, spawnAccountDir)) ?? usage;
+    } catch (err) {
+      deps.reportFailure("[autopilot] classifier usage read failed:", err);
+    }
+
     try {
       deps.store.completeReviewerSpawn(sessionId, usage, deps.now());
     } catch (err) {
@@ -199,7 +207,7 @@ async function teardownClassifier(
   } finally {
     if (cwd) {
       try {
-        await reapHelperRun(deps.herdr, terminalId, cwd, deps.cleanup);
+        await reapHelperRun(deps.herdr, null, cwd, deps.cleanup);
       } catch (err) {
         deps.reportFailure("[autopilot] classifier cleanup failed:", err);
       }
@@ -223,8 +231,7 @@ export async function classifyStop(
     makeTmpDir = defaultMakeTmpDir,
     readVerdict = defaultReadVerdict,
     cleanup = cleanupHelperDir,
-    readUsage = readSessionUsage,
-    cleanup = defaultCleanup,
+    readUsage = (cwd, id, accountDir) => readReviewerSpawnUsage(deps.store, cwd, id, accountDir),
     warn = (message, err) => console.warn(message, err),
     provider = "claude",
     model = "haiku",

--- a/src/autopilot-llm.ts
+++ b/src/autopilot-llm.ts
@@ -6,10 +6,12 @@ import {
   reapHelperRun,
   realSleep,
 } from "./transient-helper-lifecycle";
+import type { SessionStore } from "./store";
 import type { AutopilotVerdict, AgentProvider } from "./types";
 import type { OperatorLanguage } from "./operator-language";
 import { apiKeyFailClosed, apiKeyPassthroughEnv } from "./spawn-auth";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
+import { readSessionUsage, type SessionUsage } from "./usage";
 import {
   VERDICT_FILE,
   SURFACE,
@@ -27,9 +29,17 @@ export type { RawVerdict } from "./autopilot-classify-core";
 
 export interface ClassifierDeps {
   herdr: Pick<HerdrDriver, "start" | "stop">;
+  store: Pick<SessionStore, "recordReviewerSpawn" | "completeReviewerSpawn">;
+  taskSessionId: string;
   makeTmpDir?: () => string;
   readVerdict?: (cwd: string) => RawVerdict | null;
+  readUsage?: (
+    cwd: string,
+    sessionId: string,
+    spawnAccountDir?: string | null,
+  ) => Promise<SessionUsage | null>;
   cleanup?: (cwd: string) => void;
+  warn?: (message: string, err: unknown) => void;
   provider?: AgentProvider;
   model?: string | null;
   effort?: string | null;
@@ -65,7 +75,7 @@ function classifierArgv(
   model: string | null,
   prompt: string,
   effort?: string | null,
-): string[] {
+): { argv: string[]; sessionId: string } {
   // The autopilot classifier READS the `-o` last-message fallback → opt in.
   return buildTransientAgentArgv("writer-only", {
     provider,
@@ -73,8 +83,21 @@ function classifierArgv(
     effort,
     prompt,
     captureLastMessage: true,
-  }).argv;
+  });
 }
+
+const ZEROED_USAGE: SessionUsage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  total: 0,
+  messageCount: 0,
+  lastActivity: null,
+  byModel: {},
+  fullRecaches: 0,
+  sidechainCount: 0,
+};
 
 interface PollClock {
   now: () => number;
@@ -97,6 +120,93 @@ async function pollForVerdict(
   return null;
 }
 
+type ReportFailure = (message: string, err: unknown) => void;
+
+function failureReporter(warn: NonNullable<ClassifierDeps["warn"]>): ReportFailure {
+  return (message, err) => {
+    try {
+      warn(message, err);
+    } catch {
+      /* logging must not change the classifier verdict or teardown */
+    }
+  };
+}
+
+interface ClassifierTeardownState {
+  cwd: string | null;
+  terminalId: string | null;
+  sessionId: string | null;
+  spawnedAt: number | null;
+  spawnAccountDir?: string;
+}
+
+interface ClassifierTeardownDeps {
+  herdr: ClassifierDeps["herdr"];
+  store: ClassifierDeps["store"];
+  taskSessionId: string;
+  readUsage: NonNullable<ClassifierDeps["readUsage"]>;
+  cleanup: NonNullable<ClassifierDeps["cleanup"]>;
+  reportFailure: ReportFailure;
+  provider: AgentProvider;
+  model: string | null;
+  effort: string | null;
+  now: () => number;
+}
+
+async function teardownClassifier(
+  state: ClassifierTeardownState,
+  deps: ClassifierTeardownDeps,
+): Promise<void> {
+  const { cwd, terminalId, sessionId, spawnedAt, spawnAccountDir } = state;
+  try {
+    if (!terminalId) return;
+
+    try {
+      await deps.herdr.stop(terminalId);
+    } catch (err) {
+      deps.reportFailure("[autopilot] classifier stop failed:", err);
+    }
+
+    if (!cwd || !sessionId) return;
+    let usage = ZEROED_USAGE;
+    try {
+      usage = (await deps.readUsage(cwd, sessionId, spawnAccountDir)) ?? ZEROED_USAGE;
+    } catch (err) {
+      deps.reportFailure("[autopilot] classifier usage read failed:", err);
+    }
+
+    try {
+      deps.store.recordReviewerSpawn({
+        reviewerSessionId: sessionId,
+        taskSessionId: deps.taskSessionId,
+        kind: "classifier",
+        worktreePath: cwd,
+        reviewerProvider: deps.provider,
+        model: deps.model,
+        reviewerEffort: deps.effort,
+        spawnedAt: spawnedAt ?? deps.now(),
+      });
+    } catch (err) {
+      deps.reportFailure("[autopilot] classifier usage record failed:", err);
+      return;
+    }
+
+    try {
+      deps.store.completeReviewerSpawn(sessionId, usage, deps.now());
+    } catch (err) {
+      deps.reportFailure("[autopilot] classifier usage completion failed:", err);
+    }
+  } finally {
+    if (cwd) {
+      try {
+        await reapHelperRun(deps.herdr, terminalId, cwd, deps.cleanup);
+      } catch (err) {
+        deps.reportFailure("[autopilot] classifier cleanup failed:", err);
+      }
+    }
+  }
+}
+
 /**
  * Classify why an agent stopped, via a transient interactive `claude` (subscription OAuth —
  * NOT `claude -p`). Spawns the classifier model in a fresh temp dir with only the Write
@@ -113,6 +223,9 @@ export async function classifyStop(
     makeTmpDir = defaultMakeTmpDir,
     readVerdict = defaultReadVerdict,
     cleanup = cleanupHelperDir,
+    readUsage = readSessionUsage,
+    cleanup = defaultCleanup,
+    warn = (message, err) => console.warn(message, err),
     provider = "claude",
     model = "haiku",
     effort = null,
@@ -126,6 +239,7 @@ export async function classifyStop(
     timeoutMs = 120_000,
     pollMs = 1_000,
   } = deps;
+  const reportFailure = failureReporter(warn);
 
   // Fail closed: in Anthropic api-key mode without a configured key, a Claude spawn must NOT bill
   // the subscription — surface to the operator rather than auto-classifying on the wrong footing.
@@ -137,24 +251,39 @@ export async function classifyStop(
 
   let cwd: string | null = null;
   let terminalId: string | null = null;
+  let classifierSessionId: string | null = null;
+  let spawnedAt: number | null = null;
+  let spawnAccountDir: string | undefined;
   try {
     cwd = makeTmpDir();
     const prompt = classifierPrompt(tail, taskPrompt, operatorLanguage);
     try {
-      terminalId = (
-        await deps.herdr.start(
-          label,
-          cwd,
-          classifierArgv(provider, model, prompt, effort),
-          apiKeyPassthroughEnv(false),
-        )
-      ).terminalId;
+      const built = classifierArgv(provider, model, prompt, effort);
+      classifierSessionId = built.sessionId;
+      const spawnEnv = apiKeyPassthroughEnv(false);
+      spawnAccountDir = spawnEnv?.CLAUDE_CONFIG_DIR;
+      terminalId = (await deps.herdr.start(label, cwd, built.argv, spawnEnv)).terminalId;
+      spawnedAt = now();
     } catch {
       return SURFACE; // herdr/claude unavailable → surface (don't auto-proceed blind)
     }
     const raw = await pollForVerdict(readVerdict, cwd, { now, sleep, timeoutMs, pollMs });
     return normalize(raw);
   } finally {
-    await reapHelperRun(deps.herdr, terminalId, cwd, cleanup);
+    await teardownClassifier(
+      { cwd, terminalId, sessionId: classifierSessionId, spawnedAt, spawnAccountDir },
+      {
+        herdr: deps.herdr,
+        store: deps.store,
+        taskSessionId: deps.taskSessionId,
+        readUsage,
+        cleanup,
+        reportFailure,
+        provider,
+        model,
+        effort,
+        now,
+      },
+    );
   }
 }

--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -156,7 +156,12 @@ export interface AutopilotDeps {
     "get" | "list" | "getRepoConfig" | "setAutopilotState" | "setAutoMergeState"
   >;
   /** Classify why an agent stopped (src/autopilot-llm.classifyStop, pre-bound to herdr+model). */
-  classify: (tail: string[], taskPrompt: string, label: string) => Promise<AutopilotVerdict>;
+  classify: (
+    tail: string[],
+    taskPrompt: string,
+    label: string,
+    taskSessionId: string,
+  ) => Promise<AutopilotVerdict>;
   /** Steer text into the session's live PTY (SessionService.reply). false = didn't land. */
   steer: (id: string, text: string) => Promise<boolean>;
   /** Resume an exited session so it can be steered (SessionService.resume, async — the
@@ -413,7 +418,7 @@ export class AutopilotService {
     this.pending.add(id);
     let v: AutopilotVerdict;
     try {
-      v = await this.deps.classify(tail, s.prompt, label);
+      v = await this.deps.classify(tail, s.prompt, label, s.id);
     } finally {
       this.pending.delete(id);
     }

--- a/src/codex-activity.ts
+++ b/src/codex-activity.ts
@@ -610,6 +610,7 @@ export async function codexSessionActivity(
 
 /** What the backfill needs from the store (kept structural so it's trivially injectable). */
 export interface CodexUsageBackfillStore {
+  setReviewerSpawnProviderSessionId(reviewerSessionId: string, providerSessionId: string): void;
   listBackfillableCodexSpawns(limit?: number): Array<{
     reviewerSessionId: string;
     worktreePath: string;
@@ -660,6 +661,7 @@ export function backfillCodexSpawnUsage(
         providerSessionId: row.providerSessionId,
       });
       if (!hit) continue; // rollout gone or still ambiguous → stays NULL (honest)
+      store.setReviewerSpawnProviderSessionId(row.reviewerSessionId, hit.rolloutId);
       // A resolved rollout is the proof, so its totals are booked as-is — including a genuine zero
       // (a run whose rollout records no `token_count`). That is exactly what finalize does for the
       // same case, and `0` is the contract's *proven* zero, distinct from NULL = unknown. Skipping

--- a/src/codex-usage.ts
+++ b/src/codex-usage.ts
@@ -240,6 +240,42 @@ export function readCodexModelUsage(dbPath: string | null, cutoff: number): Reco
   }
 }
 
+/** Read the authoritative token total for one provider-native Codex thread. */
+export function readCodexThreadUsage(
+  dbPath: string | null,
+  threadId: string,
+): { model: string; totalTokens: number } | null {
+  if (!dbPath || !existsSync(dbPath)) return null;
+  let db: Database | null = null;
+  try {
+    db = new Database(dbPath, { readonly: true });
+    const columns = db.query(`PRAGMA table_info(threads)`).all() as { name: string }[];
+    const hasModel = columns.some((column) => column.name === "model");
+    if (hasModel) {
+      const row = db
+        .query<{ model: string; totalTokens: number }, [string]>(
+          `SELECT COALESCE(NULLIF(model, ''), 'unknown') AS model, tokens_used AS totalTokens
+           FROM threads
+           WHERE id = ? AND model_provider = 'openai'`,
+        )
+        .get(threadId);
+      return row ? { model: row.model, totalTokens: row.totalTokens } : null;
+    }
+    const row = db
+      .query<{ totalTokens: number }, [string]>(
+        `SELECT tokens_used AS totalTokens
+         FROM threads
+         WHERE id = ? AND model_provider = 'openai'`,
+      )
+      .get(threadId);
+    return row ? { model: "unknown", totalTokens: row.totalTokens } : null;
+  } catch {
+    return null;
+  } finally {
+    db?.close();
+  }
+}
+
 /** One rollout's `rate_limits.primary`/`.secondary` shape (Codex CLI session log). */
 interface RolloutLimitWindow {
   used_percent?: number;

--- a/src/codex-usage.ts
+++ b/src/codex-usage.ts
@@ -205,10 +205,7 @@ export function readCodexTokenUsage(dbPath: string, now: number): UsageProviderS
 }
 
 /** Raw Codex token totals grouped by model for OpenAI threads updated in the selected range. */
-export function readCodexModelUsage(
-  dbPath: string | null,
-  cutoff: number,
-): Record<string, number> {
+export function readCodexModelUsage(dbPath: string | null, cutoff: number): Record<string, number> {
   if (!dbPath || !existsSync(dbPath)) return {};
   let db: Database | null = null;
   try {
@@ -233,7 +230,9 @@ export function readCodexModelUsage(
          GROUP BY COALESCE(NULLIF(model, ''), 'unknown')`,
       )
       .all(cutoff);
-    return Object.fromEntries(rows.filter((row) => row.tokens > 0).map((row) => [row.model, row.tokens]));
+    return Object.fromEntries(
+      rows.filter((row) => row.tokens > 0).map((row) => [row.model, row.tokens]),
+    );
   } catch {
     return {};
   } finally {

--- a/src/codex-usage.ts
+++ b/src/codex-usage.ts
@@ -204,6 +204,43 @@ export function readCodexTokenUsage(dbPath: string, now: number): UsageProviderS
   return st ? tokenSnapshot(st, now) : null;
 }
 
+/** Raw Codex token totals grouped by model for OpenAI threads updated in the selected range. */
+export function readCodexModelUsage(
+  dbPath: string | null,
+  cutoff: number,
+): Record<string, number> {
+  if (!dbPath || !existsSync(dbPath)) return {};
+  let db: Database | null = null;
+  try {
+    db = new Database(dbPath, { readonly: true });
+    const columns = db.query(`PRAGMA table_info(threads)`).all() as { name: string }[];
+    if (!columns.some((column) => column.name === "model")) {
+      const row = db
+        .query<{ tokens: number | null }, [number]>(
+          `SELECT SUM(tokens_used) AS tokens
+           FROM threads
+           WHERE model_provider = 'openai' AND updated_at_ms >= ?`,
+        )
+        .get(cutoff);
+      return row?.tokens ? { unknown: row.tokens } : {};
+    }
+
+    const rows = db
+      .query<{ model: string; tokens: number }, [number]>(
+        `SELECT COALESCE(NULLIF(model, ''), 'unknown') AS model, SUM(tokens_used) AS tokens
+         FROM threads
+         WHERE model_provider = 'openai' AND updated_at_ms >= ?
+         GROUP BY COALESCE(NULLIF(model, ''), 'unknown')`,
+      )
+      .all(cutoff);
+    return Object.fromEntries(rows.filter((row) => row.tokens > 0).map((row) => [row.model, row.tokens]));
+  } catch {
+    return {};
+  } finally {
+    db?.close();
+  }
+}
+
 /** One rollout's `rate_limits.primary`/`.secondary` shape (Codex CLI session log). */
 interface RolloutLimitWindow {
   used_percent?: number;

--- a/src/codex-usage.ts
+++ b/src/codex-usage.ts
@@ -204,73 +204,38 @@ export function readCodexTokenUsage(dbPath: string, now: number): UsageProviderS
   return st ? tokenSnapshot(st, now) : null;
 }
 
-/** Raw Codex token totals grouped by model for OpenAI threads updated in the selected range. */
-export function readCodexModelUsage(dbPath: string | null, cutoff: number): Record<string, number> {
-  if (!dbPath || !existsSync(dbPath)) return {};
-  let db: Database | null = null;
-  try {
-    db = new Database(dbPath, { readonly: true });
-    const columns = db.query(`PRAGMA table_info(threads)`).all() as { name: string }[];
-    if (!columns.some((column) => column.name === "model")) {
-      const row = db
-        .query<{ tokens: number | null }, [number]>(
-          `SELECT SUM(tokens_used) AS tokens
-           FROM threads
-           WHERE model_provider = 'openai' AND updated_at_ms >= ?`,
-        )
-        .get(cutoff);
-      return row?.tokens ? { unknown: row.tokens } : {};
-    }
-
-    const rows = db
-      .query<{ model: string; tokens: number }, [number]>(
-        `SELECT COALESCE(NULLIF(model, ''), 'unknown') AS model, SUM(tokens_used) AS tokens
-         FROM threads
-         WHERE model_provider = 'openai' AND updated_at_ms >= ?
-         GROUP BY COALESCE(NULLIF(model, ''), 'unknown')`,
-      )
-      .all(cutoff);
-    return Object.fromEntries(
-      rows.filter((row) => row.tokens > 0).map((row) => [row.model, row.tokens]),
-    );
-  } catch {
-    return {};
-  } finally {
-    db?.close();
-  }
+export interface CodexModelUsage {
+  byModel: Record<string, number>;
+  byThread: Record<string, { model: string; totalTokens: number }>;
 }
 
-/** Read the authoritative token total for one provider-native Codex thread. */
-export function readCodexThreadUsage(
-  dbPath: string | null,
-  threadId: string,
-): { model: string; totalTokens: number } | null {
-  if (!dbPath || !existsSync(dbPath)) return null;
+/** One native snapshot supplies both model totals and exact in-window role allocations. */
+export function readCodexModelUsage(dbPath: string | null, cutoff: number): CodexModelUsage {
+  const empty: CodexModelUsage = { byModel: {}, byThread: {} };
+  if (!dbPath || !existsSync(dbPath)) return empty;
   let db: Database | null = null;
   try {
     db = new Database(dbPath, { readonly: true });
     const columns = db.query(`PRAGMA table_info(threads)`).all() as { name: string }[];
-    const hasModel = columns.some((column) => column.name === "model");
-    if (hasModel) {
-      const row = db
-        .query<{ model: string; totalTokens: number }, [string]>(
-          `SELECT COALESCE(NULLIF(model, ''), 'unknown') AS model, tokens_used AS totalTokens
-           FROM threads
-           WHERE id = ? AND model_provider = 'openai'`,
-        )
-        .get(threadId);
-      return row ? { model: row.model, totalTokens: row.totalTokens } : null;
-    }
-    const row = db
-      .query<{ totalTokens: number }, [string]>(
-        `SELECT tokens_used AS totalTokens
-         FROM threads
-         WHERE id = ? AND model_provider = 'openai'`,
+    const model = columns.some((column) => column.name === "model")
+      ? "COALESCE(NULLIF(model, ''), 'unknown')"
+      : "'unknown'";
+    const rows = db
+      .query<{ id: string; model: string; totalTokens: number }, [number]>(
+        `SELECT id, ${model} AS model, tokens_used AS totalTokens
+       FROM threads WHERE model_provider = 'openai' AND updated_at_ms >= ? AND tokens_used > 0`,
       )
-      .get(threadId);
-    return row ? { model: "unknown", totalTokens: row.totalTokens } : null;
+      .all(cutoff);
+    const byModel: Record<string, number> = {};
+    for (const row of rows) byModel[row.model] = (byModel[row.model] ?? 0) + row.totalTokens;
+    return {
+      byModel,
+      byThread: Object.fromEntries(
+        rows.map(({ id, model, totalTokens }) => [id, { model, totalTokens }]),
+      ),
+    };
   } catch {
-    return null;
+    return empty;
   } finally {
     db?.close();
   }

--- a/src/doc-agent.ts
+++ b/src/doc-agent.ts
@@ -725,7 +725,7 @@ export class DocAgentService {
       this.deps.worktree.remove(wt.worktreePath);
       return { ok: false, result: { status: "error", reason: "spawn failed" } };
     }
-    const { terminalId, spawnSessionId } = spawned;
+    const { terminalId, spawnSessionId, reviewerProvider, model, reviewerEffort } = spawned;
     const startedAt = this.now();
     this.inflight.set(repoPath, {
       repoPath,
@@ -748,7 +748,9 @@ export class DocAgentService {
       taskSessionId: repoPath,
       kind: "doc_agent",
       worktreePath: wt.worktreePath,
-      model: this.deps.env?.().model ?? null,
+      reviewerProvider,
+      model,
+      reviewerEffort,
       spawnedAt: startedAt,
     });
     return { ok: true };
@@ -822,7 +824,18 @@ export class DocAgentService {
     agentName: string,
     base: string,
     promptCtx?: RetargetPromptCtx,
-  ): Promise<{ terminalId: string; spawnSessionId: string } | null | "aborted" | "refused"> {
+  ): Promise<
+    | {
+        terminalId: string;
+        spawnSessionId: string;
+        reviewerProvider: RoleEnvironment["provider"];
+        model: string | null;
+        reviewerEffort: string | null;
+      }
+    | null
+    | "aborted"
+    | "refused"
+  > {
     const env = this.deps.env?.() ?? { provider: "claude" as const, model: null };
     const { argv, sessionId } = buildTransientAgentArgv("doc", {
       provider: env.provider,
@@ -842,7 +855,7 @@ export class DocAgentService {
       descriptor: {
         sessionId,
         kind: "doc",
-        model: this.deps.env?.().model ?? null,
+        model: env.model,
       },
     });
     if ("refused" in aux) {
@@ -860,7 +873,13 @@ export class DocAgentService {
       const terminalId = (
         await this.deps.herdr.start(agentName, worktreePath, aux.wrapped, aux.spawnEnv)
       ).terminalId;
-      return { terminalId, spawnSessionId: sessionId };
+      return {
+        terminalId,
+        spawnSessionId: sessionId,
+        reviewerProvider: env.provider,
+        model: env.model,
+        reviewerEffort: env.effort ?? null,
+      };
     } catch (err) {
       if (err instanceof HerdrUnavailableError) {
         console.warn(`[doc-agent] herdr unavailable for ${repoPath}:`, err);

--- a/src/doc-agent.ts
+++ b/src/doc-agent.ts
@@ -14,7 +14,7 @@ import type { SessionStore } from "./store";
 import type { DocAgentOutcome, DocAgentRun, Session } from "./types";
 import type { RoleEnvironment } from "./default-model";
 import type { SessionUsage } from "./usage";
-import { readSessionUsage } from "./usage";
+import { readReviewerSpawnUsage } from "./reviewer-usage";
 import { apiKeyFailClosed } from "./spawn-auth";
 import { resolveAuxSpawn, type MembraneSeams } from "./spawn-membrane";
 import type { WorktreeMgr } from "./worktree";
@@ -286,6 +286,7 @@ export interface DocAgentDeps extends MembraneSeams {
     SessionStore,
     | "getSetting"
     | "setSetting"
+    | "setReviewerSpawnProviderSessionId"
     | "recordReviewerSpawn"
     | "completeReviewerSpawn"
     | "listReviewerSpawns"
@@ -387,7 +388,7 @@ export class DocAgentService {
     this.readSentinel = deps.readSentinel ?? defaultReadSentinel;
     this.buildPrompt = deps.buildPrompt ?? ((base, ctx) => docAgentPrompt(base, ctx));
     this.act = deps.act ?? false;
-    this.readUsage = deps.readUsage ?? readSessionUsage;
+    this.readUsage = deps.readUsage ?? ((cwd, id) => readReviewerSpawnUsage(deps.store, cwd, id));
     this.idleThresholdMs = deps.idleThresholdMs ?? DEFAULT_IDLE_THRESHOLD_MS;
     this.writeMarkerFn = deps.writeMarker ?? ((p, c) => writeFileSync(p, c, "utf8"));
     this.readMarkerFn = deps.readMarker ?? defaultReadMarker;
@@ -1029,7 +1030,9 @@ export class DocAgentService {
       // and act) BEFORE the worktree is removed — mirrors recap.ts / review.ts.
       // completeReviewerSpawn no-ops on an unknown id, so an empty/missing id is safe.
       const usage = await this.readUsage(f.worktreePath, f.spawnSessionId).catch(() => null);
-      this.deps.store.completeReviewerSpawn(f.spawnSessionId, usage ?? ZEROED_USAGE, this.now());
+      const fallback =
+        this.uncompletedRowFor(f.worktreePath)?.reviewerProvider === "codex" ? null : ZEROED_USAGE;
+      this.deps.store.completeReviewerSpawn(f.spawnSessionId, usage ?? fallback, this.now());
       // Cleanup mirrors Promoter.cleanup: stop the agent (closes its tab), remove the worktree, and
       // force-delete the local branch (the pushed remote branch backs any opened PR).
       await this.deps.herdr.stop(f.terminalId);
@@ -1511,7 +1514,8 @@ export class DocAgentService {
     const row = this.uncompletedRowFor(worktreePath);
     if (!row) return;
     const u = await this.readUsage(worktreePath, row.reviewerSessionId).catch(() => null);
-    this.deps.store.completeReviewerSpawn(row.reviewerSessionId, u ?? ZEROED_USAGE, this.now());
+    const fallback = row.reviewerProvider === "codex" ? null : ZEROED_USAGE;
+    this.deps.store.completeReviewerSpawn(row.reviewerSessionId, u ?? fallback, this.now());
   }
 
   /** The uncompleted `doc_agent` reviewer_spawns row for a worktree path, or undefined. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,11 +53,7 @@ import { parseManualSteps } from "./manual-steps";
 import { annotateHandoff } from "./repo-roles";
 import { AccountUsageIndex, SessionUsageRollup } from "./usage";
 import { UsageLimitsService, calibrateDelay, type UsageLimits } from "./usage-limits";
-import {
-  CodexUsageProvider,
-  latestCodexStateDb,
-  readCodexModelUsage,
-} from "./codex-usage";
+import { CodexUsageProvider, latestCodexStateDb, readCodexModelUsage } from "./codex-usage";
 import { singleFlight } from "./single-flight";
 import { HerdrUsageProbe } from "./usage-probe";
 import { sweepStaging, STAGING_TTL_MS } from "./uploads";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1954,13 +1954,15 @@ function readVisibleBuffer(id: string): string | null {
 // (drive to a PR). Genuine questions pause the session loudly (distinct state + push).
 const autopilot = new AutopilotService({
   store,
-  classify: (tail, taskPrompt, label) => {
+  classify: (tail, taskPrompt, label, taskSessionId) => {
     const env = roleEnv(config.autopilotCli, config.autopilotModel, config.autopilotEffort);
     return classifyStop(
       tail,
       taskPrompt,
       {
         herdr,
+        store,
+        taskSessionId,
         provider: env.provider,
         model: env.model,
         effort: env.effort,

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,11 @@ import { parseManualSteps } from "./manual-steps";
 import { annotateHandoff } from "./repo-roles";
 import { AccountUsageIndex, SessionUsageRollup } from "./usage";
 import { UsageLimitsService, calibrateDelay, type UsageLimits } from "./usage-limits";
-import { CodexUsageProvider } from "./codex-usage";
+import {
+  CodexUsageProvider,
+  latestCodexStateDb,
+  readCodexModelUsage,
+} from "./codex-usage";
 import { singleFlight } from "./single-flight";
 import { HerdrUsageProbe } from "./usage-probe";
 import { sweepStaging, STAGING_TTL_MS } from "./uploads";
@@ -2884,6 +2888,7 @@ const appDeps: AppDeps = {
   pluginsDir: config.pluginsDir,
   usageLimits,
   usageRollup,
+  codexModelUsage: (cutoff) => readCodexModelUsage(latestCodexStateDb(), cutoff),
   refreshUsage,
   // Live GitHub REST + GraphQL buckets for the usage view. `gh api rate_limit`
   // is quota-exempt, so it works even when the GraphQL bucket is at zero.

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -40,7 +40,7 @@ import type { RoleEnvironment } from "./default-model";
 import type { OperatorLanguage } from "./operator-language";
 import type { ActivityEntry } from "./activity";
 import type { SessionUsage } from "./usage";
-import { readSessionUsage } from "./usage";
+import { readReviewerSpawnUsage } from "./reviewer-usage";
 import { computeDiff } from "./diff";
 import { parseActivity, readTranscriptTail } from "./activity";
 import { jsonlPathFor } from "./usage";
@@ -323,6 +323,7 @@ export interface RecapServiceDeps {
     | "generatingRecaps"
     | "dropRecap"
     | "getReview"
+    | "setReviewerSpawnProviderSessionId"
     | "recordReviewerSpawn"
     | "completeReviewerSpawn"
     | "listReviewerSpawns"
@@ -440,7 +441,9 @@ export class RecapService {
     this._readTranscript = optional(deps.readTranscript, defaultReadTranscript);
     this._readPlan = optional(deps.readPlan, defaultReadPlan);
     this._readVerdict = optional(deps.readVerdict, defaultReadVerdict);
-    this._readUsage = optional(deps.readUsage, readSessionUsage);
+    this._readUsage = optional(deps.readUsage, (cwd, id) =>
+      readReviewerSpawnUsage(deps.store, cwd, id),
+    );
     this._currentBranch = optional(deps.currentBranch, defaultCurrentBranch);
     this._headContainedInBase = optional(deps.headContainedInBase, defaultHeadContainedInBase);
     this._landedWorkEvidence = optional(deps.landedWorkEvidence, () => null);

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -1153,7 +1153,7 @@ export class RecapService {
       // Best-effort usage capture.
       try {
         const u = await this._readUsage(r.cwd, r.spawnSessionId);
-        if (u) this.deps.store.completeReviewerSpawn(r.spawnSessionId, u, t);
+        this.deps.store.completeReviewerSpawn(r.spawnSessionId, u, t);
       } catch (err) {
         console.warn(`[recap] usage capture failed for ${r.sessionId}:`, err);
       }

--- a/src/reviewer-usage.ts
+++ b/src/reviewer-usage.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import type { SessionStore } from "./store";
+import { createCodexRolloutResolver, parseCodexUsage } from "./codex-activity";
+import { readSessionUsage, type SessionUsage } from "./usage";
+
+/** Finalize-time reader for helpers whose provider is recorded on their spawn row. */
+export async function readReviewerSpawnUsage(
+  store: Pick<SessionStore, "listReviewerSpawns" | "setReviewerSpawnProviderSessionId">,
+  worktreePath: string,
+  trackingId: string,
+  spawnAccountDir?: string | null,
+  resolver = createCodexRolloutResolver(),
+): Promise<SessionUsage | null> {
+  const row = store.listReviewerSpawns().find((spawn) => spawn.reviewerSessionId === trackingId);
+  if (row?.reviewerProvider !== "codex") {
+    return readSessionUsage(worktreePath, trackingId, spawnAccountDir);
+  }
+  try {
+    const hit = resolver.resolve(
+      { trackingId, worktreePath, source: "exec", providerSessionId: row.providerSessionId },
+      { bypassBackoff: true },
+    );
+    if (!hit) return null;
+    store.setReviewerSpawnProviderSessionId(trackingId, hit.rolloutId);
+    return parseCodexUsage(readFileSync(hit.path, "utf8"), row.model);
+  } catch {
+    return null;
+  } finally {
+    resolver.reset(trackingId);
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -324,6 +324,8 @@ export interface AppDeps {
   refreshUsage?: () => Promise<{ limits: UsageLimits; scraped: boolean }>;
   /** Incremental per-session rollup; absent in tests → breakdown falls back to re-parsing JSONL. */
   usageRollup?: SessionUsageRollup;
+  /** Range-filtered Codex raw tokens by model; absent in tests → empty Codex model block. */
+  codexModelUsage?: (cutoff: number) => Record<string, number>;
   /** Live GitHub REST + GraphQL rate-limit buckets (via `gh api rate_limit`, which is
    *  itself quota-exempt); absent in tests → `/api/usage/github` 503s. */
   githubRateLimit?: () => Promise<GithubRateLimitPayload>;
@@ -4507,6 +4509,7 @@ async function handleUsageBreakdown({ req, parts, url, deps }: Ctx): Promise<Res
     now: Date.now(),
     apiKey: isApiKeyMode(),
     usageRollup: deps.usageRollup,
+    codexModelUsage: deps.codexModelUsage,
   });
   return json(breakdown);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -325,7 +325,7 @@ export interface AppDeps {
   /** Incremental per-session rollup; absent in tests → breakdown falls back to re-parsing JSONL. */
   usageRollup?: SessionUsageRollup;
   /** Range-filtered Codex raw tokens by model; absent in tests → empty Codex model block. */
-  codexModelUsage?: (cutoff: number) => Record<string, number>;
+  codexModelUsage?: (cutoff: number) => import("./codex-usage").CodexModelUsage;
   /** Live GitHub REST + GraphQL rate-limit buckets (via `gh api rate_limit`, which is
    *  itself quota-exempt); absent in tests → `/api/usage/github` 503s. */
   githubRateLimit?: () => Promise<GithubRateLimitPayload>;

--- a/src/standalone-critic.ts
+++ b/src/standalone-critic.ts
@@ -34,7 +34,8 @@ import {
 } from "./house-rules";
 import { checksCleared, repoHasNoCiCached } from "./checks-gate";
 import { apiKeyFailClosed } from "./spawn-auth";
-import { readSessionUsage, type SessionUsage } from "./usage";
+import type { SessionUsage } from "./usage";
+import { readReviewerSpawnUsage } from "./reviewer-usage";
 import {
   prReviewPrompt,
   defaultReadVerdict,
@@ -87,6 +88,8 @@ export interface StandalonePrCriticDeps extends MembraneSeams {
     | "getPrReview"
     | "putPrReview"
     | "bumpPrReviewHead"
+    | "setReviewerSpawnProviderSessionId"
+    | "listReviewerSpawns"
     | "recordReviewerSpawn"
     | "completeReviewerSpawn"
     | "listEpicCompleted"
@@ -170,7 +173,7 @@ export class StandalonePrCriticService {
     this.readVerdict = deps.readVerdict ?? defaultReadVerdict;
     this.computePatchId = deps.computePatchId ?? defaultComputePatchId;
     this.collectBaseDelta = deps.collectBaseDelta ?? defaultCollectBaseDelta;
-    this.readUsage = deps.readUsage ?? readSessionUsage;
+    this.readUsage = deps.readUsage ?? ((cwd, id) => readReviewerSpawnUsage(deps.store, cwd, id));
     this.readReviewPolicy = deps.readReviewPolicy ?? defaultReadReviewPolicy;
     this.houseRulesBudgetFn =
       deps.houseRulesBudgetChars ?? (() => HOUSE_RULES_DEFAULT_BUDGET_CHARS);
@@ -397,14 +400,13 @@ export class StandalonePrCriticService {
 
       let wt;
       try {
-        // createDetached is (repoPath, branch, sha, slug?, pullRef?) — slug is undefined here (the
-        // PR head sha is already unique per PR, so the default `…-review-<sha>` path is collision-
-        // free and reused-on-restart to reclaim an interrupted run). pullRef lands the fork head.
+        // A unique cwd per launch lets the Codex resolver distinguish a restarted review
+        // from the interrupted run at the same head. pullRef lands a fork's head.
         wt = await this.deps.worktree.createDetached(
           repoPath,
           pr.headRefName!,
           pr.headSha!,
-          undefined,
+          randomUUID(),
           pullRef,
         );
       } catch (err) {

--- a/src/standalone-critic.ts
+++ b/src/standalone-critic.ts
@@ -513,14 +513,14 @@ export class StandalonePrCriticService {
       landing?: LandingContext | null;
     },
   ): Promise<void> {
-    if (apiKeyFailClosed(this.deps.env?.().provider ?? "claude")) {
+    const env = this.deps.env?.() ?? { provider: "claude" as const, model: null };
+    if (apiKeyFailClosed(env.provider)) {
       this.log(
         `[pr-critic] ${repoPath}#${pr.number} api-key mode enabled but no API key configured — skipping (fail closed, not billing subscription)`,
       );
       this.deps.worktree.remove(worktreePath);
       return;
     }
-    const env = this.deps.env?.() ?? { provider: "claude" as const, model: null };
     // #2154: repo policy from the BASE COMMIT (never the checked-out PR head — this is the site
     // where the head may be a fork nobody vetted), plus the repo's standing house rules, scoped by
     // the diff's changed files. Both null ⇒ the composed prompt is unchanged.
@@ -559,7 +559,7 @@ export class StandalonePrCriticService {
       descriptor: {
         sessionId: criticSessionId,
         kind: "review",
-        model: this.deps.env?.().model ?? null,
+        model: env.model,
       },
     });
     if ("refused" in patch) {
@@ -657,7 +657,9 @@ export class StandalonePrCriticService {
       taskSessionId: `pr:${repoPath}#${pr.number}`,
       kind: "review",
       worktreePath,
-      model: this.deps.env?.().model ?? null,
+      reviewerProvider: env.provider,
+      model: env.model,
+      reviewerEffort: env.effort ?? null,
       spawnedAt: this.now(),
     });
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -3962,13 +3962,13 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
   }
 
   // ── reviewer spawn cost attribution ──────────────────────────────────────────
-  /** Record a freshly-spawned reviewer session. Token/completed columns stay NULL until
+  /** Record a freshly-spawned reviewer/satellite session. Token/completed columns stay NULL until
    *  finalize (`completeReviewerSpawn`). A plain INSERT is correct — every spawn forces a
    *  fresh reviewerSessionId UUID, so the PK never collides. */
   recordReviewerSpawn(r: {
     reviewerSessionId: string;
     taskSessionId: string;
-    kind: "review" | "plan_gate" | "recap" | "doc_agent" | "maintain";
+    kind: "review" | "plan_gate" | "recap" | "doc_agent" | "maintain" | "classifier";
     worktreePath: string;
     reviewerProvider?: AgentProvider | null;
     model: string | null;

--- a/src/store.ts
+++ b/src/store.ts
@@ -1694,6 +1694,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       cacheReadUnits REAL NOT NULL,
       messageCount   INTEGER NOT NULL,
       byModel        TEXT NOT NULL DEFAULT '{}',
+      rawByModel     TEXT NOT NULL DEFAULT '{}',
       createdAt      INTEGER NOT NULL,
       archivedAt     INTEGER NOT NULL,
       snapshotAt     INTEGER NOT NULL)`);
@@ -1707,6 +1708,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       weightedUnits  REAL NOT NULL,
       cacheReadUnits REAL NOT NULL,
       byModel        TEXT NOT NULL DEFAULT '{}',
+      rawByModel     TEXT NOT NULL DEFAULT '{}',
       PRIMARY KEY (sessionId, bucketStart),
       FOREIGN KEY (sessionId) REFERENCES session_usage(sessionId) ON DELETE CASCADE
     )`);
@@ -1719,6 +1721,12 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     if (!usageCols.some((c) => c.name === "name")) {
       this.db.run(`ALTER TABLE session_usage ADD COLUMN name TEXT NOT NULL DEFAULT ''`);
     }
+    this.addMissingColumns("session_usage", {
+      rawByModel: "TEXT NOT NULL DEFAULT '{}'",
+    });
+    this.addMissingColumns("session_usage_bucket", {
+      rawByModel: "TEXT NOT NULL DEFAULT '{}'",
+    });
     // provenance column (see SessionUsageRow.claudeSessionId): legacy rows default to '',
     // which the archived-usage read tolerates as "pre-provenance"
     if (!usageCols.some((c) => c.name === "claudeSessionId")) {
@@ -6223,8 +6231,8 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     this.db.run(
       `INSERT INTO session_usage
          (sessionId, desig, name, claudeSessionId, repoPath, model, input, output, cacheRead, cacheWrite, total,
-          weightedUnits, cacheReadUnits, messageCount, byModel, createdAt, archivedAt, snapshotAt)
-       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+          weightedUnits, cacheReadUnits, messageCount, byModel, rawByModel, createdAt, archivedAt, snapshotAt)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
        ON CONFLICT(sessionId) DO UPDATE SET
          desig = excluded.desig,
          name = excluded.name,
@@ -6240,6 +6248,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
          cacheReadUnits = excluded.cacheReadUnits,
          messageCount = excluded.messageCount,
          byModel = excluded.byModel,
+         rawByModel = excluded.rawByModel,
          createdAt = excluded.createdAt,
          archivedAt = excluded.archivedAt,
          snapshotAt = excluded.snapshotAt`,
@@ -6259,6 +6268,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
         snap.cacheReadUnits,
         snap.messageCount,
         JSON.stringify(snap.byModel),
+        JSON.stringify(snap.rawByModel),
         snap.createdAt,
         snap.archivedAt,
         snap.snapshotAt,
@@ -6266,13 +6276,18 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     );
   }
 
-  /** All session usage snapshots, with byModel hydrated from JSON. */
+  /** All session usage snapshots, with model maps hydrated from JSON. */
   listSessionUsage(): SessionUsageSnapshot[] {
     const rows = this.db.query(`SELECT * FROM session_usage`).all() as SessionUsageRow[];
-    return rows.map((row) => ({
-      ...row,
-      byModel: JSON.parse(row.byModel) as Record<string, number>,
-    }));
+    return rows.map((row) => {
+      const rawByModel = JSON.parse(row.rawByModel) as Record<string, number>;
+      if (Object.keys(rawByModel).length === 0 && row.total > 0) rawByModel.unknown = row.total;
+      return {
+        ...row,
+        byModel: JSON.parse(row.byModel) as Record<string, number>,
+        rawByModel,
+      };
+    });
   }
 
   /** One session's archive-time usage snapshot, or null when none was recorded
@@ -6281,7 +6296,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     const row = this.db
       .query(`SELECT * FROM session_usage WHERE sessionId = ?`)
       .get(sessionId) as SessionUsageRow | null;
-    return row ? { ...row, byModel: JSON.parse(row.byModel) as Record<string, number> } : null;
+    return row ? { ...row, byModel: JSON.parse(row.byModel) as Record<string, number>, rawByModel: JSON.parse(row.rawByModel) as Record<string, number> } : null;
   }
 
   /** Drop a session's archive-time usage snapshot (+ its buckets via FK cascade). Called on
@@ -6304,8 +6319,8 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       for (const b of buckets) {
         this.db.run(
           `INSERT INTO session_usage_bucket
-             (sessionId, bucketStart, input, output, cacheRead, cacheWrite, weightedUnits, cacheReadUnits, byModel)
-           VALUES (?,?,?,?,?,?,?,?,?)`,
+             (sessionId, bucketStart, input, output, cacheRead, cacheWrite, weightedUnits, cacheReadUnits, byModel, rawByModel)
+           VALUES (?,?,?,?,?,?,?,?,?,?)`,
           [
             // bind the method's sessionId (which scoped the DELETE), not b.sessionId, so a
             // bucket row can never land under a different parent than the one being replaced.
@@ -6318,6 +6333,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
             b.weightedUnits,
             b.cacheReadUnits,
             JSON.stringify(b.byModel),
+            JSON.stringify(b.rawByModel),
           ],
         );
       }
@@ -6339,11 +6355,12 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       weightedUnits: number;
       cacheReadUnits: number;
       byModel: string;
+      rawByModel: string;
     };
     const rows = this.db
       .query(
         `SELECT sessionId, bucketStart, input, output, cacheRead, cacheWrite,
-                weightedUnits, cacheReadUnits, byModel
+                weightedUnits, cacheReadUnits, byModel, rawByModel
          FROM session_usage_bucket
          WHERE bucketStart = 0 OR bucketStart >= ?`,
       )
@@ -6353,6 +6370,11 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     for (const row of rows) {
       const existing = result.get(row.sessionId);
       const rowByModel = JSON.parse(row.byModel) as Record<string, number>;
+      const rowRawByModel = JSON.parse(row.rawByModel) as Record<string, number>;
+      const rowRawTotal = row.input + row.output + row.cacheRead + row.cacheWrite;
+      if (Object.keys(rowRawByModel).length === 0 && rowRawTotal > 0) {
+        rowRawByModel.unknown = rowRawTotal;
+      }
       if (!existing) {
         result.set(row.sessionId, {
           input: row.input,
@@ -6362,6 +6384,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
           weightedUnits: row.weightedUnits,
           cacheReadUnits: row.cacheReadUnits,
           byModel: { ...rowByModel },
+          rawByModel: { ...rowRawByModel },
         });
       } else {
         existing.input += row.input;
@@ -6372,6 +6395,9 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
         existing.cacheReadUnits += row.cacheReadUnits;
         for (const [model, units] of Object.entries(rowByModel)) {
           existing.byModel[model] = (existing.byModel[model] ?? 0) + units;
+        }
+        for (const [model, tokens] of Object.entries(rowRawByModel)) {
+          existing.rawByModel[model] = (existing.rawByModel[model] ?? 0) + tokens;
         }
       }
     }

--- a/src/store.ts
+++ b/src/store.ts
@@ -6296,7 +6296,13 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     const row = this.db
       .query(`SELECT * FROM session_usage WHERE sessionId = ?`)
       .get(sessionId) as SessionUsageRow | null;
-    return row ? { ...row, byModel: JSON.parse(row.byModel) as Record<string, number>, rawByModel: JSON.parse(row.rawByModel) as Record<string, number> } : null;
+    return row
+      ? {
+          ...row,
+          byModel: JSON.parse(row.byModel) as Record<string, number>,
+          rawByModel: JSON.parse(row.rawByModel) as Record<string, number>,
+        }
+      : null;
   }
 
   /** Drop a session's archive-time usage snapshot (+ its buckets via FK cascade). Called on

--- a/src/types.ts
+++ b/src/types.ts
@@ -922,8 +922,8 @@ export interface DocAgentRun {
   outcome: DocAgentOutcome;
 }
 
-/** Append-only, archive-decoupled record of one spawned critic/plan-gate reviewer
- *  session and its token total. Keyed by the *reviewer* session id (NOT the task) and
+/** Append-only, archive-decoupled record of one spawned satellite LLM session and its token total.
+ *  Keyed by the *reviewer* session id (NOT the task) and
  *  deliberately carries no FK to `sessions`, so it outlives task archive + prune —
  *  letting post-hoc cost reports attribute reviewer token burn the task row can't. */
 export interface ReviewerSpawnRow {
@@ -931,7 +931,7 @@ export interface ReviewerSpawnRow {
   taskSessionId: string;
   /** `rundown` is READ-ONLY history: the Herd Rundown was removed and nothing writes that
    *  kind any more, but its past rows carry real token spend the usage breakdown attributes. */
-  kind: "review" | "plan_gate" | "recap" | "rundown" | "doc_agent" | "maintain";
+  kind: "review" | "plan_gate" | "recap" | "rundown" | "doc_agent" | "maintain" | "classifier";
   worktreePath: string;
   reviewerProvider: AgentProvider | null;
   model: string | null;
@@ -1573,12 +1573,13 @@ export interface UsageRepoBreakdown {
 // per-task `satelliteUnits` attribution (different filter axis + includes unattributed
 // buckets like doc_agent/standalone-critic) — see buildUsageBreakdown.
 export interface UsageKindUnits {
-  kind: string; // "review" | "plan_gate" | "recap" | "doc_agent" | "maintain" (+ historical "rundown") — data, not translated
+  kind: string; // "review" | "plan_gate" | "recap" | "doc_agent" | "maintain" | "classifier" (+ historical "rundown") — data, not translated
   units: number; // weighted units for that kind, in range
   count: number; // number of completed passes of that kind, in range
 }
 
-export type UsageRole = "coding" | "review" | "plan_gate" | "recap" | "rundown" | "doc_agent";
+export type UsageRole =
+  "coding" | "classifier" | "review" | "plan_gate" | "recap" | "rundown" | "doc_agent";
 export type UsageByRole = Partial<Record<UsageRole, Record<string, number>>>;
 
 export interface UsageModelBreakdown {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1578,9 +1578,13 @@ export interface UsageKindUnits {
   count: number; // number of completed passes of that kind, in range
 }
 
+export type UsageRole = "coding" | "review" | "plan_gate" | "recap" | "rundown" | "doc_agent";
+export type UsageByRole = Partial<Record<UsageRole, Record<string, number>>>;
+
 export interface UsageModelBreakdown {
   totalTokens: number;
   byModel: Record<string, number>;
+  byRole: UsageByRole;
 }
 
 export interface UsageBreakdown {
@@ -1671,7 +1675,7 @@ export const USAGE_REPO_KEYS = [
 // Mirrors UsageKindUnits:
 export const USAGE_KIND_UNITS_KEYS = ["kind", "units", "count"] as const;
 // Mirrors UsageModelBreakdown:
-export const USAGE_MODEL_BREAKDOWN_KEYS = ["totalTokens", "byModel"] as const;
+export const USAGE_MODEL_BREAKDOWN_KEYS = ["totalTokens", "byModel", "byRole"] as const;
 // Mirrors UsageBreakdown:
 export const USAGE_BREAKDOWN_KEYS = [
   "range",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1579,7 +1579,7 @@ export interface UsageKindUnits {
 }
 
 export type UsageRole =
-  "coding" | "classifier" | "review" | "plan_gate" | "recap" | "rundown" | "doc_agent";
+  "coding" | "classifier" | "review" | "plan_gate" | "recap" | "rundown" | "doc_agent" | "maintain";
 export type UsageByRole = Partial<Record<UsageRole, Record<string, number>>>;
 
 export interface UsageModelBreakdown {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1460,7 +1460,7 @@ export interface HeldTask {
 
 // ── per-session usage snapshot ────────────────────────────────────────────────
 
-/** SQLite row type for session_usage (byModel stored as JSON TEXT). */
+/** SQLite row type for session_usage (model maps stored as JSON TEXT). */
 export interface SessionUsageRow {
   sessionId: string;
   desig: string;
@@ -1481,6 +1481,7 @@ export interface SessionUsageRow {
   cacheReadUnits: number;
   messageCount: number;
   byModel: string; // JSON: Record<string, number>
+  rawByModel: string; // JSON: Record<string, number>
   createdAt: number;
   archivedAt: number;
   snapshotAt: number;
@@ -1505,6 +1506,7 @@ export interface SessionUsageSnapshot {
   cacheReadUnits: number;
   messageCount: number;
   byModel: Record<string, number>; // weighted units per model id
+  rawByModel: Record<string, number>; // raw tokens per model id
   createdAt: number;
   archivedAt: number;
   snapshotAt: number;
@@ -1521,6 +1523,7 @@ export interface SessionUsageBucket {
   weightedUnits: number;
   cacheReadUnits: number;
   byModel: Record<string, number>; // weighted units per model
+  rawByModel: Record<string, number>; // raw tokens per model
 }
 
 /** Per-session windowed sum returned by sumSessionUsageBucketsSince. */
@@ -1532,6 +1535,7 @@ export interface WindowedBucketSum {
   weightedUnits: number;
   cacheReadUnits: number;
   byModel: Record<string, number>;
+  rawByModel: Record<string, number>;
 }
 
 // Mirror of the UsageBreakdown contract in ui/src/lib/types.ts — keep in sync.
@@ -1574,6 +1578,11 @@ export interface UsageKindUnits {
   count: number; // number of completed passes of that kind, in range
 }
 
+export interface UsageModelBreakdown {
+  totalTokens: number;
+  byModel: Record<string, number>;
+}
+
 export interface UsageBreakdown {
   range: UsageRange;
   generatedAt: number;
@@ -1584,6 +1593,10 @@ export interface UsageBreakdown {
   generationUnits: number;
   satelliteByKind: UsageKindUnits[]; // global per-kind satellite tally, sorted desc by units
   dollars: number | null; // absolute USD spend; null unless api-key auth mode (subscription mode shows no dollars)
+  models: {
+    claude: UsageModelBreakdown;
+    codex: UsageModelBreakdown;
+  };
   repos: UsageRepoBreakdown[];
 }
 
@@ -1657,6 +1670,8 @@ export const USAGE_REPO_KEYS = [
 ] as const;
 // Mirrors UsageKindUnits:
 export const USAGE_KIND_UNITS_KEYS = ["kind", "units", "count"] as const;
+// Mirrors UsageModelBreakdown:
+export const USAGE_MODEL_BREAKDOWN_KEYS = ["totalTokens", "byModel"] as const;
 // Mirrors UsageBreakdown:
 export const USAGE_BREAKDOWN_KEYS = [
   "range",
@@ -1668,6 +1683,7 @@ export const USAGE_BREAKDOWN_KEYS = [
   "generationUnits",
   "satelliteByKind",
   "dollars",
+  "models",
   "repos",
 ] as const;
 // Mirrors UsageTimelineHour:

--- a/src/usage-breakdown.ts
+++ b/src/usage-breakdown.ts
@@ -1,6 +1,8 @@
 import { basename } from "node:path";
 import type { SessionStore } from "./store";
+import { MODELS } from "./types";
 import type {
+  UsageByRole,
   UsageRange,
   UsageBreakdown,
   UsageKindUnits,
@@ -12,6 +14,9 @@ import type {
 import { isOperationalArchetype } from "./usage-archetype";
 import { jsonlPathFor, sessionCost, dominantModel, SessionUsageRollup } from "./usage";
 import { weightedUnits } from "./pricing";
+
+const CLAUDE_MODEL_ALIASES = new Set<string>(MODELS);
+const CLAUDE_FULL_MODEL_ID = /^claude-(?:opus|sonnet|haiku)(?:-\d+)+$/i;
 
 /** Internal accumulator — public fields + private cacheRead accumulators. */
 interface TaskAccum {
@@ -221,6 +226,92 @@ function satelliteUnitsByKind(
   return [...byKind.entries()]
     .map(([kind, b]) => ({ kind, units: b.units, count: b.count }))
     .sort((a, b) => b.units - a.units);
+}
+
+function usableModel(model: string | null): string | null {
+  const normalized = model?.trim();
+  if (!normalized || normalized === "<synthetic>") return null;
+  return normalized;
+}
+
+function isLegacyClaudeModel(model: string): boolean {
+  return CLAUDE_MODEL_ALIASES.has(model) || CLAUDE_FULL_MODEL_ID.test(model);
+}
+
+function codingUsageByModel(taskMap: Map<string, TaskAccum>): Record<string, number> {
+  const coding: Record<string, number> = {};
+  for (const task of taskMap.values()) {
+    for (const [rawModel, tokens] of Object.entries(task.rawByModel)) {
+      const model = usableModel(rawModel);
+      if (!model || tokens <= 0) continue;
+      coding[model] = (coding[model] ?? 0) + tokens;
+    }
+  }
+  return coding;
+}
+
+function spawnRawTokens(spawn: ReturnType<SessionStore["listReviewerSpawns"]>[number]): number {
+  return (
+    (spawn.inputTokens ?? 0) +
+    (spawn.outputTokens ?? 0) +
+    (spawn.cacheReadTokens ?? 0) +
+    (spawn.cacheWriteTokens ?? 0)
+  );
+}
+
+function claudeSpawnModel(
+  spawn: ReturnType<SessionStore["listReviewerSpawns"]>[number],
+  cutoff: number,
+): string | null {
+  if (spawn.totalTokens == null) return null;
+  if ((spawn.completedAt ?? spawn.spawnedAt) < cutoff) return null;
+  const model = usableModel(spawn.model);
+  if (!model) return null;
+  if (spawn.reviewerProvider === "claude") return model;
+  if (spawn.reviewerProvider == null && isLegacyClaudeModel(model)) return model;
+  return null;
+}
+
+function claudeSpawnUsageByRole(
+  spawns: ReturnType<SessionStore["listReviewerSpawns"]>,
+  cutoff: number,
+): UsageByRole {
+  const byRole: UsageByRole = {};
+  for (const sp of spawns) {
+    const model = claudeSpawnModel(sp, cutoff);
+    if (!model) continue;
+
+    const tokens = spawnRawTokens(sp);
+    if (tokens <= 0) continue;
+
+    const role = byRole[sp.kind] ?? {};
+    role[model] = (role[model] ?? 0) + tokens;
+    byRole[sp.kind] = role;
+  }
+
+  return byRole;
+}
+
+function claudeUsageByRole(
+  taskMap: Map<string, TaskAccum>,
+  spawns: ReturnType<SessionStore["listReviewerSpawns"]>,
+  cutoff: number,
+): UsageByRole {
+  const byRole = claudeSpawnUsageByRole(spawns, cutoff);
+  const coding = codingUsageByModel(taskMap);
+  if (Object.keys(coding).length > 0) byRole.coding = coding;
+  return byRole;
+}
+
+function foldModels(byRole: UsageByRole): Record<string, number> {
+  const byModel: Record<string, number> = {};
+  for (const models of Object.values(byRole)) {
+    if (!models) continue;
+    for (const [model, tokens] of Object.entries(models)) {
+      byModel[model] = (byModel[model] ?? 0) + tokens;
+    }
+  }
+  return byModel;
 }
 
 /** Group task accumulators by repo, sort within each repo, and produce public repo breakdowns. */
@@ -437,16 +528,13 @@ export async function buildUsageBreakdown(opts: {
   // Global per-kind satellite tally — spawn-timestamp-filtered, independent of attribution.
   const satelliteByKind = satelliteUnitsByKind(spawns, cutoff);
 
-  const claudeByModel: Record<string, number> = {};
-  for (const task of taskMap.values()) {
-    for (const [model, tokens] of Object.entries(task.rawByModel)) {
-      claudeByModel[model] = (claudeByModel[model] ?? 0) + tokens;
-    }
-  }
+  const claudeByRole = claudeUsageByRole(taskMap, spawns, cutoff);
+  const claudeByModel = foldModels(claudeByRole);
   const codexByModel = opts.codexModelUsage?.(cutoff) ?? {};
-  const modelBreakdown = (byModel: Record<string, number>) => ({
+  const modelBreakdown = (byModel: Record<string, number>, byRole: UsageByRole = {}) => ({
     totalTokens: Object.values(byModel).reduce((sum, tokens) => sum + tokens, 0),
     byModel,
+    byRole,
   });
 
   return {
@@ -456,7 +544,7 @@ export async function buildUsageBreakdown(opts: {
     satelliteByKind,
     dollars: apiKey ? totals.totalUnits : null,
     models: {
-      claude: modelBreakdown(claudeByModel),
+      claude: modelBreakdown(claudeByModel, claudeByRole),
       codex: modelBreakdown(codexByModel),
     },
     repos,

--- a/src/usage-breakdown.ts
+++ b/src/usage-breakdown.ts
@@ -24,6 +24,7 @@ interface TaskAccum {
   satelliteUnits: number;
   tokens: UsageTokens;
   byModel: Record<string, number>;
+  rawByModel: Record<string, number>;
   authoringCacheReadUnits: number;
   satelliteCacheReadUnits: number;
 }
@@ -53,6 +54,7 @@ function snapshotToAccum(snap: ReturnType<SessionStore["listSessionUsage"]>[numb
       cacheWrite: snap.cacheWrite,
     },
     byModel: snap.byModel,
+    rawByModel: snap.rawByModel,
     authoringCacheReadUnits: snap.cacheReadUnits,
     satelliteCacheReadUnits: 0,
   };
@@ -78,6 +80,7 @@ function windowedSnapshotToAccum(
       cacheWrite: w.cacheWrite,
     },
     byModel: w.byModel,
+    rawByModel: w.rawByModel,
     authoringCacheReadUnits: w.cacheReadUnits,
     satelliteCacheReadUnits: 0,
   };
@@ -95,6 +98,7 @@ function zeroAuthoringAccum(snap: ReturnType<SessionStore["listSessionUsage"]>[n
     satelliteUnits: 0,
     tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     byModel: {},
+    rawByModel: {},
     authoringCacheReadUnits: 0,
     satelliteCacheReadUnits: 0,
   };
@@ -131,6 +135,7 @@ async function liveSessionToAccum(
       cacheWrite: sc.usage.cacheWrite,
     },
     byModel: sc.weightedByModel,
+    rawByModel: sc.usage.byModel,
     authoringCacheReadUnits: sc.cacheReadUnits,
     satelliteCacheReadUnits: 0,
   };
@@ -368,6 +373,7 @@ async function addLiveRollupTasks(
         cacheWrite: w.cacheWrite,
       },
       byModel: w.byModel,
+      rawByModel: w.rawByModel,
       authoringCacheReadUnits: w.cacheReadUnits,
       satelliteCacheReadUnits: 0,
     });
@@ -380,6 +386,7 @@ export async function buildUsageBreakdown(opts: {
   now: number;
   apiKey: boolean;
   usageRollup?: SessionUsageRollup;
+  codexModelUsage?: (cutoff: number) => Record<string, number>;
 }): Promise<UsageBreakdown> {
   const { store, range, now, apiKey } = opts;
 
@@ -430,12 +437,28 @@ export async function buildUsageBreakdown(opts: {
   // Global per-kind satellite tally — spawn-timestamp-filtered, independent of attribution.
   const satelliteByKind = satelliteUnitsByKind(spawns, cutoff);
 
+  const claudeByModel: Record<string, number> = {};
+  for (const task of taskMap.values()) {
+    for (const [model, tokens] of Object.entries(task.rawByModel)) {
+      claudeByModel[model] = (claudeByModel[model] ?? 0) + tokens;
+    }
+  }
+  const codexByModel = opts.codexModelUsage?.(cutoff) ?? {};
+  const modelBreakdown = (byModel: Record<string, number>) => ({
+    totalTokens: Object.values(byModel).reduce((sum, tokens) => sum + tokens, 0),
+    byModel,
+  });
+
   return {
     range,
     generatedAt: now,
     ...totals,
     satelliteByKind,
     dollars: apiKey ? totals.totalUnits : null,
+    models: {
+      claude: modelBreakdown(claudeByModel),
+      codex: modelBreakdown(codexByModel),
+    },
     repos,
   };
 }

--- a/src/usage-breakdown.ts
+++ b/src/usage-breakdown.ts
@@ -1,3 +1,4 @@
+import type { CodexModelUsage } from "./codex-usage";
 import { basename } from "node:path";
 import type { SessionStore } from "./store";
 import { MODELS } from "./types";
@@ -303,46 +304,23 @@ function claudeUsageByRole(
   return byRole;
 }
 
-interface CodexRoleAllocation {
-  role: ReturnType<SessionStore["listReviewerSpawns"]>[number]["kind"];
-  model: string;
-  tokens: number;
-}
-
-function codexRoleAllocation(
-  sp: ReturnType<SessionStore["listReviewerSpawns"]>[number],
-  cutoff: number,
-  remaining: Record<string, number>,
-): CodexRoleAllocation | null {
-  if (sp.reviewerProvider !== "codex" || !sp.providerSessionId) return null;
-  if (sp.completedAt == null || sp.completedAt < cutoff) return null;
-  if (sp.totalTokens == null || sp.totalTokens <= 0) return null;
-  const model = usableModel(sp.model);
-  if (!model) return null;
-  const tokens = Math.min(sp.totalTokens, remaining[model] ?? 0);
-  return tokens > 0 ? { role: sp.kind, model, tokens } : null;
-}
-
-/** Attribute captured Codex role spawns from the authoritative per-model thread totals. */
+/** Bind each completed role to its exact native thread in the same range as the model mix. */
 function codexUsageByRole(
   spawns: ReturnType<SessionStore["listReviewerSpawns"]>,
-  cutoff: number,
-  byModel: Record<string, number>,
+  usage: CodexModelUsage,
 ): UsageByRole {
-  const remaining = Object.fromEntries(
-    Object.entries(byModel).map(([model, tokens]) => [model, Math.max(0, tokens)]),
-  );
+  const remaining = { ...usage.byModel };
   const byRole: UsageByRole = {};
-
   for (const sp of spawns) {
-    const allocation = codexRoleAllocation(sp, cutoff, remaining);
-    if (!allocation) continue;
-    const role = byRole[allocation.role] ?? {};
-    role[allocation.model] = (role[allocation.model] ?? 0) + allocation.tokens;
-    byRole[allocation.role] = role;
-    remaining[allocation.model] = (remaining[allocation.model] ?? 0) - allocation.tokens;
+    if (sp.reviewerProvider !== "codex" || !sp.providerSessionId || sp.completedAt == null)
+      continue;
+    const thread = usage.byThread[sp.providerSessionId];
+    if (!thread) continue;
+    const role = byRole[sp.kind] ?? {};
+    role[thread.model] = (role[thread.model] ?? 0) + thread.totalTokens;
+    byRole[sp.kind] = role;
+    remaining[thread.model] = (remaining[thread.model] ?? 0) - thread.totalTokens;
   }
-
   const coding = Object.fromEntries(Object.entries(remaining).filter(([, tokens]) => tokens > 0));
   if (Object.keys(coding).length > 0) byRole.coding = coding;
   return byRole;
@@ -522,7 +500,7 @@ export async function buildUsageBreakdown(opts: {
   now: number;
   apiKey: boolean;
   usageRollup?: SessionUsageRollup;
-  codexModelUsage?: (cutoff: number) => Record<string, number>;
+  codexModelUsage?: (cutoff: number) => CodexModelUsage;
 }): Promise<UsageBreakdown> {
   const { store, range, now, apiKey } = opts;
 
@@ -575,8 +553,9 @@ export async function buildUsageBreakdown(opts: {
 
   const claudeByRole = claudeUsageByRole(taskMap, spawns, cutoff);
   const claudeByModel = foldModels(claudeByRole);
-  const codexByModel = opts.codexModelUsage?.(cutoff) ?? {};
-  const codexByRole = codexUsageByRole(spawns, cutoff, codexByModel);
+  const codexUsage = opts.codexModelUsage?.(cutoff) ?? { byModel: {}, byThread: {} };
+  const codexByModel = codexUsage.byModel;
+  const codexByRole = codexUsageByRole(spawns, codexUsage);
   const modelBreakdown = (byModel: Record<string, number>, byRole: UsageByRole = {}) => ({
     totalTokens: Object.values(byModel).reduce((sum, tokens) => sum + tokens, 0),
     byModel,

--- a/src/usage-breakdown.ts
+++ b/src/usage-breakdown.ts
@@ -303,6 +303,51 @@ function claudeUsageByRole(
   return byRole;
 }
 
+interface CodexRoleAllocation {
+  role: ReturnType<SessionStore["listReviewerSpawns"]>[number]["kind"];
+  model: string;
+  tokens: number;
+}
+
+function codexRoleAllocation(
+  sp: ReturnType<SessionStore["listReviewerSpawns"]>[number],
+  cutoff: number,
+  remaining: Record<string, number>,
+): CodexRoleAllocation | null {
+  if (sp.reviewerProvider !== "codex" || !sp.providerSessionId) return null;
+  if (sp.completedAt == null || sp.completedAt < cutoff) return null;
+  if (sp.totalTokens == null || sp.totalTokens <= 0) return null;
+  const model = usableModel(sp.model);
+  if (!model) return null;
+  const tokens = Math.min(sp.totalTokens, remaining[model] ?? 0);
+  return tokens > 0 ? { role: sp.kind, model, tokens } : null;
+}
+
+/** Attribute captured Codex role spawns from the authoritative per-model thread totals. */
+function codexUsageByRole(
+  spawns: ReturnType<SessionStore["listReviewerSpawns"]>,
+  cutoff: number,
+  byModel: Record<string, number>,
+): UsageByRole {
+  const remaining = Object.fromEntries(
+    Object.entries(byModel).map(([model, tokens]) => [model, Math.max(0, tokens)]),
+  );
+  const byRole: UsageByRole = {};
+
+  for (const sp of spawns) {
+    const allocation = codexRoleAllocation(sp, cutoff, remaining);
+    if (!allocation) continue;
+    const role = byRole[allocation.role] ?? {};
+    role[allocation.model] = (role[allocation.model] ?? 0) + allocation.tokens;
+    byRole[allocation.role] = role;
+    remaining[allocation.model] = (remaining[allocation.model] ?? 0) - allocation.tokens;
+  }
+
+  const coding = Object.fromEntries(Object.entries(remaining).filter(([, tokens]) => tokens > 0));
+  if (Object.keys(coding).length > 0) byRole.coding = coding;
+  return byRole;
+}
+
 function foldModels(byRole: UsageByRole): Record<string, number> {
   const byModel: Record<string, number> = {};
   for (const models of Object.values(byRole)) {
@@ -531,6 +576,7 @@ export async function buildUsageBreakdown(opts: {
   const claudeByRole = claudeUsageByRole(taskMap, spawns, cutoff);
   const claudeByModel = foldModels(claudeByRole);
   const codexByModel = opts.codexModelUsage?.(cutoff) ?? {};
+  const codexByRole = codexUsageByRole(spawns, cutoff, codexByModel);
   const modelBreakdown = (byModel: Record<string, number>, byRole: UsageByRole = {}) => ({
     totalTokens: Object.values(byModel).reduce((sum, tokens) => sum + tokens, 0),
     byModel,
@@ -545,7 +591,7 @@ export async function buildUsageBreakdown(opts: {
     dollars: apiKey ? totals.totalUnits : null,
     models: {
       claude: modelBreakdown(claudeByModel, claudeByRole),
-      codex: modelBreakdown(codexByModel),
+      codex: modelBreakdown(codexByModel, codexByRole),
     },
     repos,
   };

--- a/src/usage-snapshot.ts
+++ b/src/usage-snapshot.ts
@@ -14,6 +14,7 @@ function sumBuckets(buckets: Map<number, SessionBucket>): {
   weightedUnits: number;
   cacheReadUnits: number;
   byModel: Record<string, number>;
+  rawByModel: Record<string, number>;
 } {
   let input = 0,
     output = 0,
@@ -22,6 +23,7 @@ function sumBuckets(buckets: Map<number, SessionBucket>): {
     weightedUnits = 0,
     cacheReadUnits = 0;
   const byModel: Record<string, number> = {};
+  const rawByModel: Record<string, number> = {};
   for (const b of buckets.values()) {
     input += b.input;
     output += b.output;
@@ -32,8 +34,20 @@ function sumBuckets(buckets: Map<number, SessionBucket>): {
     for (const [model, units] of Object.entries(b.byModel)) {
       byModel[model] = (byModel[model] ?? 0) + units;
     }
+    for (const [model, tokens] of Object.entries(b.rawByModel)) {
+      rawByModel[model] = (rawByModel[model] ?? 0) + tokens;
+    }
   }
-  return { input, output, cacheRead, cacheWrite, weightedUnits, cacheReadUnits, byModel };
+  return {
+    input,
+    output,
+    cacheRead,
+    cacheWrite,
+    weightedUnits,
+    cacheReadUnits,
+    byModel,
+    rawByModel,
+  };
 }
 
 /** Persist a session's authoring spend into the session_usage table.
@@ -89,6 +103,7 @@ export async function snapshotSessionUsage(
       cacheReadUnits: agg.cacheReadUnits,
       messageCount: fold.messageCount,
       byModel: agg.byModel,
+      rawByModel: agg.rawByModel,
       createdAt: s.createdAt,
       archivedAt: asOf,
       snapshotAt: asOf,
@@ -105,6 +120,7 @@ export async function snapshotSessionUsage(
       weightedUnits: b.weightedUnits,
       cacheReadUnits: b.cacheReadUnits,
       byModel: b.byModel,
+      rawByModel: b.rawByModel,
     }));
     store.replaceSessionUsageBuckets(s.id, buckets);
 

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -367,6 +367,7 @@ export interface SessionBucket {
   weightedUnits: number;
   cacheReadUnits: number;
   byModel: Record<string, number>; // weighted units per model
+  rawByModel: Record<string, number>; // raw tokens per model
 }
 
 export interface SessionFold {
@@ -403,6 +404,7 @@ export function foldSessionBuckets(lines: Iterable<string>): SessionFold {
         weightedUnits: 0,
         cacheReadUnits: 0,
         byModel: {},
+        rawByModel: {},
       };
       buckets.set(bucketStart, b);
     }
@@ -423,6 +425,7 @@ export function foldSessionBuckets(lines: Iterable<string>): SessionFold {
     b.cacheReadUnits += cru;
 
     const rawTokens = r.input + r.output + r.cacheRead + r.cacheWrite5m + r.cacheWrite1h;
+    b.rawByModel[r.model] = (b.rawByModel[r.model] ?? 0) + rawTokens;
     rawByModel[r.model] = (rawByModel[r.model] ?? 0) + rawTokens;
   }
 
@@ -439,6 +442,7 @@ export interface RollupWindow {
   weightedUnits: number;
   cacheReadUnits: number;
   byModel: Record<string, number>; // weighted units per model (in-window)
+  rawByModel: Record<string, number>; // raw tokens per model (in-window)
   dominantModel: string | null; // from in-window raw tokens (cutoff>0) or session-wide (cutoff===0)
   messageCount: number;
 }
@@ -657,6 +661,7 @@ export class SessionUsageRollup {
         weightedUnits: agg.weightedUnits,
         cacheReadUnits: agg.cacheReadUnits,
         byModel: { ...agg.weightedByModel },
+        rawByModel: { ...agg.rawByModel },
         dominantModel: dominantModelOf(agg.rawByModel),
         messageCount: agg.messageCount,
       };
@@ -700,6 +705,7 @@ export class SessionUsageRollup {
       weightedUnits: wu,
       cacheReadUnits: cru,
       byModel,
+      rawByModel,
       dominantModel: dominantModelOf(rawByModel),
       messageCount,
     };

--- a/test/autopilot-llm.test.ts
+++ b/test/autopilot-llm.test.ts
@@ -224,7 +224,7 @@ test("classifyStop persists classifier usage after stop and immediately finalize
   const verdict = await classifyStop(["Ready to start? (y/n)"], "task", deps, "autopilot task");
 
   expect(verdict).toEqual({ kind: "gate", summary: "continue" });
-  expect(calls.order).toEqual(["start", "stop", "read", "record", "complete", "cleanup"]);
+  expect(calls.order).toEqual(["start", "stop", "record", "read", "complete", "cleanup"]);
   const [row] = store.listReviewerSpawns();
   expect(row).toMatchObject({
     taskSessionId: "task-session-1727",
@@ -275,7 +275,7 @@ test("classifyStop finalizes a zero-token classifier row when usage parsing thro
 for (const failingStage of ["stop", "record", "complete", "cleanup"] as const) {
   test(`classifyStop preserves the verdict when ${failingStage} fails`, async () => {
     const order: string[] = [];
-    const completedUsages: SessionUsage[] = [];
+    const completedUsages: (SessionUsage | null)[] = [];
     const { deps } = makeDeps({
       herdr: {
         start: async (_name, cwd) => ({ terminalId: "term_failure", cwd }) as any,
@@ -285,6 +285,8 @@ for (const failingStage of ["stop", "record", "complete", "cleanup"] as const) {
         },
       },
       store: {
+        listReviewerSpawns: () => [],
+        setReviewerSpawnProviderSessionId: () => {},
         recordReviewerSpawn: () => {
           order.push("record");
           if (failingStage === "record") throw new Error("record failed");
@@ -311,7 +313,7 @@ for (const failingStage of ["stop", "record", "complete", "cleanup"] as const) {
 
     expect(verdict).toEqual({ kind: "gate", summary: "continue" });
     expect(order).toContain("cleanup");
-    expect(order.slice(0, 3)).toEqual(["stop", "read", "record"]);
+    expect(order.slice(0, 2)).toEqual(["stop", "record"]);
     if (failingStage === "record") {
       expect(order).not.toContain("complete");
     } else {
@@ -543,4 +545,17 @@ test("classifyStop: api-key guard wins over pre-filter (non-empty tail, no key â
   });
   expect(result).toEqual({ kind: "unknown", summary: "" });
   expect(calls.started).toBeNull();
+});
+
+test("Codex classifier usage stays unknown until a delayed rollout is available", async () => {
+  const store = new SessionStore(":memory:");
+  const { deps } = makeDeps({
+    store,
+    provider: "codex",
+    readUsage: async () => null,
+    readVerdict: () => ({ kind: "gate", summary: "continue" }),
+  });
+  await classifyStop(["Ready?"], "task", deps, "classifier");
+  expect(store.listReviewerSpawns()[0]?.totalTokens).toBeNull();
+  expect(store.listReviewerSpawns()[0]?.completedAt).not.toBeNull();
 });

--- a/test/autopilot-llm.test.ts
+++ b/test/autopilot-llm.test.ts
@@ -1,7 +1,9 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
 import { classifyStop, classifierPrompt, preClassify, VERDICT_FILE } from "../src/autopilot-llm";
 import { config } from "../src/config";
+import { SessionStore } from "../src/store";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
+import type { SessionUsage } from "../src/usage";
 
 beforeEach(() => {
   __setApiKeyConfigDirProvisionForTest(() => "/tmp/shepherd-test-apikey-config");
@@ -29,21 +31,35 @@ async function withAuth<T>(
 }
 
 function makeDeps(over: Partial<import("../src/autopilot-llm").ClassifierDeps> = {}) {
-  const calls: any = { started: null, stopped: false, cleaned: false };
+  const calls: any = { started: null, stopped: false, cleaned: false, order: [] };
   const base = {
     herdr: {
       start: async (name: string, cwd: string, argv: string[], env?: Record<string, string>) => {
+        calls.order.push("start");
         calls.started = { name, cwd, argv, env };
         return { terminalId: "term_c", cwd } as any;
       },
       stop: async () => {
+        calls.order.push("stop");
         calls.stopped = true;
       },
     },
+    store: {
+      recordReviewerSpawn: () => {
+        calls.order.push("record");
+      },
+      completeReviewerSpawn: () => {
+        calls.order.push("complete");
+      },
+    },
+    taskSessionId: "task-s1",
+    readUsage: async () => null,
     makeTmpDir: () => "/tmp/autopilot-xyz",
     cleanup: () => {
+      calls.order.push("cleanup");
       calls.cleaned = true;
     },
+    warn: () => {},
     now: () => 0,
     sleep: async () => {},
     timeoutMs: 30_000,
@@ -52,6 +68,19 @@ function makeDeps(over: Partial<import("../src/autopilot-llm").ClassifierDeps> =
   };
   return { deps: base as any, calls };
 }
+
+const CLASSIFIER_USAGE: SessionUsage = {
+  input: 10,
+  output: 20,
+  cacheRead: 30,
+  cacheWrite: 40,
+  total: 100,
+  messageCount: 1,
+  lastActivity: 123,
+  byModel: { "claude-haiku-4-5": 100 },
+  fullRecaches: 0,
+  sidechainCount: 0,
+};
 
 test("classifierPrompt embeds the tail + task and asks for the verdict file", () => {
   const p = classifierPrompt(["agent: Shall I write the spec first? (y/n)"], "Build a login page");
@@ -166,6 +195,132 @@ test("classifyStop: parses a gate verdict; spawns haiku, dontAsk, Write-only", a
   expect(calls.cleaned).toBe(true);
 });
 
+test("classifyStop persists classifier usage after stop and immediately finalizes before cleanup", async () => {
+  const store = new SessionStore(":memory:");
+  const { deps, calls } = makeDeps({
+    store,
+    taskSessionId: "task-session-1727",
+    model: "haiku",
+    effort: "low",
+    now: () => 1_750_000_000_000,
+    readVerdict: () => ({ kind: "gate", summary: "continue" }),
+    readUsage: async (cwd, sessionId, spawnAccountDir) => {
+      calls.order.push("read");
+      calls.usageRead = { cwd, sessionId, spawnAccountDir };
+      return CLASSIFIER_USAGE;
+    },
+  });
+  const record = store.recordReviewerSpawn.bind(store);
+  store.recordReviewerSpawn = ((row) => {
+    calls.order.push("record");
+    record(row);
+  }) as typeof store.recordReviewerSpawn;
+  const complete = store.completeReviewerSpawn.bind(store);
+  store.completeReviewerSpawn = ((sessionId, usage, completedAt) => {
+    calls.order.push("complete");
+    complete(sessionId, usage, completedAt);
+  }) as typeof store.completeReviewerSpawn;
+
+  const verdict = await classifyStop(["Ready to start? (y/n)"], "task", deps, "autopilot task");
+
+  expect(verdict).toEqual({ kind: "gate", summary: "continue" });
+  expect(calls.order).toEqual(["start", "stop", "read", "record", "complete", "cleanup"]);
+  const [row] = store.listReviewerSpawns();
+  expect(row).toMatchObject({
+    taskSessionId: "task-session-1727",
+    kind: "classifier",
+    worktreePath: "/tmp/autopilot-xyz",
+    reviewerProvider: "claude",
+    model: "claude-haiku-4-5",
+    reviewerEffort: "low",
+    spawnedAt: 1_750_000_000_000,
+    completedAt: 1_750_000_000_000,
+    inputTokens: 10,
+    outputTokens: 20,
+    cacheReadTokens: 30,
+    cacheWriteTokens: 40,
+    totalTokens: 100,
+  });
+  expect(calls.usageRead.cwd).toBe("/tmp/autopilot-xyz");
+  expect(calls.usageRead.sessionId).toBe(row?.reviewerSessionId);
+  expect(calls.usageRead.spawnAccountDir).toBeUndefined();
+});
+
+test("classifyStop finalizes a zero-token classifier row when usage parsing throws", async () => {
+  const store = new SessionStore(":memory:");
+  const { deps } = makeDeps({
+    store,
+    taskSessionId: "task-session-1727",
+    readVerdict: () => ({ kind: "question", summary: "Need input" }),
+    readUsage: async () => {
+      throw new Error("malformed transcript");
+    },
+  });
+
+  const verdict = await classifyStop(["Which option?"], "task", deps, "autopilot task");
+
+  expect(verdict).toEqual({ kind: "question", summary: "Need input" });
+  expect(store.listReviewerSpawns()).toHaveLength(1);
+  expect(store.listReviewerSpawns()[0]).toMatchObject({
+    kind: "classifier",
+    completedAt: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    totalTokens: 0,
+  });
+});
+
+for (const failingStage of ["stop", "record", "complete", "cleanup"] as const) {
+  test(`classifyStop preserves the verdict when ${failingStage} fails`, async () => {
+    const order: string[] = [];
+    const completedUsages: SessionUsage[] = [];
+    const { deps } = makeDeps({
+      herdr: {
+        start: async (_name, cwd) => ({ terminalId: "term_failure", cwd }) as any,
+        stop: async () => {
+          order.push("stop");
+          if (failingStage === "stop") throw new Error("stop failed");
+        },
+      },
+      store: {
+        recordReviewerSpawn: () => {
+          order.push("record");
+          if (failingStage === "record") throw new Error("record failed");
+        },
+        completeReviewerSpawn: (_sessionId, usage) => {
+          order.push("complete");
+          completedUsages.push(usage);
+          if (failingStage === "complete") throw new Error("complete failed");
+        },
+      },
+      readVerdict: () => ({ kind: "gate", summary: "continue" }),
+      readUsage: async () => {
+        order.push("read");
+        return CLASSIFIER_USAGE;
+      },
+      cleanup: () => {
+        order.push("cleanup");
+        if (failingStage === "cleanup") throw new Error("cleanup failed");
+      },
+      warn: () => {},
+    });
+
+    const verdict = await classifyStop(["Ready?"], "task", deps, "autopilot task");
+
+    expect(verdict).toEqual({ kind: "gate", summary: "continue" });
+    expect(order).toContain("cleanup");
+    expect(order.slice(0, 3)).toEqual(["stop", "read", "record"]);
+    if (failingStage === "record") {
+      expect(order).not.toContain("complete");
+    } else {
+      expect(order).toContain("complete");
+      expect(completedUsages).toEqual([CLASSIFIER_USAGE]);
+    }
+  });
+}
+
 test("classifyStop: threads effort into the classifier argv (issue #1418)", async () => {
   const { deps, calls } = makeDeps({
     effort: "high",
@@ -224,8 +379,19 @@ test("classifyStop: subscription mode — --settings unchanged + no env 4th arg"
 });
 
 test("classifyStop: api-key mode — apiKeyHelper in --settings + CLAUDE_CONFIG_DIR env", async () => {
+  const usageReads: Array<{
+    cwd: string;
+    sessionId: string;
+    spawnAccountDir?: string | null;
+  }> = [];
   const { calls } = await withAuth("api-key", "/helper.sh", async () => {
-    const d = makeDeps({ readVerdict: () => ({ kind: "gate", summary: "x" }) });
+    const d = makeDeps({
+      readVerdict: () => ({ kind: "gate", summary: "x" }),
+      readUsage: async (cwd, sessionId, spawnAccountDir) => {
+        usageReads.push({ cwd, sessionId, spawnAccountDir });
+        return null;
+      },
+    });
     await classifyStop(["…"], "task", d.deps, "l");
     return d;
   });
@@ -234,6 +400,7 @@ test("classifyStop: api-key mode — apiKeyHelper in --settings + CLAUDE_CONFIG_
   expect(settings.disableAllHooks).toBe(true);
   expect(settings.apiKeyHelper).toBe("/helper.sh");
   expect(Object.keys(calls.started.env)).toEqual(["CLAUDE_CONFIG_DIR"]);
+  expect(usageReads[0]?.spawnAccountDir).toBe("/tmp/shepherd-test-apikey-config");
 });
 
 test("classifyStop: api-key without configured key fails closed → SURFACE, no spawn", async () => {
@@ -244,6 +411,22 @@ test("classifyStop: api-key without configured key fails closed → SURFACE, no 
   });
   expect(result).toEqual({ kind: "unknown", summary: "" });
   expect(calls.started).toBeNull();
+});
+
+test("classifyStop: spawn setup failure surfaces and still cleans up", async () => {
+  const { result, calls } = await withAuth("api-key", "/helper.sh", async () => {
+    __setApiKeyConfigDirProvisionForTest(() => {
+      throw new Error("provision failed");
+    });
+    const d = makeDeps({ readVerdict: () => ({ kind: "gate", summary: "x" }) });
+    const r = await classifyStop(["…"], "task", d.deps, "l");
+    return { result: r, calls: d.calls };
+  });
+
+  expect(result).toEqual({ kind: "unknown", summary: "" });
+  expect(calls.started).toBeNull();
+  expect(calls.cleaned).toBe(true);
+  expect(calls.order).not.toContain("record");
 });
 
 test("classifyStop: unknown/surface on timeout (null verdict)", async () => {
@@ -274,13 +457,26 @@ test("classifyStop: valid kind but non-string summary → summary dropped, kind 
 });
 
 test("classifyStop: surfaces (and cleans up) when the spawn throws", async () => {
-  const calls: any = { cleaned: false };
+  const calls: any = { cleaned: false, recorded: false, completed: false, usageRead: false };
   const deps: any = {
     herdr: {
       start: async () => {
         throw new Error("herdr down");
       },
       stop: async () => {},
+    },
+    store: {
+      recordReviewerSpawn: () => {
+        calls.recorded = true;
+      },
+      completeReviewerSpawn: () => {
+        calls.completed = true;
+      },
+    },
+    taskSessionId: "task-s1",
+    readUsage: async () => {
+      calls.usageRead = true;
+      return CLASSIFIER_USAGE;
     },
     makeTmpDir: () => "/tmp/autopilot-xyz",
     cleanup: () => {
@@ -292,6 +488,9 @@ test("classifyStop: surfaces (and cleans up) when the spawn throws", async () =>
   const v = await classifyStop(["…"], "task", deps, "l");
   expect(v).toEqual({ kind: "unknown", summary: "" });
   expect(calls.cleaned).toBe(true); // temp dir still removed
+  expect(calls.recorded).toBe(false);
+  expect(calls.completed).toBe(false);
+  expect(calls.usageRead).toBe(false);
 });
 
 // --- preClassify unit tests ---

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -120,6 +120,12 @@ function harness(opts: {
   let cur = opts.session;
   const events: any[] = [];
   const setAutoMergeStateCalls: any[] = [];
+  const classified: Array<{
+    tail: string[];
+    taskPrompt: string;
+    label: string;
+    taskSessionId: string | undefined;
+  }> = [];
   let classifyCalls = 0;
   const svc = new AutopilotService({
     store: {
@@ -176,8 +182,9 @@ function harness(opts: {
         };
       },
     } as any,
-    classify: async () => {
+    classify: async (tail, taskPrompt, label, taskSessionId) => {
       classifyCalls++;
+      classified.push({ tail, taskPrompt, label, taskSessionId });
       return opts.verdict ?? { kind: "unknown", summary: "" };
     },
     steer: async (_id, text) => {
@@ -214,8 +221,21 @@ function harness(opts: {
     state: () => cur,
     mergeStateCalls: setAutoMergeStateCalls,
     classifyCount: () => classifyCalls,
+    classified,
   };
 }
+
+test("classifier receives the exact triggering task session id", async () => {
+  const h = harness({
+    session: sess({ id: "task-session-1727" }),
+    verdict: { kind: "gate", summary: "asking to start" },
+  });
+
+  await h.svc.onBlock("task-session-1727", block());
+
+  expect(h.classified).toHaveLength(1);
+  expect(h.classified[0]?.taskSessionId).toBe("task-session-1727");
+});
 
 test("gate verdict → proceed steer + step++", async () => {
   const h = harness({ session: sess(), verdict: { kind: "gate", summary: "asking to start" } });

--- a/test/codex-rollout-resolve.test.ts
+++ b/test/codex-rollout-resolve.test.ts
@@ -151,6 +151,7 @@ describe("backfillCodexSpawnUsage", () => {
     const filled: Array<{ id: string; total: number }> = [];
     return {
       filled,
+      setReviewerSpawnProviderSessionId: () => {},
       listBackfillableCodexSpawns: () => rows as never,
       backfillReviewerSpawnUsage: (id: string, u: { total: number }) => {
         filled.push({ id, total: u.total });

--- a/test/codex-usage.test.ts
+++ b/test/codex-usage.test.ts
@@ -10,6 +10,7 @@ import {
   recentCodexRolloutPaths,
   readCodexRateLimits,
   readCodexModelUsage,
+  readCodexThreadUsage,
   readCodexTokenUsage,
 } from "../src/codex-usage";
 
@@ -139,6 +140,81 @@ test("readCodexModelUsage uses one unknown bucket when the model column is absen
   db.close();
 
   expect(readCodexModelUsage(path, NOW - 5 * H)).toEqual({ unknown: 1000 });
+});
+
+test("readCodexThreadUsage reads one exact OpenAI thread with its model", () => {
+  const dir = tempDir();
+  const path = join(dir, "state_5.sqlite");
+  const db = new Database(path);
+  db.exec(`
+    CREATE TABLE threads (
+      id TEXT PRIMARY KEY,
+      model_provider TEXT NOT NULL,
+      model TEXT,
+      tokens_used INTEGER NOT NULL DEFAULT 0,
+      updated_at_ms INTEGER NOT NULL
+    )
+  `);
+  const insert = db.query(
+    "INSERT INTO threads (id, model_provider, model, tokens_used, updated_at_ms) VALUES (?, ?, ?, ?, ?)",
+  );
+  insert.run("target", "openai", "gpt-5.6", 4321, NOW);
+  insert.run("other", "openai", "gpt-5.5", 9999, NOW);
+  db.close();
+
+  expect(readCodexThreadUsage(path, "target")).toEqual({ model: "gpt-5.6", totalTokens: 4321 });
+});
+
+test("readCodexThreadUsage normalizes an empty model and rejects non-OpenAI threads", () => {
+  const dir = tempDir();
+  const path = join(dir, "state_5.sqlite");
+  const db = new Database(path);
+  db.exec(`
+    CREATE TABLE threads (
+      id TEXT PRIMARY KEY,
+      model_provider TEXT NOT NULL,
+      model TEXT,
+      tokens_used INTEGER NOT NULL DEFAULT 0,
+      updated_at_ms INTEGER NOT NULL
+    )
+  `);
+  const insert = db.query(
+    "INSERT INTO threads (id, model_provider, model, tokens_used, updated_at_ms) VALUES (?, ?, ?, ?, ?)",
+  );
+  insert.run("unknown", "openai", "", 0, NOW);
+  insert.run("local", "ollama", "llama", 9999, NOW);
+  db.close();
+
+  expect(readCodexThreadUsage(path, "unknown")).toEqual({ model: "unknown", totalTokens: 0 });
+  expect(readCodexThreadUsage(path, "local")).toBeNull();
+});
+
+test("readCodexThreadUsage uses unknown when the model column is absent", () => {
+  const dir = tempDir();
+  const path = join(dir, "state_5.sqlite");
+  const db = createStateDb(path);
+  db.query(
+    "INSERT INTO threads (id, model_provider, tokens_used, updated_at_ms) VALUES (?, ?, ?, ?)",
+  ).run("target", "openai", 777, NOW);
+  db.close();
+
+  expect(readCodexThreadUsage(path, "target")).toEqual({ model: "unknown", totalTokens: 777 });
+});
+
+test("readCodexThreadUsage fails closed when required state schema is unavailable", () => {
+  const dir = tempDir();
+  for (const [name, schema] of [
+    ["missing-table", "CREATE TABLE unrelated (id TEXT)"],
+    ["missing-provider", "CREATE TABLE threads (id TEXT PRIMARY KEY, tokens_used INTEGER)"],
+    ["missing-tokens", "CREATE TABLE threads (id TEXT PRIMARY KEY, model_provider TEXT)"],
+  ] as const) {
+    const path = join(dir, `${name}.sqlite`);
+    const db = new Database(path);
+    db.exec(schema);
+    db.close();
+
+    expect(readCodexThreadUsage(path, "target")).toBeNull();
+  }
 });
 
 /** A Codex rollout `token_count` line carrying a rate-limit reading. */

--- a/test/codex-usage.test.ts
+++ b/test/codex-usage.test.ts
@@ -9,6 +9,7 @@ import {
   parseCodexRateLimits,
   recentCodexRolloutPaths,
   readCodexRateLimits,
+  readCodexModelUsage,
   readCodexTokenUsage,
 } from "../src/codex-usage";
 
@@ -93,6 +94,51 @@ test("readCodexTokenUsage returns null when no OpenAI Codex threads exist", () =
   db.close();
 
   expect(readCodexTokenUsage(path, NOW)).toBeNull();
+});
+
+test("readCodexModelUsage groups in-range OpenAI threads and maps null models to unknown", () => {
+  const dir = tempDir();
+  const path = join(dir, "state_5.sqlite");
+  const db = new Database(path);
+  db.exec(`
+    CREATE TABLE threads (
+      id TEXT PRIMARY KEY,
+      model_provider TEXT NOT NULL,
+      model TEXT,
+      tokens_used INTEGER NOT NULL DEFAULT 0,
+      updated_at_ms INTEGER NOT NULL
+    )
+  `);
+  const insert = db.query(
+    "INSERT INTO threads (id, model_provider, model, tokens_used, updated_at_ms) VALUES (?, ?, ?, ?, ?)",
+  );
+  insert.run("recent-gpt", "openai", "gpt-5.5", 1000, NOW - H);
+  insert.run("recent-unknown", "openai", null, 250, NOW - H);
+  insert.run("empty-model", "openai", "", 125, NOW - H);
+  insert.run("at-cutoff", "openai", "gpt-5.5", 300, NOW - 5 * H);
+  insert.run("old", "openai", "gpt-5.4", 4000, NOW - 10 * H);
+  insert.run("local", "ollama", "llama", 8000, NOW - H);
+  db.close();
+
+  expect(readCodexModelUsage(path, NOW - 5 * H)).toEqual({
+    "gpt-5.5": 1300,
+    unknown: 375,
+  });
+});
+
+test("readCodexModelUsage uses one unknown bucket when the model column is absent", () => {
+  const dir = tempDir();
+  const path = join(dir, "state_5.sqlite");
+  const db = createStateDb(path);
+  const insert = db.query(
+    "INSERT INTO threads (id, model_provider, tokens_used, updated_at_ms) VALUES (?, ?, ?, ?)",
+  );
+  insert.run("recent", "openai", 1000, NOW - H);
+  insert.run("old", "openai", 4000, NOW - 10 * H);
+  insert.run("local", "ollama", 8000, NOW - H);
+  db.close();
+
+  expect(readCodexModelUsage(path, NOW - 5 * H)).toEqual({ unknown: 1000 });
 });
 
 /** A Codex rollout `token_count` line carrying a rate-limit reading. */

--- a/test/codex-usage.test.ts
+++ b/test/codex-usage.test.ts
@@ -10,7 +10,6 @@ import {
   recentCodexRolloutPaths,
   readCodexRateLimits,
   readCodexModelUsage,
-  readCodexThreadUsage,
   readCodexTokenUsage,
 } from "../src/codex-usage";
 
@@ -121,7 +120,7 @@ test("readCodexModelUsage groups in-range OpenAI threads and maps null models to
   insert.run("local", "ollama", "llama", 8000, NOW - H);
   db.close();
 
-  expect(readCodexModelUsage(path, NOW - 5 * H)).toEqual({
+  expect(readCodexModelUsage(path, NOW - 5 * H).byModel).toEqual({
     "gpt-5.5": 1300,
     unknown: 375,
   });
@@ -139,82 +138,7 @@ test("readCodexModelUsage uses one unknown bucket when the model column is absen
   insert.run("local", "ollama", 8000, NOW - H);
   db.close();
 
-  expect(readCodexModelUsage(path, NOW - 5 * H)).toEqual({ unknown: 1000 });
-});
-
-test("readCodexThreadUsage reads one exact OpenAI thread with its model", () => {
-  const dir = tempDir();
-  const path = join(dir, "state_5.sqlite");
-  const db = new Database(path);
-  db.exec(`
-    CREATE TABLE threads (
-      id TEXT PRIMARY KEY,
-      model_provider TEXT NOT NULL,
-      model TEXT,
-      tokens_used INTEGER NOT NULL DEFAULT 0,
-      updated_at_ms INTEGER NOT NULL
-    )
-  `);
-  const insert = db.query(
-    "INSERT INTO threads (id, model_provider, model, tokens_used, updated_at_ms) VALUES (?, ?, ?, ?, ?)",
-  );
-  insert.run("target", "openai", "gpt-5.6", 4321, NOW);
-  insert.run("other", "openai", "gpt-5.5", 9999, NOW);
-  db.close();
-
-  expect(readCodexThreadUsage(path, "target")).toEqual({ model: "gpt-5.6", totalTokens: 4321 });
-});
-
-test("readCodexThreadUsage normalizes an empty model and rejects non-OpenAI threads", () => {
-  const dir = tempDir();
-  const path = join(dir, "state_5.sqlite");
-  const db = new Database(path);
-  db.exec(`
-    CREATE TABLE threads (
-      id TEXT PRIMARY KEY,
-      model_provider TEXT NOT NULL,
-      model TEXT,
-      tokens_used INTEGER NOT NULL DEFAULT 0,
-      updated_at_ms INTEGER NOT NULL
-    )
-  `);
-  const insert = db.query(
-    "INSERT INTO threads (id, model_provider, model, tokens_used, updated_at_ms) VALUES (?, ?, ?, ?, ?)",
-  );
-  insert.run("unknown", "openai", "", 0, NOW);
-  insert.run("local", "ollama", "llama", 9999, NOW);
-  db.close();
-
-  expect(readCodexThreadUsage(path, "unknown")).toEqual({ model: "unknown", totalTokens: 0 });
-  expect(readCodexThreadUsage(path, "local")).toBeNull();
-});
-
-test("readCodexThreadUsage uses unknown when the model column is absent", () => {
-  const dir = tempDir();
-  const path = join(dir, "state_5.sqlite");
-  const db = createStateDb(path);
-  db.query(
-    "INSERT INTO threads (id, model_provider, tokens_used, updated_at_ms) VALUES (?, ?, ?, ?)",
-  ).run("target", "openai", 777, NOW);
-  db.close();
-
-  expect(readCodexThreadUsage(path, "target")).toEqual({ model: "unknown", totalTokens: 777 });
-});
-
-test("readCodexThreadUsage fails closed when required state schema is unavailable", () => {
-  const dir = tempDir();
-  for (const [name, schema] of [
-    ["missing-table", "CREATE TABLE unrelated (id TEXT)"],
-    ["missing-provider", "CREATE TABLE threads (id TEXT PRIMARY KEY, tokens_used INTEGER)"],
-    ["missing-tokens", "CREATE TABLE threads (id TEXT PRIMARY KEY, model_provider TEXT)"],
-  ] as const) {
-    const path = join(dir, `${name}.sqlite`);
-    const db = new Database(path);
-    db.exec(schema);
-    db.close();
-
-    expect(readCodexThreadUsage(path, "target")).toBeNull();
-  }
+  expect(readCodexModelUsage(path, NOW - 5 * H).byModel).toEqual({ unknown: 1000 });
 });
 
 /** A Codex rollout `token_count` line carrying a rate-limit reading. */

--- a/test/doc-agent.test.ts
+++ b/test/doc-agent.test.ts
@@ -223,6 +223,9 @@ function mkHarness(opts?: {
   runSpawnHooks?: (d: unknown) => Promise<unknown>;
   /** Per-role reasoning-effort override threaded into the spawn env (issue #1418). */
   effort?: string | null;
+  provider?: "claude" | "codex";
+  model?: string | null;
+  usageUnavailable?: boolean;
 }): Harness {
   const o = {
     forgeKind: "github" as "github" | "local" | null,
@@ -255,6 +258,8 @@ function mkHarness(opts?: {
     editPrThrows: false,
     noEditPr: false,
     effort: null as string | null,
+    provider: "claude" as "claude" | "codex",
+    model: null as string | null,
     ...opts,
   };
 
@@ -474,7 +479,7 @@ function mkHarness(opts?: {
     repos: () => o.repos,
     store: store as any,
     nightlyHour: o.nightlyHour,
-    env: () => ({ provider: "claude", model: null, effort: o.effort }),
+    env: () => ({ provider: o.provider, model: o.model, effort: o.effort }),
     act: o.act,
     onChange: (f) => finalizes.push(f),
     now: o.now,
@@ -506,18 +511,21 @@ function mkHarness(opts?: {
       markers.set(p, c);
     },
     readMarker: (p: string) => markers.get(p) ?? null,
-    readUsage: async () => ({
-      input: 5,
-      output: 7,
-      cacheRead: 0,
-      cacheWrite: 0,
-      total: 12,
-      messageCount: 1,
-      lastActivity: null,
-      byModel: {},
-      fullRecaches: 0,
-      sidechainCount: 0,
-    }),
+    readUsage: async () =>
+      o.usageUnavailable
+        ? null
+        : {
+            input: 5,
+            output: 7,
+            cacheRead: 0,
+            cacheWrite: 0,
+            total: 12,
+            messageCount: 1,
+            lastActivity: null,
+            byModel: {},
+            fullRecaches: 0,
+            sidechainCount: 0,
+          },
   });
 
   return {
@@ -1088,6 +1096,28 @@ test("row completed at finalize: act path completes the spawn row", async () => 
   await h.svc.tick();
   expect(h.completedRows).toHaveLength(1);
   expect(h.completedRows[0]!.reviewerSessionId).toBe(h.spawnRows[0]!.reviewerSessionId);
+});
+
+test("Claude doc row uses zero usage when its transcript is unavailable", async () => {
+  const h = mkHarness({ provider: "claude", usageUnavailable: true });
+  await h.svc.consider("/repo");
+  await h.svc.tick();
+
+  expect(h.completedRows).toHaveLength(1);
+  expect(h.completedRows[0]!.total).toBe(0);
+  expect(h.spawnRows[0]!.completedAt).not.toBeNull();
+});
+
+test("Codex doc agent persists the provider environment used for its spawn", async () => {
+  const h = mkHarness({ provider: "codex", model: "gpt-5.6", effort: "high" });
+  await h.svc.consider("/repo");
+  expect(h.spawnRows[0]).toMatchObject({
+    reviewerProvider: "codex",
+    model: "gpt-5.6",
+    reviewerEffort: "high",
+  });
+  await h.svc.tick();
+  expect(h.completedRows).toHaveLength(1);
 });
 
 // ── prettier pre-format (fix: doc-agent auto-PRs fail CI lint gate) ─────────────

--- a/test/doc-agent.test.ts
+++ b/test/doc-agent.test.ts
@@ -72,7 +72,7 @@ interface SpawnRow {
 interface CompletedRow {
   reviewerSessionId: string;
   completedAt: number;
-  total: number;
+  total: number | null;
 }
 
 interface Harness {
@@ -297,10 +297,10 @@ function mkHarness(opts?: {
     },
     completeReviewerSpawn: (
       reviewerSessionId: string,
-      u: { total: number },
+      u: { total: number } | null,
       completedAt: number,
     ) => {
-      completedRows.push({ reviewerSessionId, completedAt, total: u.total });
+      completedRows.push({ reviewerSessionId, completedAt, total: u?.total ?? null });
       const row = spawnRows.find((s) => s.reviewerSessionId === reviewerSessionId);
       if (row) row.completedAt = completedAt;
     },
@@ -1979,4 +1979,12 @@ test("onSpawn abortSpawn → doc run skipped, worktree reaped, no spawn", async 
   expect(res.reason).toBe("plugin aborted spawn");
   expect(h.starts).toHaveLength(0); // herdr.start never reached
   expect(h.removedWorktrees.length).toBeGreaterThan(0); // the doc worktree was reaped
+});
+
+test("Codex doc usage stays unknown so a delayed rollout can be backfilled", async () => {
+  const h = mkHarness({ provider: "codex", usageUnavailable: true });
+  await h.svc.consider("/repo");
+  await h.svc.tick();
+  expect(h.completedRows[0]?.total).toBeNull();
+  expect(h.spawnRows[0]?.completedAt).not.toBeNull();
 });

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -544,6 +544,28 @@ test("tick: generating row + valid verdict → state 'ready' + usage + stop + cl
   expect(cleaned).toContain("/tmp/recap-s1");
 });
 
+test("tick completes a Codex recap even when no Claude usage transcript exists", async () => {
+  const rec = makeRecap({
+    state: "generating",
+    cwd: "/tmp/recap-codex",
+    spawnSessionId: "sp-codex",
+    spawnedAt: 100_000,
+  });
+  const store = makeStore([], [rec]);
+  const svc = buildSvc({
+    store,
+    herdr: makeHerdr([{ cwd: rec.cwd, terminalId: "t-codex" }]),
+    nowFn: () => 200_000,
+    timeoutMs: 300_000,
+    verdictJson: VALID_VERDICT_JSON,
+    readUsage: async () => null,
+  });
+
+  await svc.tick();
+
+  expect(store.completedSpawns).toEqual([{ id: "sp-codex", u: null, at: 200_000 }]);
+});
+
 // TASK-561 follow-up: the #822 failsafe still left recap generation failing on retry. A chatty
 // agent wraps the JSON in prose, jsonrepair rescues it into an ARRAY (["Here is the recap:", {…}]),
 // and the OLD finalize → parseRecapVerdict rejected arrays → `failed`. The fix unwraps the recap

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -511,6 +511,29 @@ test("completes the spawn's token total on finalize (issue #502)", async () => {
   expect(completedSpawns[0]!.id).toBe(recordedSpawns[0]!.reviewerSessionId);
 });
 
+test("Codex review records its resolved provider and completes without Claude usage", async () => {
+  const env = { provider: "codex" as const, model: "gpt-5.6", effort: "high" };
+  const {
+    deps: d,
+    recordedSpawns,
+    completedSpawns,
+  } = makeDeps({
+    env: () => env,
+    readUsage: async () => null,
+  });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+
+  expect(recordedSpawns[0]).toMatchObject({
+    reviewerProvider: "codex",
+    model: "gpt-5.6",
+    reviewerEffort: "high",
+  });
+  expect(completedSpawns).toHaveLength(1);
+  expect(completedSpawns[0]!.u).toBeNull();
+});
+
 test("onReviewing fires true on spawn and false on finalize", async () => {
   const events: { id: string; reviewing: boolean }[] = [];
   const { deps: d } = makeDeps({

--- a/test/reviewer-usage.test.ts
+++ b/test/reviewer-usage.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "bun:test";
+import { SessionStore } from "../src/store";
+import { CodexRolloutResolver, backfillCodexSpawnUsage } from "../src/codex-activity";
+import { readReviewerSpawnUsage } from "../src/reviewer-usage";
+
+for (const kind of ["recap", "doc_agent", "classifier", "review"] as const) {
+  test(`${kind} captures Codex usage and persists the existing provider session identity`, async () => {
+    const store = new SessionStore(":memory:");
+    store.recordReviewerSpawn({
+      reviewerSessionId: "spawn",
+      taskSessionId: "task",
+      kind,
+      worktreePath: "/unique-cwd",
+      reviewerProvider: "codex",
+      model: "gpt-5.6-sol",
+      spawnedAt: 1,
+    });
+    const resolver = new CodexRolloutResolver({
+      now: () => 2,
+      listMetas: () => [
+        {
+          path: `${import.meta.dir}/fixtures/codex-activity/rollout-role-exec.jsonl`,
+          cwd: "/unique-cwd",
+          rolloutId: "native-thread",
+          source: "exec",
+          mtimeMs: 2,
+        },
+      ],
+    });
+    const usage = await readReviewerSpawnUsage(store, "/unique-cwd", "spawn", undefined, resolver);
+    expect(usage?.total).toBe(52976);
+    expect(store.listReviewerSpawns()[0]?.providerSessionId).toBe("native-thread");
+  });
+}
+
+test("unresolved Codex helper usage stays unknown", async () => {
+  const store = new SessionStore(":memory:");
+  store.recordReviewerSpawn({
+    reviewerSessionId: "spawn",
+    taskSessionId: "task",
+    kind: "recap",
+    worktreePath: "/unique-cwd",
+    reviewerProvider: "codex",
+    model: null,
+    spawnedAt: 1,
+  });
+  const resolver = new CodexRolloutResolver({ now: () => 2, listMetas: () => [] });
+  expect(
+    await readReviewerSpawnUsage(store, "/unique-cwd", "spawn", undefined, resolver),
+  ).toBeNull();
+  expect(store.listReviewerSpawns()[0]?.providerSessionId).toBeNull();
+});
+
+test("delayed Codex usage backfill also persists the role's native thread identity", () => {
+  const store = new SessionStore(":memory:");
+  store.recordReviewerSpawn({
+    reviewerSessionId: "spawn",
+    taskSessionId: "task",
+    kind: "recap",
+    worktreePath: "/unique-cwd",
+    reviewerProvider: "codex",
+    model: "gpt-5.6-sol",
+    spawnedAt: 1,
+  });
+  store.completeReviewerSpawn("spawn", null, 2);
+  expect(
+    backfillCodexSpawnUsage(store, () => [
+      {
+        path: `${import.meta.dir}/fixtures/codex-activity/rollout-role-exec.jsonl`,
+        cwd: "/unique-cwd",
+        rolloutId: "native-thread",
+        source: "exec",
+        mtimeMs: 3,
+      },
+    ]),
+  ).toBe(1);
+  expect(store.listReviewerSpawns()[0]).toMatchObject({
+    providerSessionId: "native-thread",
+    totalTokens: 52976,
+  });
+});

--- a/test/server-usage-breakdown.test.ts
+++ b/test/server-usage-breakdown.test.ts
@@ -84,8 +84,9 @@ test("GET /api/usage/breakdown?range=7d → 200 with correct shape", async () =>
   expect(body.models.claude).toEqual({
     totalTokens: 3600,
     byModel: { "claude-sonnet-4": 3600 },
+    byRole: { coding: { "claude-sonnet-4": 3600 } },
   });
-  expect(body.models.codex).toEqual({ totalTokens: 0, byModel: {} });
+  expect(body.models.codex).toEqual({ totalTokens: 0, byModel: {}, byRole: {} });
 
   for (const repo of body.repos) {
     exactKeys(repo, USAGE_REPO_KEYS);
@@ -134,15 +135,14 @@ test("GET /api/usage/breakdown forwards cutoff to the Codex model dependency", a
   });
 
   const before = Date.now() - 7 * 86_400_000;
-  const body = await (
-    await app.fetch(new Request("http://x/api/usage/breakdown?range=7d"))
-  ).json();
+  const body = await (await app.fetch(new Request("http://x/api/usage/breakdown?range=7d"))).json();
   const after = Date.now() - 7 * 86_400_000;
   expect(receivedCutoff).toBeGreaterThanOrEqual(before);
   expect(receivedCutoff).toBeLessThanOrEqual(after);
   expect(body.models.codex).toEqual({
     totalTokens: 1000,
     byModel: { "gpt-5.5": 700, unknown: 300 },
+    byRole: {},
   });
 });
 

--- a/test/server-usage-breakdown.test.ts
+++ b/test/server-usage-breakdown.test.ts
@@ -8,6 +8,7 @@ import { EventHub } from "../src/events";
 import {
   USAGE_BREAKDOWN_KEYS,
   USAGE_KIND_UNITS_KEYS,
+  USAGE_MODEL_BREAKDOWN_KEYS,
   USAGE_REPO_KEYS,
   USAGE_TASK_KEYS,
   USAGE_TOKENS_KEYS,
@@ -15,13 +16,17 @@ import {
 import type { SessionUsageSnapshot } from "../src/types";
 import { SessionUsageRollup } from "../src/usage";
 
-function harness(): { app: ReturnType<typeof makeApp>; store: SessionStore } {
+function harness(overrides: Partial<AppDeps> = {}): {
+  app: ReturnType<typeof makeApp>;
+  store: SessionStore;
+} {
   const store = new SessionStore(":memory:");
   const deps: AppDeps = {
     store,
     service: {} as any,
     events: new EventHub(),
     usageLimits: { limits: () => ({}) } as any,
+    ...overrides,
   };
   return { app: makeApp(deps), store };
 }
@@ -50,6 +55,7 @@ function seedSnapshot(store: SessionStore, overrides: Partial<SessionUsageSnapsh
     cacheReadUnits: 0.01,
     messageCount: 10,
     byModel: { "claude-sonnet-4": 0.05 },
+    rawByModel: { "claude-sonnet-4": 3600 },
     createdAt: NOW - 1000,
     archivedAt: NOW - 500,
     snapshotAt: NOW - 100,
@@ -72,6 +78,14 @@ test("GET /api/usage/breakdown?range=7d → 200 with correct shape", async () =>
   expect(body.range).toBe("7d");
   // api-key gate: subscription harness defaults to non-api-key mode → dollars must be null
   expect(body.dollars).toBeNull();
+  expect(Object.keys(body.models).sort()).toEqual(["claude", "codex"]);
+  exactKeys(body.models.claude, USAGE_MODEL_BREAKDOWN_KEYS);
+  exactKeys(body.models.codex, USAGE_MODEL_BREAKDOWN_KEYS);
+  expect(body.models.claude).toEqual({
+    totalTokens: 3600,
+    byModel: { "claude-sonnet-4": 3600 },
+  });
+  expect(body.models.codex).toEqual({ totalTokens: 0, byModel: {} });
 
   for (const repo of body.repos) {
     exactKeys(repo, USAGE_REPO_KEYS);
@@ -108,6 +122,28 @@ test("GET /api/usage/breakdown?range=bogus → 400", async () => {
   expect(res.status).toBe(400);
   const body = await res.json();
   expect(body.error).toBe("invalid range");
+});
+
+test("GET /api/usage/breakdown forwards cutoff to the Codex model dependency", async () => {
+  let receivedCutoff: number | null = null;
+  const { app } = harness({
+    codexModelUsage: (cutoff) => {
+      receivedCutoff = cutoff;
+      return { "gpt-5.5": 700, unknown: 300 };
+    },
+  });
+
+  const before = Date.now() - 7 * 86_400_000;
+  const body = await (
+    await app.fetch(new Request("http://x/api/usage/breakdown?range=7d"))
+  ).json();
+  const after = Date.now() - 7 * 86_400_000;
+  expect(receivedCutoff).toBeGreaterThanOrEqual(before);
+  expect(receivedCutoff).toBeLessThanOrEqual(after);
+  expect(body.models.codex).toEqual({
+    totalTokens: 1000,
+    byModel: { "gpt-5.5": 700, unknown: 300 },
+  });
 });
 
 // ── satelliteByKind: global per-kind tally incl. unattributed buckets ─────────

--- a/test/server-usage-breakdown.test.ts
+++ b/test/server-usage-breakdown.test.ts
@@ -142,7 +142,40 @@ test("GET /api/usage/breakdown forwards cutoff to the Codex model dependency", a
   expect(body.models.codex).toEqual({
     totalTokens: 1000,
     byModel: { "gpt-5.5": 700, unknown: 300 },
-    byRole: {},
+    byRole: { coding: { "gpt-5.5": 700, unknown: 300 } },
+  });
+});
+
+test("GET /api/usage/breakdown returns attributed Codex roles plus the exact coding remainder", async () => {
+  const { app, store } = harness({ codexModelUsage: () => ({ "gpt-5.6": 1_000 }) });
+  // @ts-expect-error accessing internal db for focused endpoint setup
+  store.db.run(
+    `INSERT INTO reviewer_spawns
+       (reviewerSessionId, taskSessionId, kind, worktreePath, reviewerProvider, model,
+        providerSessionId, spawnedAt, completedAt, totalTokens)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      "codex-review",
+      "task",
+      "review",
+      "/wt/codex-review",
+      "codex",
+      "gpt-5.6",
+      "thread-review",
+      NOW - 2_000,
+      NOW - 1_000,
+      250,
+    ],
+  );
+
+  const body = await (await app.fetch(new Request("http://x/api/usage/breakdown?range=7d"))).json();
+  expect(body.models.codex).toEqual({
+    totalTokens: 1_000,
+    byModel: { "gpt-5.6": 1_000 },
+    byRole: {
+      review: { "gpt-5.6": 250 },
+      coding: { "gpt-5.6": 750 },
+    },
   });
 });
 

--- a/test/server-usage-breakdown.test.ts
+++ b/test/server-usage-breakdown.test.ts
@@ -130,7 +130,7 @@ test("GET /api/usage/breakdown forwards cutoff to the Codex model dependency", a
   const { app } = harness({
     codexModelUsage: (cutoff) => {
       receivedCutoff = cutoff;
-      return { "gpt-5.5": 700, unknown: 300 };
+      return { byModel: { "gpt-5.5": 700, unknown: 300 }, byThread: {} };
     },
   });
 
@@ -147,7 +147,12 @@ test("GET /api/usage/breakdown forwards cutoff to the Codex model dependency", a
 });
 
 test("GET /api/usage/breakdown returns attributed Codex roles plus the exact coding remainder", async () => {
-  const { app, store } = harness({ codexModelUsage: () => ({ "gpt-5.6": 1_000 }) });
+  const { app, store } = harness({
+    codexModelUsage: () => ({
+      byModel: { "gpt-5.6": 1_000 },
+      byThread: { "thread-review": { model: "gpt-5.6", totalTokens: 250 } },
+    }),
+  });
   // @ts-expect-error accessing internal db for focused endpoint setup
   store.db.run(
     `INSERT INTO reviewer_spawns

--- a/test/server-usage-timeline.test.ts
+++ b/test/server-usage-timeline.test.ts
@@ -40,6 +40,7 @@ function seedHour(store: SessionStore, sessionId: string, units: number): number
     cacheReadUnits: 0,
     messageCount: 1,
     byModel: { "claude-opus-4-8": units },
+    rawByModel: { "claude-opus-4-8": 2 },
     createdAt: NOW - 2 * HOUR,
     archivedAt: NOW - 500,
     snapshotAt: NOW - 500,
@@ -56,6 +57,7 @@ function seedHour(store: SessionStore, sessionId: string, units: number): number
       weightedUnits: units,
       cacheReadUnits: 0,
       byModel: { "claude-opus-4-8": units },
+      rawByModel: { "claude-opus-4-8": 0 },
     },
   ]);
   return hour;

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -305,6 +305,7 @@ test("usage ladder: archived session serves its snapshot — raw fields, byModel
     weightedUnits: 7,
     cacheReadUnits: 3,
     messageCount: 5,
+    rawByModel: {},
     byModel: { opus: 7 }, // weighted units — must NOT surface in the raw-token DTO field
     createdAt: s.createdAt,
     archivedAt: s.createdAt + 1000,
@@ -344,6 +345,7 @@ function usageSnapFor(
     weightedUnits: 7,
     cacheReadUnits: 3,
     messageCount: 5,
+    rawByModel: {},
     byModel: { opus: 7 },
     createdAt: s.createdAt,
     archivedAt: s.createdAt + 1000,

--- a/test/standalone-critic.test.ts
+++ b/test/standalone-critic.test.ts
@@ -1140,3 +1140,13 @@ test("#2154 learnings off ⇒ no house-rules block at the session-less critic", 
   expect(prompt).not.toContain("REPO HOUSE RULES");
   expect(prompt).not.toContain("must not be shown");
 });
+
+test("restarting a standalone review of the same head gives each rollout its own cwd", async () => {
+  const first = makeDeps();
+  const restarted = makeDeps();
+  await new StandalonePrCriticService(first.deps as any).sweep();
+  await new StandalonePrCriticService(restarted.deps as any).sweep();
+  expect(first.spies.created[0]?.sha).toBe(restarted.spies.created[0]?.sha);
+  expect(first.spies.created[0]?.slug).toBeTruthy();
+  expect(first.spies.created[0]?.slug).not.toBe(restarted.spies.created[0]?.slug);
+});

--- a/test/standalone-critic.test.ts
+++ b/test/standalone-critic.test.ts
@@ -266,6 +266,24 @@ test("reviews a fresh open green regular session-less PR", async () => {
   expect(settings.env).toBeUndefined();
 });
 
+test("Codex critic records its resolved provider and completes without Claude usage", async () => {
+  const { deps, spies } = makeDeps({
+    env: () => ({ provider: "codex", model: "gpt-5.6", effort: "high" }),
+    readUsage: async () => null,
+  });
+  const svc = new StandalonePrCriticService(deps as any);
+  await svc.sweep();
+  await svc.tick();
+
+  expect(spies.recordedSpawns[0]).toMatchObject({
+    reviewerProvider: "codex",
+    model: "gpt-5.6",
+    reviewerEffort: "high",
+  });
+  expect(spies.completedSpawns).toHaveLength(1);
+  expect(spies.completedSpawns[0]!.u).toBeNull();
+});
+
 test("reviews a REST-enumerated green PR while GraphQL backoff is active", async () => {
   graphRateLimit.noteLimitError(60);
   let metaCalls = 0;

--- a/test/store-session-usage.test.ts
+++ b/test/store-session-usage.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
 import { expect, test } from "bun:test";
 import { SessionStore } from "../src/store";
 import type { SessionUsageBucket, SessionUsageSnapshot } from "../src/types";
@@ -17,6 +21,7 @@ const snap = (over: Partial<SessionUsageSnapshot> = {}): SessionUsageSnapshot =>
   cacheReadUnits: 0.25,
   messageCount: 10,
   byModel: { "claude-sonnet-4-5": 3.14 },
+  rawByModel: { "claude-sonnet-4-5": 1750 },
   createdAt: 1_000_000,
   archivedAt: 2_000_000,
   snapshotAt: 2_000_001,
@@ -43,6 +48,7 @@ test("session_usage: upsert then list round-trips all fields", () => {
   expect(r.cacheReadUnits).toBe(0.25);
   expect(r.messageCount).toBe(10);
   expect(r.byModel).toEqual({ "claude-sonnet-4-5": 3.14 });
+  expect(r.rawByModel).toEqual({ "claude-sonnet-4-5": 1750 });
   expect(r.createdAt).toBe(1_000_000);
   expect(r.archivedAt).toBe(2_000_000);
   expect(r.snapshotAt).toBe(2_000_001);
@@ -79,6 +85,7 @@ const bucket = (over: Partial<SessionUsageBucket> = {}): SessionUsageBucket => (
   weightedUnits: 1.5,
   cacheReadUnits: 0.1,
   byModel: { "claude-sonnet-4-5": 1.5 },
+  rawByModel: { "claude-sonnet-4-5": 175 },
   ...over,
 });
 
@@ -167,6 +174,79 @@ test("session_usage_bucket: sumSessionUsageBucketsSince merges byModel across ro
   expect(bm["sonnet"]).toBeCloseTo(3.0, 10); // 1.0 + 2.0
   expect(bm["opus"]).toBeCloseTo(0.5, 10); // only in bucket 0
   expect(bm["haiku"]).toBeCloseTo(0.3, 10); // bucket 3H
+});
+
+test("session_usage_bucket: sumSessionUsageBucketsSince merges rawByModel across rows", () => {
+  const s = new SessionStore(":memory:");
+  s.upsertSessionUsage(snap());
+
+  const H = 3_600_000;
+  s.replaceSessionUsageBuckets("sess-1", [
+    bucket({ bucketStart: 0, rawByModel: { sonnet: 100, opus: 50 } }),
+    bucket({ bucketStart: 2 * H, rawByModel: { sonnet: 200 } }),
+    bucket({ bucketStart: 3 * H, rawByModel: { haiku: 30 } }),
+  ]);
+
+  expect(s.sumSessionUsageBucketsSince(2 * H).get("sess-1")!.rawByModel).toEqual({
+    sonnet: 300,
+    opus: 50,
+    haiku: 30,
+  });
+});
+
+test("legacy empty rawByModel falls back to unknown raw token totals", () => {
+  const s = new SessionStore(":memory:");
+  s.upsertSessionUsage(snap({ rawByModel: {} }));
+  expect(s.listSessionUsage()[0]!.rawByModel).toEqual({ unknown: 1750 });
+
+  s.replaceSessionUsageBuckets("sess-1", [bucket({ rawByModel: {} })]);
+  expect(s.sumSessionUsageBucketsSince(0).get("sess-1")!.rawByModel).toEqual({ unknown: 175 });
+});
+
+test("legacy usage tables migrate rawByModel columns and preserve totals as unknown", () => {
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-usage-model-migration-"));
+  const dbPath = join(dir, "test.db");
+  try {
+    const raw = new Database(dbPath);
+    raw.exec(`
+      CREATE TABLE session_usage (
+        sessionId TEXT PRIMARY KEY, desig TEXT NOT NULL, name TEXT NOT NULL DEFAULT '',
+        repoPath TEXT NOT NULL, model TEXT NOT NULL, input INTEGER NOT NULL,
+        output INTEGER NOT NULL, cacheRead INTEGER NOT NULL, cacheWrite INTEGER NOT NULL,
+        total INTEGER NOT NULL, weightedUnits REAL NOT NULL, cacheReadUnits REAL NOT NULL,
+        messageCount INTEGER NOT NULL, byModel TEXT NOT NULL DEFAULT '{}',
+        createdAt INTEGER NOT NULL, archivedAt INTEGER NOT NULL, snapshotAt INTEGER NOT NULL
+      );
+      CREATE TABLE session_usage_bucket (
+        sessionId TEXT NOT NULL, bucketStart INTEGER NOT NULL, input INTEGER NOT NULL,
+        output INTEGER NOT NULL, cacheRead INTEGER NOT NULL, cacheWrite INTEGER NOT NULL,
+        weightedUnits REAL NOT NULL, cacheReadUnits REAL NOT NULL,
+        byModel TEXT NOT NULL DEFAULT '{}', PRIMARY KEY (sessionId, bucketStart),
+        FOREIGN KEY (sessionId) REFERENCES session_usage(sessionId) ON DELETE CASCADE
+      );
+      INSERT INTO session_usage VALUES (
+        'legacy', 'TASK-00', 'legacy', '/repos/legacy', 'claude-sonnet-4-5',
+        100, 50, 20, 5, 175, 1.5, 0.1, 1, '{}', 1, 2, 3
+      );
+      INSERT INTO session_usage_bucket VALUES (
+        'legacy', 0, 100, 50, 20, 5, 1.5, 0.1, '{}'
+      );
+    `);
+    raw.close();
+
+    const s = new SessionStore(dbPath);
+    const db = (s as unknown as { db: Database }).db;
+    const usageColumns = db.query(`PRAGMA table_info(session_usage)`).all() as { name: string }[];
+    const bucketColumns = db.query(`PRAGMA table_info(session_usage_bucket)`).all() as {
+      name: string;
+    }[];
+    expect(usageColumns.some((column) => column.name === "rawByModel")).toBe(true);
+    expect(bucketColumns.some((column) => column.name === "rawByModel")).toBe(true);
+    expect(s.listSessionUsage()[0]!.rawByModel).toEqual({ unknown: 175 });
+    expect(s.sumSessionUsageBucketsSince(0).get("legacy")!.rawByModel).toEqual({ unknown: 175 });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("session_usage_bucket: sumSessionUsageBucketsSince sums multiple sessions independently", () => {

--- a/test/usage-backfill.test.ts
+++ b/test/usage-backfill.test.ts
@@ -146,6 +146,7 @@ test("skip existing: archived session with pre-existing usage row is NOT overwri
     cacheReadUnits: 0,
     messageCount: 99,
     byModel: { "sentinel-model": 42.0 },
+    rawByModel: { "sentinel-model": 9999 },
     createdAt: 1,
     archivedAt: 1,
     snapshotAt: 1,

--- a/test/usage-breakdown.test.ts
+++ b/test/usage-breakdown.test.ts
@@ -111,7 +111,195 @@ function makeSnap(over: {
   };
 }
 
+function seedRoleSpawn(
+  store: SessionStore,
+  r: {
+    id: string;
+    kind: "review" | "plan_gate" | "recap" | "rundown" | "doc_agent";
+    provider: "claude" | "codex" | null;
+    model: string | null;
+    spawnedAt?: number;
+    completedAt?: number | null;
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+  },
+): void {
+  const input = r.input ?? 0;
+  const output = r.output ?? 0;
+  const cacheRead = r.cacheRead ?? 0;
+  const cacheWrite = r.cacheWrite ?? 0;
+  // @ts-expect-error accessing internal db for focused aggregate setup
+  store.db.run(
+    `INSERT INTO reviewer_spawns
+       (reviewerSessionId, taskSessionId, kind, worktreePath, reviewerProvider, model,
+        spawnedAt, completedAt, inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens,
+        totalTokens)
+     VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+    [
+      r.id,
+      "task-a",
+      r.kind,
+      "/wt/" + r.id,
+      r.provider,
+      r.model,
+      r.spawnedAt ?? NOW - 2_000,
+      r.completedAt === undefined ? NOW - 1_000 : r.completedAt,
+      input,
+      output,
+      cacheRead,
+      cacheWrite,
+      input + output + cacheRead + cacheWrite,
+    ],
+  );
+}
+
 // ── actual test suite ─────────────────────────────────────────────────────────
+
+test("Claude model breakdown preserves role × model identity and exact token total", async () => {
+  const store = new SessionStore(":memory:");
+  store.upsertSessionUsage(
+    makeSnap({
+      sessionId: "task-a",
+      desig: "TASK-01",
+      repoPath: "/repos/alpha",
+      input: 100,
+      output: 200,
+      weightedUnits: 0,
+      cacheReadUnits: 0,
+      rawByModel: { "claude-opus-4-8": 100, "claude-sonnet-4-8": 200 },
+      snapshotAt: NOW,
+    }),
+  );
+
+  seedRoleSpawn(store, {
+    id: "review",
+    kind: "review",
+    provider: "claude",
+    model: "claude-opus-4-8",
+    input: 10,
+    output: 20,
+    cacheRead: 30,
+    cacheWrite: 40,
+  });
+  seedRoleSpawn(store, {
+    id: "plan",
+    kind: "plan_gate",
+    provider: "claude",
+    model: "claude-sonnet-4-8",
+    input: 50,
+  });
+  seedRoleSpawn(store, {
+    id: "recap",
+    kind: "recap",
+    provider: null,
+    model: "fable",
+    input: 25,
+  });
+  seedRoleSpawn(store, {
+    id: "rundown",
+    kind: "rundown",
+    provider: "claude",
+    model: "claude-opus-4-8",
+    output: 15,
+  });
+  seedRoleSpawn(store, {
+    id: "doc",
+    kind: "doc_agent",
+    provider: "claude",
+    model: "haiku",
+    cacheRead: 10,
+  });
+
+  const bd = await buildUsageBreakdown({ store, range: "all", now: NOW, apiKey: false });
+
+  expect(bd.models.claude).toEqual({
+    totalTokens: 500,
+    byModel: {
+      "claude-opus-4-8": 215,
+      "claude-sonnet-4-8": 250,
+      fable: 25,
+      haiku: 10,
+    },
+    byRole: {
+      coding: { "claude-opus-4-8": 100, "claude-sonnet-4-8": 200 },
+      review: { "claude-opus-4-8": 100 },
+      plan_gate: { "claude-sonnet-4-8": 50 },
+      recap: { fable: 25 },
+      rundown: { "claude-opus-4-8": 15 },
+      doc_agent: { haiku: 10 },
+    },
+  });
+  expect(bd.models.codex.byRole).toEqual({});
+  const roleTotal = Object.values(bd.models.claude.byRole).reduce(
+    (total, models) => total + Object.values(models ?? {}).reduce((sum, tokens) => sum + tokens, 0),
+    0,
+  );
+  expect(roleTotal).toBe(bd.models.claude.totalTokens);
+});
+
+test("legacy null-provider Claude classifier is anchored and range-filtered", async () => {
+  const store = new SessionStore(":memory:");
+  const accepted = [
+    "fable",
+    "opus",
+    "opus[1m]",
+    "sonnet",
+    "sonnet[1m]",
+    "haiku",
+    "claude-opus-4-8",
+    "claude-sonnet-4-20250514",
+    "claude-haiku-3-5",
+  ];
+  accepted.forEach((model, index) => {
+    seedRoleSpawn(store, {
+      id: `accepted-${index}`,
+      kind: "recap",
+      provider: null,
+      model,
+      input: 1,
+    });
+  });
+  for (const [index, model] of [
+    "my-claude-opus-4-8",
+    "claude-opus-latest",
+    "gpt-5.5",
+    "<synthetic>",
+    " ",
+  ].entries()) {
+    seedRoleSpawn(store, {
+      id: `rejected-${index}`,
+      kind: "recap",
+      provider: null,
+      model,
+      input: 100,
+    });
+  }
+  seedRoleSpawn(store, {
+    id: "explicit-codex-wins",
+    kind: "review",
+    provider: "codex",
+    model: "claude-opus-4-8",
+    input: 100,
+  });
+  seedRoleSpawn(store, {
+    id: "stale",
+    kind: "review",
+    provider: "claude",
+    model: "claude-opus-4-8",
+    spawnedAt: NOW - 2 * H24,
+    completedAt: null,
+    input: 100,
+  });
+
+  const bd = await buildUsageBreakdown({ store, range: "24h", now: NOW, apiKey: false });
+
+  expect(bd.models.claude.byRole).toEqual({
+    recap: Object.fromEntries(accepted.map((model) => [model, 1])),
+  });
+  expect(bd.models.claude.totalTokens).toBe(accepted.length);
+});
 
 test("repo→task grouping, sorting, field mapping", async () => {
   const store = new SessionStore(":memory:");
@@ -842,7 +1030,11 @@ test("persisted windowed sub-session: 24h returns only recent hour; 30d/all retu
   expect(task24h!.tokens.input).toBe(300);
   expect(task24h!.tokens.output).toBe(100);
   expect(task24h!.authoringUnits).toBeCloseTo(recentWu, 10);
-  expect(bd24h.models.claude).toEqual({ totalTokens: 400, byModel: { [model]: 400 } });
+  expect(bd24h.models.claude).toEqual({
+    totalTokens: 400,
+    byModel: { [model]: 400 },
+    byRole: { coding: { [model]: 400 } },
+  });
 
   // 30d: both buckets (old hour is 48h ago, within 30d)
   const bd30d = await buildUsageBreakdown({ store, range: "30d", now: NOW, apiKey: false });
@@ -851,7 +1043,11 @@ test("persisted windowed sub-session: 24h returns only recent hour; 30d/all retu
   expect(task30d!.tokens.input).toBe(800);
   expect(task30d!.tokens.output).toBe(300);
   expect(task30d!.authoringUnits).toBeCloseTo(totalWu, 10);
-  expect(bd30d.models.claude).toEqual({ totalTokens: 1100, byModel: { [model]: 1100 } });
+  expect(bd30d.models.claude).toEqual({
+    totalTokens: 1100,
+    byModel: { [model]: 1100 },
+    byRole: { coding: { [model]: 1100 } },
+  });
 
   // all: uses aggregate row → same total
   const bdAll = await buildUsageBreakdown({ store, range: "all", now: NOW, apiKey: false });

--- a/test/usage-breakdown.test.ts
+++ b/test/usage-breakdown.test.ts
@@ -81,6 +81,7 @@ function makeSnap(over: {
   weightedUnits: number;
   cacheReadUnits: number;
   byModel?: Record<string, number>;
+  rawByModel?: Record<string, number>;
   snapshotAt: number;
 }) {
   const model = over.model ?? "claude-opus-4-8";
@@ -103,6 +104,7 @@ function makeSnap(over: {
     cacheReadUnits: over.cacheReadUnits,
     messageCount: 1,
     byModel: over.byModel ?? { [model]: input + output + cacheRead + cacheWrite },
+    rawByModel: over.rawByModel ?? { [model]: input + output + cacheRead + cacheWrite },
     createdAt: over.snapshotAt - 1000,
     archivedAt: over.snapshotAt,
     snapshotAt: over.snapshotAt,
@@ -817,6 +819,7 @@ test("persisted windowed sub-session: 24h returns only recent hour; 30d/all retu
         weightedUnits: oldWu,
         cacheReadUnits: 0,
         byModel: { [model]: oldWu },
+        rawByModel: { [model]: 700 },
       },
       {
         bucketStart: recentHourFloor,
@@ -827,6 +830,7 @@ test("persisted windowed sub-session: 24h returns only recent hour; 30d/all retu
         weightedUnits: recentWu,
         cacheReadUnits: 0,
         byModel: { [model]: recentWu },
+        rawByModel: { [model]: 400 },
       },
     ],
   );
@@ -838,6 +842,7 @@ test("persisted windowed sub-session: 24h returns only recent hour; 30d/all retu
   expect(task24h!.tokens.input).toBe(300);
   expect(task24h!.tokens.output).toBe(100);
   expect(task24h!.authoringUnits).toBeCloseTo(recentWu, 10);
+  expect(bd24h.models.claude).toEqual({ totalTokens: 400, byModel: { [model]: 400 } });
 
   // 30d: both buckets (old hour is 48h ago, within 30d)
   const bd30d = await buildUsageBreakdown({ store, range: "30d", now: NOW, apiKey: false });
@@ -846,6 +851,7 @@ test("persisted windowed sub-session: 24h returns only recent hour; 30d/all retu
   expect(task30d!.tokens.input).toBe(800);
   expect(task30d!.tokens.output).toBe(300);
   expect(task30d!.authoringUnits).toBeCloseTo(totalWu, 10);
+  expect(bd30d.models.claude).toEqual({ totalTokens: 1100, byModel: { [model]: 1100 } });
 
   // all: uses aggregate row → same total
   const bdAll = await buildUsageBreakdown({ store, range: "all", now: NOW, apiKey: false });
@@ -957,6 +963,7 @@ test("bucketed zero-window: dropped when no spawn; retained as zero-authoring wh
         weightedUnits: oldWu,
         cacheReadUnits: 0,
         byModel: { [model]: oldWu },
+        rawByModel: { [model]: 550 },
       },
     ]);
   }
@@ -1076,6 +1083,7 @@ test("live via rollup == re-parse fallback: identical authoringUnits/tokens/byMo
   expect(taskWithRollup!.authoringUnits).toBeCloseTo(taskFallback!.authoringUnits, 10);
   expect(taskWithRollup!.model).toBe(taskFallback!.model);
   expect(taskWithRollup!.byModel).toEqual(taskFallback!.byModel);
+  expect(bdWithRollup.models.claude).toEqual(bdFallback.models.claude);
 
   // Sanity: actual values match the 24h window (both records are within 24h)
   expect(taskWithRollup!.tokens.input).toBe(450);
@@ -1131,6 +1139,7 @@ test("cutoff===0 persisted uses aggregate rows (bucketed session all-time = aggr
         weightedUnits: oldWu,
         cacheReadUnits: 0,
         byModel: { [model]: oldWu },
+        rawByModel: { [model]: 700 },
       },
       {
         bucketStart: recentHourFloor,
@@ -1141,6 +1150,7 @@ test("cutoff===0 persisted uses aggregate rows (bucketed session all-time = aggr
         weightedUnits: recentWu,
         cacheReadUnits: 0,
         byModel: { [model]: recentWu },
+        rawByModel: { [model]: 400 },
       },
     ],
   );

--- a/test/usage-breakdown.test.ts
+++ b/test/usage-breakdown.test.ts
@@ -7,10 +7,11 @@ import { config } from "../src/config";
 import { buildUsageBreakdown } from "../src/usage-breakdown";
 import { jsonlPathFor, SessionUsageRollup } from "../src/usage";
 import { weightedUnits } from "../src/pricing";
-import type { SessionUsageBucket } from "../src/types";
+import type { SessionUsageBucket, UsageRole } from "../src/types";
 
 const NOW = 1_750_000_000_000; // fixed epoch ms for tests
 const H24 = 86_400_000;
+const CLASSIFIER_ROLE = "classifier" satisfies UsageRole;
 
 // Build a minimal assistant JSONL line matching the shape parseLine expects.
 function asst(opts: {
@@ -115,7 +116,7 @@ function seedRoleSpawn(
   store: SessionStore,
   r: {
     id: string;
-    kind: "review" | "plan_gate" | "recap" | "rundown" | "doc_agent";
+    kind: "review" | "plan_gate" | "recap" | "rundown" | "doc_agent" | "classifier";
     provider: "claude" | "codex" | null;
     model: string | null;
     spawnedAt?: number;
@@ -211,16 +212,23 @@ test("Claude model breakdown preserves role × model identity and exact token to
     model: "haiku",
     cacheRead: 10,
   });
+  seedRoleSpawn(store, {
+    id: "classifier",
+    kind: CLASSIFIER_ROLE,
+    provider: "claude",
+    model: "haiku",
+    input: 60,
+  });
 
   const bd = await buildUsageBreakdown({ store, range: "all", now: NOW, apiKey: false });
 
   expect(bd.models.claude).toEqual({
-    totalTokens: 500,
+    totalTokens: 560,
     byModel: {
       "claude-opus-4-8": 215,
       "claude-sonnet-4-8": 250,
       fable: 25,
-      haiku: 10,
+      haiku: 70,
     },
     byRole: {
       coding: { "claude-opus-4-8": 100, "claude-sonnet-4-8": 200 },
@@ -229,6 +237,7 @@ test("Claude model breakdown preserves role × model identity and exact token to
       recap: { fable: 25 },
       rundown: { "claude-opus-4-8": 15 },
       doc_agent: { haiku: 10 },
+      classifier: { haiku: 60 },
     },
   });
   expect(bd.models.codex.byRole).toEqual({});

--- a/test/usage-breakdown.test.ts
+++ b/test/usage-breakdown.test.ts
@@ -1,4 +1,6 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { readCodexModelUsage } from "../src/codex-usage";
 import { mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -362,7 +364,13 @@ test("Codex roles reconcile to authoritative per-model totals with legacy usage 
     range: "24h",
     now: NOW,
     apiKey: false,
-    codexModelUsage: () => ({ "gpt-5.6": 1_000, unknown: 300 }),
+    codexModelUsage: () => ({
+      byModel: { "gpt-5.6": 1_000, unknown: 300 },
+      byThread: {
+        "thread-review": { model: "gpt-5.6", totalTokens: 200 },
+        "thread-plan": { model: "gpt-5.6", totalTokens: 100 },
+      },
+    }),
   });
 
   expect(bd.models.codex).toEqual({
@@ -376,7 +384,7 @@ test("Codex roles reconcile to authoritative per-model totals with legacy usage 
   });
 });
 
-test("Codex role attribution is capped by each authoritative model budget", async () => {
+test("Codex role attribution uses native thread totals instead of stale spawn totals", async () => {
   const store = new SessionStore(":memory:");
   seedRoleSpawn(store, {
     id: "review",
@@ -400,7 +408,13 @@ test("Codex role attribution is capped by each authoritative model budget", asyn
     range: "all",
     now: NOW,
     apiKey: false,
-    codexModelUsage: () => ({ "gpt-5.6": 250 }),
+    codexModelUsage: () => ({
+      byModel: { "gpt-5.6": 250 },
+      byThread: {
+        "thread-review": { model: "gpt-5.6", totalTokens: 200 },
+        "thread-plan": { model: "gpt-5.6", totalTokens: 50 },
+      },
+    }),
   });
 
   expect(bd.models.codex.byRole).toEqual({
@@ -1466,4 +1480,79 @@ test("cutoff===0 persisted uses aggregate rows (bucketed session all-time = aggr
   expect(taskAll!.tokens.input).toBe(800);
   expect(taskAll!.tokens.output).toBe(300);
   expect(taskAll!.authoringUnits).toBeCloseTo(totalWu, 10);
+});
+
+function codexBreakdownFixture() {
+  const store = new SessionStore(":memory:");
+  const dbPath = join(tmpDir, "native.sqlite");
+  const db = new Database(dbPath);
+  db.exec(
+    "CREATE TABLE threads (id TEXT PRIMARY KEY, model_provider TEXT, model TEXT, tokens_used INTEGER, updated_at_ms INTEGER)",
+  );
+  const breakdown = () =>
+    buildUsageBreakdown({
+      store,
+      range: "24h",
+      now: NOW,
+      apiKey: false,
+      codexModelUsage: (cutoff) => readCodexModelUsage(dbPath, cutoff),
+    });
+  return { store, db, breakdown };
+}
+
+test("Codex roles refresh a zero snapshot after the native thread records its tokens", async () => {
+  const { store, db, breakdown } = codexBreakdownFixture();
+  try {
+    seedRoleSpawn(store, {
+      id: "review",
+      kind: "review",
+      provider: "codex",
+      model: "gpt-5.6",
+      providerSessionId: "native-review",
+      totalTokens: 0,
+    });
+    db.run("INSERT INTO threads VALUES ('native-review', 'openai', 'gpt-5.6', 0, ?)", [NOW]);
+    expect((await breakdown()).models.codex.totalTokens).toBe(0);
+    db.run("UPDATE threads SET tokens_used = 4321");
+    expect((await breakdown()).models.codex.byRole).toEqual({ review: { "gpt-5.6": 4321 } });
+    db.run("UPDATE threads SET tokens_used = 5000, model = 'gpt-5.6-sol'");
+    expect((await breakdown()).models.codex.byRole).toEqual({ review: { "gpt-5.6-sol": 5000 } });
+  } finally {
+    db.close();
+  }
+});
+
+test("Codex roles never claim tokens from a thread outside the native time window", async () => {
+  const { store, db, breakdown } = codexBreakdownFixture();
+  try {
+    seedRoleSpawn(store, {
+      id: "review",
+      kind: "review",
+      provider: "codex",
+      model: "gpt-5.6",
+      providerSessionId: "native-review",
+      completedAt: NOW - H24 + 1000,
+      totalTokens: 800,
+    });
+    db.run("INSERT INTO threads VALUES ('native-review', 'openai', 'gpt-5.6', 800, ?)", [
+      NOW - H24 - 1000,
+    ]);
+    db.run("INSERT INTO threads VALUES ('coding', 'openai', 'gpt-5.6', 1000, ?)", [NOW]);
+    expect((await breakdown()).models.codex.byRole).toEqual({ coding: { "gpt-5.6": 1000 } });
+    // Completion ages out before the native thread: membership follows the same native window.
+    db.run("UPDATE threads SET updated_at_ms = ? WHERE id = 'native-review'", [NOW]);
+    const later = await buildUsageBreakdown({
+      store,
+      range: "24h",
+      now: NOW + 2000,
+      apiKey: false,
+      codexModelUsage: (cutoff) => readCodexModelUsage(join(tmpDir, "native.sqlite"), cutoff),
+    });
+    expect(later.models.codex.byRole).toEqual({
+      review: { "gpt-5.6": 800 },
+      coding: { "gpt-5.6": 1000 },
+    });
+  } finally {
+    db.close();
+  }
 });

--- a/test/usage-breakdown.test.ts
+++ b/test/usage-breakdown.test.ts
@@ -125,6 +125,8 @@ function seedRoleSpawn(
     output?: number;
     cacheRead?: number;
     cacheWrite?: number;
+    providerSessionId?: string | null;
+    totalTokens?: number | null;
   },
 ): void {
   const input = r.input ?? 0;
@@ -136,8 +138,8 @@ function seedRoleSpawn(
     `INSERT INTO reviewer_spawns
        (reviewerSessionId, taskSessionId, kind, worktreePath, reviewerProvider, model,
         spawnedAt, completedAt, inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens,
-        totalTokens)
-     VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+        totalTokens, providerSessionId)
+     VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
     [
       r.id,
       "task-a",
@@ -151,7 +153,8 @@ function seedRoleSpawn(
       output,
       cacheRead,
       cacheWrite,
-      input + output + cacheRead + cacheWrite,
+      r.totalTokens === undefined ? input + output + cacheRead + cacheWrite : r.totalTokens,
+      r.providerSessionId ?? null,
     ],
   );
 }
@@ -308,6 +311,102 @@ test("legacy null-provider Claude classifier is anchored and range-filtered", as
     recap: Object.fromEntries(accepted.map((model) => [model, 1])),
   });
   expect(bd.models.claude.totalTokens).toBe(accepted.length);
+});
+
+test("Codex roles reconcile to authoritative per-model totals with legacy usage in coding", async () => {
+  const store = new SessionStore(":memory:");
+  seedRoleSpawn(store, {
+    id: "review",
+    kind: "review",
+    provider: "codex",
+    model: "gpt-5.6",
+    providerSessionId: "thread-review",
+    totalTokens: 200,
+  });
+  seedRoleSpawn(store, {
+    id: "plan",
+    kind: "plan_gate",
+    provider: "codex",
+    model: "gpt-5.6",
+    providerSessionId: "thread-plan",
+    totalTokens: 100,
+  });
+  seedRoleSpawn(store, {
+    id: "legacy",
+    kind: "recap",
+    provider: "codex",
+    model: "gpt-5.6",
+    totalTokens: 999,
+  });
+  seedRoleSpawn(store, {
+    id: "old",
+    kind: "review",
+    provider: "codex",
+    model: "gpt-5.6",
+    providerSessionId: "thread-old",
+    completedAt: NOW - 2 * H24,
+    totalTokens: 500,
+  });
+  seedRoleSpawn(store, {
+    id: "unfinished",
+    kind: "review",
+    provider: "codex",
+    model: "gpt-5.6",
+    providerSessionId: "thread-unfinished",
+    completedAt: null,
+    totalTokens: 500,
+  });
+
+  const bd = await buildUsageBreakdown({
+    store,
+    range: "24h",
+    now: NOW,
+    apiKey: false,
+    codexModelUsage: () => ({ "gpt-5.6": 1_000, unknown: 300 }),
+  });
+
+  expect(bd.models.codex).toEqual({
+    totalTokens: 1_300,
+    byModel: { "gpt-5.6": 1_000, unknown: 300 },
+    byRole: {
+      review: { "gpt-5.6": 200 },
+      plan_gate: { "gpt-5.6": 100 },
+      coding: { "gpt-5.6": 700, unknown: 300 },
+    },
+  });
+});
+
+test("Codex role attribution is capped by each authoritative model budget", async () => {
+  const store = new SessionStore(":memory:");
+  seedRoleSpawn(store, {
+    id: "review",
+    kind: "review",
+    provider: "codex",
+    model: "gpt-5.6",
+    providerSessionId: "thread-review",
+    totalTokens: 200,
+  });
+  seedRoleSpawn(store, {
+    id: "plan",
+    kind: "plan_gate",
+    provider: "codex",
+    model: "gpt-5.6",
+    providerSessionId: "thread-plan",
+    totalTokens: 200,
+  });
+
+  const bd = await buildUsageBreakdown({
+    store,
+    range: "all",
+    now: NOW,
+    apiKey: false,
+    codexModelUsage: () => ({ "gpt-5.6": 250 }),
+  });
+
+  expect(bd.models.codex.byRole).toEqual({
+    review: { "gpt-5.6": 200 },
+    plan_gate: { "gpt-5.6": 50 },
+  });
 });
 
 test("repo→task grouping, sorting, field mapping", async () => {

--- a/test/usage-snapshot.test.ts
+++ b/test/usage-snapshot.test.ts
@@ -130,6 +130,7 @@ test("normal session → one row with correct fields", async () => {
   expect(r.cacheReadUnits).toBeGreaterThan(0);
   expect(typeof r.byModel).toBe("object");
   expect(r.byModel["claude-opus-4-8"]).toBeGreaterThan(0);
+  expect(r.rawByModel).toEqual({ "claude-opus-4-8": 445 });
   expect(r.createdAt).toBe(1_000_000);
   expect(r.archivedAt).toBe(r.snapshotAt);
   expect(r.archivedAt).toBeGreaterThanOrEqual(before);
@@ -358,6 +359,7 @@ test("snapshot aggregate parity: snapshotSessionUsage matches sessionCost for sa
   for (const model of legacyModels) {
     expect(row.byModel[model]).toBeCloseTo(legacy.weightedByModel[model]!, 6);
   }
+  expect(row.rawByModel).toEqual(legacy.usage.byModel);
 });
 
 test("bucket row count: ≥2 UTC hours produce ≥2 distinct bucket rows (cutoff-split proof)", async () => {

--- a/test/usage-timeline.test.ts
+++ b/test/usage-timeline.test.ts
@@ -161,7 +161,6 @@ test("finalized reviewer spawns add units at floorHour(completedAt); unfinalized
       messageCount: 1,
       lastActivity: NOW - HOUR,
       byModel: { [MODEL]: 450 },
-      rawByModel: { [MODEL]: 0 },
       fullRecaches: 0,
       sidechainCount: 0,
     },

--- a/test/usage-timeline.test.ts
+++ b/test/usage-timeline.test.ts
@@ -39,6 +39,7 @@ function seedBuckets(
     cacheReadUnits: 0,
     messageCount: 1,
     byModel: { [MODEL]: 0 },
+    rawByModel: { [MODEL]: 2 },
     createdAt: NOW - H24,
     archivedAt: NOW - 500,
     snapshotAt: NOW - 500,
@@ -60,6 +61,7 @@ function bucket(bucketStart: number, units: number): Omit<SessionUsageBucket, "s
     weightedUnits: units,
     cacheReadUnits: 0,
     byModel: { [MODEL]: units },
+    rawByModel: { [MODEL]: 0 },
   };
 }
 
@@ -159,6 +161,7 @@ test("finalized reviewer spawns add units at floorHour(completedAt); unfinalized
       messageCount: 1,
       lastActivity: NOW - HOUR,
       byModel: { [MODEL]: 450 },
+      rawByModel: { [MODEL]: 0 },
       fullRecaches: 0,
       sidechainCount: 0,
     },

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -275,6 +275,7 @@ test("foldSessionBuckets: summing all buckets matches sessionCost totals (no win
     cacheWrite = 0,
     weightedUnits = 0,
     cacheReadUnits = 0;
+  const rawByModel: Record<string, number> = {};
   for (const b of fold.buckets.values()) {
     input += b.input;
     output += b.output;
@@ -282,6 +283,9 @@ test("foldSessionBuckets: summing all buckets matches sessionCost totals (no win
     cacheWrite += b.cacheWrite;
     weightedUnits += b.weightedUnits;
     cacheReadUnits += b.cacheReadUnits;
+    for (const [model, tokens] of Object.entries(b.rawByModel)) {
+      rawByModel[model] = (rawByModel[model] ?? 0) + tokens;
+    }
   }
 
   expect(input).toBe(ref.usage.input);
@@ -290,6 +294,8 @@ test("foldSessionBuckets: summing all buckets matches sessionCost totals (no win
   expect(cacheWrite).toBe(ref.usage.cacheWrite);
   expect(weightedUnits).toBeCloseTo(ref.weightedUnits, 10);
   expect(cacheReadUnits).toBeCloseTo(ref.cacheReadUnits, 10);
+  expect(rawByModel).toEqual(ref.usage.byModel);
+  expect(fold.rawByModel).toEqual(ref.usage.byModel);
 });
 
 test("foldSessionBuckets: messageCount equals sessionCost messageCount", () => {
@@ -315,6 +321,7 @@ test("foldSessionBuckets: ts=0 record folds into bucket 0", () => {
   const fold = foldSessionBuckets(lines);
   expect(fold.buckets.has(0)).toBe(true);
   expect(fold.buckets.get(0)!.input).toBe(77);
+  expect(fold.buckets.get(0)!.rawByModel["claude-opus-4-8"]).toBe(77);
 });
 
 // ── SessionUsageRollup ────────────────────────────────────────────────────────

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3883,5 +3883,6 @@
   "feat_classifier_usage_title": "Klassifizierer-Nutzung nach Modell",
   "feat_classifier_usage_body": "Nutzung → Modelle zeigt die Tokens des Autopilot-Klassifizierers jetzt als eigene Rolle — einschließlich des verwendeten Claude-Modells.",
   "feat_codex_role_usage_title": "Codex-Verbrauch nach Rolle erkennen",
-  "feat_codex_role_usage_body": "Klappe Coding, Review, Plan Gate und weitere Codex-Rollen unter Nutzung → Modelle auf, um zu sehen, wohin die Tokens der einzelnen Modelle geflossen sind."
+  "feat_codex_role_usage_body": "Klappe Coding, Review, Plan Gate und weitere Codex-Rollen unter Nutzung → Modelle auf, um zu sehen, wohin die Tokens der einzelnen Modelle geflossen sind.",
+  "usage_models_unknown": "Unbekannt"
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2012,7 +2012,7 @@
   "feat_usage_satellite_by_type_title": "Satelliten-Ausgaben nach Typ",
   "feat_usage_satellite_by_type_body": "Die Ansicht Nutzung → Overhead schlüsselt Satelliten-Durchläufe jetzt nach Typ auf — Review, Plan-Gate, Zusammenfassung, Rundown und Doc-Agent — jeweils mit Anzahl der Durchläufe und gewichtetem Einheiten-Anteil.",
   "gloss_satellite_pass_term": "Satelliten-Durchlauf",
-  "gloss_satellite_pass_def": "Ein automatisierter LLM-Durchlauf, den Shepherd parallel zum Hauptaufgaben-Agenten startet — Critic / PR-Review, Plan-Gate, Recap oder Doc-Agent. Sein Token-Verbrauch ist echter Overhead, der der Aufgabe zusätzlich zu den eigenen Authoring-Tokens angerechnet wird.",
+  "gloss_satellite_pass_def": "Ein automatisierter LLM-Durchlauf, den Shepherd parallel zum Hauptaufgaben-Agenten startet — Klassifizierer, Critic / PR-Review, Plan-Gate, Recap oder Doc-Agent. Sein Token-Verbrauch ist echter Overhead, der der Aufgabe zusätzlich zu den eigenen Authoring-Tokens angerechnet wird.",
   "usage_limits_window_5h": "5-Stunden-Fenster",
   "usage_limits_window_week": "Wöchentliches Fenster",
   "usage_limits_window_week_model": "Wöchentliches Fenster ({model})",
@@ -3878,5 +3878,8 @@
   "usage_models_role_coding": "Coding",
   "usage_models_codex_roles_unavailable": "Pro Rolle nicht aufgeschlüsselt",
   "feat_usage_role_model_breakdown_title": "Claude-Verbrauch nach Rolle und Modell erkennen",
-  "feat_usage_role_model_breakdown_body": "Klappe Coding, Review, Plan Gate und weitere Claude-Rollen unter Nutzung → Modelle auf, um das verwendete Modell, seine Tokens und den jeweiligen Anteil zu sehen."
+  "feat_usage_role_model_breakdown_body": "Klappe Coding, Review, Plan Gate und weitere Claude-Rollen unter Nutzung → Modelle auf, um das verwendete Modell, seine Tokens und den jeweiligen Anteil zu sehen.",
+  "usage_kind_classifier": "Klassifizierer",
+  "feat_classifier_usage_title": "Klassifizierer-Nutzung nach Modell",
+  "feat_classifier_usage_body": "Nutzung → Modelle zeigt die Tokens des Autopilot-Klassifizierers jetzt als eigene Rolle — einschließlich des verwendeten Claude-Modells."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3866,5 +3866,12 @@
   "feat_codex_reasoning_tiers_body": "Wähle Max oder Ultra für GPT-6 Astra, GPT-5.6 Sol und Terra; Luna bietet ebenfalls Max. Ultra nutzt automatische Unteragenten. Shepherd gibt den gewählten Denkaufwand beim Starten und Fortsetzen unverändert weiter. Sol bleibt der eingebaute Codex-Standard.",
   "feat_codex_reasoning_tiers_title": "Codex-Reasoning mit Max und Ultra",
   "model_guidance_codex_6_astra": "Leistungsfähigstes Codex-Modell für komplexes, mehrstufiges Coding, Recherche und Dokumentarbeit.",
-  "effort_label_ultra": "Ultra"
+  "effort_label_ultra": "Ultra",
+  "usage_models_tab": "Modelle",
+  "usage_models_total": "{tokens} gesamt",
+  "usage_models_other": "Andere",
+  "usage_models_empty": "In diesem Zeitraum wurde keine Modellnutzung erfasst",
+  "usage_models_bar_aria": "Modell-Mix für {provider}, {tokens} gesamt",
+  "feat_usage_model_breakdown_title": "Modell-Mix nach Provider",
+  "feat_usage_model_breakdown_body": "Nutzung → Modelle zeigt den Roh-Token-Anteil jedes Modells im gewählten Zeitraum. Claude Code und Codex bleiben in getrennten 100-%-Blöcken mit eigener Token-Gesamtsumme."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3873,5 +3873,10 @@
   "usage_models_empty": "In diesem Zeitraum wurde keine Modellnutzung erfasst",
   "usage_models_bar_aria": "Modell-Mix für {provider}, {tokens} gesamt",
   "feat_usage_model_breakdown_title": "Modell-Mix nach Provider",
-  "feat_usage_model_breakdown_body": "Nutzung → Modelle zeigt den Roh-Token-Anteil jedes Modells im gewählten Zeitraum. Claude Code und Codex bleiben in getrennten 100-%-Blöcken mit eigener Token-Gesamtsumme."
+  "feat_usage_model_breakdown_body": "Nutzung → Modelle zeigt den Roh-Token-Anteil jedes Modells im gewählten Zeitraum. Claude Code und Codex bleiben in getrennten 100-%-Blöcken mit eigener Token-Gesamtsumme.",
+  "usage_models_by_role": "Aufschlüsselung nach Rolle",
+  "usage_models_role_coding": "Coding",
+  "usage_models_codex_roles_unavailable": "Pro Rolle nicht aufgeschlüsselt",
+  "feat_usage_role_model_breakdown_title": "Claude-Verbrauch nach Rolle und Modell erkennen",
+  "feat_usage_role_model_breakdown_body": "Klappe Coding, Review, Plan Gate und weitere Claude-Rollen unter Nutzung → Modelle auf, um das verwendete Modell, seine Tokens und den jeweiligen Anteil zu sehen."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3881,5 +3881,7 @@
   "feat_usage_role_model_breakdown_body": "Klappe Coding, Review, Plan Gate und weitere Claude-Rollen unter Nutzung → Modelle auf, um das verwendete Modell, seine Tokens und den jeweiligen Anteil zu sehen.",
   "usage_kind_classifier": "Klassifizierer",
   "feat_classifier_usage_title": "Klassifizierer-Nutzung nach Modell",
-  "feat_classifier_usage_body": "Nutzung → Modelle zeigt die Tokens des Autopilot-Klassifizierers jetzt als eigene Rolle — einschließlich des verwendeten Claude-Modells."
+  "feat_classifier_usage_body": "Nutzung → Modelle zeigt die Tokens des Autopilot-Klassifizierers jetzt als eigene Rolle — einschließlich des verwendeten Claude-Modells.",
+  "feat_codex_role_usage_title": "Codex-Verbrauch nach Rolle erkennen",
+  "feat_codex_role_usage_body": "Klappe Coding, Review, Plan Gate und weitere Codex-Rollen unter Nutzung → Modelle auf, um zu sehen, wohin die Tokens der einzelnen Modelle geflossen sind."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3881,5 +3881,7 @@
   "feat_usage_role_model_breakdown_body": "Expand Coding, Review, Plan gate, and other Claude roles in Usage → Models to see which model consumed their tokens and what share it represents.",
   "usage_kind_classifier": "Classifier",
   "feat_classifier_usage_title": "Classifier usage by model",
-  "feat_classifier_usage_body": "Usage → Models now shows Autopilot classifier tokens as a separate role, including the Claude model that produced them."
+  "feat_classifier_usage_body": "Usage → Models now shows Autopilot classifier tokens as a separate role, including the Claude model that produced them.",
+  "feat_codex_role_usage_title": "See Codex usage by role",
+  "feat_codex_role_usage_body": "Expand Coding, Review, Plan gate, and other Codex roles in Usage → Models to see where each model's tokens went."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2012,7 +2012,7 @@
   "feat_usage_satellite_by_type_title": "Satellite spend by type",
   "feat_usage_satellite_by_type_body": "The Usage → Overhead lens now breaks satellite passes down by type — review, plan gate, recap, rundown, and doc agent — with a pass count and weighted-unit share for each.",
   "gloss_satellite_pass_term": "satellite pass",
-  "gloss_satellite_pass_def": "An automated LLM pass Shepherd spawns alongside the main task agent — critic / PR-review, plan-gate, recap, or doc-agent. Its token spend is real overhead attributed back to the task, on top of the agent's own authoring.",
+  "gloss_satellite_pass_def": "An automated LLM pass Shepherd spawns alongside the main task agent — classifier, critic / PR-review, plan-gate, recap, or doc-agent. Its token spend is real overhead attributed back to the task, on top of the agent's own authoring.",
   "usage_limits_window_5h": "5-hour window",
   "usage_limits_window_week": "Weekly window",
   "usage_limits_window_week_model": "Weekly window ({model})",
@@ -3878,5 +3878,8 @@
   "usage_models_role_coding": "Coding",
   "usage_models_codex_roles_unavailable": "Not broken down by role",
   "feat_usage_role_model_breakdown_title": "See Claude usage by role and model",
-  "feat_usage_role_model_breakdown_body": "Expand Coding, Review, Plan gate, and other Claude roles in Usage → Models to see which model consumed their tokens and what share it represents."
+  "feat_usage_role_model_breakdown_body": "Expand Coding, Review, Plan gate, and other Claude roles in Usage → Models to see which model consumed their tokens and what share it represents.",
+  "usage_kind_classifier": "Classifier",
+  "feat_classifier_usage_title": "Classifier usage by model",
+  "feat_classifier_usage_body": "Usage → Models now shows Autopilot classifier tokens as a separate role, including the Claude model that produced them."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3873,5 +3873,10 @@
   "usage_models_empty": "No model usage recorded in this range",
   "usage_models_bar_aria": "{provider} model mix, {tokens} total",
   "feat_usage_model_breakdown_title": "See model mix by provider",
-  "feat_usage_model_breakdown_body": "Usage → Models shows the raw-token share for each model across the selected range. Claude Code and Codex stay in separate 100% blocks with their own token totals."
+  "feat_usage_model_breakdown_body": "Usage → Models shows the raw-token share for each model across the selected range. Claude Code and Codex stay in separate 100% blocks with their own token totals.",
+  "usage_models_by_role": "Breakdown by role",
+  "usage_models_role_coding": "Coding",
+  "usage_models_codex_roles_unavailable": "Not broken down by role",
+  "feat_usage_role_model_breakdown_title": "See Claude usage by role and model",
+  "feat_usage_role_model_breakdown_body": "Expand Coding, Review, Plan gate, and other Claude roles in Usage → Models to see which model consumed their tokens and what share it represents."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3883,5 +3883,6 @@
   "feat_classifier_usage_title": "Classifier usage by model",
   "feat_classifier_usage_body": "Usage → Models now shows Autopilot classifier tokens as a separate role, including the Claude model that produced them.",
   "feat_codex_role_usage_title": "See Codex usage by role",
-  "feat_codex_role_usage_body": "Expand Coding, Review, Plan gate, and other Codex roles in Usage → Models to see where each model's tokens went."
+  "feat_codex_role_usage_body": "Expand Coding, Review, Plan gate, and other Codex roles in Usage → Models to see where each model's tokens went.",
+  "usage_models_unknown": "Unknown"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3866,5 +3866,12 @@
   "feat_codex_reasoning_tiers_body": "Choose Max or Ultra for GPT-6 Astra, GPT-5.6 Sol, and Terra; Luna also offers Max. Ultra uses automatic subagents. Shepherd passes your selected effort unchanged when starting or continuing work. Sol remains the built-in Codex default.",
   "feat_codex_reasoning_tiers_title": "Codex Max and Ultra reasoning",
   "model_guidance_codex_6_astra": "Most capable Codex model for complex, multi-step coding, research, and document work.",
-  "effort_label_ultra": "Ultra"
+  "effort_label_ultra": "Ultra",
+  "usage_models_tab": "Models",
+  "usage_models_total": "{tokens} total",
+  "usage_models_other": "Other",
+  "usage_models_empty": "No model usage recorded in this range",
+  "usage_models_bar_aria": "{provider} model mix, {tokens} total",
+  "feat_usage_model_breakdown_title": "See model mix by provider",
+  "feat_usage_model_breakdown_body": "Usage → Models shows the raw-token share for each model across the selected range. Claude Code and Codex stay in separate 100% blocks with their own token totals."
 }

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -24,6 +24,13 @@
   --color-blue: var(--blue);
   --color-slate: var(--slate);
   --color-warn: var(--warn);
+  --color-data-1: var(--data-1);
+  --color-data-2: var(--data-2);
+  --color-data-3: var(--data-3);
+  --color-data-4: var(--data-4);
+  --color-data-5: var(--data-5);
+  --color-data-6: var(--data-6);
+  --color-data-7: var(--data-7);
   --color-scrim: var(--scrim);
   --color-term-fg: var(--term-fg);
   --font-mono: "Berkeley Mono", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -57,6 +64,16 @@
   --blue: #4a90d9;
   --slate: #566460;
   --warn: #e8730c;
+
+  /* Categorical data visualization. These hues identify series, never status;
+     deliberately no green so READY keeps its exclusive signal. */
+  --data-1: oklch(0.7 0.11 250);
+  --data-2: oklch(0.72 0.1 295);
+  --data-3: oklch(0.74 0.09 210);
+  --data-4: oklch(0.76 0.1 85);
+  --data-5: oklch(0.71 0.1 330);
+  --data-6: oklch(0.69 0.08 35);
+  --data-7: oklch(0.62 0.025 240);
 
   --scrim: rgba(3, 6, 5, 0.66);
   --term-fg: #c4d0cb;
@@ -210,6 +227,14 @@
   --blue: #2f6fb0;
   --slate: #6b7873;
   --warn: #b5560a;
+
+  --data-1: oklch(0.52 0.12 250);
+  --data-2: oklch(0.53 0.11 295);
+  --data-3: oklch(0.52 0.09 210);
+  --data-4: oklch(0.55 0.11 85);
+  --data-5: oklch(0.52 0.1 330);
+  --data-6: oklch(0.51 0.09 35);
+  --data-7: oklch(0.48 0.03 240);
 
   --scrim: rgba(20, 28, 25, 0.42);
   --term-fg: #2b3633;

--- a/ui/src/lib/components/Usage.browser.test.ts
+++ b/ui/src/lib/components/Usage.browser.test.ts
@@ -237,6 +237,22 @@ describe("Usage modal component", () => {
     expect(rangeGroup, "range selector present on Timeline tab").not.toBeNull();
   });
 
+  it("clicking the Models tab renders separate ranged provider blocks", async () => {
+    render(Usage, { onclose: vi.fn() });
+
+    const modelsBtn = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find(
+      (button) => button.textContent?.trim() === m.usage_models_tab(),
+    );
+    expect(modelsBtn, "Models tab button exists").not.toBeNull();
+    modelsBtn!.click();
+
+    await expect.poll(() => document.querySelectorAll(".provider-block").length).toBe(2);
+    expect(document.querySelector('[data-provider="claude"]')).not.toBeNull();
+    expect(document.querySelector('[data-provider="codex"]')).not.toBeNull();
+    expect(document.querySelector('[role="group"][aria-label]')).not.toBeNull();
+    expect(document.querySelector(".provider-strip"), "non-ranged Codex strip hidden").toBeNull();
+  });
+
   it("clicking the GitHub tab shows REST + GraphQL buckets and the GraphQL-paused banner", async () => {
     render(Usage, { onclose: vi.fn() });
 

--- a/ui/src/lib/components/Usage.svelte
+++ b/ui/src/lib/components/Usage.svelte
@@ -30,9 +30,11 @@
   import TimelineLens from "$lib/components/usage/TimelineLens.svelte";
   import DeliveryLens from "$lib/components/usage/DeliveryLens.svelte";
 
+  import ModelsLens from "$lib/components/usage/ModelsLens.svelte";
+
   let { onclose }: { onclose?: () => void } = $props();
 
-  type Tab = "spend" | "overhead" | "prompt" | "timeline" | "delivery" | "limits" | "github";
+  type Tab = "spend" | "overhead" | "prompt" | "timeline" | "delivery" | "models" | "limits" | "github";
 
   let tab = $state<Tab>("spend");
   let range = $state<UsageRange>("7d");
@@ -180,12 +182,14 @@
   }
 
   // Template-state derivations (kept out of the markup to keep the template's
-  // branching shallow). `showRange`: spend/overhead are the only ranged tabs.
+  // branching shallow). Spend, Overhead, Timeline, and Models share the range selector.
   const showRange = $derived(
-    tab === "spend" || tab === "overhead" || tab === "timeline" || tab === "delivery",
+    tab === "spend" || tab === "overhead" || tab === "timeline" || tab === "delivery" || tab === "models",
   );
-  // Non-blocking refetch banner — Spend/Overhead use `breakdown`'s error track, Timeline its own.
-  const showBreakdownError = $derived(error && (tab === "spend" || tab === "overhead"));
+  // Non-blocking refetch banner — breakdown-backed lenses share one error track.
+  const showBreakdownError = $derived(
+    error && (tab === "spend" || tab === "overhead" || tab === "models"),
+  );
   const showTimelineError = $derived(timelineError && tab === "timeline");
   // Prompt follows Timeline's shape rather than Limits'/GitHub's: banner, never inline — so a
   // refetch that fails after a first success can't leave stale numbers on screen unannounced.
@@ -193,7 +197,7 @@
   const showDeliveryError = $derived(deliveryError && tab === "delivery");
   // The active tab has data to render its lens (else we show loading/error chrome).
   const hasContent = $derived(
-    ((tab === "spend" || tab === "overhead") && !!breakdown) ||
+    ((tab === "spend" || tab === "overhead" || tab === "models") && !!breakdown) ||
       (tab === "timeline" && !!timeline) ||
       (tab === "limits" && !!limits) ||
       (tab === "github" && !!github) ||
@@ -206,7 +210,7 @@
     !hasContent && ((tab === "limits" && limitsError) || (tab === "github" && githubError)),
   );
   const bodyLoading = $derived(
-    ((tab === "spend" || tab === "overhead") && !breakdown && loading) ||
+    ((tab === "spend" || tab === "overhead" || tab === "models") && !breakdown && loading) ||
       (tab === "timeline" && !timeline && !timelineError) ||
       (tab === "limits" && !limits && !limitsError) ||
       (tab === "github" && !github && !githubError) ||
@@ -278,6 +282,13 @@
       <button
         type="button"
         class="seg-btn"
+        class:seg-active={tab === "models"}
+        aria-pressed={tab === "models"}
+        onclick={() => (tab = "models")}>{m.usage_models_tab()}</button
+      >
+      <button
+        type="button"
+        class="seg-btn"
         class:seg-active={tab === "limits"}
         aria-pressed={tab === "limits"}
         onclick={() => (tab = "limits")}>{m.usage_limits_tab()}</button
@@ -291,7 +302,7 @@
       >
     </div>
 
-    <!-- Range selector (Spend + Overhead only) -->
+    <!-- Range selector for every range-backed lens -->
     {#if showRange}
       <div class="seg-row range-row" role="group" aria-label={m.usage_range_label()}>
         <button
@@ -325,7 +336,7 @@
       </div>
     {/if}
 
-    {#if codexUsage && tab !== "limits"}
+    {#if codexUsage && tab !== "limits" && tab !== "models"}
       <div class="provider-strip" class:provider-stale={codexUsage.stale}>
         <span class="provider-name">{m.agent_provider_codex()}</span>
         <span class="provider-metric">
@@ -345,7 +356,7 @@
 
     <!-- Lens body -->
     <div class="lens-body">
-      <!-- Breakdown-error banner for the Spend/Overhead tabs. Shown even when a stale
+      <!-- Breakdown-error banner for breakdown-backed tabs. Shown even when a stale
            `breakdown` is still present (a failed range-change refetch) so the user isn't
            silently left on old-range data with no indication the new range failed. -->
       {#if showBreakdownError || showTimelineError || showPromptsError || showDeliveryError}
@@ -367,6 +378,8 @@
         <TimelineLens {timeline} />
       {:else if tab === "delivery" && delivery}
         <DeliveryLens metrics={delivery} />
+      {:else if tab === "models" && breakdown}
+        <ModelsLens models={breakdown.models} />
       {:else if tab === "limits" && limits}
         <LimitsLens {limits} {projections} {codexUsage} />
       {:else if tab === "github" && github}

--- a/ui/src/lib/components/Usage.svelte
+++ b/ui/src/lib/components/Usage.svelte
@@ -34,7 +34,8 @@
 
   let { onclose }: { onclose?: () => void } = $props();
 
-  type Tab = "spend" | "overhead" | "prompt" | "timeline" | "delivery" | "models" | "limits" | "github";
+  type Tab =
+    "spend" | "overhead" | "prompt" | "timeline" | "delivery" | "models" | "limits" | "github";
 
   let tab = $state<Tab>("spend");
   let range = $state<UsageRange>("7d");
@@ -184,7 +185,11 @@
   // Template-state derivations (kept out of the markup to keep the template's
   // branching shallow). Spend, Overhead, Timeline, and Models share the range selector.
   const showRange = $derived(
-    tab === "spend" || tab === "overhead" || tab === "timeline" || tab === "delivery" || tab === "models",
+    tab === "spend" ||
+      tab === "overhead" ||
+      tab === "timeline" ||
+      tab === "delivery" ||
+      tab === "models",
   );
   // Non-blocking refetch banner — breakdown-backed lenses share one error track.
   const showBreakdownError = $derived(

--- a/ui/src/lib/components/usage-gauges.test.ts
+++ b/ui/src/lib/components/usage-gauges.test.ts
@@ -10,6 +10,7 @@ import {
   providerCapacityRows,
   selectedProviderCapacity,
   hottestCapacityWindow,
+  modelDisplayName,
 } from "./usage-gauges";
 import type { UsageLimits, LimitWindow, CreditWindow } from "../types";
 
@@ -65,6 +66,20 @@ describe("gaugeList", () => {
   it("lists only the present window", () => {
     expect(gaugeList(limits({ week: w(20) })).map((g) => g.label)).toEqual(["WK"]);
     expect(gaugeList(limits({ session5h: w(10) })).map((g) => g.label)).toEqual(["5H"]);
+  });
+});
+
+describe("modelDisplayName", () => {
+  it("formats Claude family/version slugs", () => {
+    expect(modelDisplayName("claude-opus-4-8")).toBe("Opus 4.8");
+    expect(modelDisplayName("claude-sonnet-4-5")).toBe("Sonnet 4.5");
+  });
+
+  it("formats Fable, GPT and fallback slugs", () => {
+    expect(modelDisplayName("fable")).toBe("Fable");
+    expect(modelDisplayName("gpt-5.5")).toBe("GPT-5.5");
+    expect(modelDisplayName("unknown")).toBe("Unknown");
+    expect(modelDisplayName("custom_model-v2")).toBe("Custom Model V2");
   });
 });
 

--- a/ui/src/lib/components/usage-gauges.ts
+++ b/ui/src/lib/components/usage-gauges.ts
@@ -104,9 +104,22 @@ export function modelWeekList(limits: UsageLimits | null): ModelWeekWindow[] {
   return limits?.perModelWeek ?? [];
 }
 
-/** Proper-noun display name for a model slug (e.g. "fable" → "Fable"). Not translated. */
+/** Proper-noun display name for a model slug. Model names are data, not translated. */
 export function modelDisplayName(slug: string): string {
-  return slug.charAt(0).toUpperCase() + slug.slice(1);
+  const claude = /^(?:claude-)?(opus|sonnet|haiku)(?:-(\d+)(?:-(\d+))?)?$/i.exec(slug);
+  if (claude) {
+    const family = claude[1]!.charAt(0).toUpperCase() + claude[1]!.slice(1).toLowerCase();
+    const version = [claude[2], claude[3]].filter(Boolean).join(".");
+    return version ? `${family} ${version}` : family;
+  }
+  const gpt = /^gpt-(.+)$/i.exec(slug);
+  if (gpt) return `GPT-${gpt[1]}`;
+  if (slug === "unknown") return "Unknown";
+  return slug
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
 }
 
 export function codexTokenUsage(

--- a/ui/src/lib/components/usage-gauges.ts
+++ b/ui/src/lib/components/usage-gauges.ts
@@ -1,3 +1,4 @@
+import { m } from "../paraglide/messages";
 import type {
   UsageLimits,
   LimitWindow,
@@ -114,7 +115,7 @@ export function modelDisplayName(slug: string): string {
   }
   const gpt = /^gpt-(.+)$/i.exec(slug);
   if (gpt) return `GPT-${gpt[1]}`;
-  if (slug === "unknown") return "Unknown";
+  if (slug === "unknown") return m.usage_models_unknown();
   return slug
     .split(/[-_]/)
     .filter(Boolean)

--- a/ui/src/lib/components/usage/ModelsLens.browser.test.ts
+++ b/ui/src/lib/components/usage/ModelsLens.browser.test.ts
@@ -25,8 +25,20 @@ describe("ModelsLens", () => {
             gamma: 150,
             delta: 150,
           },
+          byRole: {
+            coding: {
+              "claude-opus-4-8": 1000,
+              "claude-sonnet-4-5": 800,
+              "claude-haiku-4-5": 600,
+              fable: 400,
+              alpha: 300,
+              beta: 200,
+              gamma: 150,
+              delta: 150,
+            },
+          },
         },
-        codex: { totalTokens: 1000, byModel: { "gpt-5.5": 700, unknown: 300 } },
+        codex: { totalTokens: 1000, byModel: { "gpt-5.5": 700, unknown: 300 }, byRole: {} },
       },
     });
 
@@ -37,6 +49,7 @@ describe("ModelsLens", () => {
     expect(claude.querySelectorAll(".model-list li")).toHaveLength(7);
     expect(codex.textContent).toContain("GPT-5.5");
     expect(codex.textContent).toContain(formatTokenLabel(1000));
+    expect(codex.querySelector(".role-unavailable")).not.toBeNull();
     expect(document.querySelectorAll('[role="img"]')).toHaveLength(2);
 
     for (const block of [claude, codex]) {
@@ -51,8 +64,8 @@ describe("ModelsLens", () => {
   it("shows a provider-specific zero total and no misleading bar for empty data", () => {
     render(ModelsLens, {
       models: {
-        claude: { totalTokens: 0, byModel: {} },
-        codex: { totalTokens: 0, byModel: {} },
+        claude: { totalTokens: 0, byModel: {}, byRole: {} },
+        codex: { totalTokens: 0, byModel: {}, byRole: {} },
       },
     });
 
@@ -75,13 +88,57 @@ describe("ModelsLens", () => {
             omega: 100,
             Zulu: 100,
           },
+          byRole: {
+            coding: {
+              alpha: 100,
+              beta: 100,
+              delta: 100,
+              epsilon: 100,
+              gamma: 100,
+              omega: 100,
+              Zulu: 100,
+            },
+          },
         },
-        codex: { totalTokens: 0, byModel: {} },
+        codex: { totalTokens: 0, byModel: {}, byRole: {} },
       },
     });
 
     const claude = document.querySelector<HTMLElement>('[data-provider="claude"]')!;
-    expect(claude.textContent).toContain("Zulu");
-    expect(claude.textContent).not.toContain("Omega");
+    const modelList = claude.querySelector<HTMLElement>(".model-list")!;
+    expect(modelList.textContent).toContain("Zulu");
+    expect(modelList.textContent).not.toContain("Omega");
+  });
+
+  it("expands Claude roles into models with provider and role percentages", () => {
+    render(ModelsLens, {
+      models: {
+        claude: {
+          totalTokens: 500,
+          byModel: { "claude-opus-4-8": 200, "claude-sonnet-4-5": 300 },
+          byRole: {
+            coding: { "claude-sonnet-4-5": 300 },
+            review: { "claude-opus-4-8": 100 },
+            plan_gate: { "claude-opus-4-8": 100 },
+          },
+        },
+        codex: { totalTokens: 0, byModel: {}, byRole: {} },
+      },
+    });
+
+    const claude = document.querySelector<HTMLElement>('[data-provider="claude"]')!;
+    const roles = claude.querySelectorAll<HTMLDetailsElement>(".role-detail");
+    expect(roles).toHaveLength(3);
+    expect([...roles].map((role) => role.dataset.role)).toEqual(["coding", "review", "plan_gate"]);
+
+    const planGate = claude.querySelector<HTMLDetailsElement>('[data-role="plan_gate"]')!;
+    expect(planGate.querySelector("summary")?.textContent).toContain("20.0%");
+    planGate.querySelector<HTMLElement>("summary")!.click();
+    expect(planGate.open).toBe(true);
+
+    const modelRow = planGate.querySelector<HTMLElement>(".role-model-row")!;
+    expect(modelRow.textContent).toContain("Opus 4.8");
+    expect(modelRow.textContent).toContain("100.0%");
+    expect(modelRow.textContent).toContain(formatTokenLabel(100));
   });
 });

--- a/ui/src/lib/components/usage/ModelsLens.browser.test.ts
+++ b/ui/src/lib/components/usage/ModelsLens.browser.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import "../../../app.css";
+import { m } from "$lib/paraglide/messages";
+import { formatTokenLabel } from "$lib/format";
+import ModelsLens from "./ModelsLens.svelte";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("ModelsLens", () => {
+  it("renders independent provider totals, top six plus Other, and exact displayed 100% sums", () => {
+    render(ModelsLens, {
+      models: {
+        claude: {
+          totalTokens: 3600,
+          byModel: {
+            "claude-opus-4-8": 1000,
+            "claude-sonnet-4-5": 800,
+            "claude-haiku-4-5": 600,
+            fable: 400,
+            alpha: 300,
+            beta: 200,
+            gamma: 150,
+            delta: 150,
+          },
+        },
+        codex: { totalTokens: 1000, byModel: { "gpt-5.5": 700, unknown: 300 } },
+      },
+    });
+
+    const claude = document.querySelector<HTMLElement>('[data-provider="claude"]')!;
+    const codex = document.querySelector<HTMLElement>('[data-provider="codex"]')!;
+    expect(claude.textContent).toContain("Opus 4.8");
+    expect(claude.textContent).toContain(m.usage_models_other());
+    expect(claude.querySelectorAll(".model-list li")).toHaveLength(7);
+    expect(codex.textContent).toContain("GPT-5.5");
+    expect(codex.textContent).toContain(formatTokenLabel(1000));
+    expect(document.querySelectorAll('[role="img"]')).toHaveLength(2);
+
+    for (const block of [claude, codex]) {
+      const sum = [...block.querySelectorAll<HTMLElement>(".model-pct")].reduce(
+        (total, node) => total + Number.parseFloat(node.textContent ?? "0"),
+        0,
+      );
+      expect(sum).toBeCloseTo(100, 10);
+    }
+  });
+
+  it("shows a provider-specific zero total and no misleading bar for empty data", () => {
+    render(ModelsLens, {
+      models: {
+        claude: { totalTokens: 0, byModel: {} },
+        codex: { totalTokens: 0, byModel: {} },
+      },
+    });
+
+    expect(document.querySelectorAll('[role="img"]')).toHaveLength(0);
+    expect(document.querySelectorAll(".empty")).toHaveLength(2);
+    expect(document.body.textContent).toContain(formatTokenLabel(0));
+  });
+
+  it("uses locale-independent slug ordering at the top-six boundary", () => {
+    render(ModelsLens, {
+      models: {
+        claude: {
+          totalTokens: 700,
+          byModel: {
+            alpha: 100,
+            beta: 100,
+            delta: 100,
+            epsilon: 100,
+            gamma: 100,
+            omega: 100,
+            Zulu: 100,
+          },
+        },
+        codex: { totalTokens: 0, byModel: {} },
+      },
+    });
+
+    const claude = document.querySelector<HTMLElement>('[data-provider="claude"]')!;
+    expect(claude.textContent).toContain("Zulu");
+    expect(claude.textContent).not.toContain("Omega");
+  });
+});

--- a/ui/src/lib/components/usage/ModelsLens.browser.test.ts
+++ b/ui/src/lib/components/usage/ModelsLens.browser.test.ts
@@ -114,10 +114,15 @@ describe("ModelsLens", () => {
     render(ModelsLens, {
       models: {
         claude: {
-          totalTokens: 500,
-          byModel: { "claude-opus-4-8": 200, "claude-sonnet-4-5": 300 },
+          totalTokens: 600,
+          byModel: {
+            "claude-opus-4-8": 200,
+            "claude-sonnet-4-5": 300,
+            "claude-haiku-4-5": 100,
+          },
           byRole: {
             coding: { "claude-sonnet-4-5": 300 },
+            classifier: { "claude-haiku-4-5": 100 },
             review: { "claude-opus-4-8": 100 },
             plan_gate: { "claude-opus-4-8": 100 },
           },
@@ -128,11 +133,23 @@ describe("ModelsLens", () => {
 
     const claude = document.querySelector<HTMLElement>('[data-provider="claude"]')!;
     const roles = claude.querySelectorAll<HTMLDetailsElement>(".role-detail");
-    expect(roles).toHaveLength(3);
-    expect([...roles].map((role) => role.dataset.role)).toEqual(["coding", "review", "plan_gate"]);
+    expect(roles).toHaveLength(4);
+    expect([...roles].map((role) => role.dataset.role)).toEqual([
+      "coding",
+      "classifier",
+      "review",
+      "plan_gate",
+    ]);
+
+    const classifier = claude.querySelector<HTMLDetailsElement>('[data-role="classifier"]')!;
+    expect(classifier.querySelector("summary")?.textContent).toContain("Classifier");
+    expect(classifier.querySelector("summary")?.textContent).toContain("16.7%");
+    classifier.querySelector<HTMLElement>("summary")!.click();
+    expect(classifier.textContent).toContain("Haiku 4.5");
+    expect(classifier.textContent).toContain(formatTokenLabel(100));
 
     const planGate = claude.querySelector<HTMLDetailsElement>('[data-role="plan_gate"]')!;
-    expect(planGate.querySelector("summary")?.textContent).toContain("20.0%");
+    expect(planGate.querySelector("summary")?.textContent).toContain("16.7%");
     planGate.querySelector<HTMLElement>("summary")!.click();
     expect(planGate.open).toBe(true);
 

--- a/ui/src/lib/components/usage/ModelsLens.browser.test.ts
+++ b/ui/src/lib/components/usage/ModelsLens.browser.test.ts
@@ -158,4 +158,32 @@ describe("ModelsLens", () => {
     expect(modelRow.textContent).toContain("100.0%");
     expect(modelRow.textContent).toContain(formatTokenLabel(100));
   });
+
+  it("expands Codex roles in canonical order and hides the unavailable badge", () => {
+    render(ModelsLens, {
+      models: {
+        claude: { totalTokens: 0, byModel: {}, byRole: {} },
+        codex: {
+          totalTokens: 1000,
+          byModel: { "gpt-5.6": 750, "gpt-5.5": 250 },
+          byRole: {
+            coding: { "gpt-5.6": 600 },
+            review: { "gpt-5.6": 150 },
+            plan_gate: { "gpt-5.5": 250 },
+          },
+        },
+      },
+    });
+
+    const codex = document.querySelector<HTMLElement>('[data-provider="codex"]')!;
+    expect(codex.querySelector(".role-unavailable")).toBeNull();
+    const roles = codex.querySelectorAll<HTMLDetailsElement>(".role-detail");
+    expect([...roles].map((role) => role.dataset.role)).toEqual(["coding", "review", "plan_gate"]);
+    expect(roles[0]!.querySelector("summary")?.textContent).toContain("60.0%");
+    expect(roles[1]!.querySelector("summary")?.textContent).toContain("15.0%");
+    expect(roles[2]!.querySelector("summary")?.textContent).toContain("25.0%");
+    roles[2]!.querySelector<HTMLElement>("summary")!.click();
+    expect(roles[2]!.textContent).toContain("GPT-5.5");
+    expect(roles[2]!.textContent).toContain("100.0%");
+  });
 });

--- a/ui/src/lib/components/usage/ModelsLens.svelte
+++ b/ui/src/lib/components/usage/ModelsLens.svelte
@@ -1,0 +1,224 @@
+<script lang="ts">
+  import type { UsageBreakdown, UsageModelBreakdown } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  import { formatTokenLabel } from "$lib/format";
+  import { modelDisplayName } from "$lib/components/usage-gauges";
+
+  let { models }: { models: UsageBreakdown["models"] } = $props();
+
+  const TONES = [
+    "var(--color-data-1)",
+    "var(--color-data-2)",
+    "var(--color-data-3)",
+    "var(--color-data-4)",
+    "var(--color-data-5)",
+    "var(--color-data-6)",
+    "var(--color-data-7)",
+  ] as const;
+
+  interface ModelRow {
+    id: string;
+    label: string;
+    tokens: number;
+    exactPct: number;
+    displayPct: number;
+    tone: string;
+  }
+
+  function rowsFor(data: UsageModelBreakdown): ModelRow[] {
+    const sorted = Object.entries(data.byModel)
+      .filter(([, tokens]) => tokens > 0)
+      .sort(
+        ([aModel, aTokens], [bModel, bTokens]) =>
+          bTokens - aTokens || (aModel < bModel ? -1 : aModel > bModel ? 1 : 0),
+      );
+    const visible = sorted.slice(0, 6).map(([id, tokens]) => ({ id, tokens }));
+    if (sorted.length > 6) {
+      visible.push({
+        id: "__other__",
+        tokens: sorted.slice(6).reduce((sum, [, tokens]) => sum + tokens, 0),
+      });
+    }
+    const total = visible.reduce((sum, row) => sum + row.tokens, 0);
+    if (total === 0) return [];
+
+    const quotas = visible.map((row) => (row.tokens / total) * 1000);
+    const tenths = quotas.map(Math.floor);
+    let remainder = 1000 - tenths.reduce((sum, value) => sum + value, 0);
+    const remainderOrder = quotas
+      .map((quota, index) => ({ index, fraction: quota - Math.floor(quota) }))
+      .sort((a, b) => b.fraction - a.fraction || a.index - b.index);
+    for (let i = 0; i < remainder; i++) tenths[remainderOrder[i]!.index] += 1;
+
+    return visible.map((row, index) => ({
+      ...row,
+      label: row.id === "__other__" ? m.usage_models_other() : modelDisplayName(row.id),
+      exactPct: (row.tokens / total) * 100,
+      displayPct: tenths[index]! / 10,
+      tone: TONES[index]!,
+    }));
+  }
+
+  const providers = $derived([
+    { id: "claude", label: m.agent_provider_claude(), data: models.claude },
+    { id: "codex", label: m.agent_provider_codex(), data: models.codex },
+  ] as const);
+</script>
+
+<div class="models-lens">
+  {#each providers as provider (provider.id)}
+    {@const rows = rowsFor(provider.data)}
+    <section class="provider-block" data-provider={provider.id}>
+      <header class="provider-head">
+        <h2>{provider.label}</h2>
+        <span>{m.usage_models_total({ tokens: formatTokenLabel(provider.data.totalTokens) })}</span>
+      </header>
+
+      {#if rows.length > 0}
+        <div
+          class="stacked-bar"
+          role="img"
+          aria-label={m.usage_models_bar_aria({
+            provider: provider.label,
+            tokens: formatTokenLabel(provider.data.totalTokens),
+          })}
+        >
+          {#each rows as row (row.id)}
+            <span
+              aria-hidden="true"
+              style:width={`${row.exactPct}%`}
+              style:background={row.tone}
+            ></span>
+          {/each}
+        </div>
+
+        <ul class="model-list">
+          {#each rows as row (row.id)}
+            <li>
+              <span class="swatch" aria-hidden="true" style:background={row.tone}></span>
+              <span class="model-name">{row.label}</span>
+              <span class="model-pct">{row.displayPct.toFixed(1)}%</span>
+              <span class="model-tokens">{formatTokenLabel(row.tokens)}</span>
+            </li>
+          {/each}
+        </ul>
+      {:else}
+        <p class="empty">{m.usage_models_empty()}</p>
+      {/if}
+    </section>
+  {/each}
+</div>
+
+<style>
+  .models-lens {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .provider-block {
+    padding-block: 18px;
+  }
+
+  .provider-block + .provider-block {
+    border-top: 1px solid var(--color-line);
+  }
+
+  .provider-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 12px;
+  }
+
+  .provider-head h2 {
+    margin: 0;
+    color: var(--color-ink-bright);
+    font-size: var(--fs-base);
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .provider-head span {
+    color: var(--color-muted);
+    font-size: var(--fs-meta);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .stacked-bar {
+    display: flex;
+    width: 100%;
+    height: 12px;
+    overflow: hidden;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line-bright);
+  }
+
+  .stacked-bar > span {
+    min-width: 1px;
+    height: 100%;
+    border-right: 1px solid var(--color-panel);
+  }
+
+  .stacked-bar > span:last-child {
+    border-right: 0;
+  }
+
+  .model-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 0;
+    margin: 10px 0 0;
+    list-style: none;
+  }
+
+  .model-list li {
+    display: grid;
+    grid-template-columns: 10px minmax(0, 1fr) 4.5rem 7rem;
+    align-items: center;
+    gap: 8px;
+    min-height: 28px;
+    color: var(--color-ink);
+    font-size: var(--fs-base);
+  }
+
+  .swatch {
+    width: 8px;
+    height: 8px;
+  }
+
+  .model-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .model-pct,
+  .model-tokens {
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+  }
+
+  .model-pct {
+    color: var(--color-ink-bright);
+  }
+
+  .model-tokens {
+    color: var(--color-muted);
+  }
+
+  .empty {
+    margin: 0;
+    color: var(--color-muted);
+    font-size: var(--fs-base);
+  }
+
+  @media (max-width: 520px) {
+    .model-list li {
+      grid-template-columns: 10px minmax(0, 1fr) 3.75rem 5.75rem;
+      gap: 6px;
+    }
+  }
+</style>

--- a/ui/src/lib/components/usage/ModelsLens.svelte
+++ b/ui/src/lib/components/usage/ModelsLens.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { UsageBreakdown, UsageModelBreakdown } from "$lib/types";
+  import type { UsageBreakdown, UsageModelBreakdown, UsageRole } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import { formatTokenLabel } from "$lib/format";
   import { modelDisplayName } from "$lib/components/usage-gauges";
@@ -23,6 +23,40 @@
     exactPct: number;
     displayPct: number;
     tone: string;
+  }
+
+  interface RoleRow {
+    id: UsageRole;
+    label: string;
+    tokens: number;
+    providerPct: number;
+    models: Array<{ id: string; label: string; tokens: number; rolePct: number }>;
+  }
+
+  const ROLE_ORDER: UsageRole[] = [
+    "coding",
+    "review",
+    "plan_gate",
+    "recap",
+    "rundown",
+    "doc_agent",
+  ];
+
+  function roleLabel(role: UsageRole): string {
+    switch (role) {
+      case "coding":
+        return m.usage_models_role_coding();
+      case "review":
+        return m.usage_kind_review();
+      case "plan_gate":
+        return m.usage_kind_plan_gate();
+      case "recap":
+        return m.usage_kind_recap();
+      case "rundown":
+        return m.usage_kind_rundown();
+      case "doc_agent":
+        return m.usage_kind_doc_agent();
+    }
   }
 
   function rowsFor(data: UsageModelBreakdown): ModelRow[] {
@@ -59,6 +93,33 @@
     }));
   }
 
+  function roleRowsFor(data: UsageModelBreakdown): RoleRow[] {
+    return ROLE_ORDER.flatMap((role) => {
+      const models = Object.entries(data.byRole[role] ?? {})
+        .filter(([, tokens]) => tokens > 0)
+        .sort(
+          ([aModel, aTokens], [bModel, bTokens]) =>
+            bTokens - aTokens || (aModel < bModel ? -1 : aModel > bModel ? 1 : 0),
+        );
+      const tokens = models.reduce((sum, [, modelTokens]) => sum + modelTokens, 0);
+      if (tokens === 0) return [];
+      return [
+        {
+          id: role,
+          label: roleLabel(role),
+          tokens,
+          providerPct: data.totalTokens > 0 ? (tokens / data.totalTokens) * 100 : 0,
+          models: models.map(([id, modelTokens]) => ({
+            id,
+            label: modelDisplayName(id),
+            tokens: modelTokens,
+            rolePct: (modelTokens / tokens) * 100,
+          })),
+        },
+      ];
+    });
+  }
+
   const providers = $derived([
     { id: "claude", label: m.agent_provider_claude(), data: models.claude },
     { id: "codex", label: m.agent_provider_codex(), data: models.codex },
@@ -68,10 +129,18 @@
 <div class="models-lens">
   {#each providers as provider (provider.id)}
     {@const rows = rowsFor(provider.data)}
+    {@const roleRows = roleRowsFor(provider.data)}
     <section class="provider-block" data-provider={provider.id}>
       <header class="provider-head">
         <h2>{provider.label}</h2>
-        <span>{m.usage_models_total({ tokens: formatTokenLabel(provider.data.totalTokens) })}</span>
+        <div class="provider-meta">
+          <span
+            >{m.usage_models_total({ tokens: formatTokenLabel(provider.data.totalTokens) })}</span
+          >
+          {#if provider.id === "codex"}
+            <span class="role-unavailable">{m.usage_models_codex_roles_unavailable()}</span>
+          {/if}
+        </div>
       </header>
 
       {#if rows.length > 0}
@@ -84,10 +153,7 @@
           })}
         >
           {#each rows as row (row.id)}
-            <span
-              aria-hidden="true"
-              style:width={`${row.exactPct}%`}
-              style:background={row.tone}
+            <span aria-hidden="true" style:width={`${row.exactPct}%`} style:background={row.tone}
             ></span>
           {/each}
         </div>
@@ -104,6 +170,32 @@
         </ul>
       {:else}
         <p class="empty">{m.usage_models_empty()}</p>
+      {/if}
+
+      {#if provider.id === "claude" && roleRows.length > 0}
+        <div class="role-breakdown">
+          <h3>{m.usage_models_by_role()}</h3>
+          {#each roleRows as role (role.id)}
+            <details class="role-detail" data-role={role.id}>
+              <summary>
+                <span class="role-summary-content">
+                  <span class="role-name">{role.label}</span>
+                  <span class="role-pct">{role.providerPct.toFixed(1)}%</span>
+                  <span class="role-tokens">{formatTokenLabel(role.tokens)}</span>
+                </span>
+              </summary>
+              <ul class="role-model-list">
+                {#each role.models as model (model.id)}
+                  <li class="role-model-row">
+                    <span class="role-model-name">{model.label}</span>
+                    <span class="role-model-pct">{model.rolePct.toFixed(1)}%</span>
+                    <span class="role-model-tokens">{formatTokenLabel(model.tokens)}</span>
+                  </li>
+                {/each}
+              </ul>
+            </details>
+          {/each}
+        </div>
       {/if}
     </section>
   {/each}
@@ -140,10 +232,27 @@
     text-transform: uppercase;
   }
 
-  .provider-head span {
+  .provider-meta {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 4px;
+  }
+
+  .provider-meta > span:first-child {
     color: var(--color-muted);
     font-size: var(--fs-meta);
     font-variant-numeric: tabular-nums;
+  }
+
+  .role-unavailable {
+    padding: 1px 6px;
+    color: var(--color-muted);
+    font-size: var(--fs-micro);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
   }
 
   .stacked-bar {
@@ -215,9 +324,92 @@
     font-size: var(--fs-base);
   }
 
+  .role-breakdown {
+    margin-top: 18px;
+    border-top: 1px solid var(--color-line);
+  }
+
+  .role-breakdown h3 {
+    margin: 12px 0 6px;
+    color: var(--color-muted);
+    font-size: var(--fs-meta);
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .role-detail {
+    border-bottom: 1px solid var(--color-line);
+  }
+
+  .role-detail summary {
+    padding: 7px 0;
+    color: var(--color-ink);
+    font-size: var(--fs-base);
+    cursor: pointer;
+  }
+
+  .role-detail summary::marker {
+    color: var(--color-muted);
+  }
+
+  .role-summary-content,
+  .role-model-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 4.5rem 7rem;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .role-name,
+  .role-model-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .role-pct,
+  .role-tokens,
+  .role-model-pct,
+  .role-model-tokens {
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+  }
+
+  .role-pct,
+  .role-model-pct {
+    color: var(--color-ink-bright);
+  }
+
+  .role-tokens,
+  .role-model-tokens,
+  .role-model-name {
+    color: var(--color-muted);
+  }
+
+  .role-model-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 0 0 8px 18px;
+    margin: 0;
+    list-style: none;
+  }
+
+  .role-model-row {
+    min-height: 24px;
+    font-size: var(--fs-meta);
+  }
+
   @media (max-width: 520px) {
     .model-list li {
       grid-template-columns: 10px minmax(0, 1fr) 3.75rem 5.75rem;
+      gap: 6px;
+    }
+
+    .role-summary-content,
+    .role-model-row {
+      grid-template-columns: minmax(0, 1fr) 3.75rem 5.75rem;
       gap: 6px;
     }
   }

--- a/ui/src/lib/components/usage/ModelsLens.svelte
+++ b/ui/src/lib/components/usage/ModelsLens.svelte
@@ -35,6 +35,7 @@
 
   const ROLE_ORDER: UsageRole[] = [
     "coding",
+    "classifier",
     "review",
     "plan_gate",
     "recap",
@@ -46,6 +47,8 @@
     switch (role) {
       case "coding":
         return m.usage_models_role_coding();
+      case "classifier":
+        return m.usage_kind_classifier();
       case "review":
         return m.usage_kind_review();
       case "plan_gate":

--- a/ui/src/lib/components/usage/ModelsLens.svelte
+++ b/ui/src/lib/components/usage/ModelsLens.svelte
@@ -140,7 +140,7 @@
           <span
             >{m.usage_models_total({ tokens: formatTokenLabel(provider.data.totalTokens) })}</span
           >
-          {#if provider.id === "codex"}
+          {#if provider.id === "codex" && roleRows.length === 0}
             <span class="role-unavailable">{m.usage_models_codex_roles_unavailable()}</span>
           {/if}
         </div>
@@ -175,7 +175,7 @@
         <p class="empty">{m.usage_models_empty()}</p>
       {/if}
 
-      {#if provider.id === "claude" && roleRows.length > 0}
+      {#if roleRows.length > 0}
         <div class="role-breakdown">
           <h3>{m.usage_models_by_role()}</h3>
           {#each roleRows as role (role.id)}

--- a/ui/src/lib/components/usage/ModelsLens.svelte
+++ b/ui/src/lib/components/usage/ModelsLens.svelte
@@ -41,6 +41,7 @@
     "recap",
     "rundown",
     "doc_agent",
+    "maintain",
   ];
 
   function roleLabel(role: UsageRole): string {
@@ -57,6 +58,8 @@
         return m.usage_kind_recap();
       case "rundown":
         return m.usage_kind_rundown();
+      case "maintain":
+        return m.usage_kind_maintain();
       case "doc_agent":
         return m.usage_kind_doc_agent();
     }

--- a/ui/src/lib/components/usage/OverheadLens.browser.test.ts
+++ b/ui/src/lib/components/usage/OverheadLens.browser.test.ts
@@ -55,7 +55,18 @@ describe("OverheadLens", () => {
   });
 
   it("satellite-by-type section renders one row per kind, sorted desc by units, with a count", async () => {
-    const breakdown = mockBreakdown("7d");
+    const base = mockBreakdown("7d");
+    const breakdown = {
+      ...base,
+      satelliteByKind: [
+        {
+          kind: "classifier",
+          units: (base.satelliteByKind[0]?.units ?? 0) + 1,
+          count: 2,
+        },
+        ...base.satelliteByKind,
+      ],
+    };
     render(OverheadLens, { breakdown });
 
     await expect.element(page.getByText("Satellite by type")).toBeInTheDocument();
@@ -64,11 +75,11 @@ describe("OverheadLens", () => {
     expect(rows.length, "one row per kind").toBe(breakdown.satelliteByKind.length);
     expect(rows.length).toBeGreaterThan(0);
 
-    // First row is the largest kind (mock is review-led) and carries a count label "N×".
+    // First row is the largest kind and carries the localized classifier label + count.
     const firstLabel = rows[0]?.querySelector(".bykind-label")?.textContent ?? "";
-    expect(firstLabel).toBe("Review");
+    expect(firstLabel).toBe("Classifier");
     const firstCount = rows[0]?.querySelector(".bykind-count")?.textContent ?? "";
-    expect(firstCount).toMatch(/^\d+×$/);
+    expect(firstCount).toBe("2×");
 
     // Each row shows a % share.
     rows.forEach((row, i) => {

--- a/ui/src/lib/components/usage/OverheadLens.svelte
+++ b/ui/src/lib/components/usage/OverheadLens.svelte
@@ -13,6 +13,8 @@
   /** Translated label for a satellite-pass kind; falls back to the raw id for unknowns. */
   function kindLabel(kind: string): string {
     switch (kind) {
+      case "classifier":
+        return m.usage_kind_classifier();
       case "review":
         return m.usage_kind_review();
       case "plan_gate":

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-classifier-usage.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-classifier-usage.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "classifier-usage",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_classifier_usage_title",
+  bodyKey: "feat_classifier_usage_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-codex-role-usage.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-codex-role-usage.ts
@@ -1,0 +1,8 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+export default {
+  id: "codex-role-usage",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_codex_role_usage_title",
+  bodyKey: "feat_codex_role_usage_body",
+} satisfies FeatureAnnouncement;

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-usage-model-breakdown.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-usage-model-breakdown.ts
@@ -1,0 +1,8 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+export default {
+  id: "usage-model-breakdown",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_usage_model_breakdown_title",
+  bodyKey: "feat_usage_model_breakdown_body",
+} satisfies FeatureAnnouncement;

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-usage-role-model-breakdown.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-usage-role-model-breakdown.ts
@@ -1,0 +1,8 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+export default {
+  id: "usage-role-model-breakdown",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_usage_role_model_breakdown_title",
+  bodyKey: "feat_usage_role_model_breakdown_body",
+} satisfies FeatureAnnouncement;

--- a/ui/src/lib/feature-announcements/entries/v1.48.0-classifier-usage.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.48.0-classifier-usage.ts
@@ -2,7 +2,7 @@ import type { FeatureAnnouncement } from "../../feature-announcements";
 
 const entry = {
   id: "classifier-usage",
-  sinceVersion: "1.44.0",
+  sinceVersion: "1.48.0",
   titleKey: "feat_classifier_usage_title",
   bodyKey: "feat_classifier_usage_body",
 } satisfies FeatureAnnouncement;

--- a/ui/src/lib/feature-announcements/entries/v1.48.0-codex-role-usage.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.48.0-codex-role-usage.ts
@@ -2,7 +2,7 @@ import type { FeatureAnnouncement } from "../../feature-announcements";
 
 export default {
   id: "codex-role-usage",
-  sinceVersion: "1.44.0",
+  sinceVersion: "1.48.0",
   titleKey: "feat_codex_role_usage_title",
   bodyKey: "feat_codex_role_usage_body",
 } satisfies FeatureAnnouncement;

--- a/ui/src/lib/feature-announcements/entries/v1.48.0-usage-model-breakdown.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.48.0-usage-model-breakdown.ts
@@ -2,7 +2,7 @@ import type { FeatureAnnouncement } from "../../feature-announcements";
 
 export default {
   id: "usage-model-breakdown",
-  sinceVersion: "1.44.0",
+  sinceVersion: "1.48.0",
   titleKey: "feat_usage_model_breakdown_title",
   bodyKey: "feat_usage_model_breakdown_body",
 } satisfies FeatureAnnouncement;

--- a/ui/src/lib/feature-announcements/entries/v1.48.0-usage-role-model-breakdown.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.48.0-usage-role-model-breakdown.ts
@@ -2,7 +2,7 @@ import type { FeatureAnnouncement } from "../../feature-announcements";
 
 export default {
   id: "usage-role-model-breakdown",
-  sinceVersion: "1.44.0",
+  sinceVersion: "1.48.0",
   titleKey: "feat_usage_role_model_breakdown_title",
   bodyKey: "feat_usage_role_model_breakdown_body",
 } satisfies FeatureAnnouncement;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1390,9 +1390,13 @@ export interface UsageKindUnits {
   count: number; // number of completed passes of that kind, in range
 }
 
+export type UsageRole = "coding" | "review" | "plan_gate" | "recap" | "rundown" | "doc_agent";
+export type UsageByRole = Partial<Record<UsageRole, Record<string, number>>>;
+
 export interface UsageModelBreakdown {
   totalTokens: number;
   byModel: Record<string, number>;
+  byRole: UsageByRole;
 }
 
 /** Top-level breakdown — serves the Spend + Overhead lenses. */

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1390,6 +1390,11 @@ export interface UsageKindUnits {
   count: number; // number of completed passes of that kind, in range
 }
 
+export interface UsageModelBreakdown {
+  totalTokens: number;
+  byModel: Record<string, number>;
+}
+
 /** Top-level breakdown — serves the Spend + Overhead lenses. */
 export interface UsageBreakdown {
   range: UsageRange;
@@ -1401,6 +1406,10 @@ export interface UsageBreakdown {
   generationUnits: number; // non-cacheRead share (Overhead b)
   satelliteByKind: UsageKindUnits[]; // global per-kind satellite tally, sorted desc by units
   dollars: number | null; // absolute USD spend; null unless api-key auth mode
+  models: {
+    claude: UsageModelBreakdown;
+    codex: UsageModelBreakdown;
+  };
   repos: UsageRepoBreakdown[];
 }
 

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1391,7 +1391,7 @@ export interface UsageKindUnits {
 }
 
 export type UsageRole =
-  "coding" | "classifier" | "review" | "plan_gate" | "recap" | "rundown" | "doc_agent";
+  "coding" | "classifier" | "review" | "plan_gate" | "recap" | "rundown" | "doc_agent" | "maintain";
 export type UsageByRole = Partial<Record<UsageRole, Record<string, number>>>;
 
 export interface UsageModelBreakdown {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1385,12 +1385,13 @@ export interface UsageRepoBreakdown {
 
 /** One satellite-pass kind's global, spawn-timestamp-filtered tally (Overhead lens). */
 export interface UsageKindUnits {
-  kind: string; // "review" | "plan_gate" | "recap" | "doc_agent" | "maintain" (+ historical "rundown") — data, not translated
+  kind: string; // "review" | "plan_gate" | "recap" | "doc_agent" | "maintain" | "classifier" (+ historical "rundown") — data, not translated
   units: number; // weighted units for that kind, in range
   count: number; // number of completed passes of that kind, in range
 }
 
-export type UsageRole = "coding" | "review" | "plan_gate" | "recap" | "rundown" | "doc_agent";
+export type UsageRole =
+  "coding" | "classifier" | "review" | "plan_gate" | "recap" | "rundown" | "doc_agent";
 export type UsageByRole = Partial<Record<UsageRole, Record<string, number>>>;
 
 export interface UsageModelBreakdown {

--- a/ui/src/lib/usage-mock.ts
+++ b/ui/src/lib/usage-mock.ts
@@ -2,7 +2,13 @@
  * Mock fixtures for the /usage token-spend dashboard (Phase 0 prototype).
  * No backend — all data is hand-written for visual prototyping.
  */
-import type { UsageBreakdown, UsageKindUnits, UsageRange, UsageTaskBreakdown } from "./types";
+import type {
+  UsageBreakdown,
+  UsageKindUnits,
+  UsageModelBreakdown,
+  UsageRange,
+  UsageTaskBreakdown,
+} from "./types";
 
 /** Single stable base to keep all timestamps deterministic across calls. */
 const BASE = Date.now();
@@ -26,6 +32,57 @@ function byKind(totalSat: number): UsageKindUnits[] {
  */
 function task(t: Omit<UsageTaskBreakdown, "dollars">): UsageTaskBreakdown {
   return { ...t, dollars: t.authoringUnits + t.satelliteUnits };
+}
+
+function modelBreakdown(byModel: Record<string, number>): UsageModelBreakdown {
+  return {
+    totalTokens: Object.values(byModel).reduce((sum, tokens) => sum + tokens, 0),
+    byModel,
+  };
+}
+
+function modelsFor(range: UsageRange): UsageBreakdown["models"] {
+  if (range === "24h") {
+    return {
+      claude: modelBreakdown({
+        "claude-opus-4-8": 2_400_000,
+        "claude-sonnet-4-5": 1_150_000,
+        fable: 420_000,
+      }),
+      codex: modelBreakdown({ "gpt-5.5": 1_800_000, "gpt-5.4": 350_000 }),
+    };
+  }
+  if (range === "7d") {
+    return {
+      claude: modelBreakdown({
+        "claude-opus-4-8": 12_800_000,
+        "claude-sonnet-4-5": 7_300_000,
+        "claude-haiku-4-5": 1_950_000,
+        fable: 1_100_000,
+      }),
+      codex: modelBreakdown({ "gpt-5.5": 8_900_000, "gpt-5.4": 2_600_000, unknown: 240_000 }),
+    };
+  }
+  if (range === "30d") {
+    return {
+      claude: modelBreakdown({
+        "claude-opus-4-8": 48_600_000,
+        "claude-sonnet-4-5": 29_400_000,
+        "claude-haiku-4-5": 8_700_000,
+        fable: 4_200_000,
+      }),
+      codex: modelBreakdown({ "gpt-5.5": 31_500_000, "gpt-5.4": 12_400_000, unknown: 860_000 }),
+    };
+  }
+  return {
+    claude: modelBreakdown({
+      "claude-opus-4-8": 76_200_000,
+      "claude-sonnet-4-5": 45_800_000,
+      "claude-haiku-4-5": 13_100_000,
+      fable: 6_700_000,
+    }),
+    codex: modelBreakdown({ "gpt-5.5": 49_600_000, "gpt-5.4": 18_900_000, unknown: 1_200_000 }),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -419,6 +476,7 @@ export function mockBreakdown(range: UsageRange): UsageBreakdown {
         generationUnits: Math.round(total * 0.25),
         satelliteByKind: byKind(totalS),
         dollars: total,
+        models: modelsFor(range),
         repos: [
           {
             repoPath: "/home/user/shepherd",
@@ -462,6 +520,7 @@ export function mockBreakdown(range: UsageRange): UsageBreakdown {
         generationUnits: Math.round(total * 0.24),
         satelliteByKind: byKind(totalS),
         dollars: total,
+        models: modelsFor(range),
         repos: [
           {
             repoPath: "/home/user/shepherd",
@@ -505,6 +564,7 @@ export function mockBreakdown(range: UsageRange): UsageBreakdown {
         generationUnits: Math.round(total * 0.23),
         satelliteByKind: byKind(totalS),
         dollars: total,
+        models: modelsFor(range),
         repos: [
           {
             repoPath: "/home/user/shepherd",
@@ -556,6 +616,7 @@ export function mockBreakdown(range: UsageRange): UsageBreakdown {
         generationUnits: Math.round(total * 0.22),
         satelliteByKind: byKind(totalS),
         dollars: total,
+        models: modelsFor(range),
         repos: [
           {
             repoPath: "/home/user/shepherd",

--- a/ui/src/lib/usage-mock.ts
+++ b/ui/src/lib/usage-mock.ts
@@ -34,53 +34,69 @@ function task(t: Omit<UsageTaskBreakdown, "dollars">): UsageTaskBreakdown {
   return { ...t, dollars: t.authoringUnits + t.satelliteUnits };
 }
 
-function modelBreakdown(byModel: Record<string, number>): UsageModelBreakdown {
+function modelBreakdown(
+  byModel: Record<string, number>,
+  includeCodingRole = false,
+): UsageModelBreakdown {
   return {
     totalTokens: Object.values(byModel).reduce((sum, tokens) => sum + tokens, 0),
     byModel,
+    byRole: includeCodingRole ? { coding: byModel } : {},
   };
 }
 
 function modelsFor(range: UsageRange): UsageBreakdown["models"] {
   if (range === "24h") {
     return {
-      claude: modelBreakdown({
-        "claude-opus-4-8": 2_400_000,
-        "claude-sonnet-4-5": 1_150_000,
-        fable: 420_000,
-      }),
+      claude: modelBreakdown(
+        {
+          "claude-opus-4-8": 2_400_000,
+          "claude-sonnet-4-5": 1_150_000,
+          fable: 420_000,
+        },
+        true,
+      ),
       codex: modelBreakdown({ "gpt-5.5": 1_800_000, "gpt-5.4": 350_000 }),
     };
   }
   if (range === "7d") {
     return {
-      claude: modelBreakdown({
-        "claude-opus-4-8": 12_800_000,
-        "claude-sonnet-4-5": 7_300_000,
-        "claude-haiku-4-5": 1_950_000,
-        fable: 1_100_000,
-      }),
+      claude: modelBreakdown(
+        {
+          "claude-opus-4-8": 12_800_000,
+          "claude-sonnet-4-5": 7_300_000,
+          "claude-haiku-4-5": 1_950_000,
+          fable: 1_100_000,
+        },
+        true,
+      ),
       codex: modelBreakdown({ "gpt-5.5": 8_900_000, "gpt-5.4": 2_600_000, unknown: 240_000 }),
     };
   }
   if (range === "30d") {
     return {
-      claude: modelBreakdown({
-        "claude-opus-4-8": 48_600_000,
-        "claude-sonnet-4-5": 29_400_000,
-        "claude-haiku-4-5": 8_700_000,
-        fable: 4_200_000,
-      }),
+      claude: modelBreakdown(
+        {
+          "claude-opus-4-8": 48_600_000,
+          "claude-sonnet-4-5": 29_400_000,
+          "claude-haiku-4-5": 8_700_000,
+          fable: 4_200_000,
+        },
+        true,
+      ),
       codex: modelBreakdown({ "gpt-5.5": 31_500_000, "gpt-5.4": 12_400_000, unknown: 860_000 }),
     };
   }
   return {
-    claude: modelBreakdown({
-      "claude-opus-4-8": 76_200_000,
-      "claude-sonnet-4-5": 45_800_000,
-      "claude-haiku-4-5": 13_100_000,
-      fable: 6_700_000,
-    }),
+    claude: modelBreakdown(
+      {
+        "claude-opus-4-8": 76_200_000,
+        "claude-sonnet-4-5": 45_800_000,
+        "claude-haiku-4-5": 13_100_000,
+        fable: 6_700_000,
+      },
+      true,
+    ),
     codex: modelBreakdown({ "gpt-5.5": 49_600_000, "gpt-5.4": 18_900_000, unknown: 1_200_000 }),
   };
 }

--- a/ui/src/routes/design-system/+page.svelte
+++ b/ui/src/routes/design-system/+page.svelte
@@ -614,8 +614,8 @@ input, select, textarea {
   <section class="panel">
     <h2>Color · categorical data</h2>
     <p class="when">
-      Use these ordered tones for categorical charts whose series are also identified by text.
-      They encode identity, never status. Green is intentionally absent so READY stays exclusive.
+      Use these ordered tones for categorical charts whose series are also identified by text. They
+      encode identity, never status. Green is intentionally absent so READY stays exclusive.
     </p>
     <div class="swatches">
       {#each dataColors as t (t.name)}

--- a/ui/src/routes/design-system/+page.svelte
+++ b/ui/src/routes/design-system/+page.svelte
@@ -68,6 +68,16 @@
     { name: "warn", note: "Caution / heads-up — not running, not error" },
   ];
 
+  const dataColors: Token[] = [
+    { name: "data-1", note: "Categorical series 1" },
+    { name: "data-2", note: "Categorical series 2" },
+    { name: "data-3", note: "Categorical series 3" },
+    { name: "data-4", note: "Categorical series 4" },
+    { name: "data-5", note: "Categorical series 5" },
+    { name: "data-6", note: "Categorical series 6" },
+    { name: "data-7", note: "Categorical series 7 / aggregate remainder" },
+  ];
+
   // Type scale — the six deliberate rungs in app.css. Never hardcode a px size;
   // reach for the nearest rung.
   const typeScale: { name: string; px: string; note: string }[] = [
@@ -593,6 +603,22 @@ input, select, textarea {
     </p>
     <div class="swatches">
       {#each accents as t (t.name)}
+        <figure class="swatch">
+          <span class="chip" style="background: var(--color-{t.name})"></span>
+          <figcaption><code>--color-{t.name}</code><span>{t.note}</span></figcaption>
+        </figure>
+      {/each}
+    </div>
+  </section>
+
+  <section class="panel">
+    <h2>Color · categorical data</h2>
+    <p class="when">
+      Use these ordered tones for categorical charts whose series are also identified by text.
+      They encode identity, never status. Green is intentionally absent so READY stays exclusive.
+    </p>
+    <div class="swatches">
+      {#each dataColors as t (t.name)}
         <figure class="swatch">
           <span class="chip" style="background: var(--color-{t.name})"></span>
           <figcaption><code>--color-{t.name}</code><span>{t.note}</span></figcaption>


### PR DESCRIPTION
Der Usage-Dialog zeigt jetzt einen Modelle-Tab mit dem Token-Mix pro Provider und einer aufklappbaren Aufschlüsselung nach Rolle und Modell. Claude-Rohtoken bleiben auch nach dem Ende einer Sitzung und beim Wechsel des Zeitfensters erhalten; Classifier und transiente Agents werden in die Rollenauswertung einbezogen.

Für Codex nutzt die Zuordnung die bestehende `providerSessionId`- und Rollout-Erfassung. Modell- und Rollenwerte stammen aus demselben aktuellen SQLite-Snapshot: Später eingetragene Token werden berücksichtigt, und ein außerhalb des Fensters liegender Review-Thread kann keine Coding-Token anderer Threads übernehmen. Fehlende Rollout-Daten bleiben für den bestehenden Backfill offen. Wiederholte Standalone-Reviews erhalten jeweils ein eindeutiges Arbeitsverzeichnis.

Die unbekannte Modellbezeichnung ist in Deutsch und Englisch übersetzt. Die Änderungen sind auf `main` rebased; die Feature-Ankündigungen sind für 1.48.0 eingeordnet.

### Validierung

- Root: `bun run test` — 9.395 bestanden, 16 übersprungen, keine Fehler.
- UI: `bun run test` — 4.952 bestanden; `bun run check` ohne Fehler oder Warnungen.
- Root-Typecheck, ESLint, Übersetzungsparität und Eval-Fingerprints bestanden.
- Vollständiger Pre-Push-Hook bestanden: Repository-Gates, Formatierung, Root/UI/Extension-Prüfungen und Builds sowie Fallow-Delta-Audit.
- Regressionstests für verspätete Codex-Token, native Zeitfenster, Rollout-Zuordnung und wiederholte Reviews; abschließende Standards- und Spec-Prüfung ohne offene Befunde.

### Grenzen der Daten

Codex-Zeitfenster verwenden weiterhin die nativen Thread-Gesamtsummen anhand von `updated_at_ms`, keine turngenaue Verbrauchshistorie. Ohne eindeutige Zuordnung zu einem abgeschlossenen Rollenlauf bleiben Token im Coding-Rest. Alte Claude-Snapshots ohne gespeicherte Rohtoken lassen sich daraus nicht rückwirkend rekonstruieren.

Closes #1729
Closes #1725
Closes #1726
Closes #1727
Closes #1728
