### PR TITLE
feat(backlog): active filter chip picks the opened tab

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3408,5 +3408,7 @@
   "feat_steers_settings_section_title": "Steers bekommen einen eigenen Einstellungsbereich",
   "feat_steers_settings_section_body": "Gespeicherte Steers liegen jetzt unter Einstellungen → Steers. Die Sitzungssteuerung bleibt fokussiert, während Stift und Steer-Kontextmenü weiterhin denselben Editor öffnen und den ausgewählten Steer beibehalten.",
   "feat_opus_5_pin_title": "Opus 5 exakt fixieren",
-  "feat_opus_5_pin_body": "Die Modellauswahl bietet jetzt zusätzlich Opus 5 und Opus 5 (1 Mio. Kontext). Die einfachen Opus-Einträge folgen immer dem neuesten Opus-Release; ein fixierter Eintrag legt genau diese Version fest, damit ein künftiges Release nicht still ändert, womit Task, Repo-Standard oder Rolle laufen."
+  "feat_opus_5_pin_body": "Die Modellauswahl bietet jetzt zusätzlich Opus 5 und Opus 5 (1 Mio. Kontext). Die einfachen Opus-Einträge folgen immer dem neuesten Opus-Release; ein fixierter Eintrag legt genau diese Version fest, damit ein künftiges Release nicht still ändert, womit Task, Repo-Standard oder Rolle laufen.",
+  "feat_pr_filter_tab_title": "Nach PRs filtern, im PR-Tab landen",
+  "feat_pr_filter_tab_body": "Unter Repos bestimmt jetzt der aktive Filter-Chip, welcher Tab beim Öffnen eines Repos erscheint: Ist „Hat PRs“ aktiv, führt ein Klick direkt zu den PRs statt zu den Issues. „Hat Issues“ macht dasselbe für Issues, und ohne aktiven Chip bleibt der aktuelle Tab unverändert."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3408,5 +3408,7 @@
   "feat_steers_settings_section_title": "Steers get their own settings section",
   "feat_steers_settings_section_body": "Saved Steers now live under Settings → Steers. Session controls stay focused, while the pencil and steer context menu still open the same editor and preserve the selected steer.",
   "feat_opus_5_pin_title": "Pin Opus 5 exactly",
-  "feat_opus_5_pin_body": "Model pickers now offer Opus 5 and Opus 5 (1M context) alongside the existing Opus rows. The plain Opus entries always track the newest Opus release; picking a pinned one locks that exact version, so a future release can't quietly change what a task, repo default, or role runs on."
+  "feat_opus_5_pin_body": "Model pickers now offer Opus 5 and Opus 5 (1M context) alongside the existing Opus rows. The plain Opus entries always track the newest Opus release; picking a pinned one locks that exact version, so a future release can't quietly change what a task, repo default, or role runs on.",
+  "feat_pr_filter_tab_title": "Filter by PRs, land on the PRs tab",
+  "feat_pr_filter_tab_body": "In Repos, the active filter chip now picks the tab a repo opens on: with \"Has PRs\" on, clicking a repo goes straight to its PRs instead of Issues. \"Has issues\" does the same for Issues, and with no chip on your current tab is left alone."
 }

--- a/ui/src/lib/components/BacklogOverlay.browser.test.ts
+++ b/ui/src/lib/components/BacklogOverlay.browser.test.ts
@@ -4,6 +4,7 @@ import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
 import BacklogOverlay from "./BacklogOverlay.svelte";
+import { m } from "$lib/paraglide/messages";
 import { backlogLayout } from "$lib/backlog-layout.svelte";
 import type { BacklogPayload, BacklogProject } from "$lib/types";
 
