### PR TITLE
fix(security): refuse symlinked TODO.md atomically; drop check-then-use pairs

### DIFF
--- a/src/commands.test.ts
+++ b/src/commands.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { listCommands } from "./commands";
@@ -7,8 +7,9 @@ import { listCommands } from "./commands";
 const roots: string[] = [];
 
 function tmpRoot(): string {
-  const root = join(tmpdir(), `shepherd-commands-${crypto.randomUUID()}`);
-  mkdirSync(root, { recursive: true });
+  // mkdtempSync both creates the dir 0700 and picks the unpredictable suffix itself — the
+  // sanctioned primitive, and one call instead of hand-rolling a name then creating it.
+  const root = mkdtempSync(join(tmpdir(), "shepherd-commands-"));
   roots.push(root);
   return root;
 }

--- a/src/repos.ts
+++ b/src/repos.ts
@@ -4,10 +4,12 @@ import {
   writeFileSync,
   existsSync,
   statSync,
-  lstatSync,
   realpathSync,
   mkdirSync,
   rmSync,
+  openSync,
+  closeSync,
+  constants,
 } from "node:fs";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
@@ -132,6 +134,22 @@ export function reconcileRealPathsToRaw(
 
 const TODO = "TODO.md";
 
+/**
+ * `O_NOFOLLOW` makes the open itself refuse a symlinked final component, replacing a
+ * check-then-use pair (`lstat`/`existsSync` then read/write) that a swap between the two
+ * calls could defeat. Only the FINAL component is covered — safe here because
+ * {@link safeRepoDir} already `realpathSync`es the directory and enforces containment
+ * before we build the path, so `dir` cannot itself be a planted symlink.
+ *
+ * POSIX, Linux and macOS report `ELOOP`; some BSDs report `EMLINK`. Both are accepted so
+ * the refusal does not depend on a platform the tests never exercise.
+ */
+const SYMLINK_ERRNOS = new Set(["ELOOP", "EMLINK"]);
+
+function isSymlinkRefusal(e: unknown): boolean {
+  return SYMLINK_ERRNOS.has(String((e as NodeJS.ErrnoException).code));
+}
+
 export function readTodo(
   repoPathRaw: string,
   repoRoot: string,
@@ -139,8 +157,25 @@ export function readTodo(
   const dir = safeRepoDir(repoPathRaw, repoRoot);
   if (!dir) return { ok: false, exists: false, content: "" };
   const file = join(dir, TODO);
-  if (!existsSync(file)) return { ok: true, exists: false, content: "" };
-  return { ok: true, exists: true, content: readFileSync(file, "utf8") };
+  let fd: number;
+  try {
+    fd = openSync(file, constants.O_RDONLY | constants.O_NOFOLLOW);
+  } catch (e) {
+    // Absent is the normal empty-TODO case. A SYMLINKED TODO.md reads as absent too:
+    // `ok: false` would surface as a 400 "invalid repo path" on a perfectly valid repo,
+    // and would regress a DANGLING symlink, which returns `exists: false` today.
+    // Reporting "no TODO yet" leaks nothing and keeps the pane usable; `writeTodo` still
+    // refuses that same file, so the symlink cannot be silently written through either.
+    if ((e as NodeJS.ErrnoException).code === "ENOENT" || isSymlinkRefusal(e)) {
+      return { ok: true, exists: false, content: "" };
+    }
+    throw e;
+  }
+  try {
+    return { ok: true, exists: true, content: readFileSync(fd, "utf8") };
+  } finally {
+    closeSync(fd);
+  }
 }
 
 export function writeTodo(repoPathRaw: string, repoRoot: string, content: string): boolean {
@@ -148,13 +183,25 @@ export function writeTodo(repoPathRaw: string, repoRoot: string, content: string
   if (!dir) return false;
   if (typeof content !== "string" || content.length > 100_000) return false;
   const file = join(dir, TODO);
-  // refuse to follow a symlinked TODO.md (prevents a symlink-swap write outside the repo)
+  let fd: number;
   try {
-    if (lstatSync(file).isSymbolicLink()) return false;
-  } catch {
-    /* file doesn't exist yet — fine */
+    // O_TRUNC is what shortens an existing TODO.md: writeFileSync(fd, …) writes from the
+    // current file position and does NOT truncate, so without it a shorter body would
+    // leave the tail of the previous one behind.
+    fd = openSync(
+      file,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | constants.O_NOFOLLOW,
+      0o666,
+    );
+  } catch (e) {
+    if (isSymlinkRefusal(e)) return false; // symlinked TODO.md — same refusal as before
+    throw e;
   }
-  writeFileSync(file, content, "utf8");
+  try {
+    writeFileSync(fd, content, "utf8");
+  } finally {
+    closeSync(fd);
+  }
   return true;
 }
 

--- a/test/herdr-install.test.ts
+++ b/test/herdr-install.test.ts
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readdirSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -187,7 +188,15 @@ function runProgram(
 }
 
 function curlCalls(shim: Shim): string {
-  return existsSync(shim.curlLog) ? execFileSync("cat", [shim.curlLog], { encoding: "utf8" }) : "";
+  // No `existsSync` guard: pairing it with the read would be the same check-then-use shape
+  // CodeQL flags elsewhere. ENOENT just means the shim was never invoked — that is "no
+  // calls", not an error. Any other errno still throws rather than reading as "no calls".
+  try {
+    return readFileSync(shim.curlLog, "utf8");
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return "";
+    throw e;
+  }
 }
 
 /** Leftover temp files in the install dir — the program must clean up on every path. */

--- a/test/repos.test.ts
+++ b/test/repos.test.ts
@@ -193,6 +193,17 @@ test("writeTodo: content exactly 100_000 chars → true", () => {
   expect(writeTodo(join(root, "alpha"), root, "x".repeat(100_000))).toBe(true);
 });
 
+// Shrink, not grow. The other round-trips only ever lengthen TODO.md, and `beforeEach`
+// mints a fresh root per test, so nothing else would catch a missing O_TRUNC: writing to
+// a numeric fd starts at position 0 but does NOT truncate, which would leave the tail of
+// the longer previous body behind.
+test("writeTodo: shorter content overwrites longer, leaving no remnant", () => {
+  const repoPath = join(root, "alpha");
+  expect(writeTodo(repoPath, root, "x".repeat(5_000))).toBe(true);
+  expect(writeTodo(repoPath, root, "short")).toBe(true);
+  expect(readTodo(repoPath, root)).toEqual({ ok: true, exists: true, content: "short" });
+});
+
 // ── symlink containment (security) ─────────────────────────────────────────────
 
 test("a symlink inside repoRoot pointing outside is rejected (realpath containment)", () => {
@@ -204,6 +215,56 @@ test("a symlink inside repoRoot pointing outside is rejected (realpath containme
     expect(writeTodo(join(root, "escape"), root, "pwned")).toBe(false);
   } finally {
     rmSync(outside, { recursive: true, force: true });
+  }
+});
+
+// The case above covers a symlinked DIRECTORY, which safeRepoDir rejects upstream. These
+// two cover a symlinked TODO.md itself — the final path component, which containment does
+// not see and only O_NOFOLLOW refuses. Untested before this pair existed.
+test("writeTodo: symlinked TODO.md is refused and the outside target is never created", () => {
+  const outsideRoot = mkdtempSync(join(tmpdir(), "shepherd-todo-out-"));
+  try {
+    // Dangling on purpose: if the write followed the link, O_CREAT would CREATE the
+    // target — so its continued absence is what proves the link was not followed.
+    const target = join(outsideRoot, "PWNED");
+    symlinkSync(target, join(root, "alpha", "TODO.md"));
+    expect(writeTodo(join(root, "alpha"), root, "pwned")).toBe(false);
+    expect(existsSync(target)).toBe(false);
+  } finally {
+    rmSync(outsideRoot, { recursive: true, force: true });
+  }
+});
+
+test("readTodo: symlinked TODO.md reads as absent, never following the link", () => {
+  const outsideRoot = mkdtempSync(join(tmpdir(), "shepherd-todo-out2-"));
+  try {
+    const secret = join(outsideRoot, "secret.txt");
+    writeFileSync(secret, "SENTINEL-must-not-leak");
+    symlinkSync(secret, join(root, "alpha", "TODO.md"));
+    const r = readTodo(join(root, "alpha"), root);
+    // `ok:true, exists:false` deliberately, NOT ok:false — the repo path is valid, and
+    // ok:false would 400 the endpoint and regress the dangling-symlink case below.
+    expect(r).toEqual({ ok: true, exists: false, content: "" });
+    expect(r.content).not.toContain("SENTINEL");
+  } finally {
+    rmSync(outsideRoot, { recursive: true, force: true });
+  }
+});
+
+// Pins today's behaviour for a DANGLING TODO.md symlink: `existsSync` followed the link,
+// found nothing, and returned exists:false. The O_NOFOLLOW rewrite must not turn that
+// into an error. Passes before and after — a guard, not a demonstration.
+test("readTodo: dangling TODO.md symlink still reads as absent (unchanged behaviour)", () => {
+  const outsideRoot = mkdtempSync(join(tmpdir(), "shepherd-todo-out3-"));
+  try {
+    symlinkSync(join(outsideRoot, "does-not-exist"), join(root, "alpha", "TODO.md"));
+    expect(readTodo(join(root, "alpha"), root)).toEqual({
+      ok: true,
+      exists: false,
+      content: "",
+    });
+  } finally {
+    rmSync(outsideRoot, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
Closes CodeQL alerts **#26, #31, #32, #93** on merit — each by removing the flagged
construct, not by suppressing it.

## What changed

**`src/repos.ts` → `writeTodo` + `readTodo` (#26 `js/file-system-race`).**
`writeTodo` already refused a symlinked `TODO.md`, but via `lstat`-then-write — a
check-then-use pair a swap inside the window could defeat. `readTodo` had **no symlink
guard at all** and would render any server-readable file into the operator's TODO pane.
Both now open with `O_NOFOLLOW`, so the refusal happens in the same syscall as the open.
The directory is unaffected: `safeRepoDir` already `realpath`s and containment-checks it,
so only the final component could be a symlink — which is exactly what `O_NOFOLLOW` covers.

Two deliberate details:

- **`readTodo` maps the symlink case to `{ok: true, exists: false}`, not `ok: false`.**
  The repo path is valid, so `ok: false` would surface as a `400 "invalid repo path"`; and
  it would regress a *dangling* `TODO.md` symlink, which returns `exists: false` today. A
  test pins both. Reading as "no TODO yet" leaks nothing and keeps the pane usable, and
  `writeTodo` still refuses the same file loudly.
- **`ELOOP` *and* `EMLINK` are both treated as the refusal.** POSIX/Linux/macOS report the
  former, some BSDs the latter, and CI only ever exercises Linux — so accepting both
  removes a platform assumption no test could catch.

**`src/commands.test.ts` → `tmpRoot` (#31, #32 `js/insecure-temporary-file`).**
`mkdirSync(join(tmpdir(), …randomUUID()))` → `mkdtempSync`. The UUID name was unguessable,
but `mkdtemp` is the sanctioned primitive and does the create in the same call.

**`test/herdr-install.test.ts` → `curlCalls` (#93 `js/unnecessary-use-of-cat`).**
Drops an `execFileSync("cat", …)` subprocess for `readFileSync`. The `existsSync` guard
goes with it — keeping it would have reproduced the very check-then-use shape flagged
elsewhere in this repo; a local `ENOENT` catch handles "shim never invoked", and any other
errno still throws instead of reading as "no calls".

## Tests

`test/repos.test.ts` gains three cases. The `readTodo` symlink test is genuinely
fail-first — against `main` it returns the sentinel contents of a file outside the repo:

```
- "content": "",           + "content": "SENTINEL-must-not-leak",
- "exists": false,         + "exists": true,
```

The other two are guards, expected to pass before *and* after: the `writeTodo` symlink case
(that refusal already existed — what changed is that it became atomic, which no test can
demonstrate since the race is not deterministically provokable), and a **shrink**
round-trip. The shrink is new coverage: every existing round-trip only ever *grows*
`TODO.md`, and `beforeEach` mints a fresh root per test, so nothing would have caught a
missing `O_TRUNC` — writing to a numeric fd does not truncate.

Verified beyond the suite: no fd leak across 400 mixed calls *including the throw paths*,
existing file mode preserved (`0600` not widened by `O_CREAT`'s `0666`), and a directory
named `TODO.md` still raises `EISDIR` exactly as before.

## Not in this PR

The remaining 25 open alerts were triaged individually against the analysis SARIF rather
than the query titles. 23 are dismissals (11 `used in tests`, 9 `false positive`, 3
`won't fix`) with per-alert rationales — see the manual step below. **#25 and #27 are
fixable on merit and are deliberately held back**; a related hardening question is being
tracked privately, and they will land with it.

```shepherd:manual-steps
- [ ] Apply the 23 code-scanning dismissals: this repo has delegated alert dismissal enabled, so they cannot be applied by an agent token. The per-alert reason + rationale list is in the session recap.
- [ ] POST-MERGE: after the next CodeQL run on main, confirm #26/#31/#32/#93 read `fixed` and dismiss any fingerprint recurrence (compare by rule+path+symbol, not alert number — a recurrence returns under a new number).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
