### PR TITLE
fix(recap): seed Claude trust before temp spawn

### DIFF
--- a/src/recap.ts
+++ b/src/recap.ts
@@ -39,6 +39,7 @@ import { computeDiff } from "./diff";
 import { parseActivity, readTranscriptTail } from "./activity";
 import { jsonlPathFor } from "./usage";
 import { apiKeyFailClosed, apiKeyPassthroughEnv } from "./spawn-auth";
+import { claudeConfigPath, readRepoRootTrusted, trustRepoRoot } from "./claude-trust";
 import {
   parseRecapVerdict,
   buildTranscriptDigest,
@@ -234,6 +235,15 @@ function defaultCleanup(cwd: string): void {
   }
 }
 
+async function defaultPrepareClaudeTrust(cwd: string, claudeDir: string): Promise<void> {
+  const configPath = claudeConfigPath(process.env.HOME ?? "", claudeDir);
+  if (!(await readRepoRootTrusted(configPath, cwd))) await trustRepoRoot(configPath, cwd);
+}
+
+function defaultClaudeDir(): string {
+  return process.env.CLAUDE_CONFIG_DIR ?? `${process.env.HOME}/.claude`;
+}
+
 /** The recap spawn's argv — the shared `writer-only` transient-agent shape (model defaults to
  *  "sonnet" at the call site). The input is the session transcript (UNTRUSTED); bare `Write` is safe
  *  via the sandbox shape, not an input-trust claim. See buildTransientAgentArgv for the rationale. */
@@ -301,6 +311,7 @@ export interface RecapServiceDeps {
     headSha: string,
   ) => Promise<LandedWorkEvidence | null> | LandedWorkEvidence | null;
   makeTmpDir?: () => string;
+  prepareClaudeTrust?: (cwd: string, claudeDir: string) => Promise<void>;
   cleanup?: (cwd: string) => void;
 }
 
@@ -342,6 +353,7 @@ export class RecapService {
     headSha: string,
   ) => Promise<LandedWorkEvidence | null> | LandedWorkEvidence | null;
   private _makeTmpDir: () => string;
+  private _prepareClaudeTrust: (cwd: string, claudeDir: string) => Promise<void>;
   private _cleanup: (cwd: string) => void;
 
   /** Per-session settled-idle debounce: stamp + fired-this-episode flag. */
@@ -385,6 +397,7 @@ export class RecapService {
     this._headContainedInBase = optional(deps.headContainedInBase, defaultHeadContainedInBase);
     this._landedWorkEvidence = optional(deps.landedWorkEvidence, () => null);
     this._makeTmpDir = optional(deps.makeTmpDir, defaultMakeTmpDir);
+    this._prepareClaudeTrust = optional(deps.prepareClaudeTrust, defaultPrepareClaudeTrust);
     this._cleanup = optional(deps.cleanup, defaultCleanup);
   }
 