@@ -214,5 +215,140 @@ describe("BacklogOverlay (Repos) mobile", () => {
     // No desktop resize affordances mounted.
     expect(document.querySelector(".resize-corner")).toBeNull();
     expect(document.querySelector(".repo-splitter")).toBeNull();
+  });
+});
+
+// ── active filter chip picks the opened tab ─────────────────────────────────
+// The rule itself (which chip wins) is unit-tested in backlog-view.test.ts via
+// tabForFilters. These mount the real BacklogView to prove the WIRING: that the
+// helper is applied at every place a repo gets selected — the desktop list, the
+// mobile list, and the desktop pinned-repo auto-seed.
+
+/** Tab buttons in their fixed BacklogTabBar order, scoped to one variant's bar. */
+function tabs(scope: ".tab-bar" | ".overlay-tabs") {
+  const btns = [...document.querySelectorAll<HTMLButtonElement>(`${scope} .tab-btn`)];
+  return { issues: btns[0], prs: btns[1], actions: btns[2] };
+}
+
+/** The filter chip carrying `label` (chips are label-matched, not index-matched). */
+function chip(label: string): HTMLButtonElement {
+  const found = [...document.querySelectorAll<HTMLButtonElement>(".filter-chip")].find((b) =>
+    b.textContent?.includes(label),
+  );
+  expect(found, `no filter chip labelled ${label}`).toBeTruthy();
+  return found!;
+}
+
+/** A repo row by its visible name (ProjectRow shows the path basename). */
+function row(name: string): HTMLElement {
+  const found = [...document.querySelectorAll<HTMLElement>(".project-row")].find(
+    (r) => r.querySelector(".row-name")?.textContent?.trim() === name,
+  );
+  expect(found, `no repo row named ${name}`).toBeTruthy();
+  return found!;
+}
+
+async function click(el: HTMLElement) {
+  el.click();
+  await tick();
+}
+
+describe("BacklogOverlay (Repos) filter chip → opened tab", () => {
+  it("desktop: has-PRs on, clicking a repo opens the PRs tab", async () => {
+    await render(BacklogOverlay, props());
+    await click(chip(m.backlog_filter_has_prs()));
+    await click(row("repo-0"));
+
+    const t = tabs(".tab-bar");
+    expect(t.prs.classList.contains("active")).toBe(true);
+    expect(t.issues.classList.contains("active")).toBe(false);
+  });
+
+  it("mobile: has-PRs on, tapping a repo opens the detail overlay on the PRs tab", async () => {
+    await render(BacklogOverlay, props({ mobile: true }));
+    await click(chip(m.backlog_filter_has_prs()));
+    await click(row("repo-0"));
+
+    // The mobile tab bar lives INSIDE the detail overlay, so its very presence
+    // means the row click reached the mobile branch's handler.
+    expect(document.querySelector(".mobile-detail-overlay")).not.toBeNull();
+    const t = tabs(".overlay-tabs");
+    expect(t.prs.classList.contains("active")).toBe(true);
+    expect(t.issues.classList.contains("active")).toBe(false);
+  });
+
+  it("has-issues on wins over has-PRs and pulls a PRs-tab reader back to Issues", async () => {
+    await render(BacklogOverlay, props());
+    await click(tabs(".tab-bar").prs);
+    await click(chip(m.backlog_filter_has_prs()));
+    await click(chip(m.backlog_filter_has_issues()));
+    await click(row("repo-0"));
+
+    const t = tabs(".tab-bar");
+    expect(t.issues.classList.contains("active")).toBe(true);
+    expect(t.prs.classList.contains("active")).toBe(false);
+  });
+
+  it("no chip active: selecting a repo leaves the current tab alone", async () => {
+    await render(BacklogOverlay, props());
+    await click(tabs(".tab-bar").prs);
+    await click(row("repo-0"));
+
+    // A `null` return must mean "leave alone", not "fall back to issues".
+    const t = tabs(".tab-bar");
+    expect(t.prs.classList.contains("active")).toBe(true);
+    expect(t.issues.classList.contains("active")).toBe(false);
+  });
+});
+
+// ── pinned-repo auto-seed honours the chip ──────────────────────────────────
+// A FRESH object every call: the seed $effect tracks the `payload` prop, so only
+// a new identity re-fires it (which is what a real poll delivers).
+function seedPayload(): BacklogPayload {
+  return {
+    pinnedPath: "/r/pinned",
+    projects: [project("/r/pinned"), { ...project("/r/nopr"), openPRs: 0 }],
+    totals: { openIssues: 0, openPRs: 0 },
+  };
+}
+
+describe("BacklogOverlay (Repos) pinned auto-seed vs filter chip", () => {
+  it("a re-seed after the filter drops the selection lands on the PRs tab", async () => {
+    const { rerender } = await render(BacklogOverlay, props({ payload: seedPayload() }));
+    // Mount seeds the pinned repo with no chip active → Issues, as today.
+    expect(tabs(".tab-bar").issues.classList.contains("active")).toBe(true);
+
+    // Move the selection to the repo without PRs, then turn has-PRs on: that repo
+    // leaves the list and the on-screen drop $effect clears the selection. The
+    // payload object is untouched, so the seed has not re-fired yet.
+    await click(row("nopr"));
+    await click(chip(m.backlog_filter_has_prs()));
+    expect(document.querySelector(".project-row.sel")).toBeNull();
+
+    // A poll delivers a new payload object → the seed re-fires.
+    await rerender(props({ payload: seedPayload() }));
+    await tick();
+
+    expect(document.querySelector(".project-row.sel")).not.toBeNull();
+    const t = tabs(".tab-bar");
+    expect(t.prs.classList.contains("active")).toBe(true);
+    expect(t.issues.classList.contains("active")).toBe(false);
+  });
+
+  it("a poll does not re-tab a still-live selection", async () => {
+    const { rerender } = await render(BacklogOverlay, props({ payload: seedPayload() }));
+    // Park on Actions with the seeded (PR-bearing) repo selected, then filter —
+    // it passes has-PRs, so the selection survives.
+    await click(tabs(".tab-bar").actions);
+    await click(chip(m.backlog_filter_has_prs()));
+    expect(document.querySelector(".project-row.sel")).not.toBeNull();
+
+    await rerender(props({ payload: seedPayload() }));
+    await tick();
+
+    // The seed's `selectedPath === null` guard held: no tab was rewritten.
+    const t = tabs(".tab-bar");
+    expect(t.actions.classList.contains("active")).toBe(true);
+    expect(t.prs.classList.contains("active")).toBe(false);
   });
 });

