### PR TITLE
fix(newtask): cover the strip above the mobile keyboard, make attach readable

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3448,5 +3448,6 @@
   "feat_spawn_notice_body": "Wenn ein Plan das Kommandozeilen-Limit des Betriebssystems überschreitet, scheiterte der Review-Start bisher stillschweigend. Jetzt kürzt Shepherd den Plan passend und markiert das Badge — oder lehnt ab und sagt es dir, falls zu wenig vom Plan übrig bliebe, statt ein selbstbewusstes Urteil über einen Stummel zu liefern.",
   "spawnnotice_review_failed_badge": "kein review",
   "spawnnotice_review_failed_title": "Code-Review konnte nicht starten",
-  "spawnnotice_review_failed_action": "Der Review-Prompt überschreitet das Argumentlimit des Betriebssystems, daher lief für diesen Commit kein Critic. Am meisten Platz schafft es, `.shepherd-plan.md` zu kürzen. „Erneut versuchen“ startet einen neuen Versuch mit den aktuellen Eingaben."
+  "spawnnotice_review_failed_action": "Der Review-Prompt überschreitet das Argumentlimit des Betriebssystems, daher lief für diesen Commit kein Critic. Am meisten Platz schafft es, `.shepherd-plan.md` zu kürzen. „Erneut versuchen“ startet einen neuen Versuch mit den aktuellen Eingaben.",
+  "newtask_attach_label": "Anhängen"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3448,5 +3448,6 @@
   "feat_spawn_notice_body": "When a plan grows past the operating system's command-line limit, Shepherd used to fail the review spawn silently. Now it shortens the plan to fit and marks the badge, or — if too little of the plan would survive — refuses outright and tells you, rather than shipping a confident verdict on a stub.",
   "spawnnotice_review_failed_badge": "no review",
   "spawnnotice_review_failed_title": "Code review could not start",
