### PR TITLE
feat(plugins): expose a curated session reader on ctx (#1958)

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -173,9 +173,11 @@ permission-scoped / out-of-process) without changing your call sites.
 
 ## Reading sessions (`ctx.sessions`)
 
-The event stream tells you _that_ something happened, not _what_ it happened to: a
-`session:status` payload is essentially `{ id, status }`. `ctx.sessions` turns that id into
-something you can render.
+The event stream tells you _that_ something happened, not _what_ it happened to. Treat a
+`session:status` payload as `{ id, status }` and nothing more — most emitters send exactly
+that, and while one currently sends the whole session row, a plugin that reads the extra
+fields is relying on an emitter detail, not on the contract. `ctx.sessions` is how you turn
+that id into something you can render.
 
 ```ts
 ctx.events.subscribe((event, data) => {

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -157,18 +157,61 @@ Neither auto-loads from the repo (the loader only ever scans `~/.shepherd/plugin
 everything goes through `ctx`, so a future Shepherd can swap the implementation (curated /
 permission-scoped / out-of-process) without changing your call sites.
 
-| Capability                         | What it does                                                                                                                                                   |
-| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ctx.onSpawn(fn)`                  | Mutate how an agent launches (see below). The load-bearing capability.                                                                                         |
-| `ctx.events.subscribe(fn)`         | Observe the **read-only** core event stream (`session:hold`, `session:status`, …). Returns an unsubscribe fn. Plugins cannot _emit_ core events.               |
-| `ctx.publishStatus(json)`          | Push a small free-form JSON blob to the status panel (rendered verbatim).                                                                                      |
-| `ctx.publishUI(view)`              | Push a declarative UI view to the Settings → Plugins panel (`null` clears). Additive.                                                                          |
-| `ctx.publishGearItem(item)`        | Add a single item to the top-bar gear menu (`null` clears). Additive.                                                                                          |
-| `ctx.state`                        | Durable, **per-plugin-scoped** key/value: `get`/`set`/`delete`/`keys`. Values are JSON. Backed by a `plugin_state` table — you never touch the session schema. |
-| `ctx.route(method, path, handler)` | Register an HTTP route under `/api/plugins/<id>/<path>`. Sits behind operator auth.                                                                            |
-| `ctx.log`                          | Namespaced logger into `shepherd.log` (`ctx.log.log` / `ctx.log.warn`).                                                                                        |
-| `ctx.config`                       | Your plugin's own `config.json` (parsed; `{}` when absent).                                                                                                    |
-| `ctx.abortSpawn(reason)`           | Hard-block the in-flight spawn from inside an `onSpawn` hook (throws).                                                                                         |
+| Capability                         | What it does                                                                                                                                                            |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ctx.onSpawn(fn)`                  | Mutate how an agent launches (see below). The load-bearing capability.                                                                                                  |
+| `ctx.events.subscribe(fn)`         | Observe the **read-only** core event stream (`session:hold`, `session:status`, …). Returns an unsubscribe fn. Plugins cannot _emit_ core events.                        |
+| `ctx.publishStatus(json)`          | Push a small free-form JSON blob to the status panel (rendered verbatim).                                                                                               |
+| `ctx.publishUI(view)`              | Push a declarative UI view to the Settings → Plugins panel (`null` clears). Additive.                                                                                   |
+| `ctx.publishGearItem(item)`        | Add a single item to the top-bar gear menu (`null` clears). Additive.                                                                                                   |
+| `ctx.state`                        | Durable, **per-plugin-scoped** key/value: `get`/`set`/`delete`/`keys`. Values are JSON. Backed by a `plugin_state` table — you never touch the session schema.          |
+| `ctx.sessions`                     | Read-only session lookup: `get(id)` / `list()` → a curated `PluginSessionSnapshot`. Resolves the bare ids that `session:*` events carry. Plugins cannot write sessions. |
+| `ctx.route(method, path, handler)` | Register an HTTP route under `/api/plugins/<id>/<path>`. Sits behind operator auth.                                                                                     |
+| `ctx.log`                          | Namespaced logger into `shepherd.log` (`ctx.log.log` / `ctx.log.warn`).                                                                                                 |
+| `ctx.config`                       | Your plugin's own `config.json` (parsed; `{}` when absent).                                                                                                             |
+| `ctx.abortSpawn(reason)`           | Hard-block the in-flight spawn from inside an `onSpawn` hook (throws).                                                                                                  |
+
+## Reading sessions (`ctx.sessions`)
+
+The event stream tells you _that_ something happened, not _what_ it happened to: a
+`session:status` payload is essentially `{ id, status }`. `ctx.sessions` turns that id into
+something you can render.
+
+```ts
+ctx.events.subscribe((event, data) => {
+  if (event !== "session:status") return;
+  const { id, status } = data as { id: string; status: string };
+  if (status !== "done") return;
+  const s = ctx.sessions.get(id);
+  if (!s) return; // pruned between the event and the read
+  notifyMyChannel(
+    `${s.desig} (${basename(s.repoPath)}) is done` + (s.pr ? ` — PR #${s.pr.number}` : ""),
+  );
+});
+```
+
+- **`get(id)`** → the snapshot, or `null` when no such session exists.
+- **`list()`** → every session core holds, **archived rows included** (filter on
+  `status === "archived"` / `archivedAt` if you only want live ones).
+
+Reads are **live**, not a boot-time freeze — hold the object from `register()` and keep
+calling it. Snapshots are point-in-time **copies**; mutating one does nothing.
+
+**The snapshot is curated, not the internal row.** It carries `id`, `desig`, `name`,
+`repoPath`, `baseBranch`, `branch`, `status`, `model`, `agentProvider`, `issueNumber`,
+`haltReason`, `createdAt`, `updatedAt`, `archivedAt`, and a `pr` block
+(`state`/`number`/`url`/`title`/`checks`/`isDraft`) projected from the cached forge state.
+It deliberately **withholds** `prompt`, `worktreePath`, `spawnAccountDir` and
+`launchMetadata` — task text and account paths widen the trust surface with no read-side use
+case, and returning the row verbatim would make every future internal field an accidental
+part of this contract.
+
+`pr` is `null` when there is no cached git state at all (never polled, or archived — the
+cache holds only non-archived sessions). That is **not** the same as a polled
+`pr.state === "none"`, which means "we looked, there is no PR yet".
+
+> **Additive API.** Older cores don't expose it — guard with
+> `typeof ctx.sessions?.get === "function"` if your plugin must run on both.
 
 ## The `onSpawn` hook
 

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -6,14 +6,19 @@ import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { PluginRegistry } from "./loader";
-import type { PluginEventBus, PluginStateStore } from "./loader";
+import type { PluginEventBus, PluginSessionReadStore, PluginStateStore } from "./loader";
 import type { PluginGearItem } from "./types";
 
 // ── fakes ──────────────────────────────────────────────────────────────────────
 
-function makeStore(): PluginStateStore {
+function makeStore(): PluginStateStore & PluginSessionReadStore {
   const data = new Map<string, string>();
   return {
+    // These tests exercise gear/UI publishing only; ctx.sessions has its own coverage in
+    // test/plugins-sessions.test.ts, so an empty session world is all this fake owes.
+    get: () => null,
+    list: () => [],
+    getSessionGitCache: () => null,
     getPluginState: (id, k) => data.get(`${id}:${k}`) ?? null,
     setPluginState: (id, k, v) => {
       data.set(`${id}:${k}`, v);

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -19,6 +19,7 @@ import {
   type PluginManifest,
   type PluginRegister,
   type PluginRouteHandler,
+  type PluginSessions,
   type PluginState,
   type PluginGearItem,
   type PluginUIView,
@@ -27,7 +28,10 @@ import {
   type SpawnPatch,
 } from "./types";
 import { browserRepositoryUrl } from "./repository";
+import { toPluginSessionSnapshot } from "./session-view";
 import { validatePluginGearItem, validatePluginUIView } from "./ui-validate";
+import type { Session } from "../types";
+import type { GitState } from "../forge/types";
 
 const DEFAULT_HOOK_TIMEOUT_MS = 5_000;
 
@@ -39,6 +43,15 @@ export interface PluginStateStore {
   listPluginStateKeys(pluginId: string): string[];
 }
 
+/** Minimal store surface backing `ctx.sessions` — READ-ONLY session lookup. Separate from
+ *  {@link PluginStateStore} so the two capabilities stay independently substitutable (and so
+ *  a test fake declares exactly what it supports). The real `SessionStore` satisfies both. */
+export interface PluginSessionReadStore {
+  get(id: string): Session | null;
+  list(): Session[];
+  getSessionGitCache(sessionId: string): GitState | null;
+}
+
 /** Minimal event-bus surface: read-only `subscribe` for plugins + `emit` for status. */
 export interface PluginEventBus {
   subscribe(fn: (event: string, data: unknown) => void): () => void;
@@ -47,7 +60,7 @@ export interface PluginEventBus {
 
 export interface PluginRegistryDeps {
   pluginsDir: string;
-  store: PluginStateStore;
+  store: PluginStateStore & PluginSessionReadStore;
   events: PluginEventBus;
   /** Per-hook timeout (ms); default 5000. Tests inject a small value. */
   hookTimeoutMs?: number;
@@ -329,6 +342,19 @@ export class PluginRegistry {
       delete: (key) => this.deps.store.deletePluginState(id, key),
       keys: () => this.deps.store.listPluginStateKeys(id),
     };
+    // Resolved lazily per call: a plugin holding `ctx.sessions` from register() must keep
+    // reading live state, never a boot-time freeze.
+    const sessions: PluginSessions = {
+      get: (sessionId) => {
+        const session = this.deps.store.get(sessionId);
+        if (!session) return null;
+        return toPluginSessionSnapshot(session, this.deps.store.getSessionGitCache(sessionId));
+      },
+      list: () =>
+        this.deps.store
+          .list()
+          .map((s) => toPluginSessionSnapshot(s, this.deps.store.getSessionGitCache(s.id))),
+    };
     return {
       manifest: Object.freeze({ ...rec.manifest }),
       onSpawn: (fn) => {
@@ -381,6 +407,7 @@ export class PluginRegistry {
         this.emitGear(rec);
       },
       state,
+      sessions,
       route: (method, path, handler) => {
         rec.routes.set(routeKey(method, path), handler);
       },

--- a/src/plugins/session-view.ts
+++ b/src/plugins/session-view.ts
@@ -1,0 +1,56 @@
+// Projection from core's internal `Session` row (+ its cached forge `GitState`) onto the
+// curated, versioned `PluginSessionSnapshot` handed to plugins through `ctx.sessions`.
+//
+// Kept as a PURE function in its own module for two reasons: it is the single place the
+// curated surface is defined (so widening it is one deliberate edit, guarded by a test that
+// asserts the withheld fields stay withheld), and it is unit-testable without standing up a
+// registry, a store, or a plugin folder.
+//
+// This module — unlike `./types`, which is import-free by design — imports the real core
+// types on purpose: a new `SessionStatus` or `AgentProvider` in core then fails to compile
+// HERE, at the seam, instead of silently diverging from the contract plugins vendor.
+
+import type { Session } from "../types";
+import type { GitState } from "../forge/types";
+import type { PluginSessionPr, PluginSessionSnapshot } from "./types";
+
+/** Project the cached forge git state onto the plugin-facing PR view. `null` git state
+ *  (never polled, or archived — `putSessionGitCache` refuses archived rows) reads as `null`,
+ *  which a plugin must distinguish from a polled `state: "none"` (no PR yet). Optional
+ *  fields are omitted rather than set to `undefined` so the snapshot round-trips through
+ *  JSON unchanged (a plugin may persist it in `ctx.state`). */
+function toPluginSessionPr(git: GitState | null): PluginSessionPr | null {
+  if (!git) return null;
+  const pr: PluginSessionPr = { state: git.state, checks: git.checks };
+  if (git.number !== undefined) pr.number = git.number;
+  if (git.url !== undefined) pr.url = git.url;
+  if (git.title !== undefined) pr.title = git.title;
+  if (git.isDraft !== undefined) pr.isDraft = git.isDraft;
+  return pr;
+}
+
+/** Build the read-only snapshot for one session. Field-by-field on purpose — a spread of
+ *  `session` would leak every future `Session` field into the plugin contract. */
+export function toPluginSessionSnapshot(
+  session: Session,
+  git: GitState | null,
+): PluginSessionSnapshot {
+  return {
+    id: session.id,
+    desig: session.desig,
+    name: session.name,
+    repoPath: session.repoPath,
+    baseBranch: session.baseBranch,
+    branch: session.branch,
+    status: session.status,
+    model: session.model,
+    // Optional on legacy rows spawned before the field existed; those are all Claude.
+    agentProvider: session.agentProvider ?? "claude",
+    issueNumber: session.issueNumber,
+    haltReason: session.haltReason,
+    createdAt: session.createdAt,
+    updatedAt: session.updatedAt,
+    archivedAt: session.archivedAt,
+    pr: toPluginSessionPr(git),
+  };
+}

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -105,6 +105,63 @@ export interface PluginLogger {
   warn(...args: unknown[]): void;
 }
 
+/** A session's PR as a plugin sees it — the display-relevant subset of the cached forge
+ *  `GitState`, projected so a plugin never depends on the forge module. `null` on a session
+ *  with no cached git state at all (never polled, or archived — the cache refuses archived
+ *  rows), which is distinct from a live `state: "none"` meaning "polled, no PR yet". */
+export interface PluginSessionPr {
+  state: "none" | "open" | "merged" | "closed";
+  number?: number;
+  url?: string;
+  title?: string;
+  checks: "none" | "pending" | "success" | "failure";
+  isDraft?: boolean;
+}
+
+/** Read-only view of a session handed to plugins by {@link PluginSessions}.
+ *
+ *  DELIBERATELY CURATED, not the internal `Session` row. Two reasons, and both are the
+ *  reason to think twice before widening it:
+ *   1. `prompt`, `worktreePath`, `spawnAccountDir` and `launchMetadata` are withheld — they
+ *      widen the trust surface (task text, account paths) with no read-side use case.
+ *   2. Returning the row verbatim would weld this versioned contract to the internal schema,
+ *      making every future `Session` field an accidental public API.
+ *  The string unions mirror core's `SessionStatus` / `AgentProvider` inline because this file
+ *  has no imports (see the header); the mapper that fills them does import the real types, so
+ *  a new core status or provider fails to compile there rather than silently lying here. */
+export interface PluginSessionSnapshot {
+  id: string;
+  /** Stable display designation, e.g. `TASK-07`. */
+  desig: string;
+  name: string;
+  repoPath: string;
+  baseBranch: string;
+  /** Work branch; null for a non-isolated cwd-fallback session. */
+  branch: string | null;
+  status: "running" | "idle" | "blocked" | "done" | "archived";
+  /** Selected CLI model alias; null = provider default. */
+  model: string | null;
+  agentProvider: "claude" | "codex";
+  /** Backlog issue this session was spawned for; null for manual/non-issue sessions. */
+  issueNumber: number | null;
+  /** Why the session halted mid-run; null when not halted. */
+  haltReason: "usage_limit" | "completed" | "operator" | "error" | null;
+  createdAt: number;
+  updatedAt: number;
+  archivedAt: number | null;
+  pr: PluginSessionPr | null;
+}
+
+/** Read-only session lookup. Snapshots are point-in-time COPIES — mutating one does nothing.
+ *  Pair with `ctx.events.subscribe` when reacting to a `session:*` event, whose payload carries
+ *  little more than the session id. */
+export interface PluginSessions {
+  /** The snapshot for `id`, or `null` when no such session exists. */
+  get(id: string): PluginSessionSnapshot | null;
+  /** Every session core currently holds, archived rows included. */
+  list(): PluginSessionSnapshot[];
+}
+
 export type PluginRouteHandler = (req: Request) => Response | Promise<Response>;
 
 /** The SOLE seam between a plugin and core. */
@@ -126,6 +183,10 @@ export interface PluginContext {
   publishGearItem(item: PluginGearItem | null): void;
   /** Durable, scoped per-plugin key/value (backed by the `plugin_state` table). */
   state: PluginState;
+  /** Read-only session lookup — resolves the bare ids that `session:*` events carry into
+   *  a curated {@link PluginSessionSnapshot}. Additive; plugins that must run on an older
+   *  core guard with `typeof ctx.sessions?.get === "function"`. */
+  sessions: PluginSessions;
   /** Register an HTTP route under the fixed `/api/plugins/<id>/<path>` namespace. */
   route(method: string, path: string, handler: PluginRouteHandler): void;
   /** Namespaced logger into `shepherd.log`. */

--- a/src/store.ts
+++ b/src/store.ts
@@ -2571,6 +2571,21 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     );
   }
 
+  /** One session's cached git state, or null when absent/unparseable. Unlike
+   *  {@link listSessionGitCache} this is strictly READ-ONLY — it never prunes an invalid or
+   *  archived row, because its caller is a plugin read (`ctx.sessions`) and a read must not
+   *  mutate core state. Archived rows are excluded to match the list view's contract (the
+   *  cache is written only for non-archived sessions; a row that raced archival reads null). */
+  getSessionGitCache(sessionId: string): GitState | null {
+    const row = this.db
+      .query(
+        `SELECT c.gitJson FROM session_git_cache c JOIN sessions s ON s.id = c.sessionId
+         WHERE c.sessionId = ? AND s.status != 'archived'`,
+      )
+      .get(sessionId) as { gitJson: string } | null;
+    return row ? parsePersistedGitState(row.gitJson) : null;
+  }
+
   listSessionGitCache(): Record<string, GitState> {
     const rows = this.db
       .query(

--- a/test/plugins-sessions.test.ts
+++ b/test/plugins-sessions.test.ts
@@ -1,0 +1,247 @@
+// Coverage for the `ctx.sessions` plugin capability (#1958): the pure projection
+// (src/plugins/session-view.ts), the read-only store getter it reads PR state from, and the
+// whole path end-to-end through a real PluginRegistry + a real plugin folder.
+//
+// Lives under test/ rather than beside the loader because CI runs `bun test ./test` only —
+// a co-located src/**/*.test.ts would not gate anything.
+import { test, expect } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { SessionStore } from "../src/store";
+import { EventHub } from "../src/events";
+import { PluginRegistry } from "../src/plugins/loader";
+import { toPluginSessionSnapshot } from "../src/plugins/session-view";
+import type { PluginSessionSnapshot } from "../src/plugins/types";
+import type { GitState } from "../src/forge/types";
+import type { Session } from "../src/types";
+
+// ── fixtures ───────────────────────────────────────────────────────────────────
+
+const sessionInput = (name: string, repo = "/repos/shepherd") => ({
+  name,
+  prompt: "secret task text",
+  repoPath: repo,
+  baseBranch: "main",
+  branch: `shepherd/${name}`,
+  worktreePath: `/worktrees/${name}`,
+  isolated: true,
+  herdrSession: "default",
+  herdrAgentId: "term_a",
+});
+
+const GIT: GitState = {
+  kind: "github",
+  state: "open",
+  number: 42,
+  url: "https://github.com/o/r/pull/42",
+  title: "feat: a thing",
+  checks: "success",
+  isDraft: false,
+  deployConfigured: false,
+};
+
+/** Point a registry at a throwaway plugin folder whose entry echoes `ctx.sessions` back
+ *  out over its own routes — the only way to observe the capability as a plugin sees it. */
+async function makeProbePlugin(dir: string): Promise<void> {
+  await writeFile(
+    join(dir, "plugin.json"),
+    JSON.stringify({
+      id: "probe",
+      name: "Probe",
+      version: "1.0.0",
+      apiVersion: 1,
+      capabilities: ["state"],
+    }),
+  );
+  await writeFile(
+    join(dir, "index.ts"),
+    `export function register(ctx) {
+       ctx.route("GET", "one", (req) => {
+         const id = new URL(req.url).searchParams.get("id");
+         return Response.json({ snapshot: ctx.sessions.get(id) });
+       });
+       ctx.route("GET", "all", () => Response.json({ list: ctx.sessions.list() }));
+     }`,
+  );
+}
+
+async function probe(registry: PluginRegistry, path: string): Promise<Record<string, unknown>> {
+  // Routes are keyed by the sub-path alone; the query string rides on the Request, exactly as
+  // the real server splits it.
+  const route = path.split("?")[0]!;
+  const res = await registry.handleRoute("GET", "probe", route, new Request(`http://x/${path}`));
+  expect(res?.status).toBe(200);
+  return (await res!.json()) as Record<string, unknown>;
+}
+
+// ── the pure projection ────────────────────────────────────────────────────────
+
+test("toPluginSessionSnapshot projects the curated fields and the PR block", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(sessionInput("alpha"));
+
+  const snap = toPluginSessionSnapshot(s, GIT);
+
+  expect(snap.id).toBe(s.id);
+  expect(snap.desig).toBe(s.desig);
+  expect(snap.name).toBe("alpha");
+  expect(snap.repoPath).toBe("/repos/shepherd");
+  expect(snap.baseBranch).toBe("main");
+  expect(snap.branch).toBe("shepherd/alpha");
+  expect(snap.status).toBe("running");
+  expect(snap.archivedAt).toBeNull();
+  expect(snap.pr).toEqual({
+    state: "open",
+    number: 42,
+    url: "https://github.com/o/r/pull/42",
+    title: "feat: a thing",
+    checks: "success",
+    isDraft: false,
+  });
+});
+
+test("toPluginSessionSnapshot withholds prompt, worktree and account fields", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(sessionInput("beta"));
+
+  const snap = toPluginSessionSnapshot(s, null) as unknown as Record<string, unknown>;
+
+  // The guard that keeps the curated surface curated as `Session` grows: these must never
+  // appear, whatever is added to the row.
+  for (const withheld of ["prompt", "worktreePath", "spawnAccountDir", "launchMetadata"]) {
+    expect(Object.keys(snap)).not.toContain(withheld);
+  }
+  expect(snap.pr).toBeNull();
+});
+
+test("toPluginSessionSnapshot omits absent optional PR fields and defaults a legacy provider", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(sessionInput("gamma"));
+  // A row predating the agentProvider column reads as undefined; every such session is Claude.
+  const legacy: Session = { ...s, agentProvider: undefined };
+
+  const snap = toPluginSessionSnapshot(legacy, {
+    kind: "github",
+    state: "none",
+    checks: "none",
+    deployConfigured: false,
+  });
+
+  expect(snap.agentProvider).toBe("claude");
+  // Omitted, not present-and-undefined — the snapshot must survive a JSON round-trip
+  // unchanged, since a plugin may persist it in ctx.state.
+  expect(snap.pr).toEqual({ state: "none", checks: "none" });
+  expect(JSON.parse(JSON.stringify(snap.pr)) as unknown).toEqual(snap.pr);
+});
+
+// ── the read-only store getter ─────────────────────────────────────────────────
+
+test("getSessionGitCache reads a cached PR back and returns null for an uncached session", () => {
+  const store = new SessionStore(":memory:");
+  const withPr = store.create(sessionInput("delta"));
+  const withoutPr = store.create(sessionInput("epsilon"));
+  expect(store.putSessionGitCache(withPr.id, GIT)).toBe(true);
+
+  expect(store.getSessionGitCache(withPr.id)?.number).toBe(42);
+  expect(store.getSessionGitCache(withoutPr.id)).toBeNull();
+  expect(store.getSessionGitCache("no-such-session")).toBeNull();
+});
+
+test("getSessionGitCache reads an archived session as null", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(sessionInput("zeta"));
+  store.putSessionGitCache(s.id, GIT);
+
+  store.archive(s.id);
+
+  expect(store.getSessionGitCache(s.id)).toBeNull();
+});
+
+test("getSessionGitCache reads an unparseable row as null WITHOUT pruning it", async () => {
+  // A file-backed store so a second connection can plant the malformed row — the read must be
+  // provably side-effect-free, which an in-memory store gives no way to observe.
+  const dir = await mkdtemp(join(tmpdir(), "shepherd-plugin-sessions-"));
+  const dbPath = join(dir, "s.db");
+  try {
+    const store = new SessionStore(dbPath);
+    const s = store.create(sessionInput("eta"));
+    store.putSessionGitCache(s.id, GIT);
+
+    const side = new Database(dbPath);
+    side.run(`UPDATE session_git_cache SET gitJson = ? WHERE sessionId = ?`, ["{not json", s.id]);
+
+    expect(store.getSessionGitCache(s.id)).toBeNull();
+    // listSessionGitCache prunes invalid rows; this read must not — a plugin read may never
+    // mutate core state.
+    const row = side
+      .query(`SELECT COUNT(*) AS n FROM session_git_cache WHERE sessionId = ?`)
+      .get(s.id) as { n: number };
+    expect(row.n).toBe(1);
+    side.close();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ── end-to-end through a real registry ─────────────────────────────────────────
+
+test("ctx.sessions resolves ids for a loaded plugin, with PR state and null for unknown ids", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "shepherd-plugin-sessions-"));
+  const pluginDir = join(dir, "probe");
+  await mkdir(pluginDir);
+  await makeProbePlugin(pluginDir);
+
+  const store = new SessionStore(":memory:");
+  const events = new EventHub();
+  const registry = new PluginRegistry({ pluginsDir: dir, store, events });
+  try {
+    const withPr = store.create(sessionInput("theta"));
+    const plain = store.create(sessionInput("iota", "/repos/other"));
+    store.putSessionGitCache(withPr.id, GIT);
+
+    await registry.loadAll();
+    expect(registry.list().find((p) => p.id === "probe")?.health).toBe("ok");
+
+    const hit = (await probe(registry, `one?id=${withPr.id}`)).snapshot as PluginSessionSnapshot;
+    expect(hit.desig).toBe(withPr.desig);
+    expect(hit.name).toBe("theta");
+    expect(hit.pr?.number).toBe(42);
+
+    const bare = (await probe(registry, `one?id=${plain.id}`)).snapshot as PluginSessionSnapshot;
+    expect(bare.repoPath).toBe("/repos/other");
+    expect(bare.pr).toBeNull();
+
+    expect((await probe(registry, "one?id=nope")).snapshot).toBeNull();
+
+    const list = (await probe(registry, "all")).list as PluginSessionSnapshot[];
+    expect(list.map((s) => s.name).sort()).toEqual(["iota", "theta"]);
+  } finally {
+    registry.teardown();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("ctx.sessions reflects state written after register(), not a boot-time freeze", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "shepherd-plugin-sessions-"));
+  const pluginDir = join(dir, "probe");
+  await mkdir(pluginDir);
+  await makeProbePlugin(pluginDir);
+
+  const store = new SessionStore(":memory:");
+  const registry = new PluginRegistry({ pluginsDir: dir, store, events: new EventHub() });
+  try {
+    await registry.loadAll();
+    expect((await probe(registry, "all")).list).toEqual([]);
+
+    // The session a plugin actually cares about is usually spawned long after it registered.
+    const late = store.create(sessionInput("kappa"));
+
+    const snap = (await probe(registry, `one?id=${late.id}`)).snapshot as PluginSessionSnapshot;
+    expect(snap.name).toBe("kappa");
+  } finally {
+    registry.teardown();
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/ui/src/lib/docs-manifest.ts
+++ b/ui/src/lib/docs-manifest.ts
@@ -99,7 +99,7 @@ export const DOCS_PAGES: readonly DocsPage[] = [
     title: "Plugins",
     path: "/reference/plugins/",
     keywords:
-      "write server-side plugins: spawn hooks, routes, status/ui panels, and gear-menu items. location & loading installing from the ui updates — in place, one click manifest (plugin.json) entry contract the ctx capability seam the onspawn hook failure behavior the single-loop discipline (important) status panel declarative ui panel (publishui) gear-menu item (publishgearitem) three action kinds validation & security additive guard http routes a fuller example: spawn-labeler",
+      "write server-side plugins: spawn hooks, routes, status/ui panels, and gear-menu items. location & loading installing from the ui updates — in place, one click manifest (plugin.json) entry contract the ctx capability seam reading sessions (ctx.sessions) the onspawn hook failure behavior the single-loop discipline (important) status panel declarative ui panel (publishui) gear-menu item (publishgearitem) three action kinds validation & security additive guard http routes a fuller example: spawn-labeler",
   },
   {
     title: "Security",


### PR DESCRIPTION
Part of #1958 (buzz-bridge: push session lifecycle into Buzz threads).

## Why

`ctx.events.subscribe` is a plugin's only read seam, and a `session:status` payload is
essentially `{ id, status }`. `PluginContext` exposes no session reader at all — so an
outbound bridge cannot say *which* session went green. That blocks the buzz-bridge plugin
this issue is about, which needs to post "TASK-07 (shepherd) is done — PR #1958" into a
Buzz thread.

Two workarounds were considered and rejected: a plugin self-calling
`http://127.0.0.1:7330/api/sessions` with `SHEPHERD_TOKEN` (an in-process plugin
HTTP-calling its own server, silently broken on an auth misconfig), and caching
`session:new` payloads (blind to every session that predates a restart).

## What

`ctx.sessions.get(id)` / `ctx.sessions.list()` → `PluginSessionSnapshot`: `desig`, `name`,
`repoPath`, `baseBranch`, `branch`, `status`, `model`, `agentProvider`, `issueNumber`,
`haltReason`, timestamps, plus a `pr` block (`state`/`number`/`url`/`title`/`checks`/`isDraft`)
projected from the cached forge `GitState`.

Two deliberate constraints worth reviewing:

- **Curated, not the raw row.** `prompt`, `worktreePath`, `spawnAccountDir` and
  `launchMetadata` are withheld — task text and account paths widen the trust surface with
  no read-side use case, and returning `Session` verbatim would make every future internal
  field an accidental part of this versioned contract. A test asserts those four stay absent,
  so widening the surface has to be deliberate.
- **The read never mutates.** `SessionStore.getSessionGitCache(id)` is a new read-only
  getter; unlike the existing `listSessionGitCache()` it does **not** prune invalid/archived
  rows, because its caller is a plugin read. A test plants a malformed row and asserts it
  reads `null` and is still there afterwards.

Additive: `PLUGIN_API_VERSION` stays **1**, no existing plugin is affected (`claude-swap`
does not touch this), and no spawn-path or UI surface changes.

`pr` is `null` when there is no cached git state at all (never polled, or archived — the
cache holds only non-archived rows), which is distinct from a polled `state: "none"`.

## Scope

This PR is the **core capability only**. The `buzz-bridge` plugin itself ships as its own
private repo (`shepherd-buzz-bridge`), following the `shepherd-claude-swap` pattern — out of
this repo by design, per the plugin trust model. The buzz-acp MCP-server side (calling the
plugin's `POST link` right after `spawn_session`) lives in another codebase and gets its own
follow-up issue.

No manual operator steps: merging completes this change. Installing the plugin is the
plugin repo's business, not this PR's.

## Verification

- `bun run lint`, `bunx tsc --noEmit` — clean
- `bun test ./test` — 7898 pass / 0 fail (8 new in `test/plugins-sessions.test.ts`)
- `cd ui && bun run check` — 0 errors; `check:i18n` in parity
- `bunx fallow audit --base origin/main --fail-on-issues` — exit 0
- docs manifest regenerated (`cd ui && bun run gen:docs`); generated-docs gate clean

[no-feature-entry] — server-side plugin API, ships no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)