--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -18,7 +18,7 @@
   import AddRepoButton from "./AddRepoButton.svelte";
   import BacklogTabBar from "./backlog-view/BacklogTabBar.svelte";
   import BacklogTabContent from "./backlog-view/BacklogTabContent.svelte";
-  import { actionsTabState, filterProjects, splitHidden } from "./backlog-view";
+  import { actionsTabState, filterProjects, splitHidden, tabForFilters } from "./backlog-view";
   import { repoConfig } from "$lib/reviews.svelte";
   import { pullMainAndToast } from "$lib/pull-offer";
   import { backlogLayout, clampSidebarWidth } from "$lib/backlog-layout.svelte";
@@ -258,6 +258,14 @@
   // would re-select a repo absent from the list (and fight the clear effect
   // below on every poll). visibleProjects is read untracked so a filter toggle
   // alone never auto-seeds; seeding stays tied to payload/pinned changes.
+  //
+  // A re-seed honours the active filter chip too (same rule as a row click, via
+  // tabForFilters). Without this, turning "has PRs" on with a no-PR repo selected
+  // drops that selection (the on-screen effect below) and the next payload update
+  // re-seeds the pinned repo on a stale Issues tab — the exact state the chip
+  // redirect exists to prevent. The chips are read untracked so this effect's
+  // dependencies stay payload/pinned only; the selectedPath === null guard above
+  // means a poll can never re-tab a selection the user is already reading.
   $effect(() => {
     const pinned = payload?.pinnedPath;
     if (
@@ -266,6 +274,8 @@
       untrack(() => selectedPath === null && visibleProjects.some((p) => p.path === pinned))
     ) {
       selectedPath = pinned;
+      const tab = untrack(() => tabForFilters({ hasIssues, hasPRs }));
+      if (tab) activeTab = tab;
     }
   });
 