-  "spawnnotice_review_failed_action": "The review prompt exceeds the operating system's argument limit, so no critic ran on this commit. Shortening `.shepherd-plan.md` is what frees the most room. Retry re-attempts with the current inputs."
+  "spawnnotice_review_failed_action": "The review prompt exceeds the operating system's argument limit, so no critic ran on this commit. Shortening `.shepherd-plan.md` is what frees the most room. Retry re-attempts with the current inputs.",
+  "newtask_attach_label": "Attach"
 }

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -467,6 +467,11 @@ describe("NewTask task attachments", () => {
     const attach = document.querySelector<HTMLButtonElement>(".toolbar .tool-btn")!;
     expect(attach.getAttribute("aria-label")).toBe(m.newtask_attach_aria());
     expect(attach.title).toBe(m.newtask_drop_hint_keyboard({ shortcut: "Ctrl+V" }));
+    // Paperclip glyph + visible word, so "you can add something here" is readable rather
+    // than inferred from a bare arrow (the ↥ this replaced).
+    expect(attach.querySelector("svg")).toBeTruthy();
+    expect(attach.textContent).toContain(m.newtask_attach_label());
+    expect(attach.textContent).not.toContain("↥");
   });
 
   it("uses the short touch hint in coarse pointer contexts", async () => {
@@ -3109,15 +3114,17 @@ describe("NewTask geometry (measurable handoff criteria)", () => {
     expect(
       Math.round(document.querySelector<HTMLElement>(".rail")!.getBoundingClientRect().width),
     ).toBe(300);
-    // Prompt hero ≥132px; toolbar buttons 28×28.
+    // Prompt hero ≥132px; the toolbar row keeps its 28px rhythm. Width is no longer the
+    // square 28: the attach button carries a visible label beside its glyph, so it sizes
+    // to its content while staying on the same baseline as the inline mic.
     expectMinPx(
       document.querySelector<HTMLElement>("#nt-prompt")!.getBoundingClientRect().height,
       132,
       "prompt hero min-height",
     );
     const tool = document.querySelector<HTMLElement>(".tool-btn")!.getBoundingClientRect();
-    expect(Math.round(tool.width)).toBe(28);
     expect(Math.round(tool.height)).toBe(28);
+    expect(tool.width).toBeGreaterThan(28);
 
     // Dual CTA present (hold-likely, Claude) and fully inside the viewport.
     await expect.poll(() => document.querySelector("button.run-hold")).toBeTruthy();

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -3514,6 +3514,51 @@ describe("NewTask keyboard-aware viewport (mobile)", () => {
     }
   });
 
+  // iOS reports the visible-viewport edge a few px above the keyboard's real top, so the
+  // strip between the (keyboard-fitted) overlay and the keyboard showed raw, unblurred app
+  // content. A full-screen backdrop sits under the overlay to cover it. The band simulated
+  // here is far wider than the real ~13px — the outcome under test is coverage + hit, not
+  // the size of the offset, which is checked on-device.
+  it("covers the strip below the keyboard-fitted overlay and closes when it is tapped", async () => {
+    const KB_TOP = 380; // simulated top edge of the keyboard (visible viewport height)
+    const { restore } = installFakeViewport(KB_TOP, 0);
+    try {
+      await page.viewport(390, 844);
+      const onclose = vi.fn();
+      mockListRepos.mockResolvedValue({ repos: makeRepos(3), recentWindowDays: 30 });
+      render(NewTask, { props: { onsubmit: vi.fn(), onclose, initialRepoPath: "/repo/kbd-00" } });
+
+      // Precondition: the overlay — and with it the opaque card — stops at the keyboard
+      // line, leaving 380→844 as the band that used to show the herd list unobscured.
+      await expect.poll(() => overlay()?.style.height).toBe(`${KB_TOP}px`);
+
+      // The backdrop really covers that band AND receives the hit there: nothing in the
+      // stacking order (or a stray pointer-events) keeps a tap from landing on it.
+      const hit = document.elementFromPoint(195, KB_TOP + 60);
+      expect(hit).toBe(document.querySelector(".nt-backdrop"));
+
+      // …and the node that takes the tap is the node that closes — not a lookalike beside it.
+      (hit as HTMLElement).click();
+      expect(onclose).toHaveBeenCalledTimes(1);
+
+      // It stays strictly below the modal: inside the overlay the hit is still the card,
+      // so the overlay's own backdrop-click path is untouched.
+      const inside = document.elementFromPoint(195, 40);
+      expect(document.querySelector("form.card")!.contains(inside)).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  it("renders no extra backdrop on the desktop layout", async () => {
+    await page.viewport(1280, 900);
+    mockListRepos.mockResolvedValue({ repos: makeRepos(3), recentWindowDays: 30 });
+    render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo/kbd-00" } });
+
+    await expect.poll(() => document.querySelector(".rail")).toBeTruthy();
+    expect(document.querySelector(".nt-backdrop")).toBeNull();
+  });
+
   it("keeps the repo filter and the results reachable above the keyboard in the context sheet", async () => {
     const KB_TOP = 380; // simulated top edge of the keyboard (visible viewport height)
     const { restore } = installFakeViewport(KB_TOP, 0);

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -1596,7 +1596,24 @@
                   onclick={() => fileInput?.click()}
                   disabled={hasOutstandingUploads}
                 >
-                  {#if hasOutstandingUploads}…{:else}↥{/if}
+                  {#if hasOutstandingUploads}
+                    …
+                  {:else}
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      aria-hidden="true"
+                    >
+                      <path
+                        d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"
+                      />
+                    </svg>
+                  {/if}
+                  <span class="tool-label">{m.newtask_attach_label()}</span>
                 </button>
                 <MicButton
                   bind:this={mic}
@@ -2332,10 +2349,14 @@
     padding: 6px 8px;
     border-top: 1px solid var(--color-line);
   }
+  /* Attach: icon + word, so the affordance is readable rather than inferred from a lone
+     glyph. A labeled control follows the `.gbtn` recipe (see /design-system), not the
+     square icon-button one — hence auto width and the meta type scale. */
   .tool-btn {
     flex-shrink: 0;
-    width: 28px;
     height: 28px;
+    padding: 0 8px;
+    gap: 6px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -2343,8 +2364,18 @@
     border: 1px solid var(--color-line);
     border-radius: 2px;
     color: var(--color-muted);
-    font: inherit;
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
     cursor: pointer;
+  }
+  .tool-btn svg {
+    width: var(--icon-btn-glyph);
+    height: var(--icon-btn-glyph);
+    display: block;
+  }
+  .tool-label {
+    white-space: nowrap;
   }
   .tool-btn:hover {
     background: var(--color-hover);
@@ -2799,8 +2830,8 @@
       padding: 8px;
     }
     .tool-btn {
-      width: 44px;
       height: 44px;
+      padding: 0 12px;
     }
     .toolbar :global(.micbtn.inline) {
       width: 44px;

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -1354,6 +1354,23 @@
   const footerCapacity = $derived(selectedProviderCapacity(usageLimits, agentProvider));
 </script>
 
+{#if mobile}
+  <!-- The overlay is sized to the region above the software keyboard, and iOS reports that
+       edge a few px short of the keyboard's real top — leaving a sliver of app content that
+       the overlay's scrim never reaches (undimmed AND unblurred, so the list behind reads
+       through). This full-screen backdrop paints underneath it, so the sliver recedes like
+       every other modal background; a tap on it closes, same as the overlay's own backdrop.
+       Sibling rather than a restructured overlay: the mobile sheets are `position: fixed`
+       and rely on `.overlay` being their containing block to stay above the keyboard. -->
+  <div
+    class="nt-backdrop scrim"
+    role="presentation"
+    onclick={() => {
+      confirmStep = false;
+      onclose?.();
+    }}
+  ></div>
+{/if}
 <div
   class="overlay"
   bind:this={overlayEl}
@@ -2021,6 +2038,13 @@
   }
   .composer.hidden {
     display: none;
+  }
+  /* Full-screen dim + blur (the canonical `.scrim` primitive supplies both) one layer
+     below the overlay, so the strip the overlay's keyboard-fitted box leaves uncovered
+     still reads as backdrop. Invisible everywhere else: on mobile the card fills the
+     overlay, so the two scrims never stack in view. */
+  .nt-backdrop {
+    z-index: 19;
   }
   .overlay {
     position: fixed;


### PR DESCRIPTION
Two mobile defects in the **New Task** modal, both demonstrated in a screen recording on an iPhone 14 Pro Max. Timestamps below refer to that recording.

## 1. A strip of the app stayed visible above the keyboard `[00:11-00:32]`

> "knapp überhalb meiner Tastatur ist Text vom vorherigen Dialog zu sehen, der müsste mehr unscharf sein"

It was not under-blurred — it was **not covered at all**. Comparing the same screen rows with the modal closed and open (mean luma per 10 px band):

| screen rows (device px) | modal closed | modal open | reading |
| --- | --- | --- | --- |
| 1500-1520 | 53, 61 | 0, 0 | behind the opaque card |
| 1560-1580 | 40, 33 | **40, 33** | **identical → uncovered** |
| 1600-1620 | 39, 32 | 14, 15 | behind the keyboard's frost |

`NewTask.svelte` mirrors `visualViewport.height` onto `.overlay`, and iOS reports that edge a few px above the keyboard's real top, so neither the scrim nor its `blur(3px)` ever reached the band.

**Fix:** paint a full-screen backdrop one layer below the overlay on mobile. It inherits the canonical dim + blur from `app.css`'s `.scrim` and carries the same tap-to-close as the overlay's own backdrop.

A sibling rather than a restructured overlay, deliberately: `MobileEngineSheet.svelte` → `.sheet` is `position: fixed; bottom: 0` and depends on `.overlay` being its containing block to stay above the keyboard, so that geometry contract is left untouched. On mobile the card fills the overlay, so the two scrims never stack in view; desktop renders no extra element.

## 2. The attach control was unreadable `[00:32-01:00]`

> "hier sollte doch bitte eine große Büroklammer sein … das ist einfach nicht eindeutig genug … man kann nicht erkennen, dass man hier etwas ergänzen kann"

**Fix:** the bare `↥` glyph becomes an inline paperclip SVG at `--icon-btn-glyph` (18 px, parity with the neighbouring mic) plus a visible label (EN "Attach" / DE "Anhängen"). Per `/design-system`, a labeled control follows the `.gbtn` recipe rather than the square icon-button one, so `.tool-btn` sizes to its content on the meta type scale and keeps its 28 px (desktop) / 44 px (mobile) height.

## Verification

- New test in the existing `NewTask keyboard-aware viewport (mobile)` describe, driven through the `FakeVisualViewport` seam: below a shrunken overlay `elementFromPoint` lands on `.nt-backdrop`, clicking that same node calls `onclose` once, and inside the overlay the hit is still `form.card`. Asserting `position: fixed` + z-index alone would not have tested either outcome — a backdrop can be correctly stacked and still be zero-height or `pointer-events: none`.
- Reproduced the artifact in a real browser at 390×844 by shrinking the overlay to a simulated keyboard line: the band's mean luma drops from 222 (crisp, fully legible content) to 133 (dimmed, blurred).
- Attach button verified live: renders the paperclip + label at 97×44 with no toolbar overflow; the existing German toolbar test (`scrollWidth <= clientWidth` at 390 px) covers the longer "Anhängen".
- `bun run check`, `check:i18n`, `bun run test` (4297 passing), `prettier --check` all green.

The desktop geometry fixture pinned the attach button at 28×28; it now asserts the 28 px row rhythm plus a label-driven width — that square was exactly the shape this changes.

## Notes for review

- **Not done, deliberately:** the shared `--scrim` blur stays at 3 px (one token for every dialog in the app), and the underlying `visualViewport` offset is not corrected — the backdrop makes the artifact invisible without touching iOS-specific geometry.
- **On-device confirmation is still open.** The `FakeVisualViewport` harness proves coverage, hit and close, but it cannot reproduce the real ~13 px offset or actual iOS blur rendering.
- **Overlap:** open PR #1926 touches the same four files (`NewTask.svelte`, its test, both catalogs). Whichever lands second will need a rebase; the message-catalog union merge driver handles the JSON side.
- `[no-feature-entry]` — both changes are fixes to an existing control, no new capability to announce.