### PR TITLE
ci: gate model-list mirror between server + ui types

### DIFF
--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -55,3 +55,5 @@ jobs:
         run: node scripts/check-glossary.mjs
       - name: Announcement versions (new entry ⇒ unreleased version)
         run: node scripts/check-announcement-versions.mjs
+      - name: Model-list mirror (src/types.ts ↔ ui/src/lib/types.ts)
+        run: node scripts/check-model-mirror.mjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ and failed pushes. Independent work runs in parallel (bounded by your core count
 lane teeing to its own `.test-logs/` file, with a per-lane wall-clock **timeout backstop**
 so a hung child can never wedge the push. The checks (per lane) are:
 
-- **gates:** branch-hygiene · feature-catalog · generated-docs · glossary · announcement-versions · herdr-types
+- **gates:** branch-hygiene · feature-catalog · generated-docs · glossary · announcement-versions · model-mirror · herdr-types
 - **prettier:** `prettier --check` over the push **delta** (see note)
 - **eslint:** root + extension eslint over the push **delta** (see note)
 - **tsc:** `bun run typecheck` (root `tsc --noEmit`)
@@ -139,6 +139,7 @@ bun run lint                 # eslint (root, covers ui/src too)
 bun run typecheck            # root tsc --noEmit (src + test)
 bun run format               # prettier --write across the repo
 bun test ./test              # core test suite
+bun run check:model-mirror   # model/effort lists identical in src/types.ts ↔ ui/src/lib/types.ts
 cd ui && bun run check       # svelte-check (ui types)
 cd ui && bun run check:i18n  # locale-catalog parity (en ↔ de)
 cd ui && bun run test        # ui test suite (vitest)

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "onboarding:test": "bun run ci/onboarding-harness/run.ts",
     "check:glossary": "node scripts/check-glossary.mjs",
     "check:announcement-versions": "node scripts/check-announcement-versions.mjs",
+    "check:model-mirror": "node scripts/check-model-mirror.mjs",
     "next-version": "node scripts/next-version.mjs",
     "gen:herdr-schema": "bun run scripts/gen-herdr-schema.ts",
     "gen:herdr-types": "bun run scripts/gen-herdr-types.ts",

--- a/scripts/check-model-mirror.d.mts
+++ b/scripts/check-model-mirror.d.mts
@@ -1,0 +1,47 @@
+// Types for the node-run model-mirror gate (scripts/check-model-mirror.mjs). The
+// gate stays plain .mjs so `node scripts/check-model-mirror.mjs` works as a CLI in
+// any context (the package script, the pre-push gates lane, PR hygiene); this
+// declaration only exists so its TypeScript importer — test/check-model-mirror.test.ts
+// — gets real types instead of `any`. Mirrors scripts/next-version.d.mts's role.
+
+/** Which side of the mirror a finding refers to. */
+export type MirrorSide = "server" | "ui";
+
+/** One constant's divergence. Empty arrays + false flags = that constant is fine. */
+export interface MirrorDelta {
+  /** The constant that diverged, e.g. "CLAUDE_MODELS". */
+  constant: string;
+  /** Sides whose array literal could not be parsed at all (fail-closed). */
+  missingIn: MirrorSide[];
+  /** Elements in src/types.ts but not ui/src/lib/types.ts. */
+  onlyInServer: string[];
+  /** Elements in ui/src/lib/types.ts but not src/types.ts. */
+  onlyInUi: string[];
+  /**
+   * Membership matches but the sequences differ — a reorder, or (degenerately) a
+   * differing number of duplicate entries. Only ever set when both `onlyIn*` are empty.
+   */
+  orderMismatch: boolean;
+}
+
+export interface MirrorResult {
+  /** True when `deltas` is empty — the two files agree on every constant. */
+  ok: boolean;
+  deltas: MirrorDelta[];
+}
+
+/** Constants declared in both files that must stay element- and order-identical. */
+export const MIRRORED_CONSTANTS: string[];
+
+/**
+ * String elements of `const <constName> = [ … ]`, or null when the literal cannot
+ * be parsed (absent, unterminated, or holding no string elements).
+ */
+export function extractArrayLiteral(source: string, constName: string): string[] | null;
+
+/** Compare every mirrored constant across the two sources, as structured deltas. */
+export function compareMirror(
+  serverSource: string,
+  uiSource: string,
+  constants?: string[],
+): MirrorResult;

--- a/scripts/check-model-mirror.mjs
+++ b/scripts/check-model-mirror.mjs
@@ -198,8 +198,12 @@ export function compareMirror(serverSource, uiSource, constants = MIRRORED_CONST
     const onlyInServer = server.filter((v) => !ui.includes(v));
     const onlyInUi = ui.filter((v) => !server.includes(v));
     // Only meaningful once membership matches: same elements, different sequence.
+    // The separator is written as the ESCAPE "\0", never a literal NUL byte — an
+    // embedded NUL makes this file binary to grep/ripgrep/file(1) (matching lines
+    // are suppressed) and invisible in review. NUL is the separator because it
+    // cannot occur in a model alias, so no pair of distinct lists can join equal.
     const orderMismatch =
-      onlyInServer.length === 0 && onlyInUi.length === 0 && server.join(" ") !== ui.join(" ");
+      onlyInServer.length === 0 && onlyInUi.length === 0 && server.join("\0") !== ui.join("\0");
 
     if (onlyInServer.length || onlyInUi.length || orderMismatch) {
       deltas.push({ constant, missingIn: [], onlyInServer, onlyInUi, orderMismatch });
@@ -247,7 +251,13 @@ function formatDelta(delta) {
   return lines;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// `fileURLToPath` rather than string-concatenating `file://` + argv[1]: import.meta.url
+// is PERCENT-ENCODED, so on any checkout path containing a space, `#`, `%` or non-ASCII
+// the concat comparison is false, the CLI block never runs, and the gate exits 0 having
+// checked nothing — the exact vacuous pass this script exists to prevent. Same idiom as
+// scripts/json-union-merge.mjs. (scripts/next-version.mjs still uses the concat form.)
+const isMain = Boolean(process.argv[1]) && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) {
   const serverSource = readFileSync(join(ROOT, SERVER_REL), "utf8");
   const uiSource = readFileSync(join(ROOT, UI_REL), "utf8");
   const { ok, deltas } = compareMirror(serverSource, uiSource);

--- a/scripts/check-model-mirror.mjs
+++ b/scripts/check-model-mirror.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+// Model-list mirror gate (#1936): the model/effort alias lists declared in BOTH
+// `src/types.ts` and `ui/src/lib/types.ts` must stay element- AND order-identical.
+//
+// THE HAZARD this closes: `CLAUDE_MODELS`, `CODEX_MODELS` and `EFFORTS` are each
+// declared twice — once server-side (validateCreate validation, the default-model
+// setting space, per-role/per-repo overrides) and once, hand-copied, in the UI
+// (pickers). Nothing enforced that the two stay identical, and a one-sided edit is
+// silent in BOTH directions, asymmetrically:
+//   • UI-only add    → the picker offers a value the server rejects with
+//                      `unknown model` at task-create time.
+//   • server-only add → the API accepts the value but no picker can reach it.
+//
+// WHY TEXTUAL rather than importing both halves into one test: all three wiring
+// points (the `check:model-mirror` package script, the pre-push `gates` lane, the
+// PR-hygiene workflow) invoke a gate as a bare command, which a `bun test`
+// assertion cannot fill; and importing `ui/src/lib/types.ts` from `test/` would
+// pull the whole UI type surface into the server `tsc` program, type-checked
+// against the server tsconfig instead of the `svelte-check` config that owns it.
+// (Note for the record: the root tsconfig's `exclude: ["ui", …]` is NOT the
+// reason — `exclude` only filters the root file set, and an import still pulls a
+// file in.)
+//
+// ORDER-SENSITIVE, not set-equality: on the UI side the literal order IS the order
+// the model dropdown renders, so a one-sided reorder is drift worth failing on.
+//
+// The parser is deliberately conservative — see `extractArrayLiteral` for the two
+// traps (prose naming the constant next to its declaration; a missing `as const`)
+// that a looser implementation falls into. It fails CLOSED: a literal that cannot
+// be parsed on EITHER side is an error, never a skipped comparison.
+//
+// Plain ESM — no dependencies, no transpile. Mirrors the shape and style of
+// scripts/check-glossary.mjs. Importable (extractArrayLiteral / compareMirror /
+// MIRRORED_CONSTANTS) by test/check-model-mirror.test.ts.
+
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Resolved from this file, never process.cwd(), so the CLI works from any directory.
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SERVER_REL = "src/types.ts";
+const UI_REL = "ui/src/lib/types.ts";
+
+/**
+ * The constants declared in both files that must stay identical.
+ *
+ * | Constant        | src/types.ts           | ui/src/lib/types.ts    |
+ * | --------------- | ---------------------- | ---------------------- |
+ * | `CLAUDE_MODELS` | `const` (non-exported) | `const` (non-exported) |
+ * | `CODEX_MODELS`  | `export const`         | `export const`         |
+ * | `EFFORTS`       | `export const`         | `export const`         |
+ *
+ * `MODELS_BY_PROVIDER` needs no entry — it is DERIVED from the two model arrays in
+ * both files, so gating the arrays covers it transitively. `PREMIUM_MODELS` is
+ * UI-only (no server counterpart), so it is not a mirror at all.
+ */
+export const MIRRORED_CONSTANTS = ["CLAUDE_MODELS", "CODEX_MODELS", "EFFORTS"];
+
+/**
+ * Walk a `[ … ]` literal from its opening bracket, returning the body with
+ * comments stripped, or null if it is never closed.
+ *
+ * The scan is string- and comment-aware because the real data demands it:
+ *   • elements CONTAIN `]` — "opus[1m]", "claude-opus-5[1m]", "sonnet[1m]" — so a
+ *     naive "up to the first `]`" scan truncates the Claude list mid-way;
+ *   • an apostrophe in a comment ("// don't …") would otherwise open a bogus
+ *     string state and swallow the rest of the file.
+ * Bracket depth is tracked so a nested array can't terminate the scan early.
+ */
+function scanArrayBody(source, openIndex) {
+  let depth = 0;
+  let quote = null;
+  let comment = null; // "line" | "block"
+  let body = "";
+
+  for (let i = openIndex; i < source.length; i += 1) {
+    const ch = source[i];
+
+    if (comment === "line") {
+      if (ch === "\n") comment = null;
+      continue;
+    }
+    if (comment === "block") {
+      if (ch === "*" && source[i + 1] === "/") {
+        comment = null;
+        i += 1;
+      }
+      continue;
+    }
+    if (quote) {
+      body += ch;
+      if (ch === "\\") {
+        // Escaped char is consumed verbatim so a trailing \" can't end the string.
+        body += source[i + 1] ?? "";
+        i += 1;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (ch === "/" && source[i + 1] === "/") {
+      comment = "line";
+      i += 1;
+      continue;
+    }
+    if (ch === "/" && source[i + 1] === "*") {
+      comment = "block";
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      quote = ch;
+      body += ch;
+      continue;
+    }
+    if (ch === "[") {
+      depth += 1;
+      if (depth > 1) body += ch;
+      continue;
+    }
+    if (ch === "]") {
+      depth -= 1;
+      if (depth === 0) return body;
+      body += ch;
+      continue;
+    }
+    body += ch;
+  }
+
+  return null; // unterminated — caller treats it as unparseable
+}
+
+/**
+ * Extract the string elements of `const <constName> = [ … ]` from a TS source, or
+ * null when the literal cannot be parsed. Two traps this deliberately avoids:
+ *
+ *  1. The opening anchor REQUIRES the `const` keyword rather than the loose
+ *     `<NAME>[^=]*=` idiom used elsewhere in scripts/, because these constant
+ *     names appear in PROSE right next to their declarations — the doc comment
+ *     above `ui/src/lib/types.ts`'s CLAUDE_MODELS reads "Mirrors src/types.ts
+ *     CLAUDE_MODELS", and src/types.ts's CODEX_MODEL_RE comment names
+ *     CODEX_MODELS just below that array. A loose anchor happens to still land on
+ *     the real declaration today, which is exactly what makes it a latent trap:
+ *     one comment reword from matching prose and extracting the wrong span.
+ *  2. The close is found by `scanArrayBody`, NOT by anchoring on `] as const`.
+ *     `as const` is incidental syntax, and an `as const`-anchored scan runs PAST
+ *     any array written without it — a shape already present in the same file
+ *     (`export const PREMIUM_MODELS: readonly string[] = [ … ];`) — all the way to
+ *     the next `] as const`. In src/types.ts that is EFFORTS', so a CLAUDE_MODELS
+ *     over-match would silently absorb the five effort tiers.
+ *
+ * An empty element list is reported as unparseable: none of the gated lists is
+ * ever legitimately empty, so zero elements means the shape changed (identifiers
+ * or an enum instead of string literals) and comparing two empty lists as "equal"
+ * would be a vacuous pass.
+ */
+export function extractArrayLiteral(source, constName) {
+  // Optional `export`, required `const`, optional type annotation (`: readonly
+  // string[]`), then `= [`. \b rejects a longer name with the same prefix.
+  const anchor = new RegExp(`(?:export\\s+)?const\\s+${constName}\\b\\s*(?::[^=]*)?=\\s*\\[`);
+  const match = anchor.exec(source);
+  if (!match) return null;
+
+  const body = scanArrayBody(source, match.index + match[0].length - 1);
+  if (body === null) return null;
+
+  const elements = [];
+  const elementRe = /"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'/g;
+  let el;
+  while ((el = elementRe.exec(body)) !== null) elements.push(el[1] ?? el[2]);
+
+  return elements.length ? elements : null;
+}
+
+/**
+ * Compare every mirrored constant across the two sources. Returns STRUCTURED
+ * deltas — prose formatting lives only in the CLI below, so tests assert on data
+ * rather than substring-matching a message that is free to be reworded.
+ */
+export function compareMirror(serverSource, uiSource, constants = MIRRORED_CONSTANTS) {
+  const deltas = [];
+
+  for (const constant of constants) {
+    const server = extractArrayLiteral(serverSource, constant);
+    const ui = extractArrayLiteral(uiSource, constant);
+
+    // Fail CLOSED on EITHER side — a one-sided rename/reshape is the likeliest
+    // real drift, and two absent literals must never compare as equal empties.
+    const missingIn = [];
+    if (!server) missingIn.push("server");
+    if (!ui) missingIn.push("ui");
+    if (missingIn.length) {
+      deltas.push({ constant, missingIn, onlyInServer: [], onlyInUi: [], orderMismatch: false });
+      continue;
+    }
+
+    const onlyInServer = server.filter((v) => !ui.includes(v));
+    const onlyInUi = ui.filter((v) => !server.includes(v));
+    // Only meaningful once membership matches: same elements, different sequence.
+    const orderMismatch =
+      onlyInServer.length === 0 && onlyInUi.length === 0 && server.join(" ") !== ui.join(" ");
+
+    if (onlyInServer.length || onlyInUi.length || orderMismatch) {
+      deltas.push({ constant, missingIn: [], onlyInServer, onlyInUi, orderMismatch });
+    }
+  }
+
+  return { ok: deltas.length === 0, deltas };
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+
+/** Human-readable lines for one delta. Wording is intentionally untested. */
+function formatDelta(delta) {
+  const lines = [];
+  if (delta.missingIn.length) {
+    const where = delta.missingIn
+      .map((side) => (side === "server" ? SERVER_REL : UI_REL))
+      .join(" and ");
+    lines.push(
+      `  ${delta.constant}: could not parse the array literal in ${where}` +
+        ` — expected \`const ${delta.constant} = [ "…", … ]\` with string elements.`,
+    );
+    return lines;
+  }
+  if (delta.onlyInServer.length) {
+    lines.push(
+      `  ${delta.constant}: ${delta.onlyInServer.map((v) => `"${v}"`).join(", ")}` +
+        ` present in ${SERVER_REL} but MISSING from ${UI_REL}` +
+        ` — the API accepts these but no picker can reach them.`,
+    );
+  }
+  if (delta.onlyInUi.length) {
+    lines.push(
+      `  ${delta.constant}: ${delta.onlyInUi.map((v) => `"${v}"`).join(", ")}` +
+        ` present in ${UI_REL} but MISSING from ${SERVER_REL}` +
+        ` — the picker offers these but task-create rejects them as unknown.`,
+    );
+  }
+  if (delta.orderMismatch) {
+    lines.push(
+      `  ${delta.constant}: same elements, DIFFERENT ORDER between ${SERVER_REL}` +
+        ` and ${UI_REL} — the UI order is the order the picker renders, so keep both identical.`,
+    );
+  }
+  return lines;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const serverSource = readFileSync(join(ROOT, SERVER_REL), "utf8");
+  const uiSource = readFileSync(join(ROOT, UI_REL), "utf8");
+  const { ok, deltas } = compareMirror(serverSource, uiSource);
+
+  if (!ok) {
+    console.error(
+      `model mirror: ${SERVER_REL} and ${UI_REL} have diverged:\n` +
+        `${deltas.flatMap(formatDelta).join("\n")}\n\n` +
+        `Fix: edit BOTH files so each list has the same elements in the same order.`,
+    );
+    process.exit(1);
+  }
+
+  const counts = MIRRORED_CONSTANTS.map(
+    (c) => `${c} (${extractArrayLiteral(serverSource, c).length})`,
+  ).join(", ");
+  console.log(`✓ model mirror: ${SERVER_REL} ↔ ${UI_REL} identical — ${counts}`);
+}

--- a/scripts/check-model-mirror.mjs
+++ b/scripts/check-model-mirror.mjs
@@ -33,7 +33,7 @@
 // scripts/check-glossary.mjs. Importable (extractArrayLiteral / compareMirror /
 // MIRRORED_CONSTANTS) by test/check-model-mirror.test.ts.
 
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -251,13 +251,34 @@ function formatDelta(delta) {
   return lines;
 }
 
-// `fileURLToPath` rather than string-concatenating `file://` + argv[1]: import.meta.url
-// is PERCENT-ENCODED, so on any checkout path containing a space, `#`, `%` or non-ASCII
-// the concat comparison is false, the CLI block never runs, and the gate exits 0 having
-// checked nothing — the exact vacuous pass this script exists to prevent. Same idiom as
-// scripts/json-union-merge.mjs. (scripts/next-version.mjs still uses the concat form.)
-const isMain = Boolean(process.argv[1]) && fileURLToPath(import.meta.url) === process.argv[1];
-if (isMain) {
+/**
+ * Is this module the process entry point (i.e. run as the CLI, not imported)?
+ *
+ * Both normalizations matter, and getting either wrong silently skips the CLI block —
+ * so `node scripts/check-model-mirror.mjs` exits 0 having compared NOTHING, the exact
+ * vacuous pass this gate exists to prevent. Verified empirically, both directions:
+ *   • `fileURLToPath`, not `` `file://${argv[1]}` `` — import.meta.url is PERCENT-ENCODED,
+ *     so a path holding a space / `#` / `%` / non-ASCII makes the concat compare false.
+ *   • `realpathSync(argv[1])` — Node realpath-resolves the ENTRY module behind
+ *     import.meta.url (`--preserve-symlinks-main` defaults off) but leaves argv[1] merely
+ *     `path.resolve`d, so any SYMLINKED path component makes a bare compare false. This
+ *     is not exotic: macOS `os.tmpdir()` is `/var/folders/…` → `/private/var/folders/…`.
+ * Both cases are covered by regression tests in test/check-model-mirror.test.ts.
+ * (scripts/next-version.mjs and scripts/json-union-merge.mjs still use unnormalized
+ * forms — pre-existing, and out of this change's scope.)
+ */
+function isMainModule() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return realpathSync(entry) === fileURLToPath(import.meta.url);
+  } catch {
+    // argv[1] isn't a resolvable path (eval/bundler harness) → not the CLI entry.
+    return false;
+  }
+}
+
+if (isMainModule()) {
   const serverSource = readFileSync(join(ROOT, SERVER_REL), "utf8");
   const uiSource = readFileSync(join(ROOT, UI_REL), "utf8");
   const { ok, deltas } = compareMirror(serverSource, uiSource);

--- a/scripts/pre-push.ts
+++ b/scripts/pre-push.ts
@@ -397,6 +397,12 @@ function buildLanes(
         args: ["scripts/check-announcement-versions.mjs"],
         cwd: repoRoot,
       },
+      {
+        label: "model mirror",
+        cmd: "node",
+        args: ["scripts/check-model-mirror.mjs"],
+        cwd: repoRoot,
+      },
       { label: "herdr types", cmd: "bun", args: ["run", "check:herdr-types"], cwd: repoRoot },
     ],
   });

--- a/test/check-model-mirror.test.ts
+++ b/test/check-model-mirror.test.ts
@@ -1,0 +1,191 @@
+import { test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  MIRRORED_CONSTANTS,
+  compareMirror,
+  extractArrayLiteral,
+} from "../scripts/check-model-mirror.mjs";
+
+// Resolved from this file, never process.cwd(), so the live-tree case below behaves
+// identically under `bun test ./test` and a single-file invocation.
+const ROOT = join(import.meta.dir, "..");
+
+/** A minimal `const NAME = [...] as const;` source, the shape both real files use. */
+function src(name: string, elements: string[]): string {
+  const body = elements.map((e) => `  "${e}",`).join("\n");
+  return `export const ${name} = [\n${body}\n] as const;\n`;
+}
+
+// ── extractArrayLiteral ──────────────────────────────────────────────────────
+
+test("parses a multi-line exported literal", () => {
+  expect(extractArrayLiteral(src("CODEX_MODELS", ["gpt-5", "o3"]), "CODEX_MODELS")).toEqual([
+    "gpt-5",
+    "o3",
+  ]);
+});
+
+test("parses a NON-exported const (the CLAUDE_MODELS shape)", () => {
+  const source = `const CLAUDE_MODELS = [\n  "opus",\n  "haiku",\n] as const;\n`;
+  expect(extractArrayLiteral(source, "CLAUDE_MODELS")).toEqual(["opus", "haiku"]);
+});
+
+test("parses a single-line literal (the EFFORTS shape)", () => {
+  const source = `export const EFFORTS = ["low", "medium", "high", "xhigh", "max"] as const;\n`;
+  expect(extractArrayLiteral(source, "EFFORTS")).toEqual(["low", "medium", "high", "xhigh", "max"]);
+});
+
+test("keeps an element containing `]` intact instead of truncating there", () => {
+  // A naive "up to the first ]" scan would stop inside "opus[1m]" and drop the rest.
+  const elements = ["fable", "opus", "opus[1m]", "claude-opus-5[1m]", "sonnet[1m]", "haiku"];
+  expect(extractArrayLiteral(src("CLAUDE_MODELS", elements), "CLAUDE_MODELS")).toEqual(elements);
+});
+
+test("does NOT run past an array that lacks `as const` into the next literal", () => {
+  // The PREMIUM_MODELS shape (plain `];`) already exists in ui/src/lib/types.ts. An
+  // `] as const`-anchored scan would swallow the following array's elements — which
+  // in src/types.ts would mean CLAUDE_MODELS absorbing the effort tiers.
+  const source =
+    `export const CLAUDE_MODELS: readonly string[] = [\n  "opus",\n  "haiku",\n];\n\n` +
+    `export const EFFORTS = ["low", "medium", "high"] as const;\n`;
+  expect(extractArrayLiteral(source, "CLAUDE_MODELS")).toEqual(["opus", "haiku"]);
+  expect(extractArrayLiteral(source, "EFFORTS")).toEqual(["low", "medium", "high"]);
+});
+
+test("ignores a doc comment naming the constant ABOVE the declaration", () => {
+  // ui/src/lib/types.ts's real shape: the comment above CLAUDE_MODELS names it, and
+  // carries a decoy bracketed list plus an `=` and an apostrophe.
+  const source =
+    `/** Selectable aliases. Mirrors src/types.ts CLAUDE_MODELS — don't diverge;\n` +
+    ` *  ["decoy", "values"] here must be ignored. "default" = no flag. */\n` +
+    `const CLAUDE_MODELS = [\n  "opus",\n  "haiku",\n] as const;\n`;
+  expect(extractArrayLiteral(source, "CLAUDE_MODELS")).toEqual(["opus", "haiku"]);
+});
+
+test("ignores a comment naming the constant BELOW the declaration", () => {
+  // src/types.ts's real shape: the CODEX_MODEL_RE comment names CODEX_MODELS after it.
+  const source =
+    `export const CODEX_MODELS = [\n  "gpt-5",\n  "o3",\n] as const;\n\n` +
+    `/** …the installed CLI may learn names before the curated CODEX_MODELS list does. */\n` +
+    `export const CODEX_MODEL_RE = /^[A-Za-z0-9]$/;\n`;
+  expect(extractArrayLiteral(source, "CODEX_MODELS")).toEqual(["gpt-5", "o3"]);
+});
+
+test("ignores quoted strings and brackets inside a comment in the array body", () => {
+  const source =
+    `export const EFFORTS = [\n` +
+    `  "low",\n` +
+    `  // "ghost" and ["more", "ghosts"] — don't pick these up\n` +
+    `  /* "block-ghost" */\n` +
+    `  "high",\n` +
+    `] as const;\n`;
+  expect(extractArrayLiteral(source, "EFFORTS")).toEqual(["low", "high"]);
+});
+
+test("does not match a longer constant sharing the prefix", () => {
+  const source = `export const CLAUDE_MODELS_LEGACY = ["opus"] as const;\n`;
+  expect(extractArrayLiteral(source, "CLAUDE_MODELS")).toBeNull();
+});
+
+test("returns null for an absent, unterminated, or element-less literal", () => {
+  expect(extractArrayLiteral(`export const OTHER = ["x"] as const;\n`, "EFFORTS")).toBeNull();
+  expect(extractArrayLiteral(`export const EFFORTS = [\n  "low",\n`, "EFFORTS")).toBeNull();
+  expect(extractArrayLiteral(`export const EFFORTS = [] as const;\n`, "EFFORTS")).toBeNull();
+  // Shape changed to identifiers instead of string literals → unparseable, not empty.
+  expect(
+    extractArrayLiteral(`export const EFFORTS = [LOW, HIGH] as const;\n`, "EFFORTS"),
+  ).toBeNull();
+});
+
+// ── compareMirror ────────────────────────────────────────────────────────────
+
+/** Both sides of a synthetic mirror, so each case varies only what it tests. */
+function pair(server: string[], ui: string[] = server): [string, string] {
+  return [src("CLAUDE_MODELS", server), src("CLAUDE_MODELS", ui)];
+}
+
+const ONLY_CLAUDE = ["CLAUDE_MODELS"];
+
+test("identical lists → ok with no deltas", () => {
+  const [s, u] = pair(["opus", "haiku"]);
+  expect(compareMirror(s, u, ONLY_CLAUDE)).toEqual({ ok: true, deltas: [] });
+});
+
+test("element added to the UI side only → onlyInUi names it", () => {
+  const [s, u] = pair(["opus", "haiku"], ["opus", "claude-opus-5", "haiku"]);
+  const { ok, deltas } = compareMirror(s, u, ONLY_CLAUDE);
+  expect(ok).toBe(false);
+  expect(deltas).toHaveLength(1);
+  expect(deltas[0]!.constant).toBe("CLAUDE_MODELS");
+  expect(deltas[0]!.onlyInUi).toEqual(["claude-opus-5"]);
+  expect(deltas[0]!.onlyInServer).toEqual([]);
+  expect(deltas[0]!.orderMismatch).toBe(false);
+  expect(deltas[0]!.missingIn).toEqual([]);
+});
+
+test("element added to the server side only → onlyInServer names it", () => {
+  const [s, u] = pair(["opus", "claude-opus-5", "haiku"], ["opus", "haiku"]);
+  const { ok, deltas } = compareMirror(s, u, ONLY_CLAUDE);
+  expect(ok).toBe(false);
+  expect(deltas[0]!.onlyInServer).toEqual(["claude-opus-5"]);
+  expect(deltas[0]!.onlyInUi).toEqual([]);
+});
+
+test("same elements, reordered → orderMismatch with both sides clean", () => {
+  const [s, u] = pair(["opus", "haiku"], ["haiku", "opus"]);
+  const { ok, deltas } = compareMirror(s, u, ONLY_CLAUDE);
+  expect(ok).toBe(false);
+  expect(deltas[0]!.orderMismatch).toBe(true);
+  expect(deltas[0]!.onlyInServer).toEqual([]);
+  expect(deltas[0]!.onlyInUi).toEqual([]);
+});
+
+test("literal unparseable on ONE side → missingIn names that side, not a skip", () => {
+  const [s] = pair(["opus", "haiku"]);
+  const renamedUi = src("CLAUDE_MODEL_ALIASES", ["opus", "haiku"]);
+
+  const ui = compareMirror(s, renamedUi, ONLY_CLAUDE);
+  expect(ui.ok).toBe(false);
+  expect(ui.deltas[0]!.missingIn).toEqual(["ui"]);
+
+  const server = compareMirror(renamedUi, s, ONLY_CLAUDE);
+  expect(server.ok).toBe(false);
+  expect(server.deltas[0]!.missingIn).toEqual(["server"]);
+});
+
+test("literal absent on BOTH sides → fails closed, never a vacuous match", () => {
+  const empty = `export const SOMETHING_ELSE = ["x"] as const;\n`;
+  const { ok, deltas } = compareMirror(empty, empty, ONLY_CLAUDE);
+  expect(ok).toBe(false);
+  expect(deltas[0]!.missingIn).toEqual(["server", "ui"]);
+});
+
+test("reports every diverged constant, not just the first", () => {
+  const server = `${src("CLAUDE_MODELS", ["opus"])}\n${src("EFFORTS", ["low", "high"])}`;
+  const ui = `${src("CLAUDE_MODELS", ["opus", "haiku"])}\n${src("EFFORTS", ["high", "low"])}`;
+  const { deltas } = compareMirror(server, ui, ["CLAUDE_MODELS", "EFFORTS"]);
+  expect(deltas.map((d) => d.constant)).toEqual(["CLAUDE_MODELS", "EFFORTS"]);
+  expect(deltas[0]!.onlyInUi).toEqual(["haiku"]);
+  expect(deltas[1]!.orderMismatch).toBe(true);
+});
+
+// ── the live tree ────────────────────────────────────────────────────────────
+
+test("the real src/types.ts and ui/src/lib/types.ts are in sync", () => {
+  const server = readFileSync(join(ROOT, "src", "types.ts"), "utf8");
+  const ui = readFileSync(join(ROOT, "ui", "src", "lib", "types.ts"), "utf8");
+  expect(compareMirror(server, ui)).toEqual({ ok: true, deltas: [] });
+});
+
+test("every mirrored constant actually parses out of both real files", () => {
+  // Guards against the parser silently under-matching after a future reformat —
+  // without this, `compareMirror` above could pass on two nulls it never saw.
+  const server = readFileSync(join(ROOT, "src", "types.ts"), "utf8");
+  const ui = readFileSync(join(ROOT, "ui", "src", "lib", "types.ts"), "utf8");
+  expect(MIRRORED_CONSTANTS).toEqual(["CLAUDE_MODELS", "CODEX_MODELS", "EFFORTS"]);
+  for (const constant of MIRRORED_CONSTANTS) {
+    expect(extractArrayLiteral(server, constant)?.length).toBeGreaterThan(0);
+    expect(extractArrayLiteral(ui, constant)?.length).toBeGreaterThan(0);
+  }
+});

--- a/test/check-model-mirror.test.ts
+++ b/test/check-model-mirror.test.ts
@@ -1,6 +1,15 @@
 import { test, expect } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -173,33 +182,65 @@ test("reports every diverged constant, not just the first", () => {
 });
 
 // ── the CLI entry point ──────────────────────────────────────────────────────
+//
+// Both cases below exercise the main guard, whose two failure modes are
+// indistinguishable from success by exit code alone: if the guard is wrong the CLI
+// block never runs and the process exits 0 having compared NOTHING. So each case
+// plants DIVERGENT halves and asserts exit 1 — only a CLI that genuinely ran can
+// produce that. `realpathSync(mkdtempSync(...))` keeps the temp root free of symlink
+// components so each case isolates the one thing it names (macOS `os.tmpdir()` is
+// `/var/folders/…` → `/private/var/folders/…`, which would otherwise make the
+// spaced-path case fail for the *symlink* reason and read as the wrong bug).
 
-test("the CLI actually runs (and fails) from a checkout path containing a space", () => {
-  // REGRESSION GUARD. A `import.meta.url === `file://${process.argv[1]}`` main-guard
-  // compares a PERCENT-ENCODED url against a raw path, so on a checkout whose path
-  // holds a space (or #, %, non-ASCII) the CLI block never ran: the gate exited 0
-  // having compared nothing — the exact vacuous pass this script exists to prevent.
-  // Exit 1 here proves the block ran, since "never ran" also exits 0.
-  const dir = mkdtempSync(join(tmpdir(), "shepherd model mirror "));
+/** Build a throwaway checkout at `dir` with a copy of the gate + divergent halves. */
+function fakeCheckout(dir: string): string {
+  for (const d of ["scripts", "src", join("ui", "src", "lib")]) {
+    mkdirSync(join(dir, d), { recursive: true });
+  }
+  const script = join(dir, "scripts", "check-model-mirror.mjs");
+  copyFileSync(join(ROOT, "scripts", "check-model-mirror.mjs"), script);
+  const halves = (claude: string[]) =>
+    src("CLAUDE_MODELS", claude) + src("CODEX_MODELS", ["gpt-5"]) + src("EFFORTS", ["low"]);
+  writeFileSync(join(dir, "src", "types.ts"), halves(["opus"]));
+  writeFileSync(join(dir, "ui", "src", "lib", "types.ts"), halves(["opus", "haiku"]));
+  return script;
+}
+
+/** Run the copied gate and assert it really executed and reported the divergence. */
+function expectGateFailed(script: string) {
+  const r = spawnSync("node", [script], { encoding: "utf8" });
+  expect(r.status).toBe(1); // 0 would mean the CLI block never ran
+  expect(`${r.stdout}${r.stderr}`).toContain("haiku");
+}
+
+test("the CLI runs (and fails) from a checkout path containing a space", () => {
+  // Guards the percent-encoding trap: import.meta.url encodes the space as %20, so a
+  // `file://` + argv[1] concat comparison is false and the CLI is skipped.
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "shepherd model mirror ")));
   expect(dir).toContain(" "); // the whole point of the case
   try {
-    for (const d of ["scripts", "src", join("ui", "src", "lib")]) {
-      mkdirSync(join(dir, d), { recursive: true });
-    }
-    const script = join(dir, "scripts", "check-model-mirror.mjs");
-    copyFileSync(join(ROOT, "scripts", "check-model-mirror.mjs"), script);
-
-    // Divergent halves, so a CLI that genuinely runs must exit 1.
-    const halves = (claude: string[]) =>
-      src("CLAUDE_MODELS", claude) + src("CODEX_MODELS", ["gpt-5"]) + src("EFFORTS", ["low"]);
-    writeFileSync(join(dir, "src", "types.ts"), halves(["opus"]));
-    writeFileSync(join(dir, "ui", "src", "lib", "types.ts"), halves(["opus", "haiku"]));
-
-    const r = spawnSync("node", [script], { encoding: "utf8" });
-    expect(r.status).toBe(1);
-    expect(`${r.stdout}${r.stderr}`).toContain("haiku");
+    expectGateFailed(fakeCheckout(dir));
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("the CLI runs (and fails) when reached through a SYMLINKED path component", () => {
+  // Guards the realpath trap: Node realpath-resolves the entry module behind
+  // import.meta.url but leaves argv[1] merely path.resolve'd, so without
+  // realpathSync(argv[1]) the comparison is false and the CLI is skipped.
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "shepherd-mm-symlink-")));
+  try {
+    const real = join(root, "real");
+    mkdirSync(real, { recursive: true });
+    const script = fakeCheckout(real);
+    const link = join(root, "link");
+    symlinkSync(real, link);
+    // Same file, reached via the symlink — argv[1] keeps "link", import.meta.url "real".
+    expect(realpathSync(join(link, "scripts", "check-model-mirror.mjs"))).toBe(script);
+    expectGateFailed(join(link, "scripts", "check-model-mirror.mjs"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
   }
 });
 

--- a/test/check-model-mirror.test.ts
+++ b/test/check-model-mirror.test.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "bun:test";
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   MIRRORED_CONSTANTS,
@@ -168,6 +170,37 @@ test("reports every diverged constant, not just the first", () => {
   expect(deltas.map((d) => d.constant)).toEqual(["CLAUDE_MODELS", "EFFORTS"]);
   expect(deltas[0]!.onlyInUi).toEqual(["haiku"]);
   expect(deltas[1]!.orderMismatch).toBe(true);
+});
+
+// ── the CLI entry point ──────────────────────────────────────────────────────
+
+test("the CLI actually runs (and fails) from a checkout path containing a space", () => {
+  // REGRESSION GUARD. A `import.meta.url === `file://${process.argv[1]}`` main-guard
+  // compares a PERCENT-ENCODED url against a raw path, so on a checkout whose path
+  // holds a space (or #, %, non-ASCII) the CLI block never ran: the gate exited 0
+  // having compared nothing — the exact vacuous pass this script exists to prevent.
+  // Exit 1 here proves the block ran, since "never ran" also exits 0.
+  const dir = mkdtempSync(join(tmpdir(), "shepherd model mirror "));
+  expect(dir).toContain(" "); // the whole point of the case
+  try {
+    for (const d of ["scripts", "src", join("ui", "src", "lib")]) {
+      mkdirSync(join(dir, d), { recursive: true });
+    }
+    const script = join(dir, "scripts", "check-model-mirror.mjs");
+    copyFileSync(join(ROOT, "scripts", "check-model-mirror.mjs"), script);
+
+    // Divergent halves, so a CLI that genuinely runs must exit 1.
+    const halves = (claude: string[]) =>
+      src("CLAUDE_MODELS", claude) + src("CODEX_MODELS", ["gpt-5"]) + src("EFFORTS", ["low"]);
+    writeFileSync(join(dir, "src", "types.ts"), halves(["opus"]));
+    writeFileSync(join(dir, "ui", "src", "lib", "types.ts"), halves(["opus", "haiku"]));
+
+    const r = spawnSync("node", [script], { encoding: "utf8" });
+    expect(r.status).toBe(1);
+    expect(`${r.stdout}${r.stderr}`).toContain("haiku");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 // ── the live tree ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #1936.

## The hazard

`CLAUDE_MODELS`, `CODEX_MODELS` and `EFFORTS` are each declared **twice** — in `src/types.ts` (validation, the default-model setting space, per-role/per-repo overrides) and hand-copied into `ui/src/lib/types.ts` (pickers). Nothing enforced that the two stay identical, and a one-sided edit was silent in both directions, asymmetrically:

- **UI-only add** → the picker offers a value `validateCreate` rejects with `unknown model` at task-create time.
- **Server-only add** → the API accepts the value but no picker can reach it.

Pre-existing hazard, not introduced by any particular change. Split out of #1937 on operator decision.

## What this adds

`scripts/check-model-mirror.mjs` compares the three literals textually — **element and order** — and is wired in exactly like every sibling hygiene gate: a `check:model-mirror` package script, a step in `scripts/pre-push.ts`'s `gates` lane, and a step in `.github/workflows/pr-hygiene.yml`.

**No list contents change.** `src/types.ts` and `ui/src/lib/types.ts` are byte-identical to `main`; this is pure hygiene infrastructure landing on an already-in-sync tree.

### Two parser decisions worth reviewing

Both are traps a looser implementation falls into, and both are covered by tests:

1. **The close is a string-aware forward scan, not a `] as const` anchor.** Elements contain `]` (`"opus[1m]"`, `"claude-opus-5[1m]"`, `"sonnet[1m]"`), so a "first `]`" scan truncates the Claude list. But anchoring on `as const` is worse: it is incidental syntax, so the scan runs past any array written without it — a shape already present in the same file (`export const PREMIUM_MODELS: readonly string[] = [ … ];`). In `src/types.ts` the next `] as const` after `CLAUDE_MODELS` is `EFFORTS`', so that over-match would have silently absorbed the five effort tiers into the model list.
2. **The opening anchor requires the `const` keyword** rather than the loose `<NAME>[^=]*=` idiom used elsewhere in `scripts/`, because these names appear in **prose right next to their declarations** — `ui/src/lib/types.ts`'s doc comment above `CLAUDE_MODELS` says "Mirrors src/types.ts CLAUDE_MODELS", and `src/types.ts`'s `CODEX_MODEL_RE` comment names `CODEX_MODELS` just below that array. A loose anchor happens to still land correctly today, which is what makes it a latent trap: one comment reword from extracting the wrong span.

It **fails closed** — a literal unparseable on *either* side (rename, reshape, no string elements) is an error, never a skipped comparison, so two absent literals can't compare as equal empties.

`compareMirror` returns structured deltas (`{ constant, missingIn, onlyInServer, onlyInUi, orderMismatch }`); prose lives only in the CLI shell, so tests assert on data rather than substring-matching a message that is free to be reworded.

### Why textual rather than importing both halves into one test

For the record, since a plausible-sounding wrong reason exists: it is **not** because the root `tsconfig.json` excludes `ui` — `exclude` only filters the root file set, an import still pulls a file in, and Bun's test runner ignores it entirely. `ui/src/lib/types.ts` has zero imports, so `expect(UI).toEqual(SERVER)` genuinely would work. Rejected because (a) all three wiring points invoke a gate as a bare command, which a `bun test` assertion can't fill, and (b) it would pull 2246 lines of UI types into the server `tsc` program, checked against the server tsconfig instead of the `svelte-check` config that owns them.

## Verification

- `bun run check:model-mirror` passes on this tree — `CLAUDE_MODELS (8), CODEX_MODELS (11), EFFORTS (5)`.
- Injected one-sided drift fails correctly, naming **both** paths: a UI-only add, a UI-only reorder, and a UI-side rename (fail-closed) each exit 1 with a distinct message. Edits reverted; both types files verified byte-identical to `main`.
- `test/check-model-mirror.test.ts` — 19 tests, incl. the bracketed-element, no-`as const`, adjacent-doc-comment (above *and* below), one-sided `missingIn`, and absent-on-both cases, plus a live-tree assertion over the real files.
- Full `pre-push` suite green (7/7 lanes, fallow clean), with `model mirror` confirmed executing in the `gates` lane log.

## Deliberately out of scope

Surveyed, not assumed — every other place a model/effort alias is written by hand:

- **Duplicated `EFFORTS` *logic*** — `src/default-effort.ts` `effortsForProvider` ↔ `ui/src/lib/effort-guidance.ts` `providerEfforts` have byte-identical bodies, and `effortBelowHigh` is duplicated across the same pair; the comments self-declare it ("keep the two byte-identical in behavior"). Genuinely the same hazard class, but it duplicates **logic, not an array literal**, so a textual extractor structurally cannot gate it — that needs behavioural equivalence (shared module or a table-driven test), a separate change. Each side has its own suite today.
- **`extension/`** — `CaptureConfig["model"]` and `Options.svelte`'s `models` are a deliberate *subset* (no `[1m]` variants, no pinned names, plus a `"default"` sentinel absent from `CLAUDE_MODELS`), so equality is the wrong assertion; a subset check is a different invariant. `models` is annotated `CaptureConfig["model"][]`, so `svelte-check` already rejects off-union values.
- **Prose enumerations** — `docs/external-task-api.md`'s `model` row and `docs-site/.../reference/configuration.md`'s `SHEPHERD_DOC_AGENT_EFFORT` row each hand-list a full set in order inside a Markdown table cell. Not generated, so `check-generated-docs.sh` doesn't reach them; prose-shaped targets, left to review.
- **`PREMIUM_MODELS`** — UI-only, no server counterpart, so not a mirror.
- **Not added to `ci.yml`'s `verify` job** — `pr-hygiene.yml` is where every sibling hygiene gate lives.

One known coverage note: eslint's root glob is `'scripts/**/*.ts'`, so it never sees the new `.mjs`/`.d.mts` — the same pre-existing gap that already leaves `check-glossary.mjs` and `next-version.mjs` unlinted. Surfaced rather than widened here, since broadening the glob would newly lint every existing `scripts/*.mjs`. Both files are covered by prettier, by the unit tests, and (for the `.d.mts`) by `tsc` through the test — verified resolving to real types, not `any`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