@@ -324,6 +334,20 @@
     activeTab = "issues";
   });
 
+  // Repo row click (shared by the mobile list and the desktop list, so the two
+  // can't drift). An active filter chip picks the tab: filtering by "has PRs" is
+  // an explicit statement of what the user is hunting for, so the click opens the
+  // PRs tab instead of always landing on Issues. No chip → tabForFilters returns
+  // null and the current tab is left exactly as it was.
+  //
+  // Re-applied on EVERY click while a chip is on — switching to Actions manually
+  // and then picking another repo lands on that chip's tab again.
+  function handleSelect(path: string) {
+    selectedPath = path;
+    const tab = tabForFilters({ hasIssues, hasPRs });
+    if (tab) activeTab = tab;
+  }
+
   // On mobile, a set selectedPath means the detail overlay is open.
   // Clearing it goes back to the project list.
   function dismissDetail() {
@@ -367,7 +391,7 @@
         ontoggleprs={() => (hasPRs = !hasPRs)}
         ontogglehidden={() => (showHidden = !showHidden)}
         onsearch={(q) => (query = q)}
-        onselect={(p) => (selectedPath = p)}
+        onselect={handleSelect}
         onhide={handleHide}
         {onaddclone}
         {onaddfork}
@@ -445,7 +469,7 @@
           ontoggleprs={() => (hasPRs = !hasPRs)}
           ontogglehidden={() => (showHidden = !showHidden)}
           onsearch={(q) => (query = q)}
-          onselect={(p) => (selectedPath = p)}
+          onselect={handleSelect}
           onhide={handleHide}
           {onaddclone}
           {onaddfork}

--- a/ui/src/lib/components/backlog-view.test.ts
+++ b/ui/src/lib/components/backlog-view.test.ts
@@ -21,6 +21,7 @@ import {
   actionsTabLabel,
   actionsTabState,
   filterProjects,
+  tabForFilters,
   partitionRecents,
   effectiveHidden,
   splitHidden,
@@ -249,6 +250,24 @@ describe("filterProjects", () => {
   it("returns an empty array when every project is excluded", () => {
     const allEmpty = [project("/repos/a", 0, 0), project("/repos/b", null, null)];
     expect(filterProjects(allEmpty, { hasIssues: true, hasPRs: true })).toEqual([]);
+  });
+});
+
+describe("tabForFilters", () => {
+  it("hasPRs alone → the PRs tab", () => {
+    expect(tabForFilters({ hasIssues: false, hasPRs: true })).toBe("prs");
+  });
+
+  it("hasIssues alone → the Issues tab", () => {
+    expect(tabForFilters({ hasIssues: true, hasPRs: false })).toBe("issues");
+  });
+
+  it("both chips on → Issues wins (both-on is not PR-hunting intent)", () => {
+    expect(tabForFilters({ hasIssues: true, hasPRs: true })).toBe("issues");
+  });
+
+  it("no chip on → null, i.e. leave the current tab alone (not 'default to issues')", () => {
+    expect(tabForFilters({ hasIssues: false, hasPRs: false })).toBeNull();
   });
 });
 

--- a/ui/src/lib/components/backlog-view.ts
+++ b/ui/src/lib/components/backlog-view.ts
@@ -188,3 +188,25 @@ export function filterProjects(
       (q === "" || (projectName(p) + " " + p.display).toLowerCase().includes(q)),
   );
 }
+
+/**
+ * Which detail tab a repo selection should land on, given the active repo-list
+ * filter chips — "the active filter picks the tab". `null` means "leave the
+ * current tab alone", NOT "fall back to issues": with no chip on, selecting a
+ * repo must keep whatever tab the user is already reading.
+ *
+ * `hasIssues` wins when BOTH chips are on: `hasPRs` alone is an unambiguous
+ * PR-hunting intent, both-on is not, so both-on keeps the default Issues tab.
+ *
+ * Returns the narrow `"issues" | "prs"` union rather than BacklogView's full
+ * `Tab` type — that type is declared per-component (BacklogView.svelte,
+ * BacklogTabBar.svelte) and hoisting it is a separate concern.
+ */
+export function tabForFilters(opts: {
+  hasIssues: boolean;
+  hasPRs: boolean;
+}): "issues" | "prs" | null {
+  if (opts.hasIssues) return "issues";
+  if (opts.hasPRs) return "prs";
+  return null;
+}

--- a/ui/src/lib/feature-announcements/entries/v1.46.0-pr-filter-tab.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.46.0-pr-filter-tab.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "pr-filter-tab",
+  sinceVersion: "1.46.0",
+  titleKey: "feat_pr_filter_tab_title",
+  bodyKey: "feat_pr_filter_tab_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
In the repo pane, the active filter chip now picks the tab a repo click opens. Filtering by **has PRs** is an explicit statement of what you're hunting for, so the click goes straight to the PRs tab instead of always landing on Issues.

| `has issues` | `has PRs` | click opens |
| ------------ | --------- | -------------------------- |
| off          | on        | **PRs**                    |
| on           | off       | **Issues**                 |
| on           | on        | **Issues**                 |
| off          | off       | unchanged (as before)      |

Issues wins when both chips are on: `has PRs` alone is unambiguous PR-hunting intent, both-on is not.

## How

- New pure `tabForFilters()` in `ui/src/lib/components/backlog-view.ts` returns `"issues" | "prs" | null`, where `null` means *leave the current tab alone* (not "fall back to Issues"). Narrow union on purpose — the full `Tab` type is declared per-component and hoisting it is a separate concern.
- `BacklogView.svelte` already owned both the chip state and `activeTab`, so no new props and no server change. The two inline `onselect={(p) => (selectedPath = p)}` props (mobile + desktop `ProjectBacklogList`) collapse into one shared `handleSelect()`, so the two branches can't drift.
- The desktop pinned-repo auto-seed applies the same rule. Its `$effect` tracks `payload?.pinnedPath`, so it re-fires on every payload update: without this, turning `has PRs` on with a no-PR repo selected drops that selection and the next poll re-seeded the pinned repo on a **stale Issues tab** — exactly the state this change exists to prevent. Chips are read via `untrack`, so the effect's dependency set is unchanged and a chip toggle alone still never seeds; the existing `selectedPath === null` guard keeps a poll from re-tabbing a selection you're already reading.

## Deliberately not changed

- **Toggling a chip while a matching repo is already open does not move the tab** — the redirect fires on selection, not on the toggle. A chip toggle is a list-scoping action; yanking the detail pane out from under someone mid-read would be worse than the inconsistency. Reviewers: this inert case is intended, not a missed wiring site.
- The EPIC-target and just-added-repo effects keep forcing Issues (an epic target *is* an issue; a brand-new repo has zero PRs, and that effect already clears both chips first).

## Testing

- `backlog-view.test.ts` — one unit test per row of the table above, including `null` meaning "leave alone".
- `BacklogOverlay.browser.test.ts` (already mounts the real `BacklogView`, no api mocking needed) — desktop click, mobile click, both-chips precedence, the no-chip leave-alone case, plus a `seedPayload()` fixture covering the poll-driven re-seed landing on PRs and its mirror: a live selection parked on Actions survives a poll un-retabbed.
- All 6 new browser assertions were checked against deliberately un-wired code first: the 4 positive cases fail, the 2 "no movement" cases correctly still pass. They bind.
- `bun run check` (0 errors), `bun run check:i18n` (2 locales, 3411 keys), `bunx vitest run` → **279 files / 4294 tests pass**; root `bun run lint` and all four pre-push hygiene gates clean.

Feature-announcement fragment `v1.46.0-pr-filter-tab.ts` with EN + DE keys included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
