### PR TITLE
fix(ui): one tap from the mobile repo chip into the repo typeahead

### DIFF
--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -2890,8 +2890,8 @@ describe("NewTask mobile sheets + shortcuts", () => {
     await expect.poll(() => document.querySelector(".ctx-sheet")).toBeTruthy();
     expect(chip().getAttribute("aria-expanded")).toBe("true");
 
-    // Change only the repo: chip + payload repoPath update; base re-derives.
-    document.querySelector<HTMLButtonElement>(".ctx-sheet .rs-trigger")!.click();
+    // Change only the repo: chip + payload repoPath update; base re-derives. The chip
+    // tap already opened the repo panel — clicking the trigger here would close it.
     await expect
       .poll(() =>
         Array.from(document.querySelectorAll<HTMLLIElement>('[role="option"]')).find((el) =>
@@ -2934,6 +2934,39 @@ describe("NewTask mobile sheets + shortcuts", () => {
     expect(onsubmit.mock.calls[0]![0]).toMatchObject({ repoPath: repoB.path, baseBranch: "main" });
   });
 
+  it("one tap on the chip opens the sheet, the repo panel and focuses the filter", async () => {
+    await renderMobile();
+    const chip = () => document.querySelector<HTMLButtonElement>(".ctx-chip")!;
+    // `renderMobile` resolves as soon as the chip exists — which is BEFORE `listRepos`
+    // populates the list. Fence on the repo name so the tap below races nothing.
+    await expect.poll(() => chip().textContent).toContain("alpha");
+
+    chip().click();
+
+    // Asserted synchronously — no await, no poll. `openRepoPicker` flushes both renders
+    // inside the click handler precisely so the focus stays in the gesture's own call
+    // stack (iOS Safari raises the software keyboard only for an in-stack focus()).
+    // If someone reintroduces an async hop there, these three fail rather than silently
+    // costing the keyboard on a device no CI lane can observe.
+    expect(document.querySelector(".ctx-sheet")).toBeTruthy();
+    expect(document.querySelector(".ctx-sheet .rs-panel")).toBeTruthy();
+    expect(document.activeElement).toBe(document.querySelector(".ctx-sheet .rs-filter"));
+
+    // The typeahead is live: typing narrows the options…
+    const filter = document.querySelector<HTMLInputElement>(".ctx-sheet .rs-filter")!;
+    filter.value = "brav";
+    filter.dispatchEvent(new Event("input", { bubbles: true }));
+    await expect.poll(() => document.querySelectorAll('.ctx-sheet [role="option"]').length).toBe(1);
+
+    // …and picking collapses the panel while the sheet stays open, so the branch control
+    // is right back in view.
+    document.querySelector<HTMLLIElement>('.ctx-sheet [role="option"]')!.click();
+    await expect.poll(() => chip().textContent).toContain("bravo");
+    await expect.poll(() => document.querySelector(".rs-panel")).toBeNull();
+    expect(document.querySelector(".ctx-sheet")).toBeTruthy();
+    expect(document.querySelector(".ctx-sheet .ctx-branch-select")).toBeTruthy();
+  });
+
   it("three-press Escape: repo panel → focus in-sheet trigger; sheet → focus chip", async () => {
     await renderMobile();
     const chip = document.querySelector<HTMLButtonElement>(".ctx-chip")!;
@@ -2942,8 +2975,7 @@ describe("NewTask mobile sheets + shortcuts", () => {
     chip.click();
     await expect.poll(() => document.querySelector(".ctx-sheet")).toBeTruthy();
 
-    const trigger = () => document.querySelector<HTMLButtonElement>(".ctx-sheet .rs-trigger")!;
-    trigger().click();
+    // The chip tap opens the repo panel too, so the ladder starts one level deep already.
     await expect.poll(() => document.querySelector(".rs-panel")).toBeTruthy();
     const filter = document.querySelector<HTMLInputElement>(".rs-filter")!;
     filter.focus();
@@ -3107,14 +3139,24 @@ describe("NewTask keyboard-aware viewport (mobile)", () => {
       // Smallest supported portrait: a long repo list forces the panel to overflow.
       await page.viewport(375, 667);
       mockListRepos.mockResolvedValue({ repos: makeRepos(20), recentWindowDays: 30 });
+      // ≥2 branches, overriding the suite default of `["main"]`: with a single option
+      // `.ctx-branch-select` cannot change value, so the branch assertion below would
+      // pass against a completely dead control.
+      mockListBranches.mockResolvedValue({
+        current: "main",
+        branches: ["main", "release"],
+        default: null,
+      });
       render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo/kbd-00" } });
-      await expect.poll(() => document.querySelector(".ctx-chip")).toBeTruthy();
+      // Wait for the repo list to land (the chip renders before `listRepos` resolves).
+      await expect
+        .poll(() => document.querySelector(".ctx-chip")?.textContent)
+        .toContain("repo-00");
       await expect.poll(() => overlay()?.style.height).toBe("380px");
 
-      // Open the context sheet, then the repo dropdown + its filter.
+      // One tap opens the context sheet AND the repo dropdown with its filter.
       document.querySelector<HTMLButtonElement>(".ctx-chip")!.click();
       await expect.poll(() => document.querySelector(".ctx-sheet")).toBeTruthy();
-      document.querySelector<HTMLButtonElement>(".ctx-sheet .rs-trigger")!.click();
       await expect.poll(() => document.querySelector(".ctx-sheet .rs-filter")).toBeTruthy();
 
       const filter = document.querySelector<HTMLInputElement>(".ctx-sheet .rs-filter")!;
@@ -3139,6 +3181,34 @@ describe("NewTask keyboard-aware viewport (mobile)", () => {
       const fr1 = filter.getBoundingClientRect();
       expect(fr1.top).toBeGreaterThanOrEqual(0);
       expect(fr1.bottom).toBeLessThanOrEqual(KB_TOP + 1);
+
+      // Branch reachability: the auto-opened list puts 20 rows between the filter and the
+      // branch control, so prove the branch control is still reachable by scrolling —
+      // present, and fully above the keyboard line rather than stranded behind it.
+      const branchCtl = document.querySelector<HTMLSelectElement>(".ctx-sheet .ctx-branch-select")!;
+      expect(branchCtl).toBeTruthy();
+      // Two real options, and we start on the first — otherwise the flip asserted below
+      // proves nothing (the suite-wide mock lists "main" alone, which cannot change).
+      expect(branchCtl.options.length).toBe(2);
+      expect(branchCtl.value).toBe("main");
+      branchCtl.scrollIntoView({ block: "nearest" });
+      await expect
+        .poll(() => branchCtl.getBoundingClientRect().bottom)
+        .toBeLessThanOrEqual(KB_TOP + 1);
+      expect(branchCtl.getBoundingClientRect().top).toBeGreaterThanOrEqual(0);
+
+      // Tapping the branch control collapses the repo list: RepoSelect's capture-phase
+      // outside-click handler fires because `.ctx-branch-select` is outside `.rs-root`.
+      // Documented, accepted behavior — the tap still lands on the branch control (hit
+      // testing precedes the reflow) and the sheet stays open, so the edit succeeds.
+      branchCtl.click();
+      branchCtl.value = "release";
+      branchCtl.dispatchEvent(new Event("change", { bubbles: true }));
+      await expect
+        .poll(() => document.querySelector(".ctx-chip")?.textContent)
+        .toContain("release");
+      await expect.poll(() => document.querySelector(".rs-panel")).toBeNull();
+      expect(document.querySelector(".ctx-sheet")).toBeTruthy();
     } finally {
       restore();
     }

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -3183,14 +3183,19 @@ describe("NewTask keyboard-aware viewport (mobile)", () => {
       expect(fr1.bottom).toBeLessThanOrEqual(KB_TOP + 1);
 
       // Branch reachability: the auto-opened list puts 20 rows between the filter and the
-      // branch control, so prove the branch control is still reachable by scrolling —
-      // present, and fully above the keyboard line rather than stranded behind it.
+      // branch control. Rewind the scroller to the top first, so the scroll below is a
+      // real one — at rest the control is genuinely past the fold, which is the whole
+      // cost this one-tap change accepts.
       const branchCtl = document.querySelector<HTMLSelectElement>(".ctx-sheet .ctx-branch-select")!;
       expect(branchCtl).toBeTruthy();
       // Two real options, and we start on the first — otherwise the flip asserted below
       // proves nothing (the suite-wide mock lists "main" alone, which cannot change).
       expect(branchCtl.options.length).toBe(2);
       expect(branchCtl.value).toBe("main");
+      sheetBody.scrollTop = 0;
+      await expect.poll(() => branchCtl.getBoundingClientRect().top).toBeGreaterThan(KB_TOP);
+
+      // …and scrolling to it brings it fully above the keyboard line, not stranded behind it.
       branchCtl.scrollIntoView({ block: "nearest" });
       await expect
         .poll(() => branchCtl.getBoundingClientRect().bottom)

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, tick } from "svelte";
+  import { flushSync, onMount, tick } from "svelte";
   import { MediaQuery } from "svelte/reactivity";
   import {
     listRepos,
@@ -999,15 +999,25 @@
     repoPath = list[(cur + dir + n) % n]!.path;
   }
 
-  /** ⌥R: on desktop the RepoSelect panel opens directly; on mobile RepoSelect lives
-   *  inside the context sheet, so the shortcut opens the sheet (closing the engine
-   *  sheet per the single-sheet invariant) and then the panel once mounted. */
-  async function openRepoPicker() {
+  /** Shared entry point for the mobile repo chip AND ⌥R. On desktop the RepoSelect
+   *  panel opens directly; on mobile RepoSelect lives inside the context sheet, so the
+   *  sheet opens first (closing the engine sheet per the single-sheet invariant) and
+   *  the panel once it's mounted.
+   *
+   *  flushSync, NOT `await tick()`: the chip is a touch gesture, and iOS Safari only
+   *  raises the software keyboard for a focus() that happens inside the gesture's own
+   *  synchronous call stack. flushSync drains the pending effects in-stack, so
+   *  RepoSelect's `open && filterInput` effect focuses the filter before this handler
+   *  returns. Never reintroduce an async hop here — it silently costs the keyboard.
+   *  (The sheet's use:dialog focus microtask runs afterwards but no-ops: its guard sees
+   *  focus already inside the sheet.) */
+  function openRepoPicker() {
     if (mobile) {
       activeSheet = "context";
-      await tick();
+      flushSync(); // mount the sheet + its RepoSelect
     }
     repoSelect?.openPanel();
+    flushSync(); // render the panel; RepoSelect's focus effect runs → filter focused
   }
 
   // Form-level keydown: ⌘/Ctrl+↵ submits from anywhere in the modal (handoff rule),
@@ -1037,7 +1047,7 @@
         break; // still swallow the chord below
       }
       case "KeyR":
-        void openRepoPicker();
+        openRepoPicker();
         break;
       default:
         return; // not ours — let it through untouched
@@ -1265,7 +1275,10 @@
       <span class="chead-title">{heading}</span>
       {#if mobile}
         <!-- Combined repo·branch chip: one control naming both payload-critical values;
-             opens the context sheet where each is independently editable. -->
+             opens the context sheet where each is independently editable. Changing the
+             repo is far more common than changing the branch, so the tap goes straight
+             through to the repo typeahead (sheet + panel + focused filter, one tap);
+             the branch control is still reachable below it in the same sheet. -->
         <button
           type="button"
           class="ctx-chip"
@@ -1275,7 +1288,7 @@
             repo: selectedRepoName || m.reposelect_placeholder(),
             branch: baseBranch,
           })}
-          onclick={() => (activeSheet = "context")}
+          onclick={openRepoPicker}
         >
           <span aria-hidden="true">{projectIcons.iconFor(repoPath) ?? "▣"}</span>
           <b>{selectedRepoName || m.reposelect_placeholder()}</b>


### PR DESCRIPTION
On the mobile new-task pane, changing the repo cost **two taps**: one on the combined `repo · branch` chip to open the context sheet, another on the `RepoSelect` trigger to reveal the typeahead. Repo changes are far more common than branch changes, so the chip now goes straight through to the filter.

## What changed

`NewTask.svelte`'s mobile header chip points at `openRepoPicker()` — the existing ⌥R handler — instead of just setting `activeSheet = "context"`. That function is now **synchronous**, using `flushSync` in place of `await tick()`:

```ts
function openRepoPicker() {
  if (mobile) {
    activeSheet = "context";
    flushSync(); // mount the sheet + its RepoSelect
  }
  repoSelect?.openPanel();
  flushSync(); // render the panel; RepoSelect's focus effect runs → filter focused
}
```

The timing is the load-bearing part, not an incidental refactor: **iOS Safari raises the software keyboard only for a `focus()` that happens inside the gesture's own call stack.** `await tick()` is fine for a key event but forfeits that for a tap. `flushSync` drains the pending effects in-stack, so `RepoSelect`'s `open && filterInput` effect focuses the filter before the handler returns. The sheet's `use:dialog` focus microtask still runs afterwards but no-ops — its guard sees focus already inside the sheet.

No `RepoSelect.svelte` change; no new messages, CSS, or catalog entry.

## Reviewer notes

**The iOS keyboard itself is not assertable here** — Chromium has no on-screen-keyboard surface, and the existing fake `visualViewport` only simulates the resulting geometry. So the new test asserts the sheet / panel / `activeElement === .rs-filter` triple **synchronously**, with no `await` or `poll`, as a structural fence: I verified it fails (`expected null to be truthy`) when the `await tick()` version is reinstated. A reintroduced async hop breaks CI rather than silently costing the keyboard. I have not run this on a physical iOS device — worth a quick check before merge.

**Branch editing stays in the same sheet**, below the repo list. Tapping the branch control while the list is open collapses the list, because `RepoSelect` registers a capture-phase window click listener and `.ctx-branch-select` sits outside `.rs-root`. This interaction is new (previously the panel was only open when deliberately opened). It's accepted rather than fixed — the tap still lands on the branch control (hit testing precedes the reflow) and the sheet stays open, so the edit succeeds; changing `RepoSelect`'s outside-click contract would affect the backlog / steers / card consumers for a one-frame reflow. It is now asserted, so changing it later is a deliberate act.

**One trap worth flagging in the test changes:** the suite-wide `mockListBranches` returns `branches: ["main"]`, which makes `.ctx-branch-select` a *single-option* select — writing its value back and dispatching `change` asserts nothing. The extended 20-repo test overrides that mock with `["main", "release"]` and pins `options.length === 2` / `value === "main"` before asserting the flip, so it can't quietly go vacuous again. (The pre-existing vacuous write in `"combined chip names both values…"` is left alone — out of scope.)

**Accepted and deliberately untested:** the chip is now the primary mobile entry point, so it will routinely be tapped while `listRepos()` is still in flight — an empty list under a focused filter that fills in on resolve, with the roving cursor left on row 0. Both new tests fence past that race (polling the chip label for the repo name before tapping) rather than encoding it.

## Verification

- `cd ui && bun run check` — 5630 files, 0 errors
- `cd ui && bun test` — 279 files, 4283 tests passing
- root `bunx prettier --check .` + `bun run lint` — clean (root lint globs include `ui/src`, so both edited files are covered)
- `check:i18n`, glossary and branch-hygiene gates pass; pre-push green

🤖 Generated with [Claude Code](https://claude.com/claude-code)