@@ -571,18 +584,17 @@ export class RecapService {
 
   // ── reapGenerating ───────────────────────────────────────────────────────────
 
-  /** Stop a generating run's pane — spawn-recorded terminalId first (#1852; the cwd
-   *  lookup is only for rows adopted across a restart and yields "" once the agent
-   *  exited, a safe stop() no-op) — then drop the in-memory handle. Keyed strictly by
-   *  the run's own cwd so a teardown racing a forced regenerate can never touch the
-   *  replacement run (see `generatingTerminals`). Never throws. */
+  /** Stop this recap run's pane, then always drop its cwd-keyed in-memory handle.
+   *  Prefer the terminalId captured at spawn (#1852); the cwd lookup only covers rows
+   *  adopted across a restart and safely resolves to "" after the agent has exited. */
   private async reapPane(cwd: string): Promise<void> {
     try {
       await this.deps.herdr.stop(this.generatingTerminals.get(cwd) ?? this.resolveTerminal(cwd));
     } catch {
       /* best-effort */
+    } finally {
+      this.generatingTerminals.delete(cwd);
     }
-    this.generatingTerminals.delete(cwd);
   }
 
   /** Reap any existing generating row for this session (stop pane + cleanup dir + drop row). */
@@ -702,6 +714,16 @@ export class RecapService {
     this.debounce.delete(sessionId);
   }
 
+  /** Best-effort because an unwritable Claude config must surface as a launch failure, not crash. */
+  private async prepareClaudeTrust(cwd: string, provider: AgentProvider, claudeDir: string) {
+    if (provider !== "claude") return;
+    try {
+      await this._prepareClaudeTrust(cwd, claudeDir);
+    } catch (err) {
+      console.warn("[recap] trust pre-seed failed; continuing", err);
+    }
+  }
+
   // ── generate ─────────────────────────────────────────────────────────────────
 
   /**
@@ -809,12 +831,13 @@ export class RecapService {
       // (#1852) — resolving by cwd later yields "" once the agent exited.
       const cwd = this._makeTmpDir();
       try {
-        const started = await this.deps.herdr.start(
-          `recap ${session.desig}`,
+        const spawnEnv = apiKeyPassthroughEnv(false);
+        await this.prepareClaudeTrust(
           cwd,
-          argv,
-          apiKeyPassthroughEnv(false),
+          env.provider,
+          spawnEnv?.CLAUDE_CONFIG_DIR ?? defaultClaudeDir(),
         );
+        const started = await this.deps.herdr.start(`recap ${session.desig}`, cwd, argv, spawnEnv);
         this.generatingTerminals.set(cwd, started.terminalId);
       } catch (err) {
         this._cleanup(cwd);

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -1,4 +1,7 @@
 import { expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { RecapService, sanitizeRecapFailureDetail } from "../src/recap";
 import type { VerdictRead } from "../src/json-tolerant";
 import type { DiffResult, Recap, Session } from "../src/types";
@@ -275,6 +278,8 @@ function buildSvc(opts: {
   timeoutMs?: number;
   cleanup?: (d: string) => void;
   makeTmpDir?: () => string;
+  prepareClaudeTrust?: (cwd: string, claudeDir: string) => Promise<void>;
+  useDefaultPrepareClaudeTrust?: boolean;
   readUsage?: () => Promise<any>;
   resolveBase?: (s: Session) => Promise<{ base: string; resolved: boolean }>;
   computeDiff?: (worktreePath: string, base: string, branch: string | null) => Promise<any>;
@@ -311,6 +316,9 @@ function buildSvc(opts: {
     headContainedInBase: opts.headContainedInBase,
     landedWorkEvidence: opts.landedWorkEvidence,
     makeTmpDir: opts.makeTmpDir ?? (() => `/tmp/recap-test-${++tmpIdx}`),
+    ...(opts.useDefaultPrepareClaudeTrust
+      ? {}
+      : { prepareClaudeTrust: opts.prepareClaudeTrust ?? (async () => {}) }),
     cleanup: opts.cleanup ?? (() => {}),
   });
 }
@@ -459,6 +467,7 @@ test("sweep: existing READY recap at headA; session re-activates then re-settles
     readVerdict: (): VerdictRead<unknown> => ({ status: "absent" }),
     readUsage: async () => null,
     makeTmpDir: () => "/tmp/recap-headb",
+    prepareClaudeTrust: async () => {},
     cleanup: () => {},
   });
 
@@ -1066,16 +1075,45 @@ test("generate: subscription mode — --settings unchanged + no env 4th arg", as
   });
 });
 
+test("generate: Claude prepares the fresh recap cwd before spawn", async () => {
+  const s = makeSession({ status: "idle" });
+  const herdr = makeHerdr();
+  const events: string[] = [];
+  const start = herdr.start;
+  herdr.start = async (...args) => {
+    events.push("start");
+    return start(...args);
+  };
+  const seen: { cwd: string; claudeDir: string }[] = [];
+  const svc = buildSvc({
+    store: makeStore([s]),
+    herdr,
+    nowFn: () => 1,
+    makeTmpDir: () => "/tmp/r",
+    prepareClaudeTrust: async (cwd, claudeDir) => {
+      events.push("trust");
+      seen.push({ cwd, claudeDir });
+    },
+  });
+
+  await svc.regenerate(s);
+
+  expect(events).toEqual(["trust", "start"]);
+  expect(seen).toEqual([{ cwd: "/tmp/r", claudeDir: config.claudeDir }]);
+});
+
 test("generate: codex provider spawns headless `codex exec` (no claude flags)", async () => {
   const s = makeSession({ status: "idle" });
   const herdr = makeHerdr();
   const store = makeStore([s]);
+  let trustCalls = 0;
   const svc = buildSvc({
     store,
     herdr,
     nowFn: () => 1,
     makeTmpDir: () => "/tmp/r",
     env: () => ({ provider: "codex", model: "gpt-5.5", effort: "high" }),
+    prepareClaudeTrust: async () => void trustCalls++,
   });
   await svc.regenerate(s);
   const argv = herdr.started[0]!.argv;
@@ -1096,6 +1134,7 @@ test("generate: codex provider spawns headless `codex exec` (no claude flags)", 
     reviewerProvider: "codex",
     reviewerEffort: "high",
   });
+  expect(trustCalls).toBe(0);
 });
 
 test("generate: threads env.effort into the recap argv (issue #1418)", async () => {
@@ -1131,19 +1170,89 @@ test("generate: api-key mode — apiKeyHelper in --settings + CLAUDE_CONFIG_DIR 
   await withAuth("api-key", "/helper.sh", async () => {
     const s = makeSession({ status: "idle" });
     const herdr = makeHerdr();
+    let preparedConfigDir = "";
     const svc = buildSvc({
       store: makeStore([s]),
       herdr,
       nowFn: () => 1,
       makeTmpDir: () => "/tmp/r",
+      prepareClaudeTrust: async (_cwd, claudeDir) => {
+        preparedConfigDir = claudeDir;
+      },
     });
     await svc.regenerate(s);
     const argv = herdr.started[0]!.argv;
     const settings = JSON.parse(argv[argv.indexOf("--settings") + 1]!);
     expect(settings.disableAllHooks).toBe(true);
     expect(settings.apiKeyHelper).toBe("/helper.sh");
-    expect(Object.keys(herdr.started[0]!.env!)).toEqual(["CLAUDE_CONFIG_DIR"]);
+    expect(herdr.started[0]!.env).toEqual({
+      CLAUDE_CONFIG_DIR: "/tmp/shepherd-test-apikey-config",
+    });
+    expect(preparedConfigDir).toBe("/tmp/shepherd-test-apikey-config");
   });
+});
+
+test("generate: default Claude trust preparation seeds the selected config file", async () => {
+  const root = await mkdtemp(join(tmpdir(), "recap-default-trust-"));
+  const mirror = join(root, "claude-config");
+  const cwd = join(root, "shepherd-recap-fixture");
+  const configPath = join(mirror, ".claude.json");
+
+  try {
+    await mkdir(mirror, { recursive: true });
+    await mkdir(cwd, { recursive: true });
+    await writeFile(configPath, JSON.stringify({ sentinel: "preserved", projects: {} }), "utf8");
+    __setApiKeyConfigDirProvisionForTest(() => mirror);
+    await withAuth("api-key", "/helper.sh", async () => {
+      const s = makeSession({ status: "idle" });
+      const herdr = makeHerdr();
+      const svc = buildSvc({
+        store: makeStore([s]),
+        herdr,
+        nowFn: () => 1,
+        makeTmpDir: () => cwd,
+        useDefaultPrepareClaudeTrust: true,
+      });
+
+      expect(await svc.regenerate(s)).toBe("started");
+      expect(herdr.started[0]!.env?.CLAUDE_CONFIG_DIR).toBe(mirror);
+      const saved = JSON.parse(await readFile(configPath, "utf8"));
+      expect(saved.sentinel).toBe("preserved");
+      expect(saved.projects[cwd].hasTrustDialogAccepted).toBe(true);
+    });
+  } finally {
+    __setApiKeyConfigDirProvisionForTest(() => "/tmp/shepherd-test-apikey-config");
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("generate: Claude trust preparation failure is best-effort", async () => {
+  const s = makeSession({ status: "idle" });
+  const herdr = makeHerdr();
+  let attempts = 0;
+  const warn = console.warn;
+  const warnings: unknown[][] = [];
+  console.warn = (...args) => warnings.push(args);
+  try {
+    const svc = buildSvc({
+      store: makeStore([s]),
+      herdr,
+      nowFn: () => 1,
+      makeTmpDir: () => "/tmp/r",
+      prepareClaudeTrust: async () => {
+        attempts++;
+        throw new Error("read-only config");
+      },
+    });
+
+    expect(await svc.regenerate(s)).toBe("started");
+  } finally {
+    console.warn = warn;
+  }
+  expect(attempts).toBe(1);
+  expect(herdr.started).toHaveLength(1);
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0]![0]).toBe("[recap] trust pre-seed failed; continuing");
 });
 
 // ─── operator-language: per-spawn read, not frozen at construction (Task 5, issue #1586) ────
@@ -1172,6 +1281,7 @@ test("generate: reads operatorLanguage per spawn, not cached at construction", a
     readPlan: () => "",
     readVerdict: (): VerdictRead<unknown> => ({ status: "absent" }),
     makeTmpDir: () => "/tmp/r1",
+    prepareClaudeTrust: async () => {},
     cleanup: () => {},
   });
 
@@ -1235,6 +1345,7 @@ test("regenerate: replaces an existing ready row", async () => {
     readVerdict: (): VerdictRead<unknown> => ({ status: "absent" }),
     readUsage: async () => null,
     makeTmpDir: () => "/tmp/recap-regen",
+    prepareClaudeTrust: async () => {},
     cleanup: (d) => cleaned.push(d),
   });
 
@@ -1331,6 +1442,7 @@ test("in-flight guard: second generate call for same session mid-await does not 
     readVerdict: (): VerdictRead<unknown> => ({ status: "absent" }),
     readUsage: async () => null,
     makeTmpDir: () => "/tmp/recap-inflight",
+    prepareClaudeTrust: async () => {},
     cleanup: () => {},
   });
 
@@ -1772,6 +1884,7 @@ test("considerForArchive: headSha throws → 'error', no throw, no spawn", async
     readVerdict: (): VerdictRead<unknown> => ({ status: "absent" }),
     readUsage: async () => null,
     makeTmpDir: () => "/tmp/recap-archive-err",
+    prepareClaudeTrust: async () => {},
     cleanup: () => {},
   });
 
@@ -1854,6 +1967,7 @@ test("generate: computeDiff rejection → visible source failure", async () => {
     readVerdict: (): VerdictRead<unknown> => ({ status: "absent" }),
     readUsage: async () => null,
     makeTmpDir: () => "/tmp/recap-diff-fail",
+    prepareClaudeTrust: async () => {},
     cleanup: (d) => cleaned.push(d),
   });
 
@@ -1887,6 +2001,7 @@ test("regenerate: headSha rejection → 'error', no throw", async () => {
     readVerdict: (): VerdictRead<unknown> => ({ status: "absent" }),
     readUsage: async () => null,
     makeTmpDir: () => "/tmp/recap-head-fail",
+    prepareClaudeTrust: async () => {},
     cleanup: () => {},
   });
 
@@ -1920,6 +2035,7 @@ test("considerSession: headSha failure leaves fired=false so next sweep retries"
     readVerdict: (): VerdictRead<unknown> => ({ status: "absent" }),
     readUsage: async () => null,
     makeTmpDir: () => "/tmp/recap-retry",
+    prepareClaudeTrust: async () => {},
     cleanup: () => {},
   });
 


### PR DESCRIPTION
## Problem

Claude recap generation runs from a new `/tmp/shepherd-recap-*` directory for every recap. On installations where Claude Code asks users to trust a fresh folder, the unattended recap process can stop at the “Do you trust the files in this folder?” prompt and remain there until Shepherd times out.

This is specific to the Claude recap path. Codex recaps use a different launch path, and some Claude installations or versions do not reproduce the prompt consistently, so changing the recap provider or model is not a reliable explanation or fix.

## Solution

- Trust the fresh recap directory immediately before launching a Claude recap.
- Write the trust entry to the same Claude configuration directory selected for the actual spawn.
- Keep Codex recap behavior unchanged.
- Continue launching with a bounded warning if trust preparation fails, preserving behavior on installations where Claude already skips the dialog.

The result is that unattended Claude recaps no longer depend on an interactive folder-trust response.

## Technical details

- Reuses `claudeConfigPath`, `readRepoRootTrusted`, and `trustRepoRoot` instead of introducing another trust-file format.
- Resolves `apiKeyPassthroughEnv(false)` once and uses its `CLAUDE_CONFIG_DIR` for both trust preparation and `herdr.start()`.
- Falls back to `config.claudeDir` in subscription mode.
- Injects the preparation callback through `RecapServiceDeps` so ordering, provider gating, and failure handling remain deterministic in tests.
- Preserves the current `main` behavior that records the `herdr.start()` terminal handle for reliable recap teardown.
- Leaves other Claude spawn paths, UI messaging, trust-entry cleanup, and trust-file schema changes out of scope.

## Validation

- Added callback tests for pre-spawn ordering, Codex gating, API-key config selection, and best-effort warning behavior.
- Added a filesystem-backed test using a temporary `.claude.json`; it verifies the exact selected config path, preserves existing fields, and writes `projects[cwd].hasTrustDialogAccepted = true`.
- Verified the filesystem regression test fails when the pre-seed call is disabled and passes when restored.
- `bun test test/claude-trust.test.ts test/recap.test.ts` — 85 tests, 296 assertions, 0 failures after rebasing onto current `main`.
- `bun run lint` — passed.
- `bun test` — passed.
- `scripts/check-branch-hygiene.sh` — passed.

Fixes #1850
