### PR TITLE
feat(ui): show attachment upload progress when creating tasks

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3421,5 +3421,19 @@
   "steerseditor_remove_no_aria": "Entfernen abbrechen",
   "feat_steers_9c_redesign_title": "Neu gestalteter Steer-Editor",
   "feat_steers_9c_redesign_body": "Einstellungen → Steers ist jetzt ein Akkordeon — tippe einen Steer an, um ihn direkt zu bearbeiten. Der Repo-Geltungsbereich ist ein Token-Feld mit Tipphilfe und Ein-Klick-Vorschlägen, Platzierungen sind Checkboxen, und jede Änderung wird automatisch gespeichert, der Speichern-Button entfällt.",
-  "steerseditor_close_save_failed": "Steers nicht gespeichert: {reason}"
+  "steerseditor_close_save_failed": "Steers nicht gespeichert: {reason}",
+  "newtask_upload_progress_aria": "Fortschritt des Anhang-Uploads",
+  "newtask_upload_file_count": "Datei {current} von {total}",
+  "newtask_upload_percent": "{percent} %",
+  "newtask_upload_eta_calculating": "Restzeit wird berechnet…",
+  "newtask_upload_eta": "Noch {time}",
+  "newtask_upload_finishing": "Upload wird abgeschlossen…",
+  "newtask_upload_cta": "Lädt hoch · {percent} %",
+  "api_upload_http_error": "Upload mit Status {status} fehlgeschlagen",
+  "api_upload_network_error": "Netzwerkfehler beim Upload",
+  "api_upload_aborted": "Upload wurde abgebrochen",
+  "api_upload_timeout": "Zeitüberschreitung beim Upload",
+  "api_upload_invalid_response": "Der Upload-Server hat eine ungültige Antwort geliefert",
+  "feat_upload_progress_title": "Upload-Fortschritt für Anhänge sehen",
+  "feat_upload_progress_body": "Neue Aufgabe zeigt jetzt Fortschritt und geschätzte Restzeit für große Anhänge und hält Erstellen & Starten deaktiviert, bis jeder Upload bestätigt ist."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3421,5 +3421,19 @@
   "steerseditor_remove_no_aria": "Cancel remove",
   "feat_steers_9c_redesign_title": "Redesigned steer editor",
   "feat_steers_9c_redesign_body": "Settings → Steers is now an accordion — tap a steer to edit it inline. Repo scope is a token field with type-ahead and one-tap suggestions, placements are checkboxes, and every change saves automatically, so the Save button is gone.",
-  "steerseditor_close_save_failed": "Steers not saved: {reason}"
+  "steerseditor_close_save_failed": "Steers not saved: {reason}",
+  "newtask_upload_progress_aria": "Attachment upload progress",
+  "newtask_upload_file_count": "File {current} of {total}",
+  "newtask_upload_percent": "{percent}%",
+  "newtask_upload_eta_calculating": "Estimating time remaining…",
+  "newtask_upload_eta": "{time} remaining",
+  "newtask_upload_finishing": "Finishing upload…",
+  "newtask_upload_cta": "Uploading · {percent}%",
+  "api_upload_http_error": "Upload failed with status {status}",
+  "api_upload_network_error": "Network error during upload",
+  "api_upload_aborted": "Upload was aborted",
+  "api_upload_timeout": "Upload timed out",
+  "api_upload_invalid_response": "The upload server returned an invalid response",
+  "feat_upload_progress_title": "See attachment upload progress",
+  "feat_upload_progress_body": "New Task now shows progress and estimated time remaining for large attachments, and keeps Create & Run disabled until every upload is confirmed."
 }

