### PR TITLE
fix(ui): make repository names readable in picker

### DIFF
--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -2687,6 +2687,57 @@ describe("NewTask manual provider change (preserved reset semantics)", () => {
 });
 
 describe("NewTask geometry (measurable handoff criteria)", () => {
+  function expectReadableRepoIdentity(container: HTMLElement) {
+    const name = container.querySelector<HTMLElement>(".rs-name")!;
+    const path = container.querySelector<HTMLElement>(".rs-path")!;
+    const owner = container.querySelector<HTMLElement>(".rs-owner")!;
+    const nameRect = name.getBoundingClientRect();
+    const pathRect = path.getBoundingClientRect();
+    const ownerRect = owner.getBoundingClientRect();
+
+    expect(name.textContent).toBe("mein-repository");
+    expect(owner.textContent).toBe("Erwins-Enkel");
+    expect(nameRect.right).toBeLessThanOrEqual(pathRect.left);
+    expect(pathRect.right).toBeLessThanOrEqual(ownerRect.left);
+    expect(name.scrollWidth).toBeLessThanOrEqual(name.clientWidth);
+    expect(owner.scrollWidth).toBeLessThanOrEqual(owner.clientWidth);
+    expectMinPx(pathRect.width, 40, "repo path visible width");
+    expect(path.scrollWidth).toBeGreaterThan(path.clientWidth);
+    expect(getComputedStyle(path).textOverflow).toBe("ellipsis");
+    expect(getComputedStyle(owner).color).toBe(getComputedStyle(path).color);
+  }
+
+  it("keeps repo name and owner visible around an ellipsized path in trigger and panel", async () => {
+    await page.viewport(1280, 800);
+    const repo: RepoEntry = {
+      name: "mein-repository-local-copy",
+      remoteSlug: "Erwins-Enkel/mein-repository",
+      path: "/repo/mein-repository-local-copy",
+      display:
+        "~/projects/client-work/active/very-long-local-checkout-name/mein-repository-local-copy",
+      realPath: "/repo/mein-repository-local-copy",
+    };
+    mockListRepos.mockResolvedValue({ repos: [repo], recentWindowDays: 30 });
+    render(NewTask, { props: base({ initialRepoPath: repo.path }) });
+
+    await expect.poll(() => document.querySelector(".repo-chip .rs-owner")?.textContent).toBe(
+      "Erwins-Enkel",
+    );
+    const card = document.querySelector<HTMLElement>("form.card")!;
+    const trigger = document.querySelector<HTMLElement>(".repo-chip .rs-trigger")!;
+    expectReadableRepoIdentity(trigger);
+
+    trigger.click();
+    await expect.poll(() => document.querySelector(".repo-chip .rs-panel")).toBeTruthy();
+    const panel = document.querySelector<HTMLElement>(".repo-chip .rs-panel")!;
+    const row = panel.querySelector<HTMLElement>(".rs-row")!;
+    expectReadableRepoIdentity(row);
+
+    expect(Math.round(panel.getBoundingClientRect().width)).toBe(560);
+    expect(Math.round(card.getBoundingClientRect().width)).toBe(880);
+    expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(1280);
+  });
+
   // Fixture A (desktop, Claude): autogrow-capped prompt + 8 chips + diverged notice +
   // submit error + hold-likely dual CTA — every state individually realizable together.
   it("fixture A: desktop 1280×800 — card 880, rail 300, surface + no overflow", async () => {

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -2720,9 +2720,9 @@ describe("NewTask geometry (measurable handoff criteria)", () => {
     mockListRepos.mockResolvedValue({ repos: [repo], recentWindowDays: 30 });
     render(NewTask, { props: base({ initialRepoPath: repo.path }) });
 
-    await expect.poll(() => document.querySelector(".repo-chip .rs-owner")?.textContent).toBe(
-      "Erwins-Enkel",
-    );
+    await expect
+      .poll(() => document.querySelector(".repo-chip .rs-owner")?.textContent)
+      .toBe("Erwins-Enkel");
     const card = document.querySelector<HTMLElement>("form.card")!;
     const trigger = document.querySelector<HTMLElement>(".repo-chip .rs-trigger")!;
     expectReadableRepoIdentity(trigger);

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -1964,18 +1964,18 @@
   /* Chip-style the existing RepoSelect trigger without touching its internals. */
   .repo-chip {
     position: relative;
-    flex-shrink: 0;
+    flex: 0 1 360px;
+    max-width: 360px;
     min-width: 0;
   }
   .repo-chip :global(.rs-root) {
-    width: auto;
+    width: 100%;
   }
   .repo-chip :global(.rs-trigger) {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    width: auto;
-    max-width: 34ch;
+    width: 100%;
     border: 1px solid var(--color-line);
     background: var(--color-panel-2);
     border-radius: 2px;
@@ -1986,13 +1986,13 @@
   .repo-chip :global(.rs-trigger b) {
     font-weight: 600;
     max-width: 22ch;
-    flex-shrink: 1;
+    flex-shrink: 0;
   }
-  .repo-chip :global(.rs-trigger .dim) {
-    display: none;
+  .repo-chip :global(.rs-trigger .rs-path) {
+    min-width: 40px;
   }
   .repo-chip :global(.rs-panel) {
-    min-width: 320px;
+    min-width: 560px;
   }
   .ctx-from {
     flex-shrink: 0;
@@ -2034,7 +2034,8 @@
   }
   .ctx-hint {
     margin-left: auto;
-    flex-shrink: 0;
+    flex: 1 1 0;
+    min-width: 0;
     font-size: var(--fs-micro);
     color: var(--color-faint);
     white-space: nowrap;

--- a/ui/src/lib/components/RepoSelect.browser.test.ts
+++ b/ui/src/lib/components/RepoSelect.browser.test.ts
@@ -179,22 +179,39 @@ describe("RepoSelect — hideHidden", () => {
 describe("RepoSelect — remote identity", () => {
   const ownerRepos: RepoEntry[] = [
     {
-      name: "api",
-      remoteSlug: "acme/api",
+      name: "local-api-copy",
+      remoteSlug: "acme/platform/api",
       path: "/repos/acme-api",
-      display: "~/repos/acme-api",
+      display: "~/repos/clients/acme/api-local-copy",
       realPath: "/repos/acme-api",
     },
     {
-      name: "api",
+      name: "sibling-api-copy",
       remoteSlug: "sibling/api",
       path: "/repos/sibling-api",
-      display: "~/repos/sibling-api",
+      display: "~/repos/clients/sibling/api-local-copy",
       realPath: "/repos/sibling-api",
     },
   ];
 
-  it("shows owner-qualified slugs for duplicate local repo names", async () => {
+  function expectIdentity(
+    container: Element,
+    expected: { name: string; path: string; owner?: string },
+  ) {
+    const name = container.querySelector<HTMLElement>(".rs-name");
+    const path = container.querySelector<HTMLElement>(".rs-path");
+    const owner = container.querySelector<HTMLElement>(".rs-owner");
+
+    expect(name?.textContent).toBe(expected.name);
+    expect(path?.textContent).toBe(expected.path);
+    expect(owner?.textContent).toBe(expected.owner);
+
+    const children = Array.from(container.children);
+    expect(children.indexOf(name!)).toBeLessThan(children.indexOf(path!));
+    if (expected.owner) expect(children.indexOf(path!)).toBeLessThan(children.indexOf(owner!));
+  }
+
+  it("shows repository name, local path, then owner in trigger and list rows", async () => {
     render(RepoSelect, {
       repos: ownerRepos,
       value: "/repos/acme-api",
@@ -202,10 +219,26 @@ describe("RepoSelect — remote identity", () => {
       windowDays: 7,
     });
 
-    await page.getByRole("button", { name: /acme\/api/ }).click();
+    const trigger = document.querySelector<HTMLElement>(".rs-trigger")!;
+    expectIdentity(trigger, {
+      name: "api",
+      path: "~/repos/clients/acme/api-local-copy",
+      owner: "acme/platform",
+    });
+    trigger.click();
 
-    await expect.element(page.getByRole("option", { name: /acme\/api/ })).toBeVisible();
-    await expect.element(page.getByRole("option", { name: /sibling\/api/ })).toBeVisible();
+    await expect.element(page.getByRole("option").first()).toBeVisible();
+    const rows = Array.from(document.querySelectorAll<HTMLElement>(".rs-row"));
+    expectIdentity(rows[0]!, {
+      name: "api",
+      path: "~/repos/clients/acme/api-local-copy",
+      owner: "acme/platform",
+    });
+    expectIdentity(rows[1]!, {
+      name: "api",
+      path: "~/repos/clients/sibling/api-local-copy",
+      owner: "sibling",
+    });
   });
 
   it("matches repositories by remote owner", async () => {
@@ -216,11 +249,11 @@ describe("RepoSelect — remote identity", () => {
       windowDays: 7,
     });
 
-    await page.getByRole("button", { name: /acme\/api/ }).click();
+    document.querySelector<HTMLButtonElement>(".rs-trigger")!.click();
     await page.getByPlaceholder(m.reposelect_filter_placeholder()).fill("sibling");
 
-    await expect.element(page.getByRole("option", { name: /sibling\/api/ })).toBeVisible();
-    expect(page.getByRole("option", { name: /acme\/api/ }).elements()).toHaveLength(0);
+    await expect.element(page.getByRole("option", { name: /api.*sibling/ })).toBeVisible();
+    expect(page.getByRole("option", { name: /api.*acme\/platform/ }).elements()).toHaveLength(0);
   });
 
   it("keeps the selected owner's identity in the closed trigger", async () => {
@@ -231,7 +264,7 @@ describe("RepoSelect — remote identity", () => {
       windowDays: 7,
     });
 
-    await expect.element(page.getByRole("button", { name: /sibling\/api/ })).toBeVisible();
+    await expect.element(page.getByRole("button", { name: /api.*sibling/ })).toBeVisible();
   });
 
   it("falls back to the local name when a remote slug is unavailable", async () => {
@@ -251,7 +284,15 @@ describe("RepoSelect — remote identity", () => {
 
     const trigger = page.getByRole("button", { name: /local-api/ });
     await expect.element(trigger).toBeVisible();
+    expectIdentity(document.querySelector(".rs-trigger")!, {
+      name: "local-api",
+      path: "~/repos/local-api",
+    });
     await trigger.click();
     await expect.element(page.getByRole("option", { name: /local-api/ })).toBeVisible();
+    expectIdentity(document.querySelector(".rs-row")!, {
+      name: "local-api",
+      path: "~/repos/local-api",
+    });
   });
 });

--- a/ui/src/lib/components/RepoSelect.svelte
+++ b/ui/src/lib/components/RepoSelect.svelte
@@ -78,6 +78,15 @@
       : m.reposelect_recent_agents_other({ count, days: windowDays });
   }
 
+  function repoIdentity(repo: RepoEntry): { name: string; owner: string | null } {
+    const slug = repo.remoteSlug;
+    if (!slug) return { name: repo.name, owner: null };
+    const slash = slug.lastIndexOf("/");
+    return slash > 0 && slash < slug.length - 1
+      ? { name: slug.slice(slash + 1), owner: slug.slice(0, slash) }
+      : { name: repo.name, owner: null };
+  }
+
   // Selected-row lookup stays over the FULL list so an already-selected (e.g. relaunch-
   // seeded) repo still renders in the trigger label even when hideHidden drops it from
   // the dropdown.
@@ -223,9 +232,11 @@
     aria-expanded={open}
   >
     {#if selected}
+      {@const identity = repoIdentity(selected)}
       <span class="rs-emoji" aria-hidden="true">{projectIcons.iconFor(selected.path) ?? "▣"}</span>
-      <b>{selected.remoteSlug ?? selected.name}</b>
-      <span class="dim">{selected.display}</span>
+      <b class="rs-name">{identity.name}</b>
+      <span class="rs-path dim">{selected.display}</span>
+      {#if identity.owner}<span class="rs-owner">{identity.owner}</span>{/if}
     {:else}
       <span class="placeholder">{m.reposelect_placeholder()}</span>
     {/if}
@@ -260,6 +271,7 @@
             <li class="rs-group-sep" role="presentation"></li>
           {/if}
           {@const r = row.repo}
+          {@const identity = repoIdentity(r)}
           <li
             id={`rs-opt-${i}`}
             class="rs-row"
@@ -286,8 +298,9 @@
             >
               {projectIcons.iconFor(r.path) ?? "▣"}
             </button>
-            <b>{r.remoteSlug ?? r.name}</b>
-            <span class="dim">{r.display}</span>
+            <b class="rs-name">{identity.name}</b>
+            <span class="rs-path dim">{r.display}</span>
+            {#if identity.owner}<span class="rs-owner">{identity.owner}</span>{/if}
             {#if row.pinned}
               {@const label = recentAgentsLabel(r.recentAgentCount ?? 0)}
               <span class="rs-count" title={label} aria-label={label}>
@@ -409,22 +422,33 @@
     box-shadow: inset 0 0 0 1px var(--color-amber);
   }
 
-  .rs-trigger b {
+  .rs-name {
     font-weight: 600;
     flex-shrink: 0;
-    max-width: 55%;
+    max-width: 45%;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
-  .rs-trigger .dim {
+  .rs-path {
     color: var(--color-muted);
     font-size: var(--fs-meta);
+    flex: 1 1 auto;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    min-width: 0;
+  }
+
+  .rs-owner {
+    color: var(--color-muted);
+    font-size: var(--fs-meta);
+    flex: 0 0 auto;
+    max-width: 30%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .rs-trigger .placeholder {
@@ -490,14 +514,6 @@
     overflow: hidden;
   }
 
-  .rs-row b {
-    flex-shrink: 0;
-    max-width: 55%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
   .rs-row:last-child {
     border-bottom: 0;
   }
@@ -516,15 +532,6 @@
 
   .rs-row.active {
     background: color-mix(in srgb, var(--color-amber) 8%, var(--color-panel));
-  }
-
-  .rs-row .dim {
-    color: var(--color-muted);
-    font-size: var(--fs-meta);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    min-width: 0;
   }
 
   /* "recently worked on" shortcut group — pinned rows at the top, set apart from


### PR DESCRIPTION
## Problem / Goal

Long owner-qualified repository slugs made the actual repository name hard to find in the New Task repository picker. The closed picker also hid the local path, while the opened list was too narrow to keep the identifying parts readable.

## Solution / Added

- Show repository identity consistently as **repository name → local path → owner** in both the closed picker and the opened list.
- Widen the desktop repository list so long local paths can ellipsize without hiding the repository name or owner.
- Give the closed picker enough room for the same identity order while allowing the adjacent shortcut hint to yield space.
- Keep repositories without a remote slug working through the existing local-name fallback.

## Technical details

- Split `remoteSlug` at its final slash inside `RepoSelect`; the final segment becomes the repository name and the preceding namespace becomes the owner.
- Reuse one set of semantic flex styles for trigger and row identities: name and owner stay visible, while the local path takes the flexible middle space and ellipsizes.
- Set the embedded desktop popover to `560px`; the surrounding New Task card remains `880px` and the page remains overflow-free at the tested desktop viewport.
- Use the design-system `--color-muted` token for both path and owner so secondary repository identity remains WCAG AA legible.
- No API, persistence, mobile layout, or user-facing copy changes are included.

## Validation

- `cd ui && bun run check` — 0 errors, 0 warnings
- `cd ui && bun run check:i18n` — 3,409 keys in parity
- `cd ui && bun run test:browser -- src/lib/components/RepoSelect.browser.test.ts src/lib/components/NewTask.browser.test.ts` — 143 tests passed
- `cd ui && bun run test` — 279 files and 4,283 tests passed
- Branch hygiene, feature catalog, announcement version, glossary, and diff checks passed

## Checklist

- [x] Conventional-commit PR title
- [x] Branch rebased onto the latest `origin/main` and kept linear
- [x] UI checks and tests pass
- [x] Existing i18n messages are reused; no new user-facing copy was added
- [x] Existing design-system tokens are used; no new literal colors or font sizes were added
- [x] No feature announcement is required for this focused readability fix
- [x] No manual operator steps are required
