### PR TITLE
fix(review): stop silent critic timeouts; make the deadline configurable

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -127,6 +127,13 @@ export const DISTILLER_INTERVAL_DAYS_MAX = 14;
 // module-local seed defaults, used by the config seeds + boot-override fallbacks only.
 const PR_REVIEW_CYCLES_DEFAULT = 3;
 const PLAN_REVIEW_CYCLES_DEFAULT = 5;
+// Hard deadline for a single critic run (both the session critic and the standalone PR critic):
+// how long to wait for the verdict file before giving up and finalizing an `error` verdict.
+// Bounded so a typo can't wedge a run forever (no ceiling → a leaked worktree + terminal per PR)
+// nor reap it before it can start.
+export const REVIEW_TIMEOUT_MS_MIN = 60_000;
+export const REVIEW_TIMEOUT_MS_MAX = 60 * 60_000;
+const REVIEW_TIMEOUT_MS_DEFAULT = 10 * 60_000;
 // Coerce any input (env/DB/request) to a valid integer cap, snapping out-of-range
 // values into [min,max] rather than rejecting (callers stay forgiving); a non-finite
 // input falls back to the supplied default.
@@ -796,6 +803,18 @@ export const config = {
     PR_REVIEW_CYCLES_MIN,
     PR_REVIEW_CYCLES_MAX,
     PR_REVIEW_CYCLES_DEFAULT,
+  ),
+  // Hard deadline for one critic run before it is abandoned with an `error` verdict. Default 10m
+  // (unchanged). Raise it for a repo whose PRs genuinely outgrow that: a large diff reviewed at
+  // criticEffort=high can still be mid-investigation at the deadline, and because the critic
+  // restarts from scratch every time, EVERY retry then dies at the same wall — the PR becomes
+  // permanently un-reviewable rather than slowly reviewed. Env-only (not UI-configurable): it is a
+  // machine-speed/PR-size escape hatch, not a product knob.
+  reviewTimeoutMs: clampCap(
+    Number(process.env.SHEPHERD_REVIEW_TIMEOUT_MS ?? REVIEW_TIMEOUT_MS_DEFAULT),
+    REVIEW_TIMEOUT_MS_MIN,
+    REVIEW_TIMEOUT_MS_MAX,
+    REVIEW_TIMEOUT_MS_DEFAULT,
   ),
   // Max plan-gate adversarial-review rounds before escalating to a human (drives
   // PlanGateService). UI-configurable + persisted; the env seeds the value on a fresh DB.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1412,13 +1412,18 @@ const reviewService = new ReviewService({
   // global, UI-configurable max auto-address rounds before escalating to the human.
   // A thunk so a settings change takes effect on the next critic run, no restart.
   cap: () => config.prReviewCyclesCap,
+  // Hard per-run deadline (SHEPHERD_REVIEW_TIMEOUT_MS). A plain number, not a thunk: it is read
+  // once at construction because it is env-seeded, not a live UI setting.
+  timeoutMs: config.reviewTimeoutMs,
 });
 
 // Standalone repo-level PR critic (#596): the session-LESS twin of reviewService.
 // Where reviewService reacts to a managed session's PR, this enumerates EVERY open,
 // CI-green PR in a `criticAllPrs` repo (human PRs, other agents', forks) on a timer and
