### PR TITLE
fix(review): converge plan-gate and PR-critic rework loops

### DIFF
--- a/src/critic-core.ts
+++ b/src/critic-core.ts
@@ -638,6 +638,7 @@ function scopeAndOutputTail(
     "- A guard/validation present on one code path but MISSING from its sibling path (e.g. one branch floors a value with Math.max(0, …) and a parallel branch computing the same kind of value does not) is a defect even when the unguarded path is currently unreachable.",
     '- A bug currently unreachable but made reachable by change THIS PR foreshadows (a param wired only in tests, a value a follow-up will populate, a path behind a not-yet-set flag) is real — "descoped", "handled in another ticket", or "never reached in production" does NOT make such an in-diff defect a non-issue.',
     '- Route by reachability TODAY. If the defect is reachable on a path that ALREADY executes, treat it as a normal bug: put it in "findings" and block it per the usual rules. If it is reachable ONLY through the foreshadowed-but-not-yet-wired future above (dormant today), it is informational: report it in a SINGLE "body" section headed exactly `Latent / future-reachable (non-blocking):`, ONE LINE PER DISTINCT ITEM, do NOT put it in "findings", and it NEVER makes the decision "request-changes". Either way it must concern a file in the diff per the SCOPE rule above.',
+    "",
     // FINDINGS ROUTING (#1948). The tail used to mandate the exact opposite — "A non-blocking nit
     // STILL goes in findings" — which contradicted the three lenses above and their stated reason:
     // ANY entry in `findings` advances the streak (buildVerdict), is auto-addressed (runAutoAddress

--- a/src/critic-core.ts
+++ b/src/critic-core.ts
@@ -150,7 +150,15 @@ export function reviewPrompt(
   authorNotes: string[] = [],
   issueBody?: string | null,
   epic?: EpicContext | null,
-  opts: { plan?: string | null; smellLens?: boolean } = {},
+  opts: {
+    plan?: string | null;
+    smellLens?: boolean;
+    /** The EFFECTIVE rework round (already clamped + spawn-count-maxed by the caller — see
+     *  ReviewService.begin), and the live cap. Both required for the ROUND block; absent ⇒ no block,
+     *  so every other caller stays byte-identical. */
+    round?: number;
+    cap?: number;
+  } = {},
 ): string {
   const lines = [
     "You are a code critic reviewing a pull request. Do NOT modify, build, commit, or run anything — read-only inspection only.",
@@ -184,6 +192,11 @@ export function reviewPrompt(
     lines.push(
       `This is a RE-REVIEW. The previous revision raised the points below. For EACH, confirm the new diff actually addresses it; if it does not, re-raise it verbatim in your findings — do not let it slide — UNLESS its file is not in \`git diff ${diffBase}...HEAD\`, in which case drop it per the scope rule below (do NOT re-raise it):`,
       ...priorFindings.map((f, i) => `${i + 1}. ${f}`),
+      // Severity-based drop, alongside the out-of-diff drop above (#1948). Prior findings PERSIST in
+      // `reviews.findings` across a deploy, so without this every nit recorded under the old
+      // "a non-blocking nit STILL goes in findings" contract is re-raised verbatim on the first
+      // review after that contract changed — and nothing converges any faster.
+      'A prior point that FINDINGS ROUTING below does not admit as blocking is likewise DROPPED — do not re-raise it in "findings". You MAY restate it once under `Nits (non-blocking):`. Saying in "body" that you dropped it, and why, IS compliance with the re-raise instruction above, not a violation of it.',
       "",
     );
   }
@@ -195,6 +208,10 @@ export function reviewPrompt(
       "",
     );
   }
+  // ROUND block (#1948) — session critic ONLY, and deliberately in this preamble rather than in
+  // scopeAndOutputTail: the tail is shared verbatim with prReviewPrompt (a test asserts byte
+  // identity), and the standalone critic has no rework loop to be late in.
+  lines.push(...roundBlock(opts.round, opts.cap, "Nits (non-blocking):", "the author"));
   // The judging clause is the ONE line that differs between the session critic ("satisfies that
   // task") and the standalone PR critic ("bugs/security/quality, intent as context") — everything
   // after it (the verdict-output contract) is identical, so it's factored into the shared tail.
@@ -455,6 +472,70 @@ function landingBlock(landing: LandingContext, diffBase: string): string[] {
   ];
 }
 
+/**
+ * The ROUND block (#1948), shared by the session PR critic ({@link reviewPrompt}) and the plan
+ * reviewer (`plan-gate.ts` → `planReviewPrompt`) so the two can never drift — the same reason
+ * {@link scopeAndOutputTail} exists. Emitted only when BOTH `round` and `cap` are supplied; absent
+ * ⇒ `[]`, so every caller that passes neither keeps a byte-identical prompt.
+ *
+ * `round` is the EFFECTIVE round the caller already computed (see {@link effectiveRound}) — this
+ * builder stays pure and does no clamping of its own.
+ *
+ * Two invariants the wording must preserve, both learned the hard way:
+ *  - Severity is never downgraded by lateness. A correctness/security defect is a finding at any
+ *    round, and an item that was blocking when first raised stays blocking — otherwise an
+ *    unaddressed blocker would be simultaneously must-re-raise and must-route-to-non-blocking.
+ *  - The last-round line HEDGES ("may be the last"). It is NOT safe to assert that findings stop
+ *    reaching the recipient here: at `priorRound === cap - 1` the steer is still delivered, and
+ *    because `round` is maxed with a spawn count it can reach `cap` while the delivered-round
+ *    counter is lower still. Asserting escalation would suppress real findings on a false premise.
+ */
+export function roundBlock(
+  round: number | undefined,
+  cap: number | undefined,
+  nonBlockingSection: string,
+  recipient: string,
+): string[] {
+  if (round === undefined || cap === undefined) return [];
+  if (!Number.isFinite(round) || !Number.isFinite(cap) || round < 1 || cap < 1) return [];
+  const n = round;
+  const m = cap;
+  const lines = [
+    `ROUND — this is rework round ${n} of at most ${m}.`,
+    "- A correctness or security defect is a finding at ANY round. Nothing below downgrades one.",
+    "- A point that was blocking when you first raised it STAYS blocking. The rules below govern only what you are noticing for the FIRST time now.",
+  ];
+  // Strictly past the halfway point (2n > m), so a 1-of-2 review is not already "late".
+  if (2 * n > m)
+    lines.push(
+      `- You are past the halfway point of the rework budget. Raise a NEW finding only if it would make the change fail outright; anything else you notice now goes to \`${nonBlockingSection}\`.`,
+    );
+  if (n >= m)
+    lines.push(
+      `- The budget is spent. Findings from this round may be the LAST that reach ${recipient} before the loop pauses for a human, so reserve blocking findings for what genuinely must not proceed.`,
+    );
+  lines.push("");
+  return lines;
+}
+
+/** The EFFECTIVE rework round both review loops brief their reviewer with (#1948).
+ *
+ *  `priorRound + 1` alone is wrong at BOTH ends, which is why this exists:
+ *   - Too high: `applyChangesRequested` HOLDS the round at the cap while `startedStatus` →
+ *     "started-at-cap" still starts reviews, so the raw value emits "round 13 of at most 12" and the
+ *     at-cap rule never fires on exactly the stalled sessions it is for. Hence the clamp.
+ *   - Too low: `resume()` writes `{ ...gate, round: 0 }` and is the ONLY operator escape offered at
+ *     the cap, so a plan reviewed 29 times would be briefed as round 1. Hence the max against
+ *     `reviewCount` — a reset-proof count of this session's reviewer spawns.
+ *
+ *  Policy this encodes: an operator Resume UNBLOCKS a session; it does not restore full review
+ *  latitude. `reviewCount` is itself clamped, so it can only ever raise the round to the cap.
+ */
+export function effectiveRound(priorRound: number, reviewCount: number, cap: number): number {
+  const clamped = Math.min(priorRound + 1, cap);
+  return Math.max(clamped, Math.min(reviewCount, cap));
+}
+
 function scopeAndOutputTail(
   diffBase: string,
   judgeClause: string,
@@ -557,9 +638,27 @@ function scopeAndOutputTail(
     "- A guard/validation present on one code path but MISSING from its sibling path (e.g. one branch floors a value with Math.max(0, …) and a parallel branch computing the same kind of value does not) is a defect even when the unguarded path is currently unreachable.",
     '- A bug currently unreachable but made reachable by change THIS PR foreshadows (a param wired only in tests, a value a follow-up will populate, a path behind a not-yet-set flag) is real — "descoped", "handled in another ticket", or "never reached in production" does NOT make such an in-diff defect a non-issue.',
     '- Route by reachability TODAY. If the defect is reachable on a path that ALREADY executes, treat it as a normal bug: put it in "findings" and block it per the usual rules. If it is reachable ONLY through the foreshadowed-but-not-yet-wired future above (dormant today), it is informational: report it in a SINGLE "body" section headed exactly `Latent / future-reachable (non-blocking):`, ONE LINE PER DISTINCT ITEM, do NOT put it in "findings", and it NEVER makes the decision "request-changes". Either way it must concern a file in the diff per the SCOPE rule above.',
+    // FINDINGS ROUTING (#1948). The tail used to mandate the exact opposite — "A non-blocking nit
+    // STILL goes in findings" — which contradicted the three lenses above and their stated reason:
+    // ANY entry in `findings` advances the streak (buildVerdict), is auto-addressed (runAutoAddress
+    // fires on non-empty findings REGARDLESS of decision), and is re-raised every round by the
+    // re-raise rule. A wording nit therefore looped until the streak ceiling paused the PR. So
+    // `findings` is now blocking-only, and nits get the same non-blocking body routing the lenses use.
+    'FINDINGS ROUTING — what belongs in "findings" and what does not:',
+    '- "findings" is for changes the author MUST make: a correctness bug, a security issue, a broken or violated contract, a missing locale/catalog counterpart, or a diff that does not do what the task/intent above requires. Any such defect is a finding REGARDLESS of how small it looks.',
+    '- A NON-BLOCKING nit — a naming or wording preference, a stylistic choice, a comment you would phrase differently, a refactor you would like but the task did not require — does NOT go in "findings". Report it in a SINGLE "body" section headed exactly `Nits (non-blocking):`, ONE LINE PER DISTINCT ITEM, and it NEVER makes the decision "request-changes". Each must concern a file in the diff per the SCOPE rule above.',
+    '- COMMENTS specifically: do NOT raise a finding asking for a comment to be reworded or expanded, or for more explanation of code that is already correct — that is a nit. A comment that is factually WRONG about what the code does IS a defect: raise it in "findings".',
+    // Advisory cap. Deliberately NOT enforced server-side: the repo's deterministic backstops
+    // (scopeFindings here, MAX_ADDS_PER_RUN in distiller.ts) each enforce a DECIDABLE predicate,
+    // whereas "is this finding blocking?" is not decidable from the verdict text. Truncating would
+    // cut blind and could discard a real blocker while keeping a nit — so the cap is worded so that
+    // it can never lose information instead.
+    '- At most 5 NEW findings per review, highest-severity first. This is a PRIORITISATION instruction, never a limit that may lose information: if more than 5 genuine blocking problems exist, emit ALL of them and say so in "summary" (the change needs reworking, not tweaking). NEVER move a blocking problem into `Nits (non-blocking):`, and never drop one, to fit the budget.',
+    "- Re-raised prior findings do NOT count against those 5.",
+    "",
     "When done, write your verdict as JSON to the file `.shepherd-review.json` in the repository root, with EXACTLY this shape:",
     '{"decision": "request-changes" | "comment", "summary": "<=100 char one-liner", "body": "<full markdown review>", "findings": ["<discrete actionable item>", ...]}',
-    'The "findings" array lists every discrete change the author must make — one entry per point, blocking or not. A non-blocking nit STILL goes in "findings" (under a "comment" decision). Use [] ONLY when there is genuinely nothing to address; "request-changes" requires at least one finding.',
+    'The "findings" array lists every discrete change the author must make — one entry per point, routed per FINDINGS ROUTING above. Use [] when everything you found is non-blocking (report those in the body sections named above) or there is genuinely nothing to address; "request-changes" requires at least one finding.',
     'Use "request-changes" ONLY for blocking problems (does not satisfy the task, logic bug, security hole). Otherwise use "comment". Never approve. Write the file as your final action, then stop.',
   ];
 }

--- a/src/critic-core.ts
+++ b/src/critic-core.ts
@@ -505,8 +505,12 @@ export function roundBlock(
     "- A correctness or security defect is a finding at ANY round. Nothing below downgrades one.",
     "- A point that was blocking when you first raised it STAYS blocking. The rules below govern only what you are noticing for the FIRST time now.",
   ];
-  // Strictly past the halfway point (2n > m), so a 1-of-2 review is not already "late".
-  if (2 * n > m)
+  // Strictly past the halfway point (2n > m), so a 1-of-2 review is not already "late" — AND never
+  // on a first-ever review. `n > 1` is load-bearing, not belt-and-braces: both caps are UI-settable
+  // down to 1 (PR_REVIEW_CYCLES_MIN / PLAN_REVIEW_CYCLES_MIN), where 2n > m holds at n = 1 and would
+  // muzzle the only review the operator gets — every finding on a first review is new, so the
+  // blocking classes FINDINGS ROUTING names would all route to the non-blocking section.
+  if (n > 1 && 2 * n > m)
     lines.push(
       `- You are past the halfway point of the rework budget. Raise a NEW finding only if it would make the change fail outright; anything else you notice now goes to \`${nonBlockingSection}\`.`,
     );

--- a/src/critic-core.ts
+++ b/src/critic-core.ts
@@ -503,7 +503,15 @@ export function roundBlock(
   const lines = [
     `ROUND — this is rework round ${n} of at most ${m}.`,
     "- A correctness or security defect is a finding at ANY round. Nothing below downgrades one.",
-    "- A point that was blocking when you first raised it STAYS blocking. The rules below govern only what you are noticing for the FIRST time now.",
+    // Scoped deliberately to "under FINDINGS ROUTING" and to "the rules below". Unqualified, this
+    // sentence contradicts the stale-prior DROP rule for exactly the priors that rule targets: the
+    // plan prompt had no non-blocking channel before this change, so EVERY stored PlanGate.findings
+    // entry was raised as blocking, and a literal reading would force all of them re-raised —
+    // defeating the mechanism that unsticks a session already at its cap. The trailing clause states
+    // the precedence the approved plan specifies (the drop rule outranks budget and thresholds)
+    // WITHOUT naming the drop rule, which is emitted only on a re-review: with no priors there is
+    // nothing to preserve, so the clause is vacuous rather than a dangling reference.
+    "- A point that was blocking UNDER FINDINGS ROUTING when you first raised it STAYS blocking — the halfway and at-cap rules below never demote one. That applies to THOSE rules only: it does not preserve a prior that FINDINGS ROUTING no longer admits as blocking.",
   ];
   // Strictly past the halfway point (2n > m), so a 1-of-2 review is not already "late" — AND never
   // on a first-ever review. `n > 1` is load-bearing, not belt-and-braces: both caps are UI-settable

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -1396,11 +1396,14 @@ function planSteerText(findings: string[]): string {
     // grows the surface the next round attacks. Observed: a plan reaching 32 KB with 28 success
     // criteria, three "why not X" essay sections and a ledger of addressed findings — written for
     // the reviewer rather than for the implementer.
+    // NB: no reference to the reviewer's non-blocking `Suggestions` section here. Only
+    // `gate.findings` is steered (steerFindings) — the verdict body stays in the gate for the
+    // operator's UI and never reaches the planner's worktree, so naming a section the agent cannot
+    // see would just be noise. The list above IS the complete set of what it must address.
     "\n\nRevise IN PLACE and keep the plan tight: edit the sections that are wrong and delete what no " +
     'longer holds. Do NOT append justification or rebuttal sections, a "why not X" essay, or a ledger ' +
     "of which finding each change answers — the plan is an instruction to the implementer, not a reply " +
-    "to the reviewer. Any `Suggestions (non-blocking):` section in the review is OPTIONAL: it is not " +
-    "part of this list and does not block approval." +
+    "to the reviewer." +
     "\n\nDon't start implementing yet — wait for the plan to be approved."
   );
 }

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -28,6 +28,9 @@ import { resolveAuxSpawn, type MembraneSeams } from "./spawn-membrane";
 import { fenceUntrusted } from "./untrusted";
 import { type OperatorLanguage } from "./operator-language";
 import { resumeThenSteer } from "./resume-then-steer";
+// The ROUND block + effective-round arithmetic are shared verbatim with the PR critic (#1948) so the
+// two review loops can never drift on them — the same reason `scopeAndOutputTail` is shared there.
+import { roundBlock, effectiveRound } from "./critic-core";
 
 /** Outcome of an on-demand `consider()`: a reviewer actually spawned (`"started"`, or
  *  `"started-at-cap"` — see below); the request was a no-op (`"skipped"` — not planning, a review
@@ -175,20 +178,33 @@ export function planReviewPrompt(
   operatorLanguage: OperatorLanguage = "en",
   anchor?: PlanAnchor | null,
   staleness?: AnchorStaleness | null,
+  /** #1948. An options BAG, deliberately not two more positional params: `operatorLanguage` above
+   *  binds positionally, so anything inserted before it silently mis-binds. `round` is the EFFECTIVE
+   *  round the caller already computed (see {@link effectiveRound}); absent ⇒ no ROUND block, so
+   *  every existing caller and test keeps a byte-identical prompt. */
+  opts: { round?: number; cap?: number } = {},
 ): string {
   const lines = [
     "You are an adversarial plan reviewer. Read-only — do NOT modify, build, commit, or run anything.",
     "A coding agent wrote the PLAN below to accomplish a TASK, BEFORE writing any code. Your job is to",
-    "try to REFUTE the plan: is it the best path? Does it actually satisfy the task? What are the hidden",
-    "risks, missing steps, wrong assumptions, or a materially simpler approach it ignored? You MAY inspect",
-    "the codebase read-only (git log/show/diff, Read, Grep) to ground your critique.",
-    // #1812 findings B + H: the plan schema now carries an explicit "Out of Scope" boundary and a
-    // "testing seams + decisions" section, giving this reviewer a scope + testability surface to
-    // attack. A plan that leaves either implicit is refutable.
-    "Scrutinise the plan's SCOPE and TESTABILITY in particular: does it draw an explicit `Out of Scope` " +
-      "boundary (so scope creep can be caught at review), and does it name concrete testing seams — " +
-      "preferring existing seams and the fewest, highest ones — rather than a vague 'add tests'? Flag " +
-      "either being missing, too broad, or untestable as a blocking concern.",
+    "try to REFUTE the plan: does it actually satisfy the task? What are the hidden risks, missing steps,",
+    "wrong assumptions, or a materially simpler approach it ignored? You MAY inspect the codebase",
+    "read-only (git log/show/diff, Read, Grep) to ground your critique.",
+    // #1948: the bar used to be "genuinely the best reasonable path", which no plan ever wins —
+    // optimality is unfalsifiable, so the gate could be re-litigated indefinitely (observed: two
+    // sessions exhausting a 12-round budget twice). Refutation now targets DEFECTS, not optimality.
+    "The bar is SOUNDNESS, not optimality. A plan does NOT have to be exhaustive, perfectly worded, or",
+    "the approach you would have chosen. It passes when its approach will work, it satisfies the task,",
+    "and whatever remains open is something the implementing agent can reasonably settle while executing.",
+    "",
+    // #1812 findings B + H, re-scoped by #1948: the scope/testability surface is still worth
+    // attacking, but "flag either as a blocking concern" manufactured a guaranteed round-1 blocker
+    // with no ceiling on how explicit a boundary had to be. Blocking now requires genuine absence.
+    "Scrutinise the plan's SCOPE and TESTABILITY: does it draw an explicit `Out of Scope` boundary (so " +
+      "scope creep can be caught at review), and does it name concrete testing seams — preferring " +
+      "existing seams and the fewest, highest ones — rather than a vague 'add tests'? A boundary or " +
+      "seam that is genuinely ABSENT is blocking. One that exists but is imperfectly worded or narrower " +
+      "than you would have drawn it is NOT — that goes under `Suggestions (non-blocking):`.",
     "",
     "TASK:",
     task,
@@ -208,16 +224,24 @@ export function planReviewPrompt(
     lines.push(
       "This is a RE-REVIEW. For EACH prior point, confirm the revised plan addresses it; if it does not, re-raise it verbatim:",
       ...priorFindings.map((f, i) => `${i + 1}. ${f}`),
+      // #1948 severity-based drop. `PlanGate.findings` PERSIST across a deploy, so without this every
+      // point recorded under the old "best reasonable path" bar is re-raised verbatim on the first
+      // review after that bar changed — and the sessions this change exists for converge no faster.
+      'EXCEPTION: a prior point that FINDINGS ROUTING below does not admit as blocking is DROPPED — do not re-raise it in "findings". You MAY restate it once under `Suggestions (non-blocking):`. Saying in "body" that you dropped it, and why, IS compliance with this instruction, not a violation of it.',
       "",
     );
   }
   // The re-raise exemption is gated on the SAME condition as the re-review block above — it cites
   // that instruction, so emitting it on a first round would point at text the prompt doesn't have.
   lines.push(...locationReferenceBlock(anchor, staleness, priorFindings.length > 0), "");
+  lines.push(...findingsRoutingBlock());
+  lines.push(
+    ...roundBlock(opts.round, opts.cap, "Suggestions (non-blocking):", "the planning agent"),
+  );
   lines.push(
     `Write your verdict as JSON to \`${PLAN_VERDICT_FILE}\` in the current directory, with EXACTLY this shape:`,
     '{"decision": "approve" | "request-changes", "summary": "<=100 char one-liner", "body": "<full markdown>", "findings": ["<discrete actionable revision>", ...]}',
-    'Use "approve" ONLY when the plan is genuinely the best reasonable path and fully satisfies the task — no remaining blocking concerns. Otherwise "request-changes" with at least one finding in "findings". Write the file as your final action, then stop.',
+    'Use "approve" when the plan clears the SOUNDNESS bar above and nothing in "findings" remains — non-blocking items under `Suggestions (non-blocking):` do NOT prevent approval. Otherwise "request-changes" with at least one finding in "findings". Write the file as your final action, then stop.',
   );
   if (operatorLanguage === "de") {
     lines.push(
@@ -229,6 +253,44 @@ export function planReviewPrompt(
     );
   }
   return lines.join("\n");
+}
+
+/**
+ * FINDINGS ROUTING (#1948) — what may block a plan and what may not.
+ *
+ * The plan reviewer's only contract used to be "approve, or request-changes with at least one
+ * finding". With no non-blocking channel, a wording preference had exactly one legal exit: a
+ * blocking finding that costs a full rework round. The PR critic solved the same problem with named
+ * non-blocking body sections (`critic-core.ts` → the scope-creep / smells / latent lenses), each
+ * forbidden from `findings` because ANY entry there advances the streak, is steered back to the
+ * agent, and is re-raised the next round. This is the plan-side counterpart.
+ *
+ * Three rules carry most of the weight, each aimed at an observed failure:
+ *  - The enumerated blocking list replaces an open-ended "is it the best path" judgement.
+ *  - The SCOPE-DEMAND rule stops findings that require the plan to grow beyond its task — the
+ *    mechanism behind plans reaching 32 KB and 28 success criteria across a dozen rounds.
+ *  - The PROSE rule stops findings that ask for more argument about a decision already stated
+ *    (observed verbatim: "Argue the rejection of X instead of listing it").
+ *
+ * The cap is ADVISORY and worded so it can never lose information: unlike `scopeFindings` in
+ * critic-core (which enforces a decidable predicate — is this path in the diff?), "is this finding
+ * blocking?" cannot be checked server-side, so a deterministic truncation would cut blind. Overflow
+ * therefore emits every blocker rather than shedding one into the non-blocking section, which would
+ * make an over-budget verdict read as clean to `signoff.ts` / `autopilot.ts`.
+ */
+function findingsRoutingBlock(): string[] {
+  return [
+    'FINDINGS ROUTING — what belongs in "findings" and what does not:',
+    "- A finding is BLOCKING only when one of these holds: the plan will not satisfy the task; a step is wrong or will not work; a stated assumption is factually false against this codebase; a named risk would cause data loss, a security hole, or breakage and is left unmitigated; or a materially simpler approach exists that the plan does not consider at all.",
+    '- EVERYTHING ELSE is non-blocking. Report it in a SINGLE "body" section headed exactly `Suggestions (non-blocking):`, ONE LINE PER DISTINCT ITEM. Non-blocking items NEVER go in "findings" and NEVER make the decision "request-changes".',
+    // The scope-demand lens — the plan-side analogue of the PR critic's SCOPE-CREEP lens, with named
+    // item classes so it is matchable rather than a bare principle.
+    "- SCOPE DEMANDS: a finding may NOT require the plan to cover work the TASK does not ask for — additional cases, extra hardening, follow-up work, or considerations outside the task's boundary. Those are suggestions. A gap is blocking ONLY when the task AS STATED is not satisfied. A plan being narrower than you would have scoped it is never a finding on its own.",
+    "- PROSE: a finding may NOT ask for more argumentation, justification, rationale, or for a decision the plan already states to be re-argued at greater length. Ask for a MISSING DECISION, never for more prose about one already made. A plan is an instruction to an implementer, not an essay defending itself.",
+    '- At most 5 NEW findings per review, highest-severity first. This is a PRIORITISATION instruction, never a limit that may lose information: if more than 5 genuine blocking problems exist, emit ALL of them and say so in "summary" (the plan needs rewriting, not revising). NEVER move a blocking problem into `Suggestions (non-blocking):`, and never drop one, to fit the budget.',
+    "- Re-raised prior findings do NOT count against those 5.",
+    "",
+  ];
 }
 
 /** The LOCATION REFERENCES block: how the reviewer must treat WHERE the plan says code lives.
@@ -570,6 +632,22 @@ export class PlanGateService {
     }
   }
 
+  /** How many plan reviews this session has already had (#1948). Unlike `gate.round` this survives
+   *  `resume()` / `dismiss()`, which write `round: 0` — and Resume is the ONLY operator escape
+   *  offered at the cap (`blocked.ts` returns that hold with no options), so without this the
+   *  late-round rules would never fire on exactly the sessions that exhausted their budget.
+   *
+   *  Reset-proof, not immortal: `pruneReviewerSpawns` drops rows older than
+   *  REVIEWER_SPAWN_RETENTION_MS (90 days), which no plan-review streak approaches. If one ever were
+   *  pruned the count simply falls and `effectiveRound` degrades to the round-based value. Error
+   *  spawns count too — see the note on ReviewService.countReviewSpawns for why that is accepted. */
+  private countPlanGateSpawns(sessionId: string): number {
+    let n = 0;
+    for (const row of this.deps.store.listReviewerSpawns())
+      if (row.kind === "plan_gate" && row.taskSessionId === sessionId) n++;
+    return n;
+  }
+
   /** Assemble the reviewer prompt, resolving the two facts that decide how it talks about
    *  locations: which tier applies (from the anchor), and whether the anchor has fallen materially
    *  behind the base branch.
@@ -590,6 +668,12 @@ export class PlanGateService {
     const staleness = anchor.anchored
       ? this.anchorStaleness(session.repoPath, anchor.sha, session.baseBranch)
       : null;
+    // #1948: the EFFECTIVE round briefed to the reviewer. `prior.round` alone is wrong at both ends
+    // — applyChangesRequested HOLDS it at the cap (so `+1` would emit "round 13 of at most 12" and
+    // the at-cap rule would never fire on a stalled session), while resume() zeroes it (so a plan
+    // reviewed 29 times would be briefed as round 1). effectiveRound clamps it and maxes it against
+    // a reset-proof spawn count.
+    const round = effectiveRound(prior?.round ?? 0, this.countPlanGateSpawns(session.id), this.cap);
     return planReviewPrompt(
       session.prompt,
       plan,
@@ -598,6 +682,7 @@ export class PlanGateService {
       this.deps.operatorLanguage?.() ?? "en",
       anchor.anchored ? { sha: anchor.sha, ahead: anchor.ahead } : undefined,
       staleness && staleness.behind > 0 ? staleness : undefined,
+      { round, cap: this.cap },
     );
   }
 
@@ -1307,6 +1392,15 @@ function planSteerText(findings: string[]): string {
   return (
     "The plan reviewer raised these points on `.shepherd-plan.md`. Revise the plan to address each, then stop so it can be re-reviewed:\n\n" +
     findings.map((f, i) => `${i + 1}. ${f}`).join("\n") +
+    // #1948: without this the only legal move is to ADD text, so each round grows the plan, which
+    // grows the surface the next round attacks. Observed: a plan reaching 32 KB with 28 success
+    // criteria, three "why not X" essay sections and a ledger of addressed findings — written for
+    // the reviewer rather than for the implementer.
+    "\n\nRevise IN PLACE and keep the plan tight: edit the sections that are wrong and delete what no " +
+    'longer holds. Do NOT append justification or rebuttal sections, a "why not X" essay, or a ledger ' +
+    "of which finding each change answers — the plan is an instruction to the implementer, not a reply " +
+    "to the reviewer. Any `Suggestions (non-blocking):` section in the review is OPTIONAL: it is not " +
+    "part of this list and does not block approval." +
     "\n\nDon't start implementing yet — wait for the plan to be approved."
   );
 }

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -639,8 +639,12 @@ export class PlanGateService {
    *
    *  Reset-proof, not immortal: `pruneReviewerSpawns` drops rows older than
    *  REVIEWER_SPAWN_RETENTION_MS (90 days), which no plan-review streak approaches. If one ever were
-   *  pruned the count simply falls and `effectiveRound` degrades to the round-based value. Error
-   *  spawns count too — see the note on ReviewService.countReviewSpawns for why that is accepted. */
+   *  pruned the count simply falls and `effectiveRound` degrades to the round-based value.
+   *
+   *  Error spawns count too: a row exists whether or not the reviewer produced a verdict, so a
+   *  repeatedly-failing reviewer reads as later than its delivered-round count. Accepted — the row
+   *  represents tokens genuinely spent on this plan, and per `roundBlock` lateness never downgrades
+   *  a blocking finding or demotes one already raised. */
   private countPlanGateSpawns(sessionId: string): number {
     let n = 0;
     for (const row of this.deps.store.listReviewerSpawns())

--- a/src/review.ts
+++ b/src/review.ts
@@ -431,7 +431,7 @@ export class ReviewService {
     // #1824 finding C: per-repo POSSIBLE-SMELLS lens flag (default OFF). Read here (not cached from
     // the criticEnabled gate above) so a toggle mid-session takes effect on the next review round.
     const smellLens = this.deps.store.getRepoConfig(session.repoPath).criticSmellLensEnabled;
-    const round = this.briefedRound(session.id, prior);
+    const round = this.briefedRound(prior);
     const { argv, sessionId: criticSessionId } = this.criticArgv(
       session,
       diffBase,
@@ -666,32 +666,27 @@ export class ReviewService {
   }
 
   /** The EFFECTIVE round this run briefs the critic with (#1948 — see {@link effectiveRound}).
-   *  `prior.addressRound` is the delivered-steer count, which runAutoAddress HOLDS at the cap and
-   *  forceReview resets to 0, so the raw value both overshoots and under-reports.
+   *  `prior.addressRound` is the delivered-steer count, which runAutoAddress HOLDS at the cap, so
+   *  the raw `+1` would overshoot into "round 4 of at most 3" on a stalled PR.
+   *
+   *  The floor is `streakReviews` — findings-bearing reviews on the CURRENT outstanding-findings
+   *  streak. It must NOT be a lifetime spawn count: a critic spawn fires per CI-green head, not per
+   *  rework round, so on a healthy session that never entered a rework loop a lifetime count would
+   *  climb with ordinary pushes and (at the default cap of 3) brief the 2nd review as "past the
+   *  halfway point" and the 3rd as "budget spent" — muzzling contract, locale-parity and
+   *  task-satisfaction findings on a PR that was never in rework at all. `streakReviews` resets to 0
+   *  on every clean verdict alongside `addressRound`, so a healthy session always reads as round 1,
+   *  while a genuine rework streak still floors the round even though error verdicts leave
+   *  `addressRound` untouched (finalizeErrorVerdict preserves the streak).
+   *
+   *  `forceReview` zeroes both, so an explicit operator re-review restores full latitude. That is
+   *  deliberate and differs from the plan gate, where Resume is the ONLY escape at the cap and must
+   *  therefore NOT hand back latitude.
    *
    *  A method rather than an inline expression in begin(): its optional-chain + nullish branches
    *  would otherwise count against that method's already-tight complexity budget (fallow health). */
-  private briefedRound(sessionId: string, prior: ReviewVerdict | null): number {
-    return effectiveRound(prior?.addressRound ?? 0, this.countReviewSpawns(sessionId), this.cap);
-  }
-
-  /** How many critic spawns this session has already had (#1948). Unlike `addressRound` this
-   *  survives `forceReview`'s streak reset, so a PR the critic has looked at ten times is still
-   *  briefed as late-round after an operator re-engages it.
-   *
-   *  Reset-proof, not immortal: `pruneReviewerSpawns` drops rows older than
-   *  REVIEWER_SPAWN_RETENTION_MS (90 days), which no review streak approaches. If one ever were
-   *  pruned the count simply falls and `effectiveRound` degrades to the round-based value.
-   *
-   *  Counts ERROR spawns too — a row exists whether or not the critic produced a verdict. A
-   *  repeatedly-failing critic therefore reads as later than its delivered-round count. Accepted:
-   *  the row represents real tokens spent, lateness never downgrades a correctness/security finding
-   *  (see roundBlock), and consecutive errors have their own `errorRound` ceiling. */
-  private countReviewSpawns(sessionId: string): number {
-    let n = 0;
-    for (const row of this.deps.store.listReviewerSpawns())
-      if (row.kind === "review" && row.taskSessionId === sessionId) n++;
-    return n;
+  private briefedRound(prior: ReviewVerdict | null): number {
+    return effectiveRound(prior?.addressRound ?? 0, prior?.streakReviews ?? 0, this.cap);
   }
 
   /** Build the read-only critic's argv — deliberately NOT --dangerously-skip-permissions. It

--- a/src/review.ts
+++ b/src/review.ts
@@ -20,6 +20,7 @@ import {
   defaultComputePatchId,
   defaultCollectBaseDelta,
   scopeFindings,
+  effectiveRound,
   buildVerdictCore,
   shouldSkipForPatchId,
   captureUsage,
@@ -53,9 +54,14 @@ export type ReviewOutcome = "started" | "skipped" | "error";
  *  would "fix" it against a tree that lacks it). So tell it where the base is. */
 function steerText(findings: string[], prNumber: number, epicBase: string | null): string {
   const lines = [
-    "The PR critic reviewed your latest push. Address each point below in this PR:",
+    "The PR critic reviewed your latest push. These are the BLOCKING points — address each in this PR:",
     "",
     ...findings.map((f, i) => `${i + 1}. ${f}`),
+    "",
+    // #1948: the critic now routes nits to a `Nits (non-blocking):` body section instead of into
+    // findings. Say so, or an agent that reads the posted review will treat those as required work
+    // and re-push for them — reintroducing through the body the churn the routing change removed.
+    "Any `Nits (non-blocking):` section in the posted review is OPTIONAL — it is not part of this list and does not need a fix or a reply.",
     "",
   ];
   if (epicBase) {
@@ -425,6 +431,7 @@ export class ReviewService {
     // #1824 finding C: per-repo POSSIBLE-SMELLS lens flag (default OFF). Read here (not cached from
     // the criticEnabled gate above) so a toggle mid-session takes effect on the next review round.
     const smellLens = this.deps.store.getRepoConfig(session.repoPath).criticSmellLensEnabled;
+    const round = this.briefedRound(session.id, prior);
     const { argv, sessionId: criticSessionId } = this.criticArgv(
       session,
       diffBase,
@@ -435,6 +442,7 @@ export class ReviewService {
       epic,
       plan,
       smellLens,
+      round,
     );
     // Fire plugin onSpawn hooks for this reviewer-style spawn (issue #1205) and bind any patched
     // env THROUGH the membrane (apiKeyPassthroughEnv handled inside). A hook that calls abortSpawn
@@ -657,6 +665,35 @@ export class ReviewService {
     return { seenNoteIds: [...priorSeenNoteIds, ...fresh.ids], authorNotes: fresh.notes };
   }
 
+  /** The EFFECTIVE round this run briefs the critic with (#1948 — see {@link effectiveRound}).
+   *  `prior.addressRound` is the delivered-steer count, which runAutoAddress HOLDS at the cap and
+   *  forceReview resets to 0, so the raw value both overshoots and under-reports.
+   *
+   *  A method rather than an inline expression in begin(): its optional-chain + nullish branches
+   *  would otherwise count against that method's already-tight complexity budget (fallow health). */
+  private briefedRound(sessionId: string, prior: ReviewVerdict | null): number {
+    return effectiveRound(prior?.addressRound ?? 0, this.countReviewSpawns(sessionId), this.cap);
+  }
+
+  /** How many critic spawns this session has already had (#1948). Unlike `addressRound` this
+   *  survives `forceReview`'s streak reset, so a PR the critic has looked at ten times is still
+   *  briefed as late-round after an operator re-engages it.
+   *
+   *  Reset-proof, not immortal: `pruneReviewerSpawns` drops rows older than
+   *  REVIEWER_SPAWN_RETENTION_MS (90 days), which no review streak approaches. If one ever were
+   *  pruned the count simply falls and `effectiveRound` degrades to the round-based value.
+   *
+   *  Counts ERROR spawns too — a row exists whether or not the critic produced a verdict. A
+   *  repeatedly-failing critic therefore reads as later than its delivered-round count. Accepted:
+   *  the row represents real tokens spent, lateness never downgrades a correctness/security finding
+   *  (see roundBlock), and consecutive errors have their own `errorRound` ceiling. */
+  private countReviewSpawns(sessionId: string): number {
+    let n = 0;
+    for (const row of this.deps.store.listReviewerSpawns())
+      if (row.kind === "review" && row.taskSessionId === sessionId) n++;
+    return n;
+  }
+
   /** Build the read-only critic's argv — deliberately NOT --dangerously-skip-permissions. It
    *  inspects an UNTRUSTED PR diff, so a prompt-injection hidden in that diff must not be able
    *  to run commands or escape its worktree. `dontAsk` auto-denies anything off the allowlist
@@ -672,6 +709,7 @@ export class ReviewService {
     epic: EpicContext | null,
     plan: string | null,
     smellLens: boolean,
+    round: number,
   ): { argv: string[]; sessionId: string } {
     // Shared with the plan reviewer: same read-only injection-contained sandbox (the PR diff is
     // UNTRUSTED). The prompt is the only critic-specific part. `diffBase` is the resolved base
@@ -692,6 +730,8 @@ export class ReviewService {
       prompt: reviewPrompt(diffBase, session.prompt, priorFindings, authorNotes, issueBody, epic, {
         plan,
         smellLens,
+        round,
+        cap: this.cap,
       }),
       // The critic READS the `-o` last-message fallback (per-spawn name for its untrusted checkout).
       captureLastMessage: true,

--- a/test/critic-core.test.ts
+++ b/test/critic-core.test.ts
@@ -19,6 +19,7 @@ import {
   effectiveRound,
 } from "../src/critic-core";
 import { allowedToolsFor } from "../src/transient-agent-argv";
+import { planReviewPrompt } from "../src/plan-gate";
 
 // ── #822 regression: malformed-JSON read path with content fidelity ─────────────────────────────
 //
@@ -1032,4 +1033,31 @@ test("#1948: the halfway rule still fires from round 2 once genuinely past halfw
   expect(roundBlock(2, 3, sec, "x").join("\n")).toContain("past the halfway point");
   expect(roundBlock(2, 4, sec, "x").join("\n")).not.toContain("past the halfway point");
   expect(roundBlock(7, 12, sec, "x").join("\n")).toContain("past the halfway point");
+});
+
+test("#1948: the STAYS-blocking bullet is scoped so it cannot defeat the stale-prior drop", () => {
+  // Unqualified, "a point that was blocking STAYS blocking" contradicts the DROP rule for exactly
+  // the priors it targets: the plan prompt had no non-blocking channel before this change, so every
+  // stored finding was raised as blocking. A literal reading would force them all re-raised.
+  const b = roundBlock(4, 8, "Nits (non-blocking):", "the author").join("\n");
+  expect(b).toContain("blocking UNDER FINDINGS ROUTING");
+  expect(b).toContain("the halfway and at-cap rules below never demote one");
+  expect(b).toContain("does not preserve a prior that FINDINGS ROUTING no longer admits");
+  // It must NOT dangle on a first review, where no drop rule is emitted: the clause names no
+  // section, so it is vacuous rather than a reference to absent text.
+  const first = roundBlock(1, 8, "Nits (non-blocking):", "the author").join("\n");
+  expect(first).toContain("does not preserve a prior");
+  expect(first).not.toContain("DROP rule above");
+});
+
+test("#1948: both prompts carry the scoped bullet, and it coexists with each drop rule", () => {
+  const pr = reviewPrompt("BASE", "do X", ["an old nit"], [], null, null, { round: 4, cap: 8 });
+  expect(pr).toContain("blocking UNDER FINDINGS ROUTING");
+  expect(pr).toContain("likewise DROPPED"); // the critic-side drop rule
+  const plan = planReviewPrompt("do X", "P", ["an old nit"], null, "en", undefined, undefined, {
+    round: 4,
+    cap: 8,
+  });
+  expect(plan).toContain("blocking UNDER FINDINGS ROUTING");
+  expect(plan).toContain("EXCEPTION"); // the plan-side drop rule
 });

--- a/test/critic-core.test.ts
+++ b/test/critic-core.test.ts
@@ -1008,3 +1008,28 @@ test("#1948: roundBlock emits nothing for absent or nonsensical inputs", () => {
   expect(roundBlock(3, 0, "X", "y")).toEqual([]);
   expect(roundBlock(NaN, 8, "X", "y")).toEqual([]);
 });
+
+test("#1948: the halfway rule never fires on a first-ever review, at any supported cap", () => {
+  // Both caps are UI-settable down to 1 (PR_REVIEW_CYCLES_MIN / PLAN_REVIEW_CYCLES_MIN). At cap 1
+  // the bare `2n > m` test holds for n = 1, which would muzzle the ONLY review the operator gets:
+  // every finding on a first review is new, so the blocking classes would all route to nits.
+  for (const m of [1, 2, 3, 8, 12]) {
+    const first = roundBlock(1, m, "Nits (non-blocking):", "the author").join("\n");
+    expect(first).toContain(`rework round 1 of at most ${m}`);
+    expect(first).not.toContain("past the halfway point");
+  }
+  // The at-cap hedge is still correct on a cap-1 first review — it IS the last round — and it
+  // reserves BLOCKING findings rather than suppressing them.
+  const capOne = roundBlock(1, 1, "Nits (non-blocking):", "the author").join("\n");
+  expect(capOne).toContain("budget is spent");
+});
+
+test("#1948: the halfway rule still fires from round 2 once genuinely past halfway", () => {
+  const sec = "Nits (non-blocking):";
+  // cap 2: round 2 is both past halfway and the last round.
+  expect(roundBlock(2, 2, sec, "x").join("\n")).toContain("past the halfway point");
+  // cap 3: round 2 is past halfway (4 > 3); cap 4: round 2 is not (4 > 4 is false).
+  expect(roundBlock(2, 3, sec, "x").join("\n")).toContain("past the halfway point");
+  expect(roundBlock(2, 4, sec, "x").join("\n")).not.toContain("past the halfway point");
+  expect(roundBlock(7, 12, sec, "x").join("\n")).toContain("past the halfway point");
+});

--- a/test/critic-core.test.ts
+++ b/test/critic-core.test.ts
@@ -15,6 +15,8 @@ import {
   prReviewPrompt,
   reapRun,
   defaultCollectBaseDelta,
+  roundBlock,
+  effectiveRound,
 } from "../src/critic-core";
 import { allowedToolsFor } from "../src/transient-agent-argv";
 
@@ -917,4 +919,92 @@ test("#1757 base commits with an EMPTY net diff (revert pair) still mean the tre
   expect(p).not.toContain("is exactly the paths below");
   expect(p).not.toContain("OVERRIDES the VERIFY rule");
   expect(p).not.toContain("⟦UNTRUSTED:base delta paths:");
+});
+
+// ── #1948: nits leave `findings`, and the ROUND block stays out of the shared tail ─────────────
+//
+// The tail used to mandate the exact opposite of its own three lenses: "A non-blocking nit STILL
+// goes in findings". Because runAutoAddress fires on non-empty findings REGARDLESS of decision and
+// the re-raise rule re-raises them, a comment nit looped until the streak ceiling paused the PR.
+
+test("#1948: findings is blocking-only; nits route to a named non-blocking body section", () => {
+  const p = reviewPrompt("BASE", "do X");
+  expect(p).not.toContain('A non-blocking nit STILL goes in "findings"');
+  expect(p).toContain("FINDINGS ROUTING");
+  expect(p).toContain("`Nits (non-blocking):`");
+  expect(p).toContain('does NOT go in "findings"');
+  // Size must never excuse a real defect.
+  expect(p).toContain("REGARDLESS of how small it looks");
+});
+
+test("#1948: comment rule — rewording is a nit, a factually wrong comment is a defect", () => {
+  const p = reviewPrompt("BASE", "do X");
+  expect(p).toContain("COMMENTS specifically");
+  expect(p).toContain("reworded or expanded");
+  expect(p).toContain("factually WRONG about what the code does IS a defect");
+});
+
+test("#1948: the cap is advisory and can never shed a blocker into Nits", () => {
+  const p = reviewPrompt("BASE", "do X");
+  expect(p).toContain("At most 5 NEW findings");
+  expect(p).toContain("emit ALL of them");
+  expect(p).toContain("NEVER move a blocking problem");
+  expect(p).toContain("do NOT count against those 5");
+});
+
+test("#1948: a stale prior the routing does not admit is dropped, not re-raised", () => {
+  const p = reviewPrompt("BASE", "do X", ["nit: rename this variable"]);
+  expect(p).toContain("does not admit as blocking is likewise DROPPED");
+  expect(p).toContain("IS compliance with the re-raise instruction");
+  // Absent without priors — nothing to drop.
+  expect(reviewPrompt("BASE", "do X")).not.toContain("likewise DROPPED");
+});
+
+test("#1948: the routing block is SHARED — the standalone critic gets it too", () => {
+  const pr = prReviewPrompt("BASE", "title", "body");
+  expect(pr).toContain("FINDINGS ROUTING");
+  expect(pr).toContain("`Nits (non-blocking):`");
+});
+
+test("#1948: the ROUND block is session-critic only and never reaches the shared tail", () => {
+  const withRound = reviewPrompt("BASE", "do X", [], [], null, null, { round: 3, cap: 8 });
+  expect(withRound).toContain("rework round 3 of at most 8");
+  // prReviewPrompt has no rework loop — it must never carry a round block.
+  expect(prReviewPrompt("BASE", "t", "b")).not.toContain("ROUND —");
+  // …and omitting the opts must leave the prompt byte-identical.
+  expect(reviewPrompt("BASE", "do X", [], [], null, null, {})).toBe(reviewPrompt("BASE", "do X"));
+});
+
+test("#1948: ROUND block thresholds + the at-cap hedge (PR critic wording)", () => {
+  const early = reviewPrompt("BASE", "do X", [], [], null, null, { round: 1, cap: 8 });
+  expect(early).not.toContain("past the halfway point");
+  const late = reviewPrompt("BASE", "do X", [], [], null, null, { round: 5, cap: 8 });
+  expect(late).toContain("past the halfway point");
+  expect(late).toContain("`Nits (non-blocking):`");
+  const atCap = reviewPrompt("BASE", "do X", [], [], null, null, { round: 8, cap: 8 });
+  expect(atCap).toContain("may be the LAST");
+  expect(atCap).toContain("the author");
+  expect(atCap).not.toContain("escalates to a human");
+});
+
+test("#1948: effectiveRound clamps at the cap and is floored by the reset-proof count", () => {
+  // Normal early round: prior+1 wins.
+  expect(effectiveRound(0, 1, 12)).toBe(1);
+  expect(effectiveRound(2, 3, 12)).toBe(3);
+  // HELD at the cap (applyChangesRequested holds gate.round) — must clamp, never emit 13-of-12.
+  expect(effectiveRound(12, 13, 12)).toBe(12);
+  expect(effectiveRound(11, 12, 12)).toBe(12);
+  // RESET to 0 by resume()/dismiss() with a long spawn history — the count must restore lateness.
+  expect(effectiveRound(0, 29, 12)).toBe(12);
+  expect(effectiveRound(0, 7, 12)).toBe(7);
+  // A fresh session with no spawns yet still reports round 1, never 0.
+  expect(effectiveRound(0, 0, 12)).toBe(1);
+});
+
+test("#1948: roundBlock emits nothing for absent or nonsensical inputs", () => {
+  expect(roundBlock(undefined, 8, "X", "y")).toEqual([]);
+  expect(roundBlock(3, undefined, "X", "y")).toEqual([]);
+  expect(roundBlock(0, 8, "X", "y")).toEqual([]);
+  expect(roundBlock(3, 0, "X", "y")).toEqual([]);
+  expect(roundBlock(NaN, 8, "X", "y")).toEqual([]);
 });

--- a/test/plan-gate-prompt.test.ts
+++ b/test/plan-gate-prompt.test.ts
@@ -279,3 +279,126 @@ test("staleness block: emitted only with behind>0 AND changed paths, and is body
     );
   }
 });
+
+// ── #1948: convergence rules — routing, the soundness bar, and the ROUND block ─────────────────
+//
+// The plan reviewer had no non-blocking channel: its only contract was approve, or
+// "request-changes with at least one finding". A wording preference therefore had exactly one legal
+// exit — a blocking finding costing a full rework round. These assert the CONTRACT (a section
+// exists, an item class is barred) rather than exact phrasing, so wording may be retuned freely.
+
+test("#1948: the bar is soundness, not optimality", () => {
+  const p = planReviewPrompt("do X", "PLAN TEXT");
+  expect(p).not.toContain("best reasonable path");
+  expect(p).not.toContain("is it the best path");
+  expect(p).toContain("SOUNDNESS, not optimality");
+  // Approval must not be blocked by non-blocking items.
+  expect(p).toContain("do NOT prevent approval");
+});
+
+test("#1948: non-blocking items route to a named body section, never to findings", () => {
+  const p = planReviewPrompt("do X", "PLAN TEXT");
+  expect(p).toContain("FINDINGS ROUTING");
+  expect(p).toContain("`Suggestions (non-blocking):`");
+  expect(p).toContain('NEVER go in "findings"');
+});
+
+test("#1948: scope-demand lens bars findings that require work the task never asked for", () => {
+  const p = planReviewPrompt("do X", "PLAN TEXT");
+  expect(p).toContain("SCOPE DEMANDS");
+  expect(p).toContain("additional cases");
+  expect(p).toContain("follow-up work");
+  // The converse must be adjacent, or the lens reads as licence to ignore real gaps.
+  expect(p).toContain("AS STATED is not satisfied");
+  expect(p).toContain("narrower than you would have scoped it is never a finding");
+});
+
+test("#1948: prose-demand ban targets 'argue it more' findings", () => {
+  const p = planReviewPrompt("do X", "PLAN TEXT");
+  expect(p).toContain("PROSE");
+  expect(p).toContain("more argumentation");
+  expect(p).toContain("MISSING DECISION");
+});
+
+test("#1948: the 5-finding cap is advisory and can never shed a blocker", () => {
+  const p = planReviewPrompt("do X", "PLAN TEXT");
+  expect(p).toContain("At most 5 NEW findings");
+  expect(p).toContain("PRIORITISATION instruction");
+  // Overflow must emit everything — shedding a blocker would read as clean to signoff/autopilot.
+  expect(p).toContain("emit ALL of them");
+  expect(p).toContain("NEVER move a blocking problem");
+  // Re-raised priors must not consume the budget, else a regression has no room.
+  expect(p).toContain("do NOT count against those 5");
+});
+
+test("#1948: a stale prior the new bar does not admit is DROPPED, and saying so is compliance", () => {
+  const p = planReviewPrompt("do X", "PLAN TEXT", ["a wording nit from the old bar"]);
+  expect(p).toContain("EXCEPTION");
+  expect(p).toContain('do not re-raise it in "findings"');
+  expect(p).toContain("IS compliance with this instruction");
+  // …and the drop rule must NOT appear when there are no priors to drop.
+  expect(planReviewPrompt("do X", "PLAN TEXT")).not.toContain("EXCEPTION");
+});
+
+test("#1948: scope/testability is blocking only when genuinely ABSENT", () => {
+  const p = planReviewPrompt("do X", "PLAN TEXT");
+  // The old text made "too broad" a guaranteed blocking concern; it must not survive.
+  expect(p).not.toContain("as a blocking concern");
+  expect(p).toContain("genuinely ABSENT is blocking");
+});
+
+test("#1948: no ROUND block without opts — every existing caller stays byte-identical", () => {
+  const withoutOpts = planReviewPrompt("do X", "PLAN TEXT", [], null, "en");
+  const withEmptyOpts = planReviewPrompt(
+    "do X",
+    "PLAN TEXT",
+    [],
+    null,
+    "en",
+    undefined,
+    undefined,
+    {},
+  );
+  expect(withoutOpts).not.toContain("ROUND —");
+  expect(withEmptyOpts).toBe(withoutOpts);
+});
+
+test("#1948: ROUND block escalates severity routing past the halfway point", () => {
+  const early = planReviewPrompt("do X", "P", [], null, "en", undefined, undefined, {
+    round: 1,
+    cap: 12,
+  });
+  expect(early).toContain("rework round 1 of at most 12");
+  expect(early).not.toContain("past the halfway point");
+  expect(early).not.toContain("budget is spent");
+
+  const late = planReviewPrompt("do X", "P", [], null, "en", undefined, undefined, {
+    round: 7,
+    cap: 12,
+  });
+  expect(late).toContain("past the halfway point");
+  expect(late).toContain("`Suggestions (non-blocking):`");
+  expect(late).not.toContain("budget is spent");
+});
+
+test("#1948: at the cap the ROUND block HEDGES — it must not claim escalation", () => {
+  const atCap = planReviewPrompt("do X", "P", [], null, "en", undefined, undefined, {
+    round: 12,
+    cap: 12,
+  });
+  expect(atCap).toContain("budget is spent");
+  expect(atCap).toContain("may be the LAST");
+  expect(atCap).toContain("the planning agent");
+  // At priorRound === cap-1 the steer IS still delivered, so asserting escalation would suppress
+  // real findings a round early on a false premise.
+  expect(atCap).not.toContain("escalates to a human");
+});
+
+test("#1948: lateness never downgrades severity or demotes a standing blocker", () => {
+  const late = planReviewPrompt("do X", "P", [], null, "en", undefined, undefined, {
+    round: 12,
+    cap: 12,
+  });
+  expect(late).toContain("finding at ANY round");
+  expect(late).toContain("STAYS blocking");
+});

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -2231,3 +2231,101 @@ test("prior findings are re-raised into the next prompt verbatim, line numbers i
   // "cite path + symbol, not line numbers" rule cannot be read as an order to rewrite it.
   expect(prompt).toContain("EXEMPTION: re-raising a prior finding verbatim is REQUIRED");
 });
+
+// ── #1948: the EFFECTIVE round briefed to the reviewer, asserted at the service seam ───────────
+//
+// `prior.round + 1` is wrong at BOTH ends, which is the whole reason effectiveRound exists:
+//  - applyChangesRequested HOLDS gate.round at the cap while startedStatus → "started-at-cap"
+//    still starts a review, so the raw value would emit "round 4 of at most 3".
+//  - resume()/dismiss() write `round: 0`, and Resume is the ONLY operator escape offered at the
+//    cap, so a plan reviewed many times would otherwise be briefed as round 1.
+// The prompt is the last argv element (see the existing "consider spawns reviewer" test).
+
+const promptOf = (h: any) => h.started[0].argv[h.started[0].argv.length - 1];
+
+test("#1948: a first review is briefed as round 1 of the cap", async () => {
+  const h = harness({ cap: 12 });
+  await h.svc.consider(planningSession() as any);
+  expect(promptOf(h)).toContain("rework round 1 of at most 12");
+});
+
+test("#1948: a gate HELD at the cap is clamped — never 'round 4 of at most 3'", async () => {
+  const h = harness({
+    cap: 3,
+    store: {
+      getPlanGate: () => ({ planHash: "x", approved: false, round: 3, findings: ["standing"] }),
+      get: () => ({ id: "s1", auto: false }),
+    },
+  });
+  await h.svc.consider({ ...planningSession(), planPhase: "planning" } as any);
+  const p = promptOf(h);
+  expect(p).toContain("rework round 3 of at most 3");
+  expect(p).not.toContain("rework round 4"); // the unclamped `prior.round + 1` value
+  expect(p).toContain("budget is spent");
+});
+
+test("#1948: a gate reset to round 0 by resume() is still briefed as late-round", async () => {
+  // The exact TASK-1981/1977 shape: the round counter was zeroed, but the spawn history proves the
+  // plan has been reviewed many times over. Without the reset-proof count the late-round routing
+  // would never fire on precisely the sessions that exhausted their budget.
+  const spawns = Array.from({ length: 9 }, (_, i) => ({
+    kind: "plan_gate",
+    taskSessionId: "s1",
+    reviewerSessionId: `r${i}`,
+    worktreePath: `/wt-${i}`,
+  }));
+  const h = harness({
+    cap: 12,
+    store: {
+      getPlanGate: () => ({ planHash: "x", approved: false, round: 0, findings: [] }),
+      listReviewerSpawns: () => spawns,
+      get: () => ({ id: "s1", auto: false }),
+    },
+  });
+  await h.svc.consider(planningSession() as any);
+  const p = promptOf(h);
+  expect(p).toContain("rework round 9 of at most 12");
+  expect(p).toContain("past the halfway point");
+});
+
+test("#1948: the spawn count only counts THIS session's plan_gate rows", async () => {
+  const h = harness({
+    cap: 12,
+    store: {
+      getPlanGate: () => ({ planHash: "x", approved: false, round: 0, findings: [] }),
+      listReviewerSpawns: () => [
+        { kind: "plan_gate", taskSessionId: "other", worktreePath: "/a" },
+        { kind: "review", taskSessionId: "s1", worktreePath: "/b" },
+        { kind: "recap", taskSessionId: "s1", worktreePath: "/c" },
+      ],
+      get: () => ({ id: "s1", auto: false }),
+    },
+  });
+  await h.svc.consider(planningSession() as any);
+  // None of those rows belong to this session's plan gate → falls back to prior.round + 1.
+  expect(promptOf(h)).toContain("rework round 1 of at most 12");
+});
+
+test("#1948: the findings steer tells the agent to revise in place, not accrete", async () => {
+  const steers: string[] = [];
+  const h = harness({
+    readVerdict: () => ({
+      decision: "request-changes",
+      summary: "no",
+      body: "B",
+      findings: ["fix A"],
+    }),
+    reply: (_id: string, t: string) => {
+      steers.push(t);
+      return true;
+    },
+  });
+  await h.svc.consider(planningSession() as any);
+  await h.svc.tick();
+  expect(steers.length).toBe(1);
+  expect(steers[0]).toContain("Revise IN PLACE");
+  expect(steers[0]).toContain("Do NOT append justification");
+  expect(steers[0]).toContain("ledger");
+  // Non-blocking suggestions must be named as optional, or they become de-facto required work.
+  expect(steers[0]).toContain("OPTIONAL");
+});

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -2326,6 +2326,7 @@ test("#1948: the findings steer tells the agent to revise in place, not accrete"
   expect(steers[0]).toContain("Revise IN PLACE");
   expect(steers[0]).toContain("Do NOT append justification");
   expect(steers[0]).toContain("ledger");
-  // Non-blocking suggestions must be named as optional, or they become de-facto required work.
-  expect(steers[0]).toContain("OPTIONAL");
+  // The steer carries ONLY gate.findings — the verdict body never reaches the planner's worktree,
+  // so it must not reference the reviewer's non-blocking section (critic finding on #1948).
+  expect(steers[0]).not.toContain("Suggestions (non-blocking):");
 });

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -184,8 +184,6 @@ function makeDeps(
      * both `verdictRead` and `over.readVerdict`.
      */
     readVerdictFn?: () => VerdictRead<RawVerdict>;
-    /** reviewer_spawns rows visible to countReviewSpawns (#1948) — the reset-proof round floor. */
-    reviewerSpawns?: any[];
   } = {},
 ) {
   const reviews: Record<string, ReviewVerdict> = {};
@@ -223,9 +221,6 @@ function makeDeps(
       recordReviewerSpawn: (r: any) => recordedSpawns.push(r),
       completeReviewerSpawn: (id: string, u: any, at: number) =>
         completedSpawns.push({ id, u, at }),
-      // Declared on ReviewServiceDeps["store"] and read by countReviewSpawns (#1948) to derive the
-      // reset-proof effective round. Overridable per-test to simulate a session's spawn history.
-      listReviewerSpawns: () => opts.reviewerSpawns ?? [],
     },
     herdr: new (class {
       readonly recorded = stopped; // this-dependent: unbound call loses this.recorded
@@ -3274,32 +3269,57 @@ test("#1948: addressRound HELD at the cap is clamped, not incremented past it", 
   expect(p).toContain("budget is spent");
 });
 
-test("#1948: a streak reset is overridden by the reset-proof spawn count", async () => {
-  const rows = Array.from({ length: 6 }, (_, i) => ({
-    kind: "review",
-    taskSessionId: "s1",
-    worktreePath: `/wt-${i}`,
-  }));
-  const { deps: d, started } = makeDeps({ cap: 8 }, { reviewerSpawns: rows });
+test("#1948: an outstanding-findings streak floors the round even while addressRound lags", async () => {
+  // Error verdicts preserve streakReviews but leave addressRound untouched, so the streak count is
+  // the honest measure of how many times this PR has actually been through rework.
+  const { deps: d, started } = makeDeps({ cap: 8 });
+  d.store.getReview = () => ({
+    sessionId: "s1",
+    headSha: "old",
+    decision: "changes_requested",
+    findings: ["still broken"],
+    addressRound: 2,
+    streakReviews: 6,
+    summary: "",
+    body: "",
+    updatedAt: 0,
+  });
   await new ReviewService(d as any).consider(session(), OPEN_GREEN);
   const p = criticPrompt(started);
   expect(p).toContain("rework round 6 of at most 8");
   expect(p).toContain("past the halfway point");
 });
 
-test("#1948: the spawn count ignores other sessions and other spawn kinds", async () => {
-  const { deps: d, started } = makeDeps(
-    { cap: 8 },
+// REGRESSION (critic finding on #1948): a critic spawn fires per CI-green head, NOT per rework
+// round, and a clean verdict resets both counters. Flooring the round on a LIFETIME spawn count
+// therefore climbed with ordinary pushes and — at the default cap of 3 — briefed the 2nd review of
+// a perfectly healthy PR as "past the halfway point" and the 3rd as "budget spent", muzzling
+// contract / locale-parity / task-satisfaction findings on a PR that was never in rework.
+test("#1948 regression: a healthy session's repeated reviews stay at round 1", async () => {
+  for (const priorClean of [
+    null,
+    // A prior CLEAN verdict: findings resolved, both counters reset — the next push must not
+    // inherit any lateness from however many reviews came before.
     {
-      reviewerSpawns: [
-        { kind: "review", taskSessionId: "other", worktreePath: "/a" },
-        { kind: "plan_gate", taskSessionId: "s1", worktreePath: "/b" },
-        { kind: "recap", taskSessionId: "s1", worktreePath: "/c" },
-      ],
+      sessionId: "s1",
+      headSha: "old",
+      decision: "commented" as const,
+      findings: [] as string[],
+      addressRound: 0,
+      streakReviews: 0,
+      summary: "",
+      body: "",
+      updatedAt: 0,
     },
-  );
-  await new ReviewService(d as any).consider(session(), OPEN_GREEN);
-  expect(criticPrompt(started)).toContain("rework round 1 of at most 8");
+  ]) {
+    const { deps: d, started } = makeDeps({ cap: 3 });
+    if (priorClean) d.store.getReview = () => priorClean;
+    await new ReviewService(d as any).consider(session(), OPEN_GREEN);
+    const p = criticPrompt(started);
+    expect(p).toContain("rework round 1 of at most 3");
+    expect(p).not.toContain("past the halfway point");
+    expect(p).not.toContain("budget is spent");
+  }
 });
 
 test("#1948: the auto-address steer names blockers and marks nits optional", async () => {

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -184,6 +184,8 @@ function makeDeps(
      * both `verdictRead` and `over.readVerdict`.
      */
     readVerdictFn?: () => VerdictRead<RawVerdict>;
+    /** reviewer_spawns rows visible to countReviewSpawns (#1948) — the reset-proof round floor. */
+    reviewerSpawns?: any[];
   } = {},
 ) {
   const reviews: Record<string, ReviewVerdict> = {};
@@ -221,6 +223,9 @@ function makeDeps(
       recordReviewerSpawn: (r: any) => recordedSpawns.push(r),
       completeReviewerSpawn: (id: string, u: any, at: number) =>
         completedSpawns.push({ id, u, at }),
+      // Declared on ReviewServiceDeps["store"] and read by countReviewSpawns (#1948) to derive the
+      // reset-proof effective round. Overridable per-test to simulate a session's spawn history.
+      listReviewerSpawns: () => opts.reviewerSpawns ?? [],
     },
     herdr: new (class {
       readonly recorded = stopped; // this-dependent: unbound call loses this.recorded
@@ -620,7 +625,11 @@ test("task prompt survives the variadic allowlist (not swallowed → no task →
   // fails, baseSha → null, diffBase falls back to session.baseBranch ("main"), and the
   // assertion is self-referential (reviewPrompt("main", …) on both sides). It would BREAK if
   // rev-parse ever resolved a SHA on that path (diffBase would become that SHA, not "main").
-  expect(argv.at(-1)).toBe(reviewPrompt("main", "do the thing"));
+  // begin() now always briefs the effective round (#1948): first review, no prior, no spawn
+  // history → effectiveRound(0, 0, DEFAULT_CAP=3) === 1.
+  expect(argv.at(-1)).toBe(
+    reviewPrompt("main", "do the thing", [], [], null, null, { round: 1, cap: 3 }),
+  );
   expect(argv.at(-3)).toBe("--permission-mode");
   expect(argv.at(-2)).toBe("dontAsk");
   // nothing between the allowlist and the prompt may be a bare allowlist entry:
@@ -2462,7 +2471,11 @@ test("critic spawn is wrapped in bwrap when backend is present", async () => {
   const sep = argv.indexOf("--");
   expect(sep).toBeGreaterThan(0);
   expect(argv[sep + 1]).not.toBe("bwrap"); // reviewer argv directly follows, not another bwrap
-  expect(argv.at(-1)).toBe(reviewPrompt("main", "do the thing"));
+  // begin() now always briefs the effective round (#1948): first review, no prior, no spawn
+  // history → effectiveRound(0, 0, DEFAULT_CAP=3) === 1.
+  expect(argv.at(-1)).toBe(
+    reviewPrompt("main", "do the thing", [], [], null, null, { round: 1, cap: 3 }),
+  );
 });
 
 test("critic spawn degrades to unwrapped when backend is null", async () => {
@@ -3229,4 +3242,87 @@ test("tab baseline: repeated critic runs (finalize + forget) leave zero open tab
   await Bun.sleep(0); // forget's stop is fire-and-forget — let it settle
   expect(openTabs.size).toBe(0);
   expect(n).toBe(4); // four real spawns; all four tabs were closed
+});
+
+// ── #1948: the effective round briefed to the PR critic, at the service seam ───────────────────
+
+const criticPrompt = (started: any[]) => started[0]!.argv.at(-1) as string;
+
+test("#1948: a first review briefs round 1 of the cap", async () => {
+  const { deps: d, started } = makeDeps({ cap: 8 });
+  await new ReviewService(d as any).consider(session(), OPEN_GREEN);
+  expect(criticPrompt(started)).toContain("rework round 1 of at most 8");
+});
+
+test("#1948: addressRound HELD at the cap is clamped, not incremented past it", async () => {
+  // runAutoAddress holds addressRound at the cap; the raw `+1` would emit "round 4 of at most 3".
+  const { deps: d, started } = makeDeps({ cap: 3 });
+  d.store.getReview = () => ({
+    sessionId: "s1",
+    headSha: "old",
+    decision: "changes_requested",
+    findings: ["standing blocker"],
+    addressRound: 3,
+    summary: "",
+    body: "",
+    updatedAt: 0,
+  });
+  await new ReviewService(d as any).consider(session(), OPEN_GREEN);
+  const p = criticPrompt(started);
+  expect(p).toContain("rework round 3 of at most 3");
+  expect(p).not.toContain("rework round 4");
+  expect(p).toContain("budget is spent");
+});
+
+test("#1948: a streak reset is overridden by the reset-proof spawn count", async () => {
+  const rows = Array.from({ length: 6 }, (_, i) => ({
+    kind: "review",
+    taskSessionId: "s1",
+    worktreePath: `/wt-${i}`,
+  }));
+  const { deps: d, started } = makeDeps({ cap: 8 }, { reviewerSpawns: rows });
+  await new ReviewService(d as any).consider(session(), OPEN_GREEN);
+  const p = criticPrompt(started);
+  expect(p).toContain("rework round 6 of at most 8");
+  expect(p).toContain("past the halfway point");
+});
+
+test("#1948: the spawn count ignores other sessions and other spawn kinds", async () => {
+  const { deps: d, started } = makeDeps(
+    { cap: 8 },
+    {
+      reviewerSpawns: [
+        { kind: "review", taskSessionId: "other", worktreePath: "/a" },
+        { kind: "plan_gate", taskSessionId: "s1", worktreePath: "/b" },
+        { kind: "recap", taskSessionId: "s1", worktreePath: "/c" },
+      ],
+    },
+  );
+  await new ReviewService(d as any).consider(session(), OPEN_GREEN);
+  expect(criticPrompt(started)).toContain("rework round 1 of at most 8");
+});
+
+test("#1948: the auto-address steer names blockers and marks nits optional", async () => {
+  const { deps: d, steers } = makeDeps(
+    {
+      readVerdict: () => ({
+        decision: "request-changes",
+        summary: "s",
+        body: "b",
+        findings: ["fix the real bug"],
+      }),
+    },
+    { autoAddressEnabled: true },
+  );
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(steers.length).toBe(1);
+  expect(steers[0]!.text).toContain("BLOCKING points");
+  expect(steers[0]!.text).toContain("fix the real bug");
+  // Nits now live in the review body; without this the agent treats them as required work.
+  expect(steers[0]!.text).toContain("`Nits (non-blocking):`");
+  expect(steers[0]!.text).toContain("OPTIONAL");
+  // The disagreement channel must survive.
+  expect(steers[0]!.text).toContain("genuinely disagree");
 });


### PR DESCRIPTION
Plan and PR-critic rework cycles were running long — two sessions (TASK-1981, TASK-1977) exhausted a 12-round plan-gate budget twice, arguing over wording and accreting scope. This fixes the mechanisms in the reviewer briefings that made that possible.

## The problem is a tail, not a slowdown

`reviewer_spawns`, last 30 days:

| plan-gate rounds | sessions | % of plan-review tokens |
| --- | --- | --- |
| 1–3 | 493 | 25% |
| 4–7 | 168 | 21% |
| 8–12 | 40 | 15% |
| **13+** | **38 (5%)** | **39%** |

The PR critic mirrors it: 23 of 828 sessions (2.8%) at 9+ rounds burn 27% of critic tokens. The median (2–3 rounds) is healthy and must not move. Both caps were already at their maxima (`planReviewCyclesCap` 12, `prReviewCyclesCap` 8), which lengthened the tail rather than converging it — so the fix belongs in the briefings, not the limits.

## What was actually driving it

**The PR critic mandated the opposite of its own lenses.** `scopeAndOutputTail()` said verbatim *"A non-blocking nit STILL goes in `findings`"*, while the three lenses directly above it forbid exactly that, and explain why: `runAutoAddress()` fires on any non-empty `findings` **regardless of decision**, and the SCOPE rule re-raises unaddressed items every round. A comment nit therefore looped until the streak ceiling paused the PR.

**The plan reviewer had no non-blocking channel at all.** Its only contract was approve, or "request-changes with at least one finding" — so a wording preference had exactly one legal exit: a blocking finding costing a full rework round. TASK-1977's two surviving findings were *"Argue the rejection of clamp-only… instead of listing it"* and *"Give it a grounded paragraph in §2b at the same standard §2a applies to…"*. Neither is a plan defect.

**Nothing barred findings that demand new scope**, which is how a plan reaches 32.6 KB and 28 success criteria — and **the reviewer never learned which round it was on**, so round 11 was briefed exactly like round 1.

## Changes

- **`findings` is blocking-only on both sides.** Nits route to `Nits (non-blocking):` / `Suggestions (non-blocking):`, matching the existing lens routing. Any correctness, security, contract, or i18n-parity defect stays blocking *regardless of size*.
- **Plan approval bar** drops "genuinely the best reasonable path" (unfalsifiable — no plan ever wins it) for soundness: it passes when the approach will work and what remains is settleable during implementation.
- **Scope-demand lens** on the plan side: a finding may not require the plan to cover work the task never asked for. A gap blocks only when the task *as stated* is unsatisfied.
- **Prose-demand ban**: a finding may not ask for more argument about a decision already stated. Ask for a missing *decision*, not more prose about one already made.
- **Advisory 5-finding cap** that can never lose information — over five blockers, emit them all and say the work needs rewriting. Never sheds a blocker into the non-blocking section.
- **Stale-prior drop rule.** `PlanGate.findings` / `reviews.findings` persist across deploy, so without this the findings recorded under the *old* bar re-raise verbatim on the first review after it changes, and nothing converges faster on precisely the two sessions that motivated this.
- **ROUND block** on an effective round: `prior.round + 1` was wrong at both ends — `applyChangesRequested` holds at the cap while at-cap reviews still start, and `resume()` zeroes it — so it is clamped and floored by a reset-proof spawn count. Policy: a Resume unblocks a session, it does not restore full review latitude.

## Notes for review

- **The at-cap line deliberately hedges** ("may be the LAST that reach the author"). Asserting escalation there would be false: at `priorRound === cap - 1` the steer *is* still delivered. An earlier draft made that claim and would have suppressed real findings a round early.
- **The cap is not deterministically enforced**, unlike `scopeFindings` here or `MAX_ADDS_PER_RUN` in `distiller.ts`. Both of those enforce a *decidable* predicate; "is this finding blocking?" is not decidable server-side, so a truncation backstop would cut blind and could discard a real blocker while keeping a nit. The wording removes the need for one instead.
- **Biggest risk, stated plainly:** `findings` gates `autopilot.ts` (won't advance while non-empty), `signoff.ts`, and `learnings-lifecycle.ts` (clean = `commented` + zero findings). A nit-only review now reads as clean and stops blocking those. That is the intended speedup, but a mis-routed real issue would slip through.
- The effective round counts **error spawns** too, so a flapping critic reads as later than its delivered-round count. Accepted: the row represents real tokens spent, lateness never downgrades a correctness/security finding, and consecutive errors have their own ceiling.
- The ROUND block lives in `reviewPrompt`'s preamble, **not** the shared tail — the byte-identity test between `reviewPrompt` and `prReviewPrompt` still passes unmodified, and the standalone critic (no rework loop) is unaffected by it.

## Verification

`bun install && bun run lint && bun test` green (7749 pass, 0 fail). Branch hygiene, i18n parity, feature-catalog and glossary gates pass; `fallow audit` clean (`begin()` was pushed over its complexity threshold by the new call and refactored back under it).

**Effect is not verified by this PR** — the criteria above assert delivery, not outcome. The plan records a post-ship check: re-run the `reviewer_spawns` query in 30 days, expecting the `13+` bucket under 20% of tokens (from 39%) with the `1-3` bucket holding ≥65% of sessions. If `13+` is still above 30%, escalate to the deferred levers (passing a prior-plan diff, then a plan-gate rebuttal channel).

Density budget for the plan-*authoring* directive was split out to #1947 to keep this change scoped to the reviewer briefings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)