### PR TITLE
docs: show how to filter archived sessions from ctx.sessions.list()

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -196,6 +196,10 @@ ctx.events.subscribe((event, data) => {
 - **`list()`** → every session core holds, **archived rows included** (filter on
   `status === "archived"` / `archivedAt` if you only want live ones).
 
+```ts
+const live = ctx.sessions.list().filter((s) => s.status !== "archived");
+```
+
 Reads are **live**, not a boot-time freeze — hold the object from `register()` and keep
 calling it. Snapshots are point-in-time **copies**; mutating one does nothing.
 


### PR DESCRIPTION
The `list()` bullet in **Reading sessions (`ctx.sessions`)** told readers archived rows are included and that they should filter, but showed no code. Adds the one-liner.

```ts
const live = ctx.sessions.list().filter((s) => s.status !== "archived");
```

Verified against `src/plugins/types.ts` → `PluginSessionSnapshot`: `status` is `"running" | "idle" | "blocked" | "done" | "archived"`, so the check is accurate.

Docs-only; no source/tests touched. [no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)