-// posts comment-only reviews. Shares reviewService's primitives + the same per-role
-// `criticModel` setting; concurrency/timeout stay at service defaults.
+// posts comment-only reviews. Shares reviewService's primitives, the same per-role
+// `criticModel` setting, and the same hard per-run deadline (one critic role, one deadline —
+// leaving this twin at the service default would half-apply an operator's raise); concurrency
+// stays at the service default.
 const standaloneCritic = new StandalonePrCriticService({
   store,
   herdr,
@@ -1428,6 +1433,7 @@ const standaloneCritic = new StandalonePrCriticService({
   runSpawnHooks: (d) => pluginRegistry.runSpawnHooks(d),
   // Same per-role critic environment as reviewService (read per spawn → live settings).
   env: () => roleEnv(config.criticCli, config.criticModel, config.criticEffort),
+  timeoutMs: config.reviewTimeoutMs,
   repos: () => listRepos(config.repoRoot).map((r) => r.path),
   // Fresh per-sweep thunk (the service calls it each sweep, never caches) — branches
   // owned by a LIVE session, so a session-critic-owned PR is skipped when criticEnabled.

--- a/src/review.ts
+++ b/src/review.ts
@@ -30,6 +30,9 @@ import {
   type EpicContext,
 } from "./critic-core";
 import { scrubStaleVerdictArtifacts } from "./codex-last-message";
+// Generic secret-redactor for a bounded diagnostic string, despite the recap-flavoured name — the
+// critic's pane tail gets the same treatment before it reaches the log.
+import { sanitizeRecapFailureDetail } from "./recap";
 import { isEpicIntegrationBranch } from "./epic-branch";
 import { resolveAuxSpawn, type MembraneSeams } from "./spawn-membrane";
 
@@ -146,7 +149,12 @@ export interface ReviewServiceDeps extends MembraneSeams {
     | "listReviewerSpawns"
     | "get"
   >;
-  herdr: Pick<HerdrDriver, "start" | "stop" | "list" | "closeTab" | "paneForegroundProcs">;
+  // `readAsync` is diagnostics-only (the no-verdict pane tail) and is called defensively, so an
+  // injected fake may omit it — the read is guarded and degrades to no tail.
+  herdr: Pick<
+    HerdrDriver,
+    "start" | "stop" | "list" | "closeTab" | "paneForegroundProcs" | "readAsync"
+  >;
   worktree: Pick<WorktreeMgr, "createDetached" | "remove" | "gitCommonDir">;
   resolveForge: (repoPath: string) => GitForge | null;
   onChange: (id: string, verdict: ReviewVerdict) => void;
@@ -806,6 +814,12 @@ export class ReviewService {
       }
       const raw: RawVerdict | null =
         action === "finalize-value" && read.status === "parsed" ? read.value : null;
+      // A null raw becomes an `error` verdict ("critic did not produce a verdict") that is
+      // otherwise INVISIBLE — before this, the only trace was the DB row, so a critic dying at the
+      // hard deadline on every retry looked like a black box. Mirrors the recap path's diagnostic
+      // (recap.ts) so the two failure modes read the same in the log. Awaited before finalize()
+      // because finalize's `finally` reaps the terminal, after which the pane tail is gone.
+      if (raw === null) await this.logNoVerdict(f, read);
       // f.finalizing stays true; always drop the entry, even if finalize throws — otherwise it
       // stays `finalizing=true` and every later tick `continue`s past it, wedging the session's
       // critic forever (and leaking its worktree/terminal).
@@ -814,6 +828,54 @@ export class ReviewService {
       } finally {
         this.inflight.delete(f.sessionId);
       }
+    }
+  }
+
+  /** Record WHY a run is about to finalize as an `error` verdict. The persisted verdict carries a
+   *  fixed summary ("critic did not produce a verdict") that cannot distinguish the two real
+   *  causes — the critic died/errored out early, or it was still working when the hard deadline
+   *  fired — and an operator re-triggering a review has no other signal. So log the environment,
+   *  the elapsed-vs-deadline that decided it, and (best-effort) the spawn's terminal tail, which is
+   *  where a CLI-level failure (expired login, weekly-limit refusal, a model the account can't use)
+   *  prints before exiting. Never throws: diagnostics must not strand a finalize. */
+  private async logNoVerdict(f: InFlight, read: VerdictRead<RawVerdict>): Promise<void> {
+    try {
+      const elapsed = Math.round((this.now() - f.startedAt) / 1000);
+      const deadline = Math.round(this.timeoutMs / 1000);
+      const cause =
+        read.status === "unparseable"
+          ? "verdict file present but unparseable even after jsonrepair"
+          : elapsed >= deadline
+            ? "hard timeout — critic still had no verdict file at the deadline"
+            : "spawn exited without writing a verdict file";
+      const tail = await this.readPaneTail(f.terminalId);
+      console.warn(
+        `[review] ${f.sessionId}: no usable verdict (${cause}). ` +
+          `spawn=${f.criticSessionId || "<none>"} pr=#${f.prNumber} cwd=${f.worktreePath} ` +
+          `provider=${f.reviewerProvider} model=${f.reviewerModel ?? "<default>"} ` +
+          `effort=${f.reviewerEffort ?? "<default>"} elapsed=${elapsed}s deadline=${deadline}s` +
+          (read.status === "unparseable" && read.raw
+            ? ` snippet: ${sanitizeRecapFailureDetail(read.raw)}`
+            : "") +
+          (tail ? ` pane-tail: ${tail}` : ""),
+      );
+    } catch (err) {
+      console.warn(`[review] no-verdict diagnostic failed for ${f.sessionId}:`, err);
+    }
+  }
+
+  /** Best-effort, bounded tail of the critic's terminal for the diagnostic above. Takes the LAST
+   *  ~300 chars, where a CLI error surfaces. "" when the pane is already gone or herdr errors —
+   *  and when the injected herdr fake has no `readAsync` at all (tests). Never throws. */
+  private async readPaneTail(terminalId: string): Promise<string> {
+    try {
+      const buf = await this.deps.herdr.readAsync(terminalId, "recent", 20);
+      const oneLine = buf.replace(/\s+/g, " ").trim();
+      return (
+        sanitizeRecapFailureDetail(oneLine.length > 300 ? `…${oneLine.slice(-300)}` : oneLine) ?? ""
+      );
+    } catch {
+      return "";
     }
   }
 

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -19,7 +19,8 @@ import {
   AUTHOR_RESPONSE_MARKER,
   EMPTY_BACKLOG_COUNTS,
 } from "../src/forge/types";
-import { config } from "../src/config";
+import { config, clampCap, REVIEW_TIMEOUT_MS_MIN, REVIEW_TIMEOUT_MS_MAX } from "../src/config";
+import { STARTUP_GRACE_MS } from "../src/json-tolerant";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
 
 beforeEach(() => {
@@ -172,6 +173,12 @@ function makeDeps(
      */
     criticProcs?: string[];
     /**
+     * Terminal buffer the critic pane returns from herdr.readAsync, feeding the no-verdict
+     * diagnostic's pane tail. Omitted → the fake has NO readAsync at all, which is itself the
+     * case worth covering: the guarded read must degrade to no tail rather than throw.
+     */
+    criticPaneTail?: string;
+    /**
      * Raw readVerdict function override — bypasses adaptLegacyVerdict. Use when you need
      * stateful behavior (e.g. throw on first call, succeed on second). Takes precedence over
      * both `verdictRead` and `over.readVerdict`.
@@ -243,6 +250,9 @@ function makeDeps(
       async closeTab() {
         /* forward-compat; used by other tests via the existing path */
       }
+      // Only defined when the test asks for a tail — see criticPaneTail.
+      readAsync =
+        opts.criticPaneTail === undefined ? undefined : async () => opts.criticPaneTail as string;
     })(),
     worktree: new (class {
       readonly recorded = removed; // this-dependent: unbound call loses this.recorded
@@ -706,6 +716,130 @@ test("timeout with no verdict → error verdict, still reaps", async () => {
   expect(reviews["s1"]?.decision).toBe("error");
   expect(stopped).toEqual(["rt"]);
   expect(removed).toEqual(["/review-wt"]);
+});
+
+// ── no-verdict diagnostic ────────────────────────────────────────────────────
+// An `error` verdict carries a fixed summary that can't say WHY, so before this the only trace of a
+// critic dying at the hard deadline was the DB row — a PR whose every review timed out looked like
+// a black box. Assert the log records the deciding numbers (elapsed vs deadline), the environment,
+// and the pane tail where a CLI-level failure prints.
+test("no verdict at the deadline → logs elapsed/deadline, environment and pane tail", async () => {
+  let t = 1000;
+  const warnings: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (...a: unknown[]) => void warnings.push(a.map(String).join(" "));
+  try {
+    const { deps: d, reviews } = makeDeps(
+      { now: () => t, readVerdict: () => null, timeoutMs: 5000 },
+      { criticPaneTail: "You've hit your weekly limit · resets Jul 29" },
+    );
+    const svc = new ReviewService(d as any);
+    await svc.consider(session(), OPEN_GREEN);
+    t = 1000 + 6000;
+    await svc.tick();
+    expect(reviews["s1"]?.decision).toBe("error");
+    const line = warnings.find((w) => w.includes("no usable verdict"));
+    expect(line).toBeDefined();
+    expect(line).toContain("s1");
+    expect(line).toContain("hard timeout"); // the cause, distinguished from an early exit
+    expect(line).toContain("elapsed=6s");
+    expect(line).toContain("deadline=5s");
+    expect(line).toContain("pane-tail: You've hit your weekly limit");
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
+// The tail is diagnostics-only: a herdr without readAsync (or one that throws) must still finalize
+// normally and still log — a broken diagnostic must never strand or crash a review.
+test("no-verdict diagnostic survives a herdr with no readAsync (no tail, still logs)", async () => {
+  let t = 1000;
+  const warnings: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (...a: unknown[]) => void warnings.push(a.map(String).join(" "));
+  try {
+    const {
+      deps: d,
+      reviews,
+      stopped,
+      removed,
+    } = makeDeps({ now: () => t, readVerdict: () => null, timeoutMs: 5000 }); // no criticPaneTail
+    const svc = new ReviewService(d as any);
+    await svc.consider(session(), OPEN_GREEN);
+    t = 1000 + 6000;
+    await svc.tick();
+    const line = warnings.find((w) => w.includes("no usable verdict"));
+    expect(line).toBeDefined();
+    expect(line).not.toContain("pane-tail:"); // degraded silently, no throw
+    expect(reviews["s1"]?.decision).toBe("error"); // finalize unaffected
+    expect(stopped).toEqual(["rt"]); // still reaped
+    expect(removed).toEqual(["/review-wt"]);
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
+// A secret printed into the critic's terminal must not be copied verbatim into the server log.
+test("no-verdict pane tail is redacted before it reaches the log", async () => {
+  let t = 1000;
+  const warnings: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (...a: unknown[]) => void warnings.push(a.map(String).join(" "));
+  try {
+    const { deps: d } = makeDeps(
+      { now: () => t, readVerdict: () => null, timeoutMs: 5000 },
+      { criticPaneTail: "auth failed: ANTHROPIC_API_KEY=sk-ant-verysecretvalue" },
+    );
+    const svc = new ReviewService(d as any);
+    await svc.consider(session(), OPEN_GREEN);
+    t = 1000 + 6000;
+    await svc.tick();
+    const line = warnings.find((w) => w.includes("no usable verdict"))!;
+    expect(line).toContain("<redacted>");
+    expect(line).not.toContain("sk-ant-verysecretvalue");
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
+// A critic that exits early (before the deadline) is a DIFFERENT failure from one that ran out of
+// time — the fix differs (a broken spawn vs. a deadline that's too short), so the log must say which.
+test("critic exits before the deadline → diagnostic says exited, not timed out", async () => {
+  let t = 1000;
+  const warnings: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (...a: unknown[]) => void warnings.push(a.map(String).join(" "));
+  try {
+    const { deps: d } = makeDeps(
+      { now: () => t, readVerdict: () => null, timeoutMs: 300_000 },
+      { criticAgentStatus: "idle", criticPaneTail: "Login expired · Please run /login" },
+    );
+    const svc = new ReviewService(d as any);
+    await svc.consider(session(), OPEN_GREEN);
+    t = 1000 + STARTUP_GRACE_MS + 1000; // past the boot grace, nowhere near the deadline
+    await svc.tick();
+    const line = warnings.find((w) => w.includes("no usable verdict"))!;
+    expect(line).toContain("spawn exited without writing a verdict file");
+    expect(line).not.toContain("hard timeout");
+    expect(line).toContain("pane-tail: Login expired");
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
+// ── SHEPHERD_REVIEW_TIMEOUT_MS ───────────────────────────────────────────────
+// The deadline is the lever for a PR the critic can't finish in 10 minutes. Assert the clamp the
+// config seed applies (config.ts is top-level module code that reads env at import, so — following
+// the server-settings precedent — assert the equivalent expression rather than re-importing it).
+test("SHEPHERD_REVIEW_TIMEOUT_MS clamps into range and falls back on garbage", () => {
+  const seed = (v: string | undefined) =>
+    clampCap(Number(v ?? DEFAULT), REVIEW_TIMEOUT_MS_MIN, REVIEW_TIMEOUT_MS_MAX, DEFAULT);
+  const DEFAULT = 10 * 60_000;
+  expect(seed(undefined)).toBe(DEFAULT); // unset → today's behavior, unchanged
+  expect(seed("1500000")).toBe(1_500_000); // 25m — the raise this knob exists for
+  expect(seed("not-a-number")).toBe(DEFAULT); // NaN would otherwise make `elapsed > NaN` false forever
+  expect(seed("1")).toBe(REVIEW_TIMEOUT_MS_MIN); // too small → snapped, never reaps at once
+  expect(seed("999999999")).toBe(REVIEW_TIMEOUT_MS_MAX); // no unbounded hang → no leaked worktree
 });
 
 // ── #822 gate (merge-gating critic path) ─────────────────────────────────────


### PR DESCRIPTION
## Problem

Two PRs (topmedia-website#171, flowagent#836) had **every** critic review error out with no diagnosable cause. Investigating the DB:

| session | review spawns | durations |
|---|---|---|
| TASK-1964 | 6 | 604, 607, 612, 612, 608, 611s |
| TASK-1971 | 4 | 603, 613, 614, 613s |

10/10 landed on `ReviewService.timeoutMs` — hardcoded `10 * 60 * 1000`, never passed at construction. The critic was still working when it was reaped: TASK-1964's last transcript entry is `19:09:32` ("Now let me verify the counter-precedent…"), finalize fired at `19:09:53`, after 61 read-only tool calls and zero writes.

Two things made this a black box:

1. **No trace.** `RecapService` logs a rich diagnostic on the identical failure (spawn id, cwd, model/provider/effort, elapsed, pane tail) — that's how recap's "Login expired" and weekly-limit failures are readable in `shepherd.log`. `ReviewService.finalize` had no equivalent; the persisted summary is a fixed string that can't distinguish "critic died early" from "ran out of time". Every manual re-trigger also resets `errorRound` to 0 (`review.ts` `forceReview`), so the consecutive-error stall signal never escalated either.
2. **No lever.** Because the critic restarts from scratch each time, a PR that needs >10 min is not *slowly* reviewed — it is *permanently* un-reviewable, and there was no way to give it more room.

Not a niche tail: 50 of 676 review spawns in the last 7 days (7.4%) ended in the 595–640s band, while 618 finished comfortably under it.

## Change

- **Diagnostic.** `logNoVerdict` logs before `finalize` (whose `finally` reaps the terminal, taking the pane tail with it): the cause — unparseable / hard timeout / exited early, distinguished because the fixes differ — plus `elapsed=Ns deadline=Ns`, the reviewer environment, and the redacted pane tail where a CLI-level failure (expired login, weekly-limit refusal) prints. Fully guarded: a diagnostic must never strand a finalize, and a herdr fake without `readAsync` degrades to no tail.
- **`SHEPHERD_REVIEW_TIMEOUT_MS`.** Clamped to `[1m, 60m]` via the existing `clampCap` — a NaN would make `elapsed > NaN` permanently false (a run that never finalizes, leaking its worktree and terminal), and an unbounded value is the same hazard. **Default is unchanged at 10m**, so merging alters no behavior. Wired into both the session critic and the standalone PR critic: one critic role, one deadline — leaving the twin at the service default would half-apply an operator's raise.

Env-only rather than a UI setting: it's a machine-speed/PR-size escape hatch, not a product knob.

## Tests

5 added to `test/review.test.ts` (7714 pass / 0 fail overall): the timeout diagnostic's numbers and pane tail; graceful degradation when herdr has no `readAsync`; secret redaction of the tail; early-exit vs. hard-timeout wording; and the config clamp (unset → 10m, garbage → 10m, out-of-range → snapped).

## Not covered

`StandalonePrCriticService` gets the configurable deadline but not the diagnostic — it has no `herdr.list()` dep, so it cannot resolve a pane to tail. Worth a follow-up if that critic starts failing silently too.

[no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)