--- a/ui/src/lib/api.browser.test.ts
+++ b/ui/src/lib/api.browser.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError, isPreviewBlocked, uploadFile } from "./api";
+import { auth } from "./auth.svelte";
+import { m } from "./paraglide/messages";
+import { overwriteGetLocale } from "./paraglide/runtime";
+
+class FakeXMLHttpRequest extends EventTarget {
+  static instances: FakeXMLHttpRequest[] = [];
+
+  readonly upload = new EventTarget();
+  method = "";
+  url = "";
+  body: Document | XMLHttpRequestBodyInit | null = null;
+  status = 0;
+  responseText = "";
+
+  constructor() {
+    super();
+    FakeXMLHttpRequest.instances.push(this);
+  }
+
+  open(method: string, url: string) {
+    this.method = method;
+    this.url = url;
+  }
+
+  send(body: Document | XMLHttpRequestBodyInit | null = null) {
+    this.body = body;
+  }
+
+  respond(status: number, body: unknown) {
+    this.status = status;
+    this.responseText = JSON.stringify(body);
+    this.dispatchEvent(new Event("load"));
+  }
+
+  fail() {
+    this.dispatchEvent(new Event("error"));
+  }
+}
+
+function request(): FakeXMLHttpRequest {
+  expect(FakeXMLHttpRequest.instances).toHaveLength(1);
+  return FakeXMLHttpRequest.instances[0]!;
+}
+
+async function rejected(promise: Promise<unknown>): Promise<Error> {
+  return (await promise.then(
+    () => null,
+    (error) => error,
+  )) as Error;
+}
+
+describe("uploadFile progress transport", () => {
+  beforeEach(() => {
+    FakeXMLHttpRequest.instances = [];
+    auth.unauthenticated = false;
+    vi.stubGlobal("XMLHttpRequest", FakeXMLHttpRequest as unknown as typeof XMLHttpRequest);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("progress uploads must not use fetch");
+      }),
+    );
+  });
+
+  afterEach(() => {
+    auth.unauthenticated = false;
+    overwriteGetLocale(() => "en");
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the existing fetch transport when no progress callback is supplied", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ path: "/worktree/plain.txt" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const file = new File(["plain"], "plain.txt", { type: "text/plain" });
+
+    await expect(uploadFile(file, "live-session")).resolves.toBe("/worktree/plain.txt");
+
+    expect(FakeXMLHttpRequest.instances).toHaveLength(0);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock.mock.calls[0]![0]).toBe("/api/uploads?session=live-session");
+    expect(fetchMock.mock.calls[0]![1]).toMatchObject({ method: "POST" });
+    expect((fetchMock.mock.calls[0]![1]!.body as FormData).get("file")).toBe(file);
+  });
+
+  it("reports upload bytes and resolves only after the server confirms the staged path", async () => {
+    const file = new File(["1234567890"], "clip.mp4", { type: "video/mp4" });
+    const onProgress = vi.fn();
+
+    const result = uploadFile(file, undefined, onProgress);
+    const xhr = request();
+
+    expect(xhr.method).toBe("POST");
+    expect(xhr.url).toBe("/api/uploads");
+    expect(xhr.body).toBeInstanceOf(FormData);
+    expect((xhr.body as FormData).get("file")).toBe(file);
+
+    xhr.upload.dispatchEvent(
+      new ProgressEvent("progress", { lengthComputable: true, loaded: 4, total: 10 }),
+    );
+    expect(onProgress).toHaveBeenCalledWith({
+      loaded: 4,
+      total: 10,
+      lengthComputable: true,
+    });
+
+    let settled = false;
+    void result.finally(() => (settled = true));
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    xhr.respond(200, { path: "/staged/clip.mp4" });
+    await expect(result).resolves.toBe("/staged/clip.mp4");
+  });
+
+  it("preserves the session upload URL when progress is requested", async () => {
+    const result = uploadFile(new File(["x"], "shot.png"), "session/one", vi.fn());
+    const xhr = request();
+
+    expect(xhr.url).toBe("/api/uploads?session=session%2Fone");
+    xhr.respond(200, { path: "/worktree/shot.png" });
+    await expect(result).resolves.toBe("/worktree/shot.png");
+  });
+
+  it("maps a generic HTTP body and a network failure to upload errors", async () => {
+    const httpResult = uploadFile(new File(["x"], "large.bin"), undefined, vi.fn());
+    request().respond(413, { error: "file too large" });
+    const httpError = await rejected(httpResult);
+
+    expect(httpError).toBeInstanceOf(ApiError);
+    expect((httpError as ApiError).status).toBe(413);
+    expect(httpError.message).toBe("file too large");
+
+    FakeXMLHttpRequest.instances = [];
+    const networkResult = uploadFile(new File(["x"], "offline.bin"), undefined, vi.fn());
+    request().fail();
+    await expect(networkResult).rejects.toThrow(m.api_upload_network_error());
+  });
+
+  it("localizes client-authored transport errors", async () => {
+    overwriteGetLocale(() => "de");
+    const result = uploadFile(new File(["x"], "offline.bin"), undefined, vi.fn());
+    request().fail();
+
+    await expect(result).rejects.toThrow("Netzwerkfehler beim Upload");
+  });
+
+  it("flips auth state for a 401 response", async () => {
+    const result = uploadFile(new File(["x"], "secret.txt"), undefined, vi.fn());
+    request().respond(401, { error: "unauthorized" });
+    const error = await rejected(result);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as ApiError).status).toBe(401);
+    expect(auth.unauthenticated).toBe(true);
+  });
+
+  it("preserves preview-origin 403 classification and localized copy", async () => {
+    const result = uploadFile(new File(["x"], "preview.txt"), undefined, vi.fn());
+    request().respond(403, { error: "forbidden: origin not allowed" });
+    const error = await rejected(result);
+
+    expect(isPreviewBlocked(error)).toBe(true);
+    expect(error.message).toBe(m.error_preview_readonly());
+  });
+
+  it("preserves host-allowlist 403 ApiError semantics and localized copy", async () => {
+    const result = uploadFile(new File(["x"], "host.txt"), undefined, vi.fn());
+    request().respond(403, { error: "forbidden: origin host not allowed" });
+    const error = await rejected(result);
+
+    expect(isPreviewBlocked(error)).toBe(false);
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as ApiError).status).toBe(403);
+    expect(error.message).toBe(m.error_origin_host_not_allowed());
+    expect((error as ApiError).serverAuthored).toBe(true);
+  });
+});

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -327,7 +327,73 @@ export const putUpnextSkipCliPicker = (value: boolean): Promise<{ upnextSkipCliP
 
 /** Upload one file; returns its absolute server path. Pass sessionId to store it
  *  inside that session's worktree (live terminal); omit for New Task staging. */
-export async function uploadFile(file: File, sessionId?: string): Promise<string> {
+export interface UploadProgress {
+  loaded: number;
+  total: number;
+  lengthComputable: boolean;
+}
+
+function uploadFileWithProgress(
+  file: File,
+  sessionId: string | undefined,
+  onProgress: (progress: UploadProgress) => void,
+): Promise<string> {
+  const fd = new FormData();
+  fd.append("file", file);
+  const q = sessionId ? `?session=${encodeURIComponent(sessionId)}` : "";
+
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    let settled = false;
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      fn();
+    };
+
+    xhr.upload.addEventListener("progress", (event) => {
+      onProgress({
+        loaded: event.loaded,
+        total: event.total,
+        lengthComputable: event.lengthComputable,
+      });
+    });
+    xhr.addEventListener("load", () => {
+      let body: { error?: string; path?: string } | null = null;
+      try {
+        body = JSON.parse(xhr.responseText) as { error?: string; path?: string };
+      } catch {
+        // Keep null: apiError() will use the same fallback as failed().
+      }
+      if (xhr.status < 200 || xhr.status >= 300) {
+        finish(() =>
+          reject(apiError(xhr.status, body, m.api_upload_http_error({ status: xhr.status }))),
+        );
+        return;
+      }
+      if (typeof body?.path !== "string") {
+        finish(() => reject(new Error(m.api_upload_invalid_response())));
+        return;
+      }
+      finish(() => resolve(body.path!));
+    });
+    xhr.addEventListener("error", () =>
+      finish(() => reject(new Error(m.api_upload_network_error()))),
+    );
+    xhr.addEventListener("abort", () => finish(() => reject(new Error(m.api_upload_aborted()))));
+    xhr.addEventListener("timeout", () => finish(() => reject(new Error(m.api_upload_timeout()))));
+    xhr.open("POST", `/api/uploads${q}`);
+    xhr.send(fd);
+  });
+}
+
+export async function uploadFile(
+  file: File,
+  sessionId?: string,
+  onProgress?: (progress: UploadProgress) => void,
+): Promise<string> {
+  if (onProgress) return uploadFileWithProgress(file, sessionId, onProgress);
+
   const fd = new FormData();
   fd.append("file", file);
   const q = sessionId ? `?session=${encodeURIComponent(sessionId)}` : "";

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -444,9 +444,11 @@ describe("NewTask task attachments", () => {
   function dropFiles(files: File[]) {
     const transfer = new DataTransfer();
     for (const file of files) transfer.items.add(file);
-    document.querySelector<HTMLFormElement>("form.card")!.dispatchEvent(
-      new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer: transfer }),
-    );
+    document
+      .querySelector<HTMLFormElement>("form.card")!
+      .dispatchEvent(
+        new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer: transfer }),
+      );
   }
 
   function pasteFiles(files: File[]) {
@@ -627,7 +629,9 @@ describe("NewTask task attachments", () => {
     await expect.poll(() => mockUploadFile.mock.calls.length).toBe(1);
     mockUploadFile.mock.calls[0]![2]!({ loaded: 40, total: 100, lengthComputable: true });
 
-    await expect.element(page.getByText("File 1 of 1 · 40% · Estimating time remaining…")).toBeVisible();
+    await expect
+      .element(page.getByText("File 1 of 1 · 40% · Estimating time remaining…"))
+      .toBeVisible();
     const footer = document.querySelector<HTMLElement>(".cfoot")!;
     const run = document.querySelector<HTMLButtonElement>("button.run")!;
     expect(run.disabled).toBe(true);
@@ -2176,16 +2180,16 @@ describe("NewTask first-task confirm step", () => {
     await fillPromptAndClickRun();
     await expect.poll(() => document.querySelector(".ftac")).toBeTruthy();
 
-    document
-      .querySelector<HTMLButtonElement>(".ftac button.primary")!
-      .click();
+    document.querySelector<HTMLButtonElement>(".ftac button.primary")!.click();
     await expect.poll(() => mockPutRepoConfig.mock.calls.length).toBe(2);
 
     const transfer = new DataTransfer();
     transfer.items.add(new File(["late"], "confirm-late.mp4", { type: "video/mp4" }));
-    document.querySelector<HTMLFormElement>("form.card")!.dispatchEvent(
-      new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer: transfer }),
-    );
+    document
+      .querySelector<HTMLFormElement>("form.card")!
+      .dispatchEvent(
+        new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer: transfer }),
+      );
     await expect.poll(() => mockUploadFile.mock.calls.length).toBe(1);
 
     confirmation.resolve(confirmedRepoConfig());

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -68,6 +68,16 @@ const mockInitEmptyCommit = vi.mocked(initEmptyCommit);
 const mockGetCommands = vi.mocked(getCommands);
 const mockUploadFile = vi.mocked(uploadFile);
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 // A full RepoConfig with the plan gate flag overridable; the composer only reads
 // planGateEnabled but the store ingests the whole shape. automationConfirmed defaults
 // to true so existing tests (which don't test the confirm step) bypass the gate.
@@ -168,6 +178,7 @@ function mockPointer(coarse: boolean) {
 }
 
 afterEach(async () => {
+  vi.useRealTimers();
   matchMediaSpy?.mockRestore();
   matchMediaSpy = undefined;
   createObjectUrlSpy?.mockRestore();
@@ -424,6 +435,28 @@ describe("NewTask task attachments", () => {
     revokeObjectUrlSpy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
   }
 
+  function pickFiles(files: File[]) {
+    const input = document.querySelector<HTMLInputElement>('input[type="file"]')!;
+    Object.defineProperty(input, "files", { value: files, configurable: true });
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+  }
+
+  function dropFiles(files: File[]) {
+    const transfer = new DataTransfer();
+    for (const file of files) transfer.items.add(file);
+    document.querySelector<HTMLFormElement>("form.card")!.dispatchEvent(
+      new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer: transfer }),
+    );
+  }
+
+  function pasteFiles(files: File[]) {
+    const transfer = new DataTransfer();
+    for (const file of files) transfer.items.add(file);
+    const event = new ClipboardEvent("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", { value: transfer });
+    window.dispatchEvent(event);
+  }
+
   it("renders the toolbar attach button with the keyboard paste-image hint as its title", async () => {
     mockPointer(false);
     render(NewTask, { props: base({ initialRepoPath: "/repo/attachments" }) });
@@ -456,6 +489,222 @@ describe("NewTask task attachments", () => {
     expect(row.scrollWidth).toBeLessThanOrEqual(row.clientWidth);
   });
 
+  it.each(["drop", "paste"] as const)(
+    "serializes a second %s batch and blocks Run until both batches finish",
+    async (source) => {
+      const pending: Array<ReturnType<typeof deferred<string>>> = [];
+      mockUploadFile.mockImplementation(() => {
+        const request = deferred<string>();
+        pending.push(request);
+        return request.promise;
+      });
+      const onsubmit = vi.fn().mockResolvedValue(undefined);
+      render(NewTask, { props: base({ onsubmit, initialRepoPath: "/repo/upload-queue" }) });
+
+      const prompt = document.querySelector<HTMLTextAreaElement>("#nt-prompt")!;
+      prompt.value = "use both files";
+      prompt.dispatchEvent(new Event("input", { bubbles: true }));
+
+      const first = new File(["first"], "first.mp4", { type: "video/mp4" });
+      const second = new File(["second"], "second.png", { type: "image/png" });
+      pickFiles([first]);
+      await expect.poll(() => mockUploadFile.mock.calls.length).toBe(1);
+
+      const attach = document.querySelector<HTMLButtonElement>(".toolbar .tool-btn")!;
+      const run = () => document.querySelector<HTMLButtonElement>("button.run")!;
+      expect(attach.disabled).toBe(true);
+      expect(run().disabled).toBe(true);
+      prompt.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", ctrlKey: true, bubbles: true }),
+      );
+      expect(onsubmit).not.toHaveBeenCalled();
+
+      if (source === "drop") dropFiles([second]);
+      else pasteFiles([second]);
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(mockUploadFile).toHaveBeenCalledTimes(1);
+      expect(run().disabled).toBe(true);
+
+      pending[0]!.resolve("/staged/first.mp4");
+      await expect.poll(() => mockUploadFile.mock.calls.length).toBe(2);
+      expect(mockUploadFile.mock.calls[1]![0]).toBe(second);
+      expect(run().disabled).toBe(true);
+
+      pending[1]!.resolve("/staged/second.png");
+      await expect.poll(() => run().disabled).toBe(false);
+      expect(attach.disabled).toBe(false);
+      expect(onsubmit).not.toHaveBeenCalled();
+    },
+  );
+
+  it("shows weighted batch progress, ETA, and the server-finishing state", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-07-24T12:00:00Z"));
+    const pending: Array<ReturnType<typeof deferred<string>>> = [];
+    mockUploadFile.mockImplementation(() => {
+      const request = deferred<string>();
+      pending.push(request);
+      return request.promise;
+    });
+    render(NewTask, {
+      props: base({ initialRepoPath: "/repo/upload-progress", holdLikely: true }),
+    });
+
+    pickFiles([
+      new File([new Uint8Array(100)], "small.mp4", { type: "video/mp4" }),
+      new File([new Uint8Array(300)], "large.mp4", { type: "video/mp4" }),
+    ]);
+    await expect.poll(() => mockUploadFile.mock.calls.length).toBe(1);
+    const firstProgress = mockUploadFile.mock.calls[0]![2]!;
+
+    vi.setSystemTime(new Date("2026-07-24T12:00:00.500Z"));
+    firstProgress({ loaded: 50, total: 100, lengthComputable: true });
+    await expect
+      .element(page.getByText("File 1 of 2 · 13% · Estimating time remaining…"))
+      .toBeVisible();
+    const progress = document.querySelector<HTMLProgressElement>("progress.upload-progress")!;
+    expect(progress.value).toBe(13);
+    expect(progress.getAttribute("aria-label")).toBe("Attachment upload progress");
+
+    vi.setSystemTime(new Date("2026-07-24T12:00:02Z"));
+    firstProgress({ loaded: 100, total: 100, lengthComputable: true });
+    await expect.element(page.getByText("File 1 of 2 · 25% · 00:06 remaining")).toBeVisible();
+
+    pending[0]!.resolve("/staged/small.mp4");
+    await expect.poll(() => mockUploadFile.mock.calls.length).toBe(2);
+    const secondProgress = mockUploadFile.mock.calls[1]![2]!;
+    vi.setSystemTime(new Date("2026-07-24T12:00:04Z"));
+    secondProgress({ loaded: 150, total: 300, lengthComputable: true });
+    await expect.element(page.getByText("File 2 of 2 · 63% · 00:03 remaining")).toBeVisible();
+
+    secondProgress({ loaded: 299, total: 300, lengthComputable: true });
+    await expect.element(page.getByText("File 2 of 2 · 99% · 00:01 remaining")).toBeVisible();
+    expect(document.querySelector<HTMLButtonElement>("button.run")!.textContent).toContain(
+      "Uploading · 99%",
+    );
+
+    secondProgress({ loaded: 300, total: 300, lengthComputable: true });
+    await expect.element(page.getByText("File 2 of 2 · 100% · Finishing upload…")).toBeVisible();
+    const uploadButtons = document.querySelectorAll<HTMLButtonElement>("button.run");
+    expect(uploadButtons).toHaveLength(1);
+    expect(uploadButtons[0]!.disabled).toBe(true);
+    expect(uploadButtons[0]!.textContent).toContain("Finishing upload…");
+
+    pending[1]!.resolve("/staged/large.mp4");
+    await expect.poll(() => document.querySelector("progress.upload-progress")).toBeNull();
+  });
+
+  it("uses an indeterminate bar without a misleading percentage when byte length is unknown", async () => {
+    const request = deferred<string>();
+    mockUploadFile.mockReturnValue(request.promise);
+    render(NewTask, { props: base({ initialRepoPath: "/repo/indeterminate-upload" }) });
+
+    pickFiles([new File(["unknown"], "unknown.bin")]);
+    await expect.poll(() => mockUploadFile.mock.calls.length).toBe(1);
+    mockUploadFile.mock.calls[0]![2]!({ loaded: 4, total: 0, lengthComputable: false });
+
+    const progress = () => document.querySelector<HTMLProgressElement>("progress.upload-progress")!;
+    await expect.poll(() => progress().hasAttribute("value")).toBe(false);
+    const summary = document.querySelector<HTMLElement>(".upload-summary")!;
+    expect(summary.textContent).toContain("File 1 of 1");
+    expect(summary.textContent).toContain(m.newtask_uploading());
+    expect(summary.textContent).not.toContain("0%");
+    expect(document.querySelector<HTMLButtonElement>("button.run")!.textContent).toContain(
+      m.newtask_uploading(),
+    );
+
+    request.resolve("/staged/unknown.bin");
+  });
+
+  it("keeps upload progress and the disabled CTA visible in the mobile footer", async () => {
+    await page.viewport(390, 800);
+    const request = deferred<string>();
+    mockUploadFile.mockReturnValue(request.promise);
+    render(NewTask, { props: base({ initialRepoPath: "/repo/mobile-progress" }) });
+
+    pickFiles([new File([new Uint8Array(100)], "mobile.mp4", { type: "video/mp4" })]);
+    await expect.poll(() => mockUploadFile.mock.calls.length).toBe(1);
+    mockUploadFile.mock.calls[0]![2]!({ loaded: 40, total: 100, lengthComputable: true });
+
+    await expect.element(page.getByText("File 1 of 1 · 40% · Estimating time remaining…")).toBeVisible();
+    const footer = document.querySelector<HTMLElement>(".cfoot")!;
+    const run = document.querySelector<HTMLButtonElement>("button.run")!;
+    expect(run.disabled).toBe(true);
+    expect(run.textContent).toContain("Uploading · 40%");
+    expect(footer.scrollWidth).toBeLessThanOrEqual(footer.clientWidth);
+
+    request.resolve("/staged/mobile.mp4");
+  });
+
+  it("retries only the failed file and the files still queued behind it", async () => {
+    let secondAttempts = 0;
+    const retrySecond = deferred<string>();
+    mockUploadFile.mockImplementation(async (file) => {
+      if (file.name === "second.mov") {
+        secondAttempts += 1;
+        if (secondAttempts === 1) throw new Error("upload interrupted");
+        if (secondAttempts === 2) return retrySecond.promise;
+      }
+      return `/staged/${file.name}`;
+    });
+    render(NewTask, { props: base({ initialRepoPath: "/repo/upload-retry" }) });
+
+    pickFiles([
+      new File(["first"], "first.mov", { type: "video/quicktime" }),
+      new File(["second"], "second.mov", { type: "video/quicktime" }),
+      new File(["third"], "third.mov", { type: "video/quicktime" }),
+    ]);
+
+    await expect.element(page.getByRole("button", { name: m.common_retry() })).toBeVisible();
+    expect(mockUploadFile.mock.calls.map(([file]) => file.name)).toEqual([
+      "first.mov",
+      "second.mov",
+    ]);
+
+    await page.getByRole("button", { name: m.common_retry() }).click();
+    await expect.poll(() => mockUploadFile.mock.calls.length).toBe(3);
+    await expect
+      .element(page.getByText("File 1 of 2 · 0% · Estimating time remaining…"))
+      .toBeVisible();
+    retrySecond.resolve("/staged/second.mov");
+    await expect.poll(() => mockUploadFile.mock.calls.length).toBe(4);
+    expect(mockUploadFile.mock.calls.map(([file]) => file.name)).toEqual([
+      "first.mov",
+      "second.mov",
+      "second.mov",
+      "third.mov",
+    ]);
+    expect(page.getByText("first.mov").all().length).toBe(1);
+    await expect.element(page.getByText("third.mov")).toBeInTheDocument();
+  });
+
+  it("invalidates a Run click when an upload starts while repo config is settling", async () => {
+    const config = deferred<RepoConfig>();
+    mockGetRepoConfig.mockReturnValue(config.promise);
+    mockUploadFile.mockResolvedValue("/staged/late.mp4");
+    const onsubmit = vi.fn().mockResolvedValue(undefined);
+    render(NewTask, { props: base({ onsubmit, initialRepoPath: "/repo/upload-ensure-race" }) });
+
+    const prompt = document.querySelector<HTMLTextAreaElement>("#nt-prompt")!;
+    prompt.value = "use the late attachment";
+    prompt.dispatchEvent(new Event("input", { bubbles: true }));
+    const run = () => document.querySelector<HTMLButtonElement>("button.run")!;
+    await expect.poll(() => run().disabled).toBe(false);
+    run().click();
+
+    pickFiles([new File(["late"], "late.mp4", { type: "video/mp4" })]);
+    await expect.element(page.getByText("late.mp4")).toBeInTheDocument();
+    config.resolve(confirmedRepoConfig());
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onsubmit).not.toHaveBeenCalled();
+    await expect.poll(() => run().disabled).toBe(false);
+    run().click();
+    await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
+    expect(onsubmit.mock.calls[0]![0]).toMatchObject({ images: ["/staged/late.mp4"] });
+  });
+
   it("uploads a non-image file, renders a chip, and submits its staged path", async () => {
     mockUploadFile.mockResolvedValue("/staged/notes.md");
     const onsubmit = vi.fn().mockResolvedValue(undefined);
@@ -469,7 +718,7 @@ describe("NewTask task attachments", () => {
     input.dispatchEvent(new Event("change", { bubbles: true }));
 
     await expect.poll(() => mockUploadFile.mock.calls.length).toBe(1);
-    expect(mockUploadFile).toHaveBeenCalledWith(file);
+    expect(mockUploadFile).toHaveBeenCalledWith(file, undefined, expect.any(Function));
     await expect.element(page.getByText("notes.md")).toBeInTheDocument();
 
     const promptField = document.querySelector<HTMLTextAreaElement>("#nt-prompt")!;
@@ -1814,6 +2063,40 @@ describe("NewTask first-task confirm step", () => {
     expect(seedCall).toBeTruthy();
   });
 
+  it("invalidates the first Run click when an upload starts while defaults are being seeded", async () => {
+    const repoPath = "/repo/ftac-seed-upload-race";
+    mockGetRepoConfig.mockResolvedValue(unconfirmedNewRepoConfig());
+    const seed = deferred<
+      RepoConfig & { automationConfirmed: boolean; automationRowExists: boolean }
+    >();
+    mockPutRepoConfig.mockReturnValueOnce(seed.promise);
+    mockUploadFile.mockResolvedValue("/staged/during-seed.mp4");
+    const onsubmit = vi.fn().mockResolvedValue(undefined);
+    render(NewTask, { props: { onsubmit, initialRepoPath: repoPath } });
+
+    await expect.poll(() => planGateSwitch()).toBeTruthy();
+    await fillPromptAndClickRun();
+    await expect.poll(() => mockPutRepoConfig.mock.calls.length).toBe(1);
+
+    const input = document.querySelector<HTMLInputElement>('input[type="file"]')!;
+    Object.defineProperty(input, "files", {
+      value: [new File(["late"], "during-seed.mp4", { type: "video/mp4" })],
+      configurable: true,
+    });
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+    await expect.element(page.getByText("during-seed.mp4")).toBeInTheDocument();
+
+    seed.resolve({ ...unconfirmedExistingRepoConfig(), planGateEnabled: true });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(document.querySelector(".ftac")).toBeNull();
+    expect(onsubmit).not.toHaveBeenCalled();
+
+    document.querySelector<HTMLButtonElement>("button.run")!.click();
+    await expect.poll(() => document.querySelector(".ftac")).toBeTruthy();
+    expect(mockPutRepoConfig).toHaveBeenCalledTimes(1);
+    expect(onsubmit).not.toHaveBeenCalled();
+  });
+
   it("unconfirmed brand-new repo + Codex: skips Claude automation confirm and submits", async () => {
     const repoPath = "/repo/ftac-codex-unconfirmed";
     mockGetRepoConfig.mockResolvedValue(unconfirmedNewRepoConfig());
@@ -1874,6 +2157,50 @@ describe("NewTask first-task confirm step", () => {
       (c) => c[1]?.automationConfirmed === true,
     );
     expect(confirmCall).toBeTruthy();
+  });
+
+  it("invalidates confirmation when an upload starts before confirmAutomation settles", async () => {
+    const repoPath = "/repo/ftac-upload-race";
+    mockGetRepoConfig.mockResolvedValue(unconfirmedNewRepoConfig());
+    mockPutRepoConfig.mockResolvedValueOnce(unconfirmedNewRepoConfig());
+    const confirmation = deferred<
+      RepoConfig & { automationConfirmed: boolean; automationRowExists: boolean }
+    >();
+    mockPutRepoConfig.mockReturnValueOnce(confirmation.promise);
+    const upload = deferred<string>();
+    mockUploadFile.mockReturnValue(upload.promise);
+    const onsubmit = vi.fn().mockResolvedValue(undefined);
+    render(NewTask, { props: { onsubmit, initialRepoPath: repoPath } });
+
+    await expect.poll(() => planGateSwitch()).toBeTruthy();
+    await fillPromptAndClickRun();
+    await expect.poll(() => document.querySelector(".ftac")).toBeTruthy();
+
+    document
+      .querySelector<HTMLButtonElement>(".ftac button.primary")!
+      .click();
+    await expect.poll(() => mockPutRepoConfig.mock.calls.length).toBe(2);
+
+    const transfer = new DataTransfer();
+    transfer.items.add(new File(["late"], "confirm-late.mp4", { type: "video/mp4" }));
+    document.querySelector<HTMLFormElement>("form.card")!.dispatchEvent(
+      new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer: transfer }),
+    );
+    await expect.poll(() => mockUploadFile.mock.calls.length).toBe(1);
+
+    confirmation.resolve(confirmedRepoConfig());
+    await expect.poll(() => document.querySelector(".ftac")).toBeNull();
+    expect(onsubmit).not.toHaveBeenCalled();
+
+    upload.resolve("/staged/confirm-late.mp4");
+    await expect.element(page.getByText("confirm-late.mp4")).toBeInTheDocument();
+    const run = document.querySelector<HTMLButtonElement>("button.run")!;
+    await expect.poll(() => run.disabled).toBe(false);
+    run.click();
+    await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
+    expect(onsubmit.mock.calls[0]![0]).toMatchObject({
+      images: ["/staged/confirm-late.mp4"],
+    });
   });
 
   it("Cancel: hides confirm step and does NOT call onsubmit", async () => {

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -327,9 +327,7 @@
     Math.min(uploadTotalFiles, uploadCompletedFiles + (activeUpload ? 1 : 0)),
   );
   const uploadFinishing = $derived(
-    hasOutstandingUploads &&
-      uploadTotalBytes > 0 &&
-      uploadTransferredBytes >= uploadTotalBytes,
+    hasOutstandingUploads && uploadTotalBytes > 0 && uploadTransferredBytes >= uploadTotalBytes,
   );
   const uploadEta = $derived.by(() => {
     const elapsedMs = Date.now() - uploadEpochStartedAt;
@@ -1742,15 +1740,15 @@
               <progress
                 class="upload-progress"
                 max="100"
-                aria-label={m.newtask_upload_progress_aria()}></progress
-              >
+                aria-label={m.newtask_upload_progress_aria()}
+              ></progress>
             {:else}
               <progress
                 class="upload-progress"
                 max="100"
                 value={uploadPercent}
-                aria-label={m.newtask_upload_progress_aria()}></progress
-              >
+                aria-label={m.newtask_upload_progress_aria()}
+              ></progress>
             {/if}
             <span class="upload-summary">
               {m.newtask_upload_file_count({

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -56,6 +56,7 @@
   import { projectIcons } from "$lib/projectIcons.svelte";
   import { modelOptionLabel } from "$lib/model-guidance";
   import { selectedProviderCapacity } from "$lib/components/usage-gauges";
+  import { elapsed } from "$lib/format";
   import { deriveReadiness } from "./new-task/readiness";
   import {
     preselectModel,
@@ -71,6 +72,10 @@
     path: string;
     name: string;
     previewFile?: File;
+  };
+
+  type QueuedUpload = {
+    file: File;
   };
 
   let {
@@ -290,7 +295,57 @@
   // svelte-ignore state_referenced_locally
   let images = $state<TaskAttachment[]>(initialImages ? [...initialImages] : []);
   let dragging = $state(false);
-  let uploading = $state(false);
+  let uploadQueue = $state<QueuedUpload[]>([]);
+  let activeUpload = $state<QueuedUpload | null>(null);
+  let uploadWorkerRunning = $state(false);
+  let failedUploadQueue = $state<QueuedUpload[]>([]);
+  let uploadQueueRevision = $state(0);
+  let uploadTotalFiles = $state(0);
+  let uploadCompletedFiles = $state(0);
+  let uploadTotalBytes = $state(0);
+  let uploadCompletedBytes = $state(0);
+  let uploadCurrentBytes = $state(0);
+  let uploadCurrentLengthComputable = $state<boolean | null>(null);
+  let uploadEpochStartedAt = $state(0);
+  const hasOutstandingUploads = $derived(
+    uploadWorkerRunning || activeUpload !== null || uploadQueue.length > 0,
+  );
+  const uploadTransferredBytes = $derived(
+    Math.min(uploadTotalBytes, uploadCompletedBytes + uploadCurrentBytes),
+  );
+  const uploadPercent = $derived(
+    uploadTotalBytes > 0
+      ? Math.min(
+          uploadTransferredBytes < uploadTotalBytes ? 99 : 100,
+          Math.round((uploadTransferredBytes / uploadTotalBytes) * 100),
+        )
+      : uploadTotalFiles > 0
+        ? Math.round((uploadCompletedFiles / uploadTotalFiles) * 100)
+        : 0,
+  );
+  const uploadFileIndex = $derived(
+    Math.min(uploadTotalFiles, uploadCompletedFiles + (activeUpload ? 1 : 0)),
+  );
+  const uploadFinishing = $derived(
+    hasOutstandingUploads &&
+      uploadTotalBytes > 0 &&
+      uploadTransferredBytes >= uploadTotalBytes,
+  );
+  const uploadEta = $derived.by(() => {
+    const elapsedMs = Date.now() - uploadEpochStartedAt;
+    if (
+      !hasOutstandingUploads ||
+      uploadFinishing ||
+      uploadCurrentLengthComputable !== true ||
+      uploadTransferredBytes <= 0 ||
+      elapsedMs < 1_000
+    ) {
+      return null;
+    }
+    const rate = uploadTransferredBytes / elapsedMs;
+    const remainingMs = (uploadTotalBytes - uploadTransferredBytes) / rate;
+    return elapsed(0, Math.ceil(remainingMs / 1_000) * 1_000);
+  });
   let fileInput = $state<HTMLInputElement>();
   let promptInput = $state<HTMLTextAreaElement>();
   // The modal backdrop. On mobile we mirror the visualViewport onto it so the card and
@@ -687,6 +742,7 @@
       repoResolved: !!repoPath.trim(),
       baseMissing,
       repairing: repairingBase,
+      uploading: hasOutstandingUploads,
       submitting,
       upstreamLoading,
       upstream: upstream ? { diverged: upstream.diverged, behind: upstream.behind } : null,
@@ -706,36 +762,91 @@
         return m.newtask_readiness_base_missing();
       case "repairing":
         return m.newtask_readiness_repairing();
+      case "uploading":
+        return m.newtask_uploading();
       case "submitting":
         return m.newtask_spawning();
     }
   }
 
-  async function addFiles(files: FileList | File[]) {
-    const uploads = Array.from(files);
+  function uploadsSettledSince(revision: number): boolean {
+    return uploadQueueRevision === revision && !hasOutstandingUploads;
+  }
+
+  function enqueueUploads(uploads: QueuedUpload[]) {
     if (uploads.length === 0) return;
-    uploading = true;
+    if (!uploadWorkerRunning) {
+      uploadTotalFiles = uploads.length;
+      uploadCompletedFiles = 0;
+      uploadTotalBytes = uploads.reduce((sum, upload) => sum + upload.file.size, 0);
+      uploadCompletedBytes = 0;
+      uploadCurrentBytes = 0;
+      uploadCurrentLengthComputable = null;
+      uploadEpochStartedAt = Date.now();
+    } else {
+      uploadTotalFiles += uploads.length;
+      uploadTotalBytes += uploads.reduce((sum, upload) => sum + upload.file.size, 0);
+    }
+    uploadQueueRevision += 1;
+    uploadQueue.push(...uploads);
     error = null;
     retry = null;
-    try {
-      for (const f of uploads) {
-        const path = await uploadFile(f);
+    failedUploadQueue = [];
+    if (!uploadWorkerRunning) {
+      uploadWorkerRunning = true;
+      void drainUploadQueue();
+    }
+  }
+
+  async function drainUploadQueue() {
+    while (uploadQueue.length > 0) {
+      const upload = uploadQueue.shift()!;
+      activeUpload = upload;
+      uploadCurrentBytes = 0;
+      uploadCurrentLengthComputable = null;
+      try {
+        const path = await uploadFile(upload.file, undefined, (progress) => {
+          if (activeUpload !== upload) return;
+          uploadCurrentLengthComputable = progress.lengthComputable && progress.total > 0;
+          if (uploadCurrentLengthComputable !== true) return;
+          const ratio = Math.min(1, Math.max(0, progress.loaded / progress.total));
+          uploadCurrentBytes = upload.file.size * ratio;
+        });
         images.push({
           path,
-          name: f.name,
-          ...(f.type.startsWith("image/") ? { previewFile: f } : {}),
+          name: upload.file.name,
+          ...(upload.file.type.startsWith("image/") ? { previewFile: upload.file } : {}),
         });
+        uploadCompletedFiles += 1;
+        uploadCompletedBytes += upload.file.size;
+        uploadCurrentBytes = 0;
+      } catch (err) {
+        failedUploadQueue = [upload, ...uploadQueue];
+        uploadQueue = [];
+        if (isPreviewBlocked(err)) {
+          error = (err as Error).message;
+        } else {
+          error = m.newtask_upload_failed({
+            reason: reason(err, m.newtask_upload_unknown_reason()),
+          });
+          retry = retryFailedUploads;
+        }
+        break;
+      } finally {
+        activeUpload = null;
       }
-    } catch (err) {
-      if (isPreviewBlocked(err)) {
-        error = (err as Error).message;
-      } else {
-        error = m.newtask_upload_failed({ reason: reason(err, m.newtask_upload_unknown_reason()) });
-        retry = () => addFiles(uploads);
-      }
-    } finally {
-      uploading = false;
     }
+    uploadWorkerRunning = false;
+  }
+
+  function retryFailedUploads() {
+    const uploads = failedUploadQueue;
+    failedUploadQueue = [];
+    enqueueUploads(uploads);
+  }
+
+  function addFiles(files: FileList | File[]) {
+    enqueueUploads(Array.from(files, (file) => ({ file })));
   }
 
   function onDrop(e: DragEvent) {
@@ -1113,7 +1224,8 @@
     );
   }
 
-  async function doSpawn(force = false) {
+  async function doSpawn(force = false, expectedUploadRevision = uploadQueueRevision) {
+    if (!uploadsSettledSince(expectedUploadRevision)) return;
     submitting = true;
     error = null;
     retry = null;
@@ -1141,7 +1253,7 @@
         error = (err as Error).message;
       } else {
         error = spawnFailureMessage(err);
-        retry = () => doSpawn(force);
+        retry = () => doSpawn(force, uploadQueueRevision);
       }
     } finally {
       // Clear submitting on every path (matters for the error path: the dialog stays
@@ -1180,17 +1292,15 @@
 
   async function submit(e: Event, force = false) {
     e.preventDefault();
-    // Single guard: the same readiness model that drives the footer + CTA. Known
-    // pre-existing race (unchanged by this redesign): a second activation during the
-    // awaited repoConfig.ensure() below can pass this guard before doSpawn sets
-    // `submitting` — see the PR body's "Known pre-existing races" note.
     if (!readiness.canSubmit) return;
+    const expectedUploadRevision = uploadQueueRevision;
     // A mid-recording submit sends the prompt as it stands: stop the mic and discard
     // the clip so nothing is uploaded while (or after) the task spawns.
     mic?.teardown();
     const repo = repoPath.trim();
     // Settle the repo config BEFORE reading confirm/rowExists (see repoConfig.ensure).
     const configLoaded = await repoConfig.ensure(repo);
+    if (!uploadsSettledSince(expectedUploadRevision)) return;
     // Editing a held task isn't a create — skip the brand-new-repo automation-confirm
     // interstitial; just persist the edit.
     if (
@@ -1200,16 +1310,23 @@
       !repoConfig.isAutomationConfirmed(repo)
     ) {
       // Brand-new repo (no row) → seed the raised default posture (plan-gate ON).
-      if (!repoConfig.automationRowExists(repo)) await repoConfig.seedNewRepoDefaults(repo);
+      if (!repoConfig.automationRowExists(repo)) {
+        await repoConfig.seedNewRepoDefaults(repo);
+        if (!uploadsSettledSince(expectedUploadRevision)) return;
+      }
       pendingForce = force; // replay the original force intent after confirmation
       confirmStep = true;
       return;
     }
-    await doSpawn(force);
+    await doSpawn(force, expectedUploadRevision);
   }
 
   async function confirmAndSpawn() {
-    if (submitting) return;
+    if (submitting || hasOutstandingUploads) {
+      confirmStep = false;
+      return;
+    }
+    const expectedUploadRevision = uploadQueueRevision;
     submitting = true;
     error = null;
     const repo = repoPath.trim();
@@ -1220,8 +1337,13 @@
       submitting = false; // re-enable so the user can retry
       return; // stay on the step; do NOT spawn if the confirm PUT failed
     }
+    if (!uploadsSettledSince(expectedUploadRevision)) {
+      submitting = false;
+      confirmStep = false;
+      return;
+    }
     confirmStep = false;
-    await doSpawn(pendingForce); // replay the force captured when the step opened
+    await doSpawn(pendingForce, expectedUploadRevision); // replay the force captured when the step opened
   }
 
   /** Compact model display for the mobile engine summary row. */
@@ -1457,9 +1579,9 @@
                     ? m.newtask_drop_hint()
                     : m.newtask_drop_hint_keyboard({ shortcut: isMac ? "⌘V" : "Ctrl+V" })}
                   onclick={() => fileInput?.click()}
-                  disabled={uploading}
+                  disabled={hasOutstandingUploads}
                 >
-                  {#if uploading}…{:else}↥{/if}
+                  {#if hasOutstandingUploads}…{:else}↥{/if}
                 </button>
                 <MicButton
                   bind:this={mic}
@@ -1614,24 +1736,71 @@
 
       <!-- Footer: readiness line + always-visible CTA. -->
       <div class="cfoot">
-        <span class="readiness">
-          {#if readiness.blocker}
-            <span class="r-blocked" aria-hidden="true">·</span>
-            {blockerCopy(readiness.blocker)}
-          {:else}
-            <span class="r-ok" aria-hidden="true">✓</span>
-            {m.newtask_readiness_ready()} ·
-            {#if mobile && footerCapacity}
-              <span class="r-cap"
-                >{footerCapacity.code}
-                {m.newtask_provider_capacity_free({ pct: footerCapacity.freePct })}</span
+        {#if hasOutstandingUploads}
+          <div class="upload-status" aria-live="polite">
+            {#if uploadCurrentLengthComputable === false}
+              <progress
+                class="upload-progress"
+                max="100"
+                aria-label={m.newtask_upload_progress_aria()}></progress
               >
             {:else}
-              {m.newtask_readiness_branches({ base: baseBranch })}
+              <progress
+                class="upload-progress"
+                max="100"
+                value={uploadPercent}
+                aria-label={m.newtask_upload_progress_aria()}></progress
+              >
             {/if}
-          {/if}
-        </span>
-        {#if showDualCta}
+            <span class="upload-summary">
+              {m.newtask_upload_file_count({
+                current: uploadFileIndex,
+                total: uploadTotalFiles,
+              })}
+              {#if uploadCurrentLengthComputable === false}
+                · {m.newtask_uploading()}
+              {:else}
+                · {m.newtask_upload_percent({ percent: uploadPercent })} ·
+                {#if uploadFinishing}
+                  {m.newtask_upload_finishing()}
+                {:else if uploadEta}
+                  {m.newtask_upload_eta({ time: uploadEta })}
+                {:else}
+                  {m.newtask_upload_eta_calculating()}
+                {/if}
+              {/if}
+            </span>
+          </div>
+        {:else}
+          <span class="readiness">
+            {#if readiness.blocker}
+              <span class="r-blocked" aria-hidden="true">·</span>
+              {blockerCopy(readiness.blocker)}
+            {:else}
+              <span class="r-ok" aria-hidden="true">✓</span>
+              {m.newtask_readiness_ready()} ·
+              {#if mobile && footerCapacity}
+                <span class="r-cap"
+                  >{footerCapacity.code}
+                  {m.newtask_provider_capacity_free({ pct: footerCapacity.freePct })}</span
+                >
+              {:else}
+                {m.newtask_readiness_branches({ base: baseBranch })}
+              {/if}
+            {/if}
+          </span>
+        {/if}
+        {#if hasOutstandingUploads}
+          <button class="run" type="button" disabled>
+            <span
+              >{uploadFinishing
+                ? m.newtask_upload_finishing()
+                : uploadCurrentLengthComputable !== false
+                  ? m.newtask_upload_cta({ percent: uploadPercent })
+                  : m.newtask_uploading()}</span
+            >
+          </button>
+        {:else if showDualCta}
           <div class="run-dual">
             <button
               class="run run-hold"
@@ -2293,6 +2462,38 @@
   .readiness .r-cap {
     font-variant-numeric: tabular-nums;
   }
+  .upload-status {
+    min-width: 0;
+    flex: 1;
+    display: grid;
+    gap: 5px;
+  }
+  .upload-progress {
+    width: 100%;
+    height: 4px;
+    appearance: none;
+    border: 0;
+    background: var(--color-inset);
+    color: var(--color-amber);
+  }
+  .upload-progress::-webkit-progress-bar {
+    background: var(--color-inset);
+  }
+  .upload-progress::-webkit-progress-value {
+    background: var(--color-amber);
+  }
+  .upload-progress::-moz-progress-bar {
+    background: var(--color-amber);
+  }
+  .upload-summary {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--color-muted);
+    font-size: var(--fs-meta);
+    font-variant-numeric: tabular-nums;
+  }
   .run {
     margin-left: auto;
     flex-shrink: 0;
@@ -2659,6 +2860,9 @@
       padding: 10px 16px calc(10px + env(safe-area-inset-bottom));
     }
     .readiness {
+      white-space: normal;
+    }
+    .upload-summary {
       white-space: normal;
     }
     .run,

--- a/ui/src/lib/components/new-task/readiness.test.ts
+++ b/ui/src/lib/components/new-task/readiness.test.ts
@@ -53,7 +53,13 @@ describe("deriveReadiness blockers", () => {
     ).toBe("submitting");
     expect(
       deriveReadiness(
-        input({ promptEmpty: true, repoResolved: false, baseMissing: true, repairing: true, uploading: true }),
+        input({
+          promptEmpty: true,
+          repoResolved: false,
+          baseMissing: true,
+          repairing: true,
+          uploading: true,
+        }),
       ).blocker,
     ).toBe("uploading");
     expect(

--- a/ui/src/lib/components/new-task/readiness.test.ts
+++ b/ui/src/lib/components/new-task/readiness.test.ts
@@ -8,6 +8,7 @@ function input(over: Partial<ReadinessInput> = {}): ReadinessInput {
     repoResolved: true,
     baseMissing: false,
     repairing: false,
+    uploading: false,
     submitting: false,
     upstreamLoading: false,
     upstream: null,
@@ -28,6 +29,7 @@ describe("deriveReadiness blockers", () => {
     ["no_repo", { repoResolved: false }],
     ["base_missing", { baseMissing: true }],
     ["repairing", { repairing: true }],
+    ["uploading", { uploading: true }],
     ["submitting", { submitting: true }],
   ] as const)("blocks with %s", (blocker, over) => {
     const r = deriveReadiness(input(over));
@@ -36,7 +38,7 @@ describe("deriveReadiness blockers", () => {
   });
 
   // Precedence: transient work states outrank structural ones outrank the prompt.
-  it("orders blockers submitting > repairing > no_repo > base_missing > empty_prompt", () => {
+  it("orders blockers submitting > uploading > repairing > no_repo > base_missing > empty_prompt", () => {
     expect(
       deriveReadiness(
         input({
@@ -44,10 +46,16 @@ describe("deriveReadiness blockers", () => {
           repoResolved: false,
           baseMissing: true,
           repairing: true,
+          uploading: true,
           submitting: true,
         }),
       ).blocker,
     ).toBe("submitting");
+    expect(
+      deriveReadiness(
+        input({ promptEmpty: true, repoResolved: false, baseMissing: true, repairing: true, uploading: true }),
+      ).blocker,
+    ).toBe("uploading");
     expect(
       deriveReadiness(
         input({ promptEmpty: true, repoResolved: false, baseMissing: true, repairing: true }),

--- a/ui/src/lib/components/new-task/readiness.ts
+++ b/ui/src/lib/components/new-task/readiness.ts
@@ -1,7 +1,7 @@
 import type { AgentProvider } from "$lib/types";
 
 export type ReadinessBlocker =
-  "empty_prompt" | "no_repo" | "base_missing" | "repairing" | "submitting";
+  "empty_prompt" | "no_repo" | "base_missing" | "repairing" | "uploading" | "submitting";
 
 export type ReadinessAdvisory = "checking" | "diverged" | "behind" | "hold_likely";
 
@@ -13,6 +13,7 @@ export interface ReadinessInput {
   repoResolved: boolean;
   baseMissing: boolean;
   repairing: boolean;
+  uploading: boolean;
   submitting: boolean;
   upstreamLoading: boolean;
   upstream: { diverged: boolean; behind: number } | null;
@@ -35,6 +36,7 @@ export interface Readiness {
  */
 function deriveBlocker(i: ReadinessInput): ReadinessBlocker | null {
   if (i.submitting) return "submitting";
+  if (i.uploading) return "uploading";
   if (i.repairing) return "repairing";
   if (!i.repoResolved) return "no_repo";
   if (i.baseMissing) return "base_missing";

--- a/ui/src/lib/feature-announcements/entries/v1.46.0-upload-progress.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.46.0-upload-progress.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "upload-progress",
+  sinceVersion: "1.46.0",
+  titleKey: "feat_upload_progress_title",
+  bodyKey: "feat_upload_progress_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
## Problem

Uploading a large video or another attachment while creating a task gave no visible progress or time estimate. The create/start action also did not clearly remain tied to the upload lifecycle, so users could try to start the task before the server had confirmed the attachment and later encounter a missing-attachment error.

## Solution

Add a responsive upload progress experience to the new-task composer. It shows file-weighted batch progress, the current file, and an estimated remaining time while keeping the create/start action disabled until every attachment has been confirmed by the server.

Failed batches can be retried without uploading files that already succeeded. Additional files dropped or pasted during an active batch join the same serialized queue, and uploads that begin during repository preparation or confirmation prevent an automatic or stale task start.

## Technical details

- Add an opt-in `XMLHttpRequest` transport to `uploadFile()` for browser upload progress while preserving the existing callback-free `fetch` path.
- Route XHR HTTP responses through the existing API error semantics, including unauthenticated `401` handling and the specialized preview/host `403` cases.
- Replace the single upload boolean in `NewTask` with a serialized outstanding-work queue, retained retry remainder, byte-weighted batch state, ETA calculation, and an indeterminate fallback.
- Add monotonic upload-revision guards around repository configuration, automation confirmation, payload construction, and submission so an upload started across an async boundary requires a new explicit start action.
- Add localized English and German progress/error copy and a v1.46.0 feature announcement.
- Add controlled browser tests for progress, queueing, retries, submission races, mobile layout, and XHR error compatibility.

## Validation

- `cd ui && bun run test` — 281 files, 4,340 tests passed
- `cd ui && bun run check` — 0 errors and 0 warnings
- `cd ui && bun run check:i18n`
- `cd ui && bun run build`
- `bun run lint`
- `bun run check:glossary`
- `bun run check:announcement-versions`
- `bash scripts/check-feature-catalog.sh origin/main`
- `bash scripts/check-branch-hygiene.sh`
- `git diff --check origin/main...HEAD`
