### PR TITLE
feat(plugin-ui): editable plugin settings — input nodes + ctx.setConfig (#1961)

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -29,8 +29,10 @@ and documented. Specific plugin **implementations** stay private under
   from Settings → Plugins (the Activate button / `POST /api/plugins/manage/activate`) —
   `register(ctx)` wires it into the live registry with no restart, since a never-imported
   folder has no module cache. What still needs a restart (`systemctl --user restart shepherd`):
-  **editing or reconfiguring an already-loaded plugin** (no hot reload — its module is cached)
-  and **unloading** one whose folder you removed.
+  **editing an already-loaded plugin's code** (no hot reload — its module is cached),
+  **hand-editing its `config.json`** (read at load), and **unloading** one whose folder you
+  removed. A plugin changing its _own_ config through [`ctx.setConfig`](#writing-config-ctxsetconfig)
+  does not need a restart — that write updates `ctx.config` live.
 - A **missing or empty** plugins dir is a clean no-op: no hooks and `/api/plugins/<id>/*`
   returns 404 — a fresh clone behaves exactly as a stock Shepherd. The Settings → Plugins
   tab still renders (so you can install the first plugin), just with an empty list.
@@ -168,7 +170,8 @@ permission-scoped / out-of-process) without changing your call sites.
 | `ctx.sessions`                     | Read-only session lookup: `get(id)` / `list()` → a curated `PluginSessionSnapshot`. Resolves the bare ids that `session:*` events carry. Plugins cannot write sessions. |
 | `ctx.route(method, path, handler)` | Register an HTTP route under `/api/plugins/<id>/<path>`. Sits behind operator auth.                                                                                     |
 | `ctx.log`                          | Namespaced logger into `shepherd.log` (`ctx.log.log` / `ctx.log.warn`).                                                                                                 |
-| `ctx.config`                       | Your plugin's own `config.json` (parsed; `{}` when absent).                                                                                                             |
+| `ctx.config`                       | Your plugin's own `config.json` (parsed; `{}` when absent). Updated **in place** by `setConfig`, so the object you capture stays live.                                  |
+| `ctx.setConfig(patch)`             | Shallow-merge `patch` into your `config.json` and persist it (atomic; re-reads the file first). **Throws** on failure — never fails open. Additive.                     |
 | `ctx.abortSpawn(reason)`           | Hard-block the in-flight spawn from inside an `onSpawn` hook (throws).                                                                                                  |
 
 ## Reading sessions (`ctx.sessions`)
@@ -312,6 +315,122 @@ if (typeof ctx.publishUI === "function") {
 - Validation is **fail-open**: size-capped (64 KB), max depth 16, max 256 nodes, max 500
   children per node; array values in `props` are also capped at 500 entries. Invalid views
   are silently dropped; the prior view is kept.
+
+### Editable settings — input nodes + a submitting button
+
+Four input nodes let an operator **type** a setting: `text-input`, `select`, `checkbox` and
+`number`. They never POST on their own. Each one contributes a **named field to the body of an
+`action-button` that opts in with `submit: true`** — so "POST a plugin-authored body to your own
+route" stays the only network shape, and the button's namespace scoping applies unchanged.
+
+```ts
+ctx.publishUI({
+  schemaVersion: 1,
+  slot: "settings-panel",
+  title: "Bridge settings",
+  root: {
+    type: "stack",
+    children: [
+      { type: "text-input", props: { name: "relayUrl", label: "Relay URL", value: cfg.relayUrl } },
+      { type: "text-input", props: { name: "keyEnv", label: "Token env var", value: cfg.keyEnv } },
+      {
+        type: "select",
+        props: {
+          name: "verbosity",
+          label: "Verbosity",
+          value: cfg.verbosity,
+          options: [
+            { value: "quiet", label: "Quiet" },
+            { value: "loud", label: "Loud" },
+          ],
+        },
+      },
+      {
+        type: "action-button",
+        props: {
+          label: "Save settings",
+          submit: true, // ← fold the fields above into the body
+          route: { method: "POST", path: "config" },
+          body: { section: "relay" }, // optional constants
+        },
+      },
+    ],
+  },
+});
+
+// The route your own plugin already owns receives them:
+ctx.route("POST", "config", async (req) => {
+  const { section, relayUrl, keyEnv, verbosity } = await req.json();
+  // …validate, then persist — see ctx.setConfig below.
+  return new Response("Saved");
+});
+```
+
+| Node         | Props                                                      | Submits             |
+| ------------ | ---------------------------------------------------------- | ------------------- |
+| `text-input` | `name`, `label?`, `value?`, `placeholder?`, `secret?`      | a string            |
+| `select`     | `name`, `label?`, `value?`, `options: { value, label? }[]` | a string            |
+| `checkbox`   | `name`, `label?`, `value?`                                 | a boolean           |
+| `number`     | `name`, `label?`, `value?`, `placeholder?`                 | a number, or `null` |
+
+Contract details worth knowing before you build a panel:
+
+- **Scope is the whole view.** All fields in one `publishUI` call land in one bucket, and every
+  `submit: true` button in that view sends the whole bucket. A button that omits `submit` is
+  unaffected — that is how you keep an unrelated action ("Test connection") from carrying them.
+- **Fields win over `body`.** On a key collision the operator's field replaces the static
+  constant, because the field is the live value.
+- **`name`** must match `/^[A-Za-z0-9_.-]{1,64}$/` and be **unique across the view**. A
+  duplicate makes the body non-deterministic, so the whole view is rejected.
+- **`value` seeds, and re-seeds only on change.** Re-publishing your panel on a timer will not
+  clobber what the operator is typing; re-publishing with a _different_ value (e.g. right after
+  a save) does snap the field to the stored truth. So publish the freshly-saved config back and
+  the panel corrects itself.
+- **`select` always submits a valid option.** An absent or unknown `value` falls back to the
+  first entry in `options`.
+- **`number` submits `null`** when the field is empty or not a number — never `NaN`. Range is
+  yours to validate in the route handler; the host does not clamp.
+- **`secret` masks, it does not protect.** The value still travels as plaintext JSON to your
+  route (as does everything else); it only keeps a token off the screen.
+- **`label` is verbatim plugin data**, never an i18n key. Omit it and the field's `name` becomes
+  its accessible name.
+
+## Writing config (`ctx.setConfig`)
+
+`ctx.setConfig(patch)` shallow-merges `patch` into your plugin's own `config.json` and persists
+it. This is what a "Save settings" route handler should call — so `ctx.config` stays the single
+source of truth and you never need a `ctx.state` overlay shadowing it.
+
+```ts
+// Guard — additive API, absent on older cores.
+ctx.route("POST", "config", async (req) => {
+  const body = await req.json();
+  if (typeof body.relayUrl !== "string") return new Response("bad relayUrl", { status: 400 });
+  if (typeof ctx.setConfig !== "function") return new Response("core too old", { status: 501 });
+
+  try {
+    await ctx.setConfig({ relayUrl: body.relayUrl });
+  } catch (e) {
+    return new Response(`Could not save: ${(e as Error).message}`, { status: 500 });
+  }
+  ctx.config.relayUrl; // ← already the new value
+  publishPanel(); // re-publish so the fields re-seed from the persisted truth
+  return new Response("Saved");
+});
+```
+
+- **`ctx.config` updates in place.** The object you captured during `register()` stays live —
+  never cache a copy of it and read that instead.
+- **The file is re-read before merging**, so an edit an operator made by hand since boot is
+  merged, not silently overwritten. Keys you do not mention are untouched.
+- **It throws; it does not fail open.** Unlike `publishUI` (where a dropped push is cosmetic), a
+  config write that silently no-ops is data loss. Expect a rejection for a non-object or
+  non-serializable patch, an oversized result (64 KB), or a write error — and deliberately when
+  `config.json` **exists but is unparseable**, so a half-edited file is never clobbered.
+- **Writes are atomic and serialized** per plugin: temp file + rename, and concurrent calls
+  queue rather than interleaving their read-modify-write.
+- **Only config goes live this way.** Changing your plugin's _code_ still needs a restart — the
+  module stays cached.
 
 ## Gear-menu item (`publishGearItem`)
 

--- a/docs/research/plugin-ui-widgets.md
+++ b/docs/research/plugin-ui-widgets.md
@@ -161,13 +161,13 @@ Start with **one slot** (`settings-panel`) — claude-swap's panel renders insid
 
 Net-new: ~1 server type + 1 `ctx` method + transport reuse; ~1 renderer + ~6 small Svelte components + 1 registry; ~1 panel edit. No new runtime dependency (DOMPurify already present and **not even needed** for the descriptor path). Gates touched: feature-announcements, i18n (EN+DE for any chrome the primitives author), `/design-system` recipes.
 
-**Component vocabulary (current):** display nodes `stack`, `text`, `badge`, `meter`, `table`, `key-value`, `callout` (Phase 0) + `gauge`, `sparkline`, `time-series`, `bar-chart`, `timeline` (#1189); and the first **interactive** node, `action-button` (#1209) — POSTs a plugin-authored body to the plugin's own route, with an optional `confirm` gate.
+**Component vocabulary (current):** display nodes `stack`, `text`, `badge`, `meter`, `table`, `key-value`, `callout` (Phase 0) + `gauge`, `sparkline`, `time-series`, `bar-chart`, `timeline` (#1189); and the first **interactive** node, `action-button` (#1209) — POSTs a plugin-authored body to the plugin's own route, with an optional `confirm` gate. **Extended by #1961** with four input nodes — `text-input`, `select`, `checkbox`, `number` — which contribute named fields to a `submit: true` action-button's body rather than posting on their own, so the single POST primitive is unchanged.
 
 ---
 
 ## 5. Risks & settled decisions
 
-- **Display vs interaction.** _v1 was display-only_ (this was the spike's deliberate scope). **Superseded by #1209:** interactivity now exists as the single, constrained `action-button` node — POST-only, scoped to the plugin's own route namespace, behind operator auth, with an optional confirm gate. General forms/optimistic-state remain out of scope; the cliff was crossed narrowly, not wholesale.
+- **Display vs interaction.** _v1 was display-only_ (this was the spike's deliberate scope). **Superseded by #1209:** interactivity now exists as the single, constrained `action-button` node — POST-only, scoped to the plugin's own route namespace, behind operator auth, with an optional confirm gate. General forms/optimistic-state remain out of scope; the cliff was crossed narrowly, not wholesale. **Extended again by #1961:** editable settings arrived as input nodes feeding that same button, plus `ctx.setConfig` to persist what they submit. Optimistic state remains out of scope — a field seeds from the published `value` and the plugin re-publishes after saving.
 - **Trust boundary is real but narrow.** Plugins are trusted, so the descriptor guards against _bugs_ (runaway trees, bad props), not _attackers_. Keep the caps anyway — fail-open, never crash the panel.
 - **Don't reach for `{@html}`/iframe/web-components.** They solve problems Shepherd doesn't have and route around the design-system/i18n gates. Iframe is the _only_ future-justified escape hatch, and only for arbitrary external web content.
 - **Schema evolution.** `schemaVersion` + unknown-node fallback tile = forward-compatible; one author owning both ends keeps the SDUI versioning tax negligible.

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -7,7 +7,7 @@
 // NOT protected against a plugin's own synchronous infinite loop (a you-bug you'd fix;
 // worker isolation would sever the synchronous spawn-mutation seam claude-swap needs).
 
-import { readdir, readFile, stat } from "node:fs/promises";
+import { readdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { join, basename } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
@@ -34,6 +34,10 @@ import type { Session } from "../types";
 import type { GitState } from "../forge/types";
 
 const DEFAULT_HOOK_TIMEOUT_MS = 5_000;
+
+/** Ceiling on a plugin's own `config.json` after a `ctx.setConfig` merge. A config file is
+ *  tiny in practice; the cap exists to catch a runaway writer, not to constrain a real one. */
+const MAX_CONFIG_BYTES = 64 * 1024;
 
 /** Minimal store surface the registry needs — the `plugin_state` accessors only. */
 export interface PluginStateStore {
@@ -84,6 +88,10 @@ interface LoadedPlugin {
   unsubs: Array<() => void>;
   teardown?: () => void;
   config: Record<string, unknown>;
+  /** Tail of this plugin's serialized `ctx.setConfig` chain, so two concurrent patches cannot
+   *  interleave their read-modify-write. Always settled-or-pending, never rejected (see
+   *  `setPluginConfig`). Set at BOTH `plugins.set()` sites, like `folder`. */
+  configWrite: Promise<void>;
 }
 
 /** Thrown internally when a hook exceeds its timeout; distinguishes `timed-out` health. */
@@ -245,6 +253,7 @@ export class PluginRegistry {
         routes: new Map(),
         unsubs: [],
         config: {},
+        configWrite: Promise.resolve(),
       });
       console.warn(
         `[plugins] ${manifest.id} skipped: apiVersion ${manifest.apiVersion} != ${PLUGIN_API_VERSION}`,
@@ -265,6 +274,7 @@ export class PluginRegistry {
       routes: new Map(),
       unsubs: [],
       config,
+      configWrite: Promise.resolve(),
     };
     this.plugins.set(manifest.id, rec);
 
@@ -319,6 +329,90 @@ export class PluginRegistry {
     } catch {
       return {};
     }
+  }
+
+  /** Read `config.json` for a MERGE. Deliberately stricter than {@link readConfig}, which
+   *  fails open to `{}` so a broken config can never block boot: here `{}` would mean
+   *  "there was nothing to keep", and the merge would then WRITE that assumption back over
+   *  the operator's file. So an existing-but-unparseable file THROWS instead. Only a genuinely
+   *  absent file (ENOENT) is `{}` — that is the first-write case. */
+  private async readConfigForMerge(dir: string, id: string): Promise<Record<string, unknown>> {
+    let raw: string;
+    try {
+      raw = await readFile(join(dir, "config.json"), "utf8");
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === "ENOENT") return {};
+      throw new Error(`[plugin:${id}] setConfig could not read config.json: ${errMsg(e)}`, {
+        cause: e,
+      });
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw new Error(
+        `[plugin:${id}] setConfig refused: config.json exists but is not valid JSON ` +
+          `(fix or delete it — refusing to overwrite what is there)`,
+      );
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error(
+        `[plugin:${id}] setConfig refused: config.json is not a JSON object ` +
+          `(refusing to overwrite what is there)`,
+      );
+    }
+    return parsed as Record<string, unknown>;
+  }
+
+  /** Queue one `ctx.setConfig` behind this plugin's in-flight writes. Serializing is what
+   *  makes concurrent patches safe: each read-modify-write runs to completion before the next
+   *  one reads. The chain swallows a prior REJECTION so one failed write never poisons later
+   *  ones — the caller that failed still gets its own rejection from the promise returned here. */
+  private setPluginConfig(rec: LoadedPlugin, patch: Record<string, unknown>): Promise<void> {
+    const task = rec.configWrite.then(() => this.writePluginConfig(rec, patch));
+    rec.configWrite = task.then(
+      () => {},
+      () => {},
+    );
+    return task;
+  }
+
+  /** Merge `patch` into the plugin's on-disk `config.json` and update `ctx.config` live.
+   *  Throws (never fails open) — a config write that silently no-ops is data loss. */
+  private async writePluginConfig(
+    rec: LoadedPlugin,
+    patch: Record<string, unknown>,
+  ): Promise<void> {
+    const id = rec.manifest.id;
+    if (!patch || typeof patch !== "object" || Array.isArray(patch)) {
+      throw new Error(`[plugin:${id}] setConfig expects a plain object patch`);
+    }
+    // Round-trip through JSON so the persisted patch is exactly what a reload would parse
+    // back (functions/undefined stripped, cycles/BigInt rejected) — same normalization the
+    // publishUI/publishGearItem seams apply.
+    let normalized: Record<string, unknown>;
+    try {
+      const s = JSON.stringify(patch);
+      if (s === undefined) throw new Error("not serializable");
+      normalized = JSON.parse(s) as Record<string, unknown>;
+    } catch {
+      throw new Error(`[plugin:${id}] setConfig patch is not JSON-serializable`);
+    }
+
+    const dir = join(this.deps.pluginsDir, rec.folder);
+    const merged = { ...(await this.readConfigForMerge(dir, id)), ...normalized };
+    // Pretty-printed + trailing newline: the file stays hand-editable, which is the whole
+    // point of persisting to config.json rather than into an opaque state table.
+    const out = JSON.stringify(merged, null, 2) + "\n";
+    if (Buffer.byteLength(out, "utf8") > MAX_CONFIG_BYTES) {
+      throw new Error(`[plugin:${id}] setConfig result exceeds ${MAX_CONFIG_BYTES} bytes`);
+    }
+    await writeConfigFile(dir, out);
+
+    // Mutate IN PLACE: a plugin that captured `ctx.config` during register() holds this exact
+    // object, so reassigning would hand it a permanently stale view.
+    for (const k of Object.keys(rec.config)) delete rec.config[k];
+    Object.assign(rec.config, merged);
   }
 
   /** Build the per-plugin `ctx` — the sole seam. No raw core singletons handed out. */
@@ -413,6 +507,7 @@ export class PluginRegistry {
       },
       log,
       config: rec.config,
+      setConfig: (patch) => this.setPluginConfig(rec, patch),
       abortSpawn: (reason) => {
         throw new PluginSpawnAborted(reason, id);
       },
@@ -581,6 +676,21 @@ class SpawnPatchMerger {
     if (this.extraArgs.length) merged.extraArgs = this.extraArgs;
     if (this.credentialDir !== undefined) merged.credentialDir = this.credentialDir;
     return merged;
+  }
+}
+
+/** Persist a plugin's `config.json` atomically: write a sibling temp file, then rename over
+ *  the target. Same directory → same filesystem → the rename is atomic, so a crash mid-write
+ *  can never leave a half-written config that the next boot would parse as truth. The temp
+ *  file is cleaned up on any failure so a failed write leaves no debris in the plugin folder. */
+async function writeConfigFile(dir: string, contents: string): Promise<void> {
+  const tmp = join(dir, ".config.json.tmp");
+  try {
+    await writeFile(tmp, contents, "utf8");
+    await rename(tmp, join(dir, "config.json"));
+  } catch (e) {
+    await rm(tmp, { force: true }).catch(() => {});
+    throw e;
   }
 }
 

--- a/src/plugins/manage.ts
+++ b/src/plugins/manage.ts
@@ -8,7 +8,10 @@
 // reachable from the UI; it adds no capability a shell couldn't already do. The UI gates
 // install behind a trust-confirm dialog. A freshly installed plugin is loaded in-process by
 // `PluginRegistry.activateOne` (no restart); an uninstalled-but-loaded one still needs a
-// restart to fully unload, as does editing/reconfiguring an already-loaded plugin.
+// restart to fully unload, as does editing an already-loaded plugin's CODE (its module stays
+// cached). CONFIG is no longer in that list: since #1961 a plugin can persist its own
+// `config.json` live through `ctx.setConfig`, which updates `ctx.config` in place. Only a
+// hand-edit of the file on disk still waits for the next boot to be read.
 
 import { readdir, readFile, lstat, stat, realpath, rm, unlink, mkdir } from "node:fs/promises";
 import { join, dirname } from "node:path";

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -282,8 +282,39 @@ export interface PluginGearItem {
  *                      MUST be `"POST"` (a GET fetch with a body throws). `body` is opaque
  *                      plugin-authored JSON sent VERBATIM. An optional `confirm` string gates
  *                      the POST behind a confirmation dialog. `label`/`confirm` are verbatim DATA.
+ *                      Set `submit: true` to also send the view's input fields (below).
  *                      props: { label: string; tone?: Tone; route: { method: "POST"; path: string };
- *                               body?: unknown; confirm?: string }
+ *                               body?: unknown; confirm?: string; submit?: boolean }
+ *
+ *  Input nodes (issue #1961) — editable settings. These NEVER post on their own: each one
+ *  contributes a NAMED FIELD to the body of a `submit: true` action-button, so "POST a
+ *  plugin-authored body to your own route" stays the only network primitive and the
+ *  action-button's namespace guard keeps applying unchanged. The field scope is the whole
+ *  published view (one `publishUI` call), and on a key collision the FIELD wins over the
+ *  button's static `body` — the input is the live value, the body is the constant.
+ *
+ *  Every input needs a `name` (`/^[A-Za-z0-9_.-]{1,64}$/`), unique across the view — two
+ *  inputs sharing a name make the posted body non-deterministic, so the whole view is
+ *  rejected. `label` is optional verbatim DATA; when absent, `name` becomes the accessible
+ *  name. `value` seeds the field and re-seeds it ONLY when the published value actually
+ *  changes, so a plugin that re-publishes its panel on a timer never clobbers what the
+ *  operator is typing.
+ *
+ *  - `text-input`   — free text. `secret: true` renders a masked field; that is MASKING ONLY,
+ *                     the value still travels as plaintext JSON to the plugin's own route.
+ *                     props: { name: string; label?: string; value?: string;
+ *                              placeholder?: string; secret?: boolean }   → posts a string
+ *  - `select`       — a choice among values the plugin enumerates. When `value` is absent or
+ *                     not among `options`, the field seeds to the FIRST option, so the posted
+ *                     value is always one the plugin offered.
+ *                     props: { name: string; label?: string; value?: string;
+ *                              options: { value: string; label?: string }[] } → posts a string
+ *  - `checkbox`     — a boolean toggle.
+ *                     props: { name: string; label?: string; value?: boolean } → posts a boolean
+ *  - `number`       — a numeric field. Posts `null` when empty or unparseable; the plugin
+ *                     validates range in its own route handler (the host does not clamp).
+ *                     props: { name: string; label?: string; value?: number;
+ *                              placeholder?: string }   → posts a number or null
  */
 export interface PluginUINode {
   type: string;

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -191,8 +191,27 @@ export interface PluginContext {
   route(method: string, path: string, handler: PluginRouteHandler): void;
   /** Namespaced logger into `shepherd.log`. */
   log: PluginLogger;
-  /** This plugin's own `config.json` (parsed; `{}` when absent). */
+  /** This plugin's own `config.json` (parsed; `{}` when absent). Mutated IN PLACE by
+   *  {@link PluginContext.setConfig}, so holding this object from `register()` keeps a live
+   *  view — never re-read it from a stale copy. */
   config: Record<string, unknown>;
+  /** Shallow-merge `patch` into this plugin's own `config.json` and persist it, so
+   *  `ctx.config` stays the single source of truth and no plugin needs a `ctx.state` overlay
+   *  shadowing it (issue #1961). Additive — guard with `typeof ctx.setConfig === "function"`.
+   *
+   *  The file is RE-READ before merging, so an operator's hand-edit made since boot is merged
+   *  rather than silently overwritten, and the write is atomic (temp file + rename).
+   *
+   *  REJECTS (the returned promise throws) rather than failing open — a rendering push that
+   *  drops is cosmetic, a config write that silently no-ops is data loss. Throws when `patch`
+   *  is not a plain JSON-serializable object, when the merged config exceeds the size cap, on
+   *  a write error, and — deliberately — when `config.json` EXISTS BUT IS UNPARSEABLE, so a
+   *  hand-broken file is never clobbered. A missing file is `{}` (the first write creates it).
+   *
+   *  Concurrent calls are serialized per plugin, so two patches cannot interleave their
+   *  read-modify-write. Only CONFIG becomes live this way: changing plugin CODE still needs a
+   *  restart, because the module stays cached. */
+  setConfig(patch: Record<string, unknown>): Promise<void>;
   /** Hard-block the in-flight spawn (opt out of the default fail-open). Throws. */
   abortSpawn(reason: string): never;
 }

--- a/src/plugins/ui-validate.ts
+++ b/src/plugins/ui-validate.ts
@@ -40,66 +40,93 @@ function validActionButtonProps(props: Record<string, unknown>): boolean {
   const path = route["path"];
   if (typeof path !== "string" || !validRoutePath(path)) return false;
   // Opt-in to sending the view's input fields (issue #1961).
-  const submit = props["submit"];
-  if (submit !== undefined && typeof submit !== "boolean") return false;
-  return true;
+  return optionalType(props["submit"], "boolean");
 }
 
-/** The input node types (issue #1961) and the JS type each one's `value` seeds from. Every
- *  entry contributes a named field to a submitting `action-button` — none of them posts alone. */
-const INPUT_VALUE_TYPES: Record<string, "string" | "number" | "boolean"> = {
-  "text-input": "string",
-  select: "string",
-  checkbox: "boolean",
-  number: "number",
-};
+/** True when `value` is absent, or present with the expected primitive type. Optional props
+ *  are only ever wrong when they are BOTH present and mistyped. */
+function optionalType(value: unknown, type: "string" | "boolean"): boolean {
+  return value === undefined || typeof value === type;
+}
+
+/** A seeded number must be finite — NaN/Infinity do not survive JSON, but a plugin could still
+ *  hand us something the control cannot render. */
+function finiteOrAbsent(value: unknown): boolean {
+  return value === undefined || Number.isFinite(value);
+}
+
+/** `select`'s choice list: required, non-empty (a select with nothing to choose is meaningless),
+ *  every entry a `{ value: string; label?: string }`. Length is already capped by
+ *  `propsWithinBounds`. */
+function validSelectOptions(options: unknown): boolean {
+  if (!Array.isArray(options) || options.length === 0) return false;
+  return options.every(
+    (o) => isPlainObject(o) && typeof o["value"] === "string" && optionalType(o["label"], "string"),
+  );
+}
 
 /** A field `name` is a JSON body key the plugin's own route handler reads back, so it is held
  *  to a safe, bounded charset rather than accepting arbitrary text. */
 const VALID_FIELD_NAME = /^[A-Za-z0-9_.-]{1,64}$/;
 
-/** Per-type validation for an input node. `names` accumulates every field name in the tree:
- *  two inputs sharing a name would make the submitted body non-deterministic (last mount wins),
- *  so a duplicate drops the whole view rather than silently posting one of the two values. */
+/** The input node types (issue #1961). `value` is the JS type that node's seed must have;
+ *  `extra` validates only what the type itself owns — the shared `name`/`label`/`value`
+ *  contract lives in {@link validInputProps}. Every entry contributes a named field to a
+ *  submitting `action-button`; none of them posts alone. */
+const INPUT_ARMS: Record<
+  string,
+  {
+    value: "string" | "number" | "boolean";
+    extra: (props: Record<string, unknown>) => boolean;
+  }
+> = {
+  "text-input": {
+    value: "string",
+    extra: (p) => optionalType(p["placeholder"], "string") && optionalType(p["secret"], "boolean"),
+  },
+  select: {
+    value: "string",
+    extra: (p) => validSelectOptions(p["options"]),
+  },
+  checkbox: {
+    value: "boolean",
+    extra: () => true,
+  },
+  number: {
+    value: "number",
+    extra: (p) => optionalType(p["placeholder"], "string") && finiteOrAbsent(p["value"]),
+  },
+};
+
+/** Validate an input node's field contract. Non-input types pass straight through.
+ *
+ *  `names` accumulates every field name in the tree: two inputs sharing a name would make the
+ *  submitted body non-deterministic (last mount wins), so a duplicate drops the whole view
+ *  rather than silently posting one of the two values. */
 function validInputProps(
   type: string,
   props: Record<string, unknown>,
   names: Set<string>,
 ): boolean {
+  const arm = INPUT_ARMS[type];
+  if (!arm) return true; // not an input node — nothing to enforce here
+
   const name = props["name"];
   if (typeof name !== "string" || !VALID_FIELD_NAME.test(name)) return false;
   if (names.has(name)) return false;
   names.add(name);
 
-  const label = props["label"];
-  if (label !== undefined && typeof label !== "string") return false;
-
   const value = props["value"];
-  if (value !== undefined && typeof value !== INPUT_VALUE_TYPES[type]) return false;
-  // A seeded number must be finite — NaN/Infinity do not survive JSON anyway, but a plugin
-  // could send a value that parses to something unrenderable.
-  if (type === "number" && value !== undefined && !Number.isFinite(value)) return false;
+  if (value !== undefined && typeof value !== arm.value) return false;
+  return optionalType(props["label"], "string") && arm.extra(props);
+}
 
-  if (type === "text-input" || type === "number") {
-    const placeholder = props["placeholder"];
-    if (placeholder !== undefined && typeof placeholder !== "string") return false;
-  }
-  if (type === "text-input") {
-    const secret = props["secret"];
-    if (secret !== undefined && typeof secret !== "boolean") return false;
-  }
-  if (type === "select") {
-    // `options` is required and non-empty — a select with nothing to choose has no meaning.
-    // Length is already capped at MAX_ARRAY by propsWithinBounds.
-    const options = props["options"];
-    if (!Array.isArray(options) || options.length === 0) return false;
-    const validOption = (o: unknown): boolean =>
-      isPlainObject(o) &&
-      typeof o["value"] === "string" &&
-      (o["label"] === undefined || typeof o["label"] === "string");
-    if (!options.every(validOption)) return false;
-  }
-  return true;
+/** Per-type prop contract, for the node types that have one. Display nodes have none — the
+ *  renderer coerces their props defensively. */
+function validNodeProps(type: string, props: Record<string, unknown>, names: Set<string>): boolean {
+  // Interactive node: its route is security-relevant, so it is validated up front (see helper).
+  if (type === "action-button") return validActionButtonProps(props);
+  return validInputProps(type, props, names);
 }
 
 /** Recursively validate one node (re-parsed JSON) against the structural caps.
@@ -118,20 +145,7 @@ function validateNode(
 
   const props = node["props"];
   if (props !== undefined && (!isPlainObject(props) || !propsWithinBounds(props))) return false;
-
-  // Interactive node: validate its route up front (security-relevant — see helper).
-  if (
-    node["type"] === "action-button" &&
-    !validActionButtonProps(isPlainObject(props) ? props : {})
-  )
-    return false;
-
-  // Input node: validate its field contract (issue #1961).
-  if (
-    Object.hasOwn(INPUT_VALUE_TYPES, node["type"]) &&
-    !validInputProps(node["type"], isPlainObject(props) ? props : {}, names)
-  )
-    return false;
+  if (!validNodeProps(node["type"], isPlainObject(props) ? props : {}, names)) return false;
 
   const children = node["children"];
   if (children === undefined) return true;

--- a/src/plugins/ui-validate.ts
+++ b/src/plugins/ui-validate.ts
@@ -39,12 +39,78 @@ function validActionButtonProps(props: Record<string, unknown>): boolean {
   if (route["method"] !== "POST") return false;
   const path = route["path"];
   if (typeof path !== "string" || !validRoutePath(path)) return false;
+  // Opt-in to sending the view's input fields (issue #1961).
+  const submit = props["submit"];
+  if (submit !== undefined && typeof submit !== "boolean") return false;
+  return true;
+}
+
+/** The input node types (issue #1961) and the JS type each one's `value` seeds from. Every
+ *  entry contributes a named field to a submitting `action-button` — none of them posts alone. */
+const INPUT_VALUE_TYPES: Record<string, "string" | "number" | "boolean"> = {
+  "text-input": "string",
+  select: "string",
+  checkbox: "boolean",
+  number: "number",
+};
+
+/** A field `name` is a JSON body key the plugin's own route handler reads back, so it is held
+ *  to a safe, bounded charset rather than accepting arbitrary text. */
+const VALID_FIELD_NAME = /^[A-Za-z0-9_.-]{1,64}$/;
+
+/** Per-type validation for an input node. `names` accumulates every field name in the tree:
+ *  two inputs sharing a name would make the submitted body non-deterministic (last mount wins),
+ *  so a duplicate drops the whole view rather than silently posting one of the two values. */
+function validInputProps(
+  type: string,
+  props: Record<string, unknown>,
+  names: Set<string>,
+): boolean {
+  const name = props["name"];
+  if (typeof name !== "string" || !VALID_FIELD_NAME.test(name)) return false;
+  if (names.has(name)) return false;
+  names.add(name);
+
+  const label = props["label"];
+  if (label !== undefined && typeof label !== "string") return false;
+
+  const value = props["value"];
+  if (value !== undefined && typeof value !== INPUT_VALUE_TYPES[type]) return false;
+  // A seeded number must be finite — NaN/Infinity do not survive JSON anyway, but a plugin
+  // could send a value that parses to something unrenderable.
+  if (type === "number" && value !== undefined && !Number.isFinite(value)) return false;
+
+  if (type === "text-input" || type === "number") {
+    const placeholder = props["placeholder"];
+    if (placeholder !== undefined && typeof placeholder !== "string") return false;
+  }
+  if (type === "text-input") {
+    const secret = props["secret"];
+    if (secret !== undefined && typeof secret !== "boolean") return false;
+  }
+  if (type === "select") {
+    // `options` is required and non-empty — a select with nothing to choose has no meaning.
+    // Length is already capped at MAX_ARRAY by propsWithinBounds.
+    const options = props["options"];
+    if (!Array.isArray(options) || options.length === 0) return false;
+    const validOption = (o: unknown): boolean =>
+      isPlainObject(o) &&
+      typeof o["value"] === "string" &&
+      (o["label"] === undefined || typeof o["label"] === "string");
+    if (!options.every(validOption)) return false;
+  }
   return true;
 }
 
 /** Recursively validate one node (re-parsed JSON) against the structural caps.
- *  `counter` accumulates the total node count across the whole tree. */
-function validateNode(node: unknown, depth: number, counter: { n: number }): boolean {
+ *  `counter` accumulates the total node count across the whole tree; `names` accumulates
+ *  every input field name so a cross-tree duplicate can be rejected. */
+function validateNode(
+  node: unknown,
+  depth: number,
+  counter: { n: number },
+  names: Set<string>,
+): boolean {
   if (depth > MAX_DEPTH) return false;
   if (!isPlainObject(node)) return false;
   if (++counter.n > MAX_NODES) return false;
@@ -60,10 +126,17 @@ function validateNode(node: unknown, depth: number, counter: { n: number }): boo
   )
     return false;
 
+  // Input node: validate its field contract (issue #1961).
+  if (
+    Object.hasOwn(INPUT_VALUE_TYPES, node["type"]) &&
+    !validInputProps(node["type"], isPlainObject(props) ? props : {}, names)
+  )
+    return false;
+
   const children = node["children"];
   if (children === undefined) return true;
   if (!Array.isArray(children) || children.length > MAX_ARRAY) return false;
-  return children.every((child) => validateNode(child, depth + 1, counter));
+  return children.every((child) => validateNode(child, depth + 1, counter, names));
 }
 
 /** Guards against a large gear item payload — a gear item is tiny in practice. */
@@ -179,5 +252,7 @@ export function validatePluginUIView(view: unknown): PluginUIView | null {
   if (parsed["schemaVersion"] !== 1) return null;
   if (typeof parsed["slot"] !== "string" || !VALID_SLOTS.has(parsed["slot"])) return null;
 
-  return validateNode(parsed["root"], 1, { n: 0 }) ? (parsed as unknown as PluginUIView) : null;
+  return validateNode(parsed["root"], 1, { n: 0 }, new Set())
+    ? (parsed as unknown as PluginUIView)
+    : null;
 }

--- a/test/plugins-config.test.ts
+++ b/test/plugins-config.test.ts
@@ -1,0 +1,254 @@
+// Integration tests for `ctx.setConfig` (issue #1961) — the official plugin config write
+// path that replaces the `ctx.state`-overlay-shadowing-`ctx.config` pattern.
+//
+// These assert on the ACTUAL file on disk rather than a mocked fs, because the whole point of
+// the seam is that `config.json` stays the single source of truth: a test against a fake would
+// pass while the real file drifted.
+
+import { test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionStore } from "../src/store";
+import { EventHub } from "../src/events";
+import { PluginRegistry } from "../src/plugins/loader";
+import type { PluginContext } from "../src/plugins/types";
+
+function tmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "shep-plugins-config-"));
+}
+
+/** A plugin that parks its `ctx` on globalThis so the test can drive `setConfig` directly —
+ *  standing in for the route handler a real plugin would call it from. */
+function writePlugin(root: string, id: string, config?: string): string {
+  const dir = join(root, id);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "plugin.json"),
+    JSON.stringify({ id, name: id, version: "1.0.0", apiVersion: 1 }),
+  );
+  writeFileSync(
+    join(dir, "index.js"),
+    `export function register(ctx) { globalThis.__cfgCtx = ctx; }`,
+  );
+  if (config !== undefined) writeFileSync(join(dir, "config.json"), config);
+  return dir;
+}
+
+async function loadOne(pluginsDir: string): Promise<PluginContext> {
+  const registry = new PluginRegistry({
+    pluginsDir,
+    store: new SessionStore(":memory:"),
+    events: new EventHub(),
+  });
+  await registry.loadAll();
+  return (globalThis as unknown as { __cfgCtx: PluginContext }).__cfgCtx;
+}
+
+function readConfig(dir: string): unknown {
+  return JSON.parse(readFileSync(join(dir, "config.json"), "utf8"));
+}
+
+test("setConfig: merges into config.json, leaving untouched keys intact", async () => {
+  const root = tmpDir();
+  try {
+    const dir = writePlugin(
+      root,
+      "cfg-merge",
+      JSON.stringify({ relayUrl: "wss://old", buzzBin: "/usr/bin/buzz", verbosity: "quiet" }),
+    );
+    const ctx = await loadOne(root);
+
+    await ctx.setConfig({ relayUrl: "wss://new" });
+
+    expect(readConfig(dir)).toEqual({
+      relayUrl: "wss://new",
+      buzzBin: "/usr/bin/buzz",
+      verbosity: "quiet",
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("setConfig: ctx.config reflects the merge at the SAME object reference", async () => {
+  const root = tmpDir();
+  try {
+    writePlugin(root, "cfg-live", JSON.stringify({ a: 1 }));
+    const ctx = await loadOne(root);
+    // A plugin that captured ctx.config during register() must keep a live view.
+    const captured = ctx.config;
+
+    await ctx.setConfig({ b: 2 });
+
+    expect(ctx.config).toBe(captured);
+    expect(captured).toEqual({ a: 1, b: 2 });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("setConfig: creates config.json when the plugin has none", async () => {
+  const root = tmpDir();
+  try {
+    const dir = writePlugin(root, "cfg-absent");
+    const ctx = await loadOne(root);
+    expect(existsSync(join(dir, "config.json"))).toBe(false);
+
+    await ctx.setConfig({ relayUrl: "wss://first" });
+
+    expect(readConfig(dir)).toEqual({ relayUrl: "wss://first" });
+    expect(ctx.config).toEqual({ relayUrl: "wss://first" });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("setConfig: an operator's hand-edit made AFTER boot survives a later patch", async () => {
+  const root = tmpDir();
+  try {
+    const dir = writePlugin(root, "cfg-reread", JSON.stringify({ relayUrl: "wss://boot" }));
+    const ctx = await loadOne(root);
+
+    // Operator edits the file while the server runs — the loader's in-memory copy is now stale.
+    writeFileSync(
+      join(dir, "config.json"),
+      JSON.stringify({ relayUrl: "wss://boot", buzzBin: "/opt/buzz" }),
+    );
+
+    await ctx.setConfig({ verbosity: "loud" });
+
+    // The hand-added key is merged, not clobbered by the boot-time snapshot.
+    expect(readConfig(dir)).toEqual({
+      relayUrl: "wss://boot",
+      buzzBin: "/opt/buzz",
+      verbosity: "loud",
+    });
+    expect(ctx.config).toEqual({
+      relayUrl: "wss://boot",
+      buzzBin: "/opt/buzz",
+      verbosity: "loud",
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("setConfig: refuses to write when config.json is unparseable, leaving it byte-identical", async () => {
+  const root = tmpDir();
+  try {
+    const broken = '{ "relayUrl": "wss://x",\n  // half-edited\n';
+    const dir = writePlugin(root, "cfg-broken", broken);
+    const ctx = await loadOne(root);
+
+    await expect(ctx.setConfig({ relayUrl: "wss://new" })).rejects.toThrow(/not valid JSON/);
+
+    expect(readFileSync(join(dir, "config.json"), "utf8")).toBe(broken);
+    // And no temp-file debris is left behind.
+    expect(existsSync(join(dir, ".config.json.tmp"))).toBe(false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("setConfig: refuses when config.json holds a non-object", async () => {
+  const root = tmpDir();
+  try {
+    const dir = writePlugin(root, "cfg-array", JSON.stringify(["not", "an", "object"]));
+    const ctx = await loadOne(root);
+
+    await expect(ctx.setConfig({ a: 1 })).rejects.toThrow(/not a JSON object/);
+    expect(readConfig(dir)).toEqual(["not", "an", "object"]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("setConfig: rejects a non-object or non-serializable patch", async () => {
+  const root = tmpDir();
+  try {
+    const dir = writePlugin(root, "cfg-badpatch", JSON.stringify({ a: 1 }));
+    const ctx = await loadOne(root);
+
+    await expect(ctx.setConfig(null as never)).rejects.toThrow(/plain object/);
+    await expect(ctx.setConfig(["a"] as never)).rejects.toThrow(/plain object/);
+    await expect(ctx.setConfig("nope" as never)).rejects.toThrow(/plain object/);
+
+    const cyclic: Record<string, unknown> = {};
+    cyclic["self"] = cyclic;
+    await expect(ctx.setConfig(cyclic)).rejects.toThrow(/not JSON-serializable/);
+
+    // Nothing was written by any of the rejected calls.
+    expect(readConfig(dir)).toEqual({ a: 1 });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("setConfig: a rejected write does not poison later writes", async () => {
+  const root = tmpDir();
+  try {
+    const dir = writePlugin(root, "cfg-recover", JSON.stringify({ a: 1 }));
+    const ctx = await loadOne(root);
+
+    await expect(ctx.setConfig(null as never)).rejects.toThrow();
+    await ctx.setConfig({ b: 2 });
+
+    expect(readConfig(dir)).toEqual({ a: 1, b: 2 });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("setConfig: concurrent patches are serialized — both survive", async () => {
+  const root = tmpDir();
+  try {
+    const dir = writePlugin(root, "cfg-concurrent", JSON.stringify({ base: true }));
+    const ctx = await loadOne(root);
+
+    // Fired without awaiting in between: an unserialized read-modify-write would lose one.
+    await Promise.all([
+      ctx.setConfig({ relayUrl: "wss://a" }),
+      ctx.setConfig({ buzzBin: "/opt/buzz" }),
+      ctx.setConfig({ verbosity: "loud" }),
+    ]);
+
+    expect(readConfig(dir)).toEqual({
+      base: true,
+      relayUrl: "wss://a",
+      buzzBin: "/opt/buzz",
+      verbosity: "loud",
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("setConfig: rejects a merged config above the size cap, leaving the file intact", async () => {
+  const root = tmpDir();
+  try {
+    const dir = writePlugin(root, "cfg-huge", JSON.stringify({ a: 1 }));
+    const ctx = await loadOne(root);
+
+    await expect(ctx.setConfig({ blob: "x".repeat(70_000) })).rejects.toThrow(/exceeds/);
+    expect(readConfig(dir)).toEqual({ a: 1 });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("setConfig: the written file is hand-editable (pretty-printed, trailing newline)", async () => {
+  const root = tmpDir();
+  try {
+    const dir = writePlugin(root, "cfg-pretty");
+    const ctx = await loadOne(root);
+
+    await ctx.setConfig({ relayUrl: "wss://x", verbosity: "quiet" });
+
+    const raw = readFileSync(join(dir, "config.json"), "utf8");
+    expect(raw.endsWith("\n")).toBe(true);
+    expect(raw).toContain('\n  "relayUrl"');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/plugins-ui.test.ts
+++ b/test/plugins-ui.test.ts
@@ -174,6 +174,19 @@ function abView(props: unknown) {
   return { schemaVersion: 1, slot: "settings-panel", root: { type: "action-button", props } };
 }
 
+test("action-button: submit must be boolean when present", () => {
+  expect(
+    validatePluginUIView(
+      abView({ label: "Save", route: { method: "POST", path: "config" }, submit: "yes" }),
+    ),
+  ).toBeNull();
+  expect(
+    validatePluginUIView(
+      abView({ label: "Save", route: { method: "POST", path: "config" }, submit: true }),
+    ),
+  ).not.toBeNull();
+});
+
 test("action-button: valid node round-trips, preserving body and confirm", () => {
   const props = {
     label: "Make primary",
@@ -239,6 +252,110 @@ test("action-button: namespace-escaping path is rejected (leading slash, .., bad
   expect(
     validatePluginUIView(abView({ label: "x", route: { method: "POST", path: "" } })),
   ).toBeNull();
+});
+
+// ── input node validation (issue #1961) ──────────────────────────────────────
+
+/** A view whose root is a stack over the given input/button nodes. */
+function formView(...children: PluginUINode[]): PluginUIView {
+  return { schemaVersion: 1, slot: "settings-panel", root: { type: "stack", children } };
+}
+
+const SAVE_BUTTON: PluginUINode = {
+  type: "action-button",
+  props: { label: "Save", submit: true, route: { method: "POST", path: "config" } },
+};
+
+test("input nodes: a full settings form round-trips unchanged", () => {
+  const view = formView(
+    {
+      type: "text-input",
+      props: { name: "relayUrl", label: "Relay URL", value: "wss://relay/buzz" },
+    },
+    { type: "text-input", props: { name: "keyEnv", secret: true, placeholder: "BUZZ_TOKEN" } },
+    {
+      type: "select",
+      props: {
+        name: "verbosity",
+        value: "normal",
+        options: [{ value: "quiet" }, { value: "normal", label: "Normal" }],
+      },
+    },
+    { type: "checkbox", props: { name: "relayEvents", value: true } },
+    { type: "number", props: { name: "retries", value: 3 } },
+    SAVE_BUTTON,
+  );
+  expect(validatePluginUIView(view)).toEqual(view);
+});
+
+test("input nodes: a missing or malformed name drops the whole view", () => {
+  expect(validatePluginUIView(formView({ type: "text-input", props: {} }))).toBeNull();
+  expect(validatePluginUIView(formView({ type: "text-input" }))).toBeNull();
+  expect(validatePluginUIView(formView({ type: "text-input", props: { name: "" } }))).toBeNull();
+  expect(
+    validatePluginUIView(formView({ type: "text-input", props: { name: "has space" } })),
+  ).toBeNull();
+  expect(validatePluginUIView(formView({ type: "text-input", props: { name: "a/b" } }))).toBeNull();
+  expect(
+    validatePluginUIView(formView({ type: "text-input", props: { name: "x".repeat(65) } })),
+  ).toBeNull();
+  expect(validatePluginUIView(formView({ type: "text-input", props: { name: 7 } }))).toBeNull();
+});
+
+test("input nodes: two inputs sharing a name drop the whole view", () => {
+  // Duplicate names would make the submitted body non-deterministic (last mount wins).
+  const dup = formView(
+    { type: "text-input", props: { name: "relayUrl" } },
+    {
+      type: "stack",
+      children: [{ type: "select", props: { name: "relayUrl", options: [{ value: "a" }] } }],
+    },
+  );
+  expect(validatePluginUIView(dup)).toBeNull();
+  // The same name in two SEPARATE views is fine — the scope is one published view.
+  expect(
+    validatePluginUIView(formView({ type: "text-input", props: { name: "relayUrl" } })),
+  ).not.toBeNull();
+});
+
+test("input nodes: a seeded value must match the node's own type", () => {
+  expect(
+    validatePluginUIView(formView({ type: "text-input", props: { name: "a", value: 1 } })),
+  ).toBeNull();
+  expect(
+    validatePluginUIView(formView({ type: "checkbox", props: { name: "a", value: "yes" } })),
+  ).toBeNull();
+  expect(
+    validatePluginUIView(formView({ type: "number", props: { name: "a", value: "3" } })),
+  ).toBeNull();
+  expect(
+    validatePluginUIView(
+      formView({ type: "select", props: { name: "a", value: 2, options: [{ value: "x" }] } }),
+    ),
+  ).toBeNull();
+  // Omitting `value` entirely is always fine — the field just starts empty.
+  expect(validatePluginUIView(formView({ type: "checkbox", props: { name: "a" } }))).not.toBeNull();
+});
+
+test("select: options are required, non-empty and string-valued", () => {
+  const sel = (props: Record<string, unknown>) =>
+    validatePluginUIView(formView({ type: "select", props }));
+  expect(sel({ name: "a" })).toBeNull();
+  expect(sel({ name: "a", options: [] })).toBeNull();
+  expect(sel({ name: "a", options: "quiet" })).toBeNull();
+  expect(sel({ name: "a", options: ["quiet"] })).toBeNull();
+  expect(sel({ name: "a", options: [{ value: 1 }] })).toBeNull();
+  expect(sel({ name: "a", options: [{ value: "q", label: 2 }] })).toBeNull();
+  expect(sel({ name: "a", options: [{ value: "q" }] })).not.toBeNull();
+});
+
+test("text-input: secret and placeholder must be well-typed when present", () => {
+  const ti = (props: Record<string, unknown>) =>
+    validatePluginUIView(formView({ type: "text-input", props }));
+  expect(ti({ name: "a", secret: "yes" })).toBeNull();
+  expect(ti({ name: "a", placeholder: 1 })).toBeNull();
+  expect(ti({ name: "a", label: 1 })).toBeNull();
+  expect(ti({ name: "a", secret: true, placeholder: "…", label: "A" })).not.toBeNull();
 });
 
 // ── loader integration tests ─────────────────────────────────────────────────

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3453,5 +3453,7 @@
   "spawnnotice_review_failed_badge": "kein review",
   "spawnnotice_review_failed_title": "Code-Review konnte nicht starten",
   "spawnnotice_review_failed_action": "Der Review-Prompt überschreitet das Argumentlimit des Betriebssystems, daher lief für diesen Commit kein Critic. Am meisten Platz schafft es, `.shepherd-plan.md` zu kürzen. „Erneut versuchen“ startet einen neuen Versuch mit den aktuellen Eingaben.",
-  "newtask_attach_label": "Anhängen"
+  "newtask_attach_label": "Anhängen",
+  "feat_plugin_ui_inputs_title": "Plugin-Einstellungen im Plugins-Panel bearbeiten",
+  "feat_plugin_ui_inputs_body": "Plugin-Panels unter Einstellungen → Plugins können jetzt bearbeitbare Felder anbieten — Text, Auswahllisten, Checkboxen und Zahlen — samt Speichern-Button, und das Plugin schreibt deine Änderungen direkt in seine eigene Konfigurationsdatei. Kein händisches Editieren der config.json mit anschließendem Neustart mehr."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3453,5 +3453,7 @@
   "spawnnotice_review_failed_badge": "no review",
   "spawnnotice_review_failed_title": "Code review could not start",
   "spawnnotice_review_failed_action": "The review prompt exceeds the operating system's argument limit, so no critic ran on this commit. Shortening `.shepherd-plan.md` is what frees the most room. Retry re-attempts with the current inputs.",
-  "newtask_attach_label": "Attach"
+  "newtask_attach_label": "Attach",
+  "feat_plugin_ui_inputs_title": "Edit plugin settings from the Plugins panel",
+  "feat_plugin_ui_inputs_body": "Plugin panels in Settings → Plugins can now offer editable fields — text, dropdowns, checkboxes and numbers — next to a Save button, and the plugin writes your changes straight to its own config file. No more editing config.json by hand and restarting."
 }

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -507,6 +507,37 @@ a.issue-list-title:hover {
   flex: none;
 }
 
+/* ── Plugin-UI field recipe ─────────────────────────────────────────────────
+   The canonical /design-system "Form fields" recipe, shared by every plugin-ui
+   input node (text-input, select, number — see ui/src/lib/plugin-ui/). Lives
+   here rather than repeated in each component's scoped <style>, so the three
+   controls cannot drift apart. Namespaced `pui-` because a plain .css import is
+   GLOBAL: a bare `.field` / `.input` would leak into unrelated components. */
+.pui-field {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+.pui-field > .pui-label {
+  font-size: var(--fs-meta);
+  color: var(--color-muted);
+}
+.pui-input {
+  background: var(--color-inset);
+  border: 1px solid var(--color-line);
+  color: var(--color-ink-bright);
+  font: inherit;
+  font-size: var(--fs-base);
+  padding: 8px 10px;
+  border-radius: 2px;
+  min-width: 0;
+}
+.pui-input:focus-visible {
+  outline: none;
+  border-color: var(--color-amber);
+}
+
 /* ── Header icon-button recipe ──────────────────────────────────────────────
    Shared .icon-btn class + .spin keyframes for terminal-header glyph controls
    (redraw, etc.). Replaces ad-hoc per-control sizing (.vp-redraw, etc.). */

--- a/ui/src/lib/docs-manifest.ts
+++ b/ui/src/lib/docs-manifest.ts
@@ -99,7 +99,7 @@ export const DOCS_PAGES: readonly DocsPage[] = [
     title: "Plugins",
     path: "/reference/plugins/",
     keywords:
-      "write server-side plugins: spawn hooks, routes, status/ui panels, and gear-menu items. location & loading installing from the ui updates — in place, one click manifest (plugin.json) entry contract the ctx capability seam reading sessions (ctx.sessions) the onspawn hook failure behavior the single-loop discipline (important) status panel declarative ui panel (publishui) gear-menu item (publishgearitem) three action kinds validation & security additive guard http routes a fuller example: spawn-labeler",
+      "write server-side plugins: spawn hooks, routes, status/ui panels, and gear-menu items. location & loading installing from the ui updates — in place, one click manifest (plugin.json) entry contract the ctx capability seam reading sessions (ctx.sessions) the onspawn hook failure behavior the single-loop discipline (important) status panel declarative ui panel (publishui) editable settings — input nodes + a submitting button writing config (ctx.setconfig) gear-menu item (publishgearitem) three action kinds validation & security additive guard http routes a fuller example: spawn-labeler",
   },
   {
     title: "Security",

--- a/ui/src/lib/feature-announcements/entries/v1.46.0-plugin-ui-inputs.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.46.0-plugin-ui-inputs.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "plugin-ui-inputs",
+  sinceVersion: "1.46.0",
+  titleKey: "feat_plugin_ui_inputs_title",
+  bodyKey: "feat_plugin_ui_inputs_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/plugin-ui/PluginUIRoot.svelte
+++ b/ui/src/lib/plugin-ui/PluginUIRoot.svelte
@@ -5,7 +5,7 @@
   // the plugin id flows to descendants without prop-drilling through every container node.
   import { setContext } from "svelte";
   import type { PluginUINode } from "$lib/types";
-  import { PLUGIN_ID_CONTEXT } from "./context";
+  import { PLUGIN_FORM_CONTEXT, PLUGIN_ID_CONTEXT, type PluginFormScope } from "./context";
   import PluginUIRenderer from "./PluginUIRenderer.svelte";
 
   let { pluginId, node }: { pluginId: string; node: PluginUINode } = $props();
@@ -13,6 +13,20 @@
   // never changes for the life of this component — the context value is stable by construction.
   // svelte-ignore state_referenced_locally
   setContext(PLUGIN_ID_CONTEXT, pluginId);
+
+  // One form scope per published view (issue #1961): input nodes register their named values
+  // here, and a `submit: true` action-button folds them into its POST body. A plain object,
+  // not $state — nothing renders from it, the button reads snapshot() once at click time.
+  const fields: Record<string, unknown> = {};
+  setContext<PluginFormScope>(PLUGIN_FORM_CONTEXT, {
+    set: (name, value) => {
+      fields[name] = value;
+    },
+    remove: (name) => {
+      delete fields[name];
+    },
+    snapshot: () => ({ ...fields }),
+  });
 </script>
 
 <PluginUIRenderer {node} />

--- a/ui/src/lib/plugin-ui/PuiActionButton.browser.test.ts
+++ b/ui/src/lib/plugin-ui/PuiActionButton.browser.test.ts
@@ -53,6 +53,26 @@ describe("PuiActionButton", () => {
     expect(calls[0].init?.body).toBe(JSON.stringify(body));
   });
 
+  it("submit: true in a view with no input nodes posts the static body unchanged", async () => {
+    // Back-compat guard for the field contract (issue #1961): opting in to submit must not
+    // reshape the request when the view contributes no fields.
+    const calls: { init?: RequestInit }[] = [];
+    mockFetch((_url, init) => {
+      calls.push({ init });
+      return new Response("ok", { status: 200 });
+    });
+    const body = { mode: "specific", account: 2 };
+    const { container } = await renderInPlugin("acct", {
+      label: "Go",
+      route: ROUTE,
+      body,
+      submit: true,
+    });
+    (container.querySelector(".pui-action") as HTMLButtonElement).click();
+    await vi.waitFor(() => expect(calls).toHaveLength(1));
+    expect(JSON.parse(calls[0].init?.body as string)).toEqual(body);
+  });
+
   it("with confirm set, a click opens a dialog and only Confirm fires the POST", async () => {
     const fetchFn = mockFetch(() => new Response("ok", { status: 200 }));
     const { container } = await renderInPlugin("acct", {

--- a/ui/src/lib/plugin-ui/PuiActionButton.svelte
+++ b/ui/src/lib/plugin-ui/PuiActionButton.svelte
@@ -10,13 +10,16 @@
   import { toasts } from "$lib/toasts.svelte";
   import { dialog } from "$lib/a11yDialog";
   import { toneColor } from "./tones";
-  import { PLUGIN_ID_CONTEXT } from "./context";
+  import { PLUGIN_FORM_CONTEXT, PLUGIN_ID_CONTEXT, type PluginFormScope } from "./context";
 
   let { node }: { node: PluginUINode } = $props();
 
   // Context-absent (a bare PluginUIRenderer mount with no PluginUIRoot wrapper): with no
   // plugin id there is no well-formed route — render disabled and never fetch.
   const pluginId = getContext<string | undefined>(PLUGIN_ID_CONTEXT);
+  // The view's editable fields (issue #1961). Absent on a bare mount, in which case a
+  // `submit` button simply posts its static body.
+  const form = getContext<PluginFormScope | undefined>(PLUGIN_FORM_CONTEXT);
 
   const p = $derived(node.props ?? {});
   const label = $derived(String(p.label ?? ""));
@@ -33,6 +36,19 @@
   const method = $derived(route?.["method"] === "POST" ? "POST" : null);
   const path = $derived(typeof route?.["path"] === "string" ? (route["path"] as string) : "");
   const body = $derived(p.body);
+  const submits = $derived(p.submit === true);
+
+  /** The body actually sent. With `submit`, the view's input fields are folded in — read at
+   *  CLICK time, so the operator's latest keystroke is included without the form scope having
+   *  to be reactive. Fields WIN over a colliding static `body` key: the field is the live
+   *  value, the static body is the constant the plugin baked in at publish time. A non-object
+   *  `body` (a plugin quirk — the seam allows any JSON) cannot be spread, so the fields
+   *  replace it outright rather than silently dropping the operator's edits. */
+  function requestBody(): unknown {
+    if (!submits) return body;
+    const fields = form?.snapshot() ?? {};
+    return isObj(body) ? { ...body, ...fields } : fields;
+  }
 
   // Client-side namespace guard, mirroring the server's validRoutePath (defense in depth):
   // non-empty, length-capped, safe charset, no leading "/", no ".." segment.
@@ -62,7 +78,7 @@
     if (!ready || pending || !pluginId) return;
     pending = true;
     try {
-      const text = await invokePluginRoute(pluginId, "POST", path, body);
+      const text = await invokePluginRoute(pluginId, "POST", path, requestBody());
       toasts.info(text.length > 0 ? text : m.plugin_action_done());
     } catch {
       toasts.info(m.plugin_action_failed(), {

--- a/ui/src/lib/plugin-ui/PuiCheckbox.svelte
+++ b/ui/src/lib/plugin-ui/PuiCheckbox.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  // `checkbox` node (issue #1961): a boolean toggle contributing a named value to a
+  // `submit: true` action-button's body. `label` is verbatim plugin DATA (never i18n).
+  import type { PluginUINode } from "$lib/types";
+  import { pluginField } from "./field.svelte";
+
+  let { node }: { node: PluginUINode } = $props();
+
+  const p = $derived(node.props ?? {});
+  const name = $derived(typeof p.name === "string" ? p.name : "");
+  const label = $derived(typeof p.label === "string" ? p.label : "");
+
+  const field = pluginField<boolean>(
+    () => name,
+    () => p.value === true,
+  );
+</script>
+
+<label class="pui-check">
+  <input
+    class="pui-box"
+    type="checkbox"
+    aria-label={label ? null : name || null}
+    checked={field.value}
+    onchange={(e) => field.set(e.currentTarget.checked)}
+  />
+  {#if label}<span class="lbl">{label}</span>{/if}
+</label>
+
+<style>
+  .pui-check {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    cursor: pointer;
+  }
+  .lbl {
+    font-size: var(--fs-base);
+    color: var(--color-ink);
+    min-width: 0;
+  }
+  /* Form-field recipe surfaces (see /design-system), sized down to a control box. */
+  .pui-box {
+    accent-color: var(--color-amber);
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    width: 14px;
+    height: 14px;
+    flex: none;
+    cursor: pointer;
+  }
+  .pui-box:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 1px var(--color-amber);
+  }
+</style>

--- a/ui/src/lib/plugin-ui/PuiFormInputs.browser.test.ts
+++ b/ui/src/lib/plugin-ui/PuiFormInputs.browser.test.ts
@@ -1,0 +1,284 @@
+// Tests for the plugin-ui input nodes (issue #1961).
+//
+// Deliberately ONE file for all four node types rather than one per component: what is under
+// test is the cross-component FORM-SCOPE CONTRACT — a value typed into any input node reaches
+// the body of a `submit: true` action-button under its `name`. Split per component, each file
+// would have to rebuild the same button + fetch scaffolding and the contract itself would be
+// visible nowhere.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { tick } from "svelte";
+import "../../app.css";
+import PluginUIRoot from "./PluginUIRoot.svelte";
+import PuiTextInput from "./PuiTextInput.svelte";
+import type { PluginUINode } from "$lib/types";
+
+const ROUTE = { method: "POST", path: "config" };
+
+/** Mount input nodes plus a submitting Save button inside a PluginUIRoot, exactly as the
+ *  Settings panel mounts a published view. */
+async function renderForm(children: PluginUINode[], buttonProps: Record<string, unknown> = {}) {
+  const node: PluginUINode = {
+    type: "stack",
+    children: [
+      ...children,
+      {
+        type: "action-button",
+        props: { label: "Save", submit: true, route: ROUTE, ...buttonProps },
+      },
+    ],
+  };
+  return await render(PluginUIRoot, { pluginId: "bridge", node });
+}
+
+let bodies: unknown[] = [];
+
+function mockFetch() {
+  bodies = [];
+  globalThis.fetch = vi.fn(async (_url: unknown, init?: RequestInit) => {
+    bodies.push(init?.body === undefined ? undefined : JSON.parse(init.body as string));
+    return new Response("saved", { status: 200 });
+  }) as unknown as typeof fetch;
+}
+
+/** Click Save and resolve once THIS click's POST body has been captured. Waiting on a growth
+ *  in `bodies` (not on it being non-empty) is what makes repeated saves in one test honest —
+ *  otherwise the second assertion races and reads the previous body back. */
+async function save(container: HTMLElement): Promise<unknown> {
+  const button = container.querySelector(".pui-action") as HTMLButtonElement;
+  const before = bodies.length;
+  button.click();
+  await vi.waitFor(() => expect(bodies.length).toBeGreaterThan(before));
+  // The button disables itself while the POST is in flight; wait for it to settle so a
+  // follow-up save in the same test isn't silently swallowed by the disabled state.
+  await vi.waitFor(() => expect(button.disabled).toBe(false));
+  return bodies[bodies.length - 1];
+}
+
+/** Type into a text-like control the way an operator does (fires `input`). */
+function type(el: HTMLInputElement, value: string): void {
+  el.value = value;
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+describe("plugin-ui input nodes", () => {
+  beforeEach(() => {
+    mockFetch();
+  });
+
+  it("sends each node type under its name, with the right JS type", async () => {
+    const { container } = await renderForm([
+      { type: "text-input", props: { name: "relayUrl", label: "Relay URL" } },
+      {
+        type: "select",
+        props: { name: "verbosity", options: [{ value: "quiet" }, { value: "loud" }] },
+      },
+      { type: "checkbox", props: { name: "relayEvents" } },
+      { type: "number", props: { name: "retries" } },
+    ]);
+
+    type(container.querySelector(".pui-input") as HTMLInputElement, "wss://relay/buzz");
+
+    const select = container.querySelector("select") as HTMLSelectElement;
+    select.value = "loud";
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+
+    const box = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    box.checked = true;
+    box.dispatchEvent(new Event("change", { bubbles: true }));
+
+    type(container.querySelectorAll("input")[2] as HTMLInputElement, "4");
+
+    expect(await save(container)).toEqual({
+      relayUrl: "wss://relay/buzz",
+      verbosity: "loud",
+      relayEvents: true,
+      retries: 4,
+    });
+  });
+
+  it("seeds fields from the published value, so an untouched form submits current config", async () => {
+    const { container } = await renderForm([
+      { type: "text-input", props: { name: "relayUrl", value: "wss://seeded" } },
+      { type: "checkbox", props: { name: "relayEvents", value: true } },
+      { type: "number", props: { name: "retries", value: 3 } },
+    ]);
+
+    expect(await save(container)).toEqual({
+      relayUrl: "wss://seeded",
+      relayEvents: true,
+      retries: 3,
+    });
+  });
+
+  it("merges fields OVER a colliding static body key", async () => {
+    const { container } = await renderForm(
+      [{ type: "text-input", props: { name: "relayUrl", value: "wss://from-field" } }],
+      { body: { section: "relay", relayUrl: "wss://from-body" } },
+    );
+
+    expect(await save(container)).toEqual({
+      section: "relay",
+      relayUrl: "wss://from-field",
+    });
+  });
+
+  it("a button WITHOUT submit posts only its static body", async () => {
+    const { container } = await renderForm(
+      [{ type: "text-input", props: { name: "relayUrl", value: "wss://ignored" } }],
+      { submit: false, body: { ping: true } },
+    );
+
+    expect(await save(container)).toEqual({ ping: true });
+  });
+
+  it("number posts null when empty or unparseable, never NaN", async () => {
+    const { container } = await renderForm([
+      { type: "number", props: { name: "retries", value: 3 } },
+    ]);
+    const input = container.querySelector(".pui-input") as HTMLInputElement;
+
+    type(input, "");
+    expect(await save(container)).toEqual({ retries: null });
+
+    type(input, "abc");
+    expect(await save(container)).toEqual({ retries: null });
+
+    type(input, "-2.5");
+    expect(await save(container)).toEqual({ retries: -2.5 });
+  });
+
+  it("number keeps half-typed input intact (no numeric round-trip clobber)", async () => {
+    const { container } = await renderForm([{ type: "number", props: { name: "retries" } }]);
+    const input = container.querySelector(".pui-input") as HTMLInputElement;
+
+    // "1." is not a complete number; the control must still show what was typed.
+    type(input, "1.");
+    await tick();
+    expect(input.value).toBe("1.");
+
+    type(input, "1.5");
+    expect(await save(container)).toEqual({ retries: 1.5 });
+  });
+
+  it("select clamps an unknown or missing seed to the first offered option", async () => {
+    const options = [{ value: "quiet", label: "Quiet" }, { value: "loud" }];
+
+    const unknownSeed = await renderForm([
+      { type: "select", props: { name: "verbosity", value: "screaming", options } },
+    ]);
+    expect(await save(unknownSeed.container)).toEqual({ verbosity: "quiet" });
+
+    mockFetch();
+    const noSeed = await renderForm([{ type: "select", props: { name: "verbosity", options } }]);
+    expect(await save(noSeed.container)).toEqual({ verbosity: "quiet" });
+  });
+
+  it("uses the label as the accessible name, falling back to the field name", async () => {
+    const { container } = await renderForm([
+      { type: "text-input", props: { name: "relayUrl", label: "Relay URL" } },
+      { type: "text-input", props: { name: "buzzBin" } },
+    ]);
+    const [labelled, bare] = [...container.querySelectorAll<HTMLInputElement>(".pui-input")];
+
+    expect(labelled.getAttribute("aria-label")).toBeNull();
+    expect(labelled.labels?.[0]?.textContent?.trim()).toBe("Relay URL");
+    expect(bare.getAttribute("aria-label")).toBe("buzzBin");
+  });
+
+  it("secret renders a masked control (masking only — the value still posts as text)", async () => {
+    const { container } = await renderForm([
+      { type: "text-input", props: { name: "token", secret: true } },
+    ]);
+    const input = container.querySelector(".pui-input") as HTMLInputElement;
+    expect(input.type).toBe("password");
+
+    type(input, "s3cret");
+    expect(await save(container)).toEqual({ token: "s3cret" });
+  });
+
+  it("without a form scope (bare mount) the input still edits but contributes nothing", async () => {
+    // Rendered directly, NOT via PluginUIRoot — no context, so no scope to register into.
+    const { container } = await render(PuiTextInput, {
+      node: { type: "text-input", props: { name: "orphan" } },
+    });
+    const input = container.querySelector(".pui-input") as HTMLInputElement;
+    type(input, "typed");
+    await tick();
+    expect(input.value).toBe("typed");
+  });
+});
+
+describe("plugin-ui form scope re-seeding", () => {
+  beforeEach(() => {
+    mockFetch();
+  });
+
+  /** Re-render the same PluginUIRoot instance with a new node tree — what a plugin's
+   *  `publishUI` does when it refreshes its panel. */
+  function form(value: string) {
+    return {
+      type: "stack",
+      children: [
+        { type: "text-input", props: { name: "relayUrl", value } },
+        { type: "action-button", props: { label: "Save", submit: true, route: ROUTE } },
+      ],
+    } as PluginUINode;
+  }
+
+  it("a re-publish with an UNCHANGED value leaves an in-progress edit alone", async () => {
+    const { container, rerender } = await render(PluginUIRoot, {
+      pluginId: "bridge",
+      node: form("wss://seeded"),
+    });
+    const input = container.querySelector(".pui-input") as HTMLInputElement;
+
+    type(input, "wss://operator-is-typing");
+    // The plugin re-publishes (e.g. a status timer) carrying the same stored value.
+    await rerender({ pluginId: "bridge", node: form("wss://seeded") });
+    await tick();
+
+    expect(input.value).toBe("wss://operator-is-typing");
+    expect(await save(container)).toEqual({ relayUrl: "wss://operator-is-typing" });
+  });
+
+  it("a re-publish with a CHANGED value snaps the field to the persisted truth", async () => {
+    const { container, rerender } = await render(PluginUIRoot, {
+      pluginId: "bridge",
+      node: form("wss://seeded"),
+    });
+    const input = container.querySelector(".pui-input") as HTMLInputElement;
+
+    type(input, "wss://typed");
+    await rerender({ pluginId: "bridge", node: form("wss://saved") });
+    await tick();
+
+    expect(input.value).toBe("wss://saved");
+    expect(await save(container)).toEqual({ relayUrl: "wss://saved" });
+  });
+
+  it("a field removed by a later publish stops contributing its key", async () => {
+    const withField: PluginUINode = {
+      type: "stack",
+      children: [
+        { type: "text-input", props: { name: "relayUrl", value: "wss://x" } },
+        { type: "action-button", props: { label: "Save", submit: true, route: ROUTE } },
+      ],
+    };
+    const withoutField: PluginUINode = {
+      type: "stack",
+      children: [{ type: "action-button", props: { label: "Save", submit: true, route: ROUTE } }],
+    };
+
+    const { container, rerender } = await render(PluginUIRoot, {
+      pluginId: "bridge",
+      node: withField,
+    });
+    expect(await save(container)).toEqual({ relayUrl: "wss://x" });
+
+    await rerender({ pluginId: "bridge", node: withoutField });
+    await tick();
+    expect(await save(container)).toEqual({});
+  });
+});

--- a/ui/src/lib/plugin-ui/PuiNumberInput.svelte
+++ b/ui/src/lib/plugin-ui/PuiNumberInput.svelte
@@ -34,7 +34,7 @@
 </script>
 
 <label class="pui-field">
-  {#if label}<span class="lbl">{label}</span>{/if}
+  {#if label}<span class="pui-label">{label}</span>{/if}
   <input
     class="pui-input"
     type="text"
@@ -45,31 +45,3 @@
     oninput={(e) => field.set(e.currentTarget.value)}
   />
 </label>
-
-<style>
-  /* Canonical form-field recipe (see /design-system → Form fields). */
-  .pui-field {
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-    min-width: 0;
-  }
-  .lbl {
-    font-size: var(--fs-meta);
-    color: var(--color-muted);
-  }
-  .pui-input {
-    background: var(--color-inset);
-    border: 1px solid var(--color-line);
-    color: var(--color-ink-bright);
-    font: inherit;
-    font-size: var(--fs-base);
-    padding: 8px 10px;
-    border-radius: 2px;
-    min-width: 0;
-  }
-  .pui-input:focus-visible {
-    outline: none;
-    border-color: var(--color-amber);
-  }
-</style>

--- a/ui/src/lib/plugin-ui/PuiNumberInput.svelte
+++ b/ui/src/lib/plugin-ui/PuiNumberInput.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  // `number` node (issue #1961): a numeric field contributing a named value to a
+  // `submit: true` action-button's body. Posts a number, or `null` when empty or unparseable —
+  // the plugin validates range in its own route handler, the host deliberately does not clamp.
+  //
+  // Deliberately `type="text"` + `inputmode="decimal"`, NOT `type="number"`. A controlled
+  // numeric input round-trips its value through the DOM's own parsing, which reports a
+  // half-typed "1." or "-" as the empty string — writing that back would delete the character
+  // the operator just typed. Holding the raw TEXT locally and mapping to a number only on the
+  // way to the form scope keeps typing intact while still submitting a real JSON number.
+  import type { PluginUINode } from "$lib/types";
+  import { pluginField } from "./field.svelte";
+
+  let { node }: { node: PluginUINode } = $props();
+
+  const p = $derived(node.props ?? {});
+  const name = $derived(typeof p.name === "string" ? p.name : "");
+  const label = $derived(typeof p.label === "string" ? p.label : "");
+  const placeholder = $derived(typeof p.placeholder === "string" ? p.placeholder : "");
+
+  /** Raw text → the JSON value submitted. Empty or unparseable is `null`, never NaN. */
+  function toNumber(text: string): number | null {
+    const trimmed = text.trim();
+    if (trimmed.length === 0) return null;
+    const n = Number(trimmed);
+    return Number.isFinite(n) ? n : null;
+  }
+
+  const field = pluginField<string>(
+    () => name,
+    () => (typeof p.value === "number" && Number.isFinite(p.value) ? String(p.value) : ""),
+    toNumber,
+  );
+</script>
+
+<label class="pui-field">
+  {#if label}<span class="lbl">{label}</span>{/if}
+  <input
+    class="pui-input"
+    type="text"
+    inputmode="decimal"
+    {placeholder}
+    aria-label={label ? null : name || null}
+    value={field.value}
+    oninput={(e) => field.set(e.currentTarget.value)}
+  />
+</label>
+
+<style>
+  /* Canonical form-field recipe (see /design-system → Form fields). */
+  .pui-field {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    min-width: 0;
+  }
+  .lbl {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+  }
+  .pui-input {
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    color: var(--color-ink-bright);
+    font: inherit;
+    font-size: var(--fs-base);
+    padding: 8px 10px;
+    border-radius: 2px;
+    min-width: 0;
+  }
+  .pui-input:focus-visible {
+    outline: none;
+    border-color: var(--color-amber);
+  }
+</style>

--- a/ui/src/lib/plugin-ui/PuiSelect.svelte
+++ b/ui/src/lib/plugin-ui/PuiSelect.svelte
@@ -37,7 +37,7 @@
 </script>
 
 <label class="pui-field">
-  {#if label}<span class="lbl">{label}</span>{/if}
+  {#if label}<span class="pui-label">{label}</span>{/if}
   <select
     class="pui-input"
     aria-label={label ? null : name || null}
@@ -49,31 +49,3 @@
     {/each}
   </select>
 </label>
-
-<style>
-  /* Canonical form-field recipe (see /design-system → Form fields). */
-  .pui-field {
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-    min-width: 0;
-  }
-  .lbl {
-    font-size: var(--fs-meta);
-    color: var(--color-muted);
-  }
-  .pui-input {
-    background: var(--color-inset);
-    border: 1px solid var(--color-line);
-    color: var(--color-ink-bright);
-    font: inherit;
-    font-size: var(--fs-base);
-    padding: 8px 10px;
-    border-radius: 2px;
-    min-width: 0;
-  }
-  .pui-input:focus-visible {
-    outline: none;
-    border-color: var(--color-amber);
-  }
-</style>

--- a/ui/src/lib/plugin-ui/PuiSelect.svelte
+++ b/ui/src/lib/plugin-ui/PuiSelect.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+  // `select` node (issue #1961): a choice among values the plugin enumerates, contributing a
+  // named value to a `submit: true` action-button's body. Option labels are verbatim plugin
+  // DATA (never i18n).
+  //
+  // The seed is clamped to the offered set: an absent or unknown `value` falls back to the
+  // FIRST option, so the value this field submits is always one the plugin itself listed.
+  import type { PluginUINode } from "$lib/types";
+  import { pluginField } from "./field.svelte";
+
+  let { node }: { node: PluginUINode } = $props();
+
+  function isObj(x: unknown): x is Record<string, unknown> {
+    return !!x && typeof x === "object" && !Array.isArray(x);
+  }
+
+  const p = $derived(node.props ?? {});
+  const name = $derived(typeof p.name === "string" ? p.name : "");
+  const label = $derived(typeof p.label === "string" ? p.label : "");
+  const options = $derived(
+    (Array.isArray(p.options) ? p.options : [])
+      .filter((o): o is Record<string, unknown> => isObj(o) && typeof o.value === "string")
+      .map((o) => ({
+        value: o.value as string,
+        label: typeof o.label === "string" ? o.label : (o.value as string),
+      })),
+  );
+
+  const field = pluginField<string>(
+    () => name,
+    () => {
+      const seeded = typeof p.value === "string" ? p.value : null;
+      if (seeded !== null && options.some((o) => o.value === seeded)) return seeded;
+      return options[0]?.value ?? "";
+    },
+  );
+</script>
+
+<label class="pui-field">
+  {#if label}<span class="lbl">{label}</span>{/if}
+  <select
+    class="pui-input"
+    aria-label={label ? null : name || null}
+    value={field.value}
+    onchange={(e) => field.set(e.currentTarget.value)}
+  >
+    {#each options as option (option.value)}
+      <option value={option.value}>{option.label}</option>
+    {/each}
+  </select>
+</label>
+
+<style>
+  /* Canonical form-field recipe (see /design-system → Form fields). */
+  .pui-field {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    min-width: 0;
+  }
+  .lbl {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+  }
+  .pui-input {
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    color: var(--color-ink-bright);
+    font: inherit;
+    font-size: var(--fs-base);
+    padding: 8px 10px;
+    border-radius: 2px;
+    min-width: 0;
+  }
+  .pui-input:focus-visible {
+    outline: none;
+    border-color: var(--color-amber);
+  }
+</style>

--- a/ui/src/lib/plugin-ui/PuiTextInput.svelte
+++ b/ui/src/lib/plugin-ui/PuiTextInput.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+  // `text-input` node (issue #1961): a free-text field that contributes a named value to the
+  // body of a `submit: true` action-button — it never POSTs on its own. `label`/`placeholder`
+  // are verbatim plugin DATA (never i18n), like every other plugin-authored string.
+  //
+  // `secret` renders a masked control so an operator can paste a token without it sitting on
+  // screen. That is MASKING ONLY: the value still travels as plaintext JSON to the plugin's
+  // own route, exactly like every other field.
+  import type { PluginUINode } from "$lib/types";
+  import { pluginField } from "./field.svelte";
+
+  let { node }: { node: PluginUINode } = $props();
+
+  const p = $derived(node.props ?? {});
+  const name = $derived(typeof p.name === "string" ? p.name : "");
+  const label = $derived(typeof p.label === "string" ? p.label : "");
+  const placeholder = $derived(typeof p.placeholder === "string" ? p.placeholder : "");
+  const secret = $derived(p.secret === true);
+
+  const field = pluginField<string>(
+    () => name,
+    () => (typeof p.value === "string" ? p.value : ""),
+  );
+</script>
+
+<label class="pui-field">
+  {#if label}<span class="lbl">{label}</span>{/if}
+  <input
+    class="pui-input"
+    type={secret ? "password" : "text"}
+    autocomplete={secret ? "off" : null}
+    {placeholder}
+    aria-label={label ? null : name || null}
+    value={field.value}
+    oninput={(e) => field.set(e.currentTarget.value)}
+  />
+</label>
+
+<style>
+  /* Canonical form-field recipe (see /design-system → Form fields). */
+  .pui-field {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    min-width: 0;
+  }
+  .lbl {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+  }
+  .pui-input {
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    color: var(--color-ink-bright);
+    font: inherit;
+    font-size: var(--fs-base);
+    padding: 8px 10px;
+    border-radius: 2px;
+    min-width: 0;
+  }
+  .pui-input:focus-visible {
+    outline: none;
+    border-color: var(--color-amber);
+  }
+</style>

--- a/ui/src/lib/plugin-ui/PuiTextInput.svelte
+++ b/ui/src/lib/plugin-ui/PuiTextInput.svelte
@@ -24,7 +24,7 @@
 </script>
 
 <label class="pui-field">
-  {#if label}<span class="lbl">{label}</span>{/if}
+  {#if label}<span class="pui-label">{label}</span>{/if}
   <input
     class="pui-input"
     type={secret ? "password" : "text"}
@@ -35,31 +35,3 @@
     oninput={(e) => field.set(e.currentTarget.value)}
   />
 </label>
-
-<style>
-  /* Canonical form-field recipe (see /design-system → Form fields). */
-  .pui-field {
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-    min-width: 0;
-  }
-  .lbl {
-    font-size: var(--fs-meta);
-    color: var(--color-muted);
-  }
-  .pui-input {
-    background: var(--color-inset);
-    border: 1px solid var(--color-line);
-    color: var(--color-ink-bright);
-    font: inherit;
-    font-size: var(--fs-base);
-    padding: 8px 10px;
-    border-radius: 2px;
-    min-width: 0;
-  }
-  .pui-input:focus-visible {
-    outline: none;
-    border-color: var(--color-amber);
-  }
-</style>

--- a/ui/src/lib/plugin-ui/context.ts
+++ b/ui/src/lib/plugin-ui/context.ts
@@ -10,3 +10,25 @@
 // read it with getContext. A Symbol key avoids collision with any plugin-authored data.
 
 export const PLUGIN_ID_CONTEXT = Symbol("plugin-ui:plugin-id");
+
+/** The editable fields of ONE published view (issue #1961), keyed by each input node's `name`.
+ *
+ *  Input nodes never POST on their own — they write here, and an `action-button` with
+ *  `submit: true` folds `snapshot()` into its request body. That keeps "POST a plugin-authored
+ *  body to your own route" the single network primitive, so the namespace guard above applies
+ *  unchanged: the fields ride along on a request that was already scoped to the plugin.
+ *
+ *  Scope is the whole view (one `publishUI` call), set by PluginUIRoot alongside the plugin id.
+ *  Deliberately NOT a `$state` rune: nothing renders from this map — the button reads it once,
+ *  at click time — so reactivity would buy nothing and only wrap plugin values in proxies. */
+export interface PluginFormScope {
+  /** Register or update one field's current value. */
+  set(name: string, value: unknown): void;
+  /** Drop a field — its node was destroyed, or the plugin re-published without it. Without
+   *  this, a removed input would keep contributing a stale key to every later submit. */
+  remove(name: string): void;
+  /** Point-in-time COPY of every registered field. */
+  snapshot(): Record<string, unknown>;
+}
+
+export const PLUGIN_FORM_CONTEXT = Symbol("plugin-ui:form-scope");

--- a/ui/src/lib/plugin-ui/field.svelte.ts
+++ b/ui/src/lib/plugin-ui/field.svelte.ts
@@ -1,0 +1,88 @@
+// Shared field plumbing for every plugin-ui input node (issue #1961). All four input
+// components (text-input / select / checkbox / number) need the exact same lifecycle —
+// register under `name`, re-seed from the published `value`, drop the key on destroy — so it
+// lives here once rather than four times.
+//
+// The subtle part is RE-SEEDING. A plugin may re-publish its panel at any time (a live panel
+// often does so on a timer), and each publish re-renders the same component instances with new
+// props. Blindly syncing local state from props on every render would erase whatever the
+// operator is mid-way through typing. So the seed is applied only when the PUBLISHED value
+// actually changes: a timer re-publish carrying the same value is a no-op, while a re-publish
+// after a save does snap the field to the persisted truth.
+
+import { getContext, onDestroy } from "svelte";
+import { PLUGIN_FORM_CONTEXT, type PluginFormScope } from "./context";
+
+export interface PluginField<T> {
+  /** What the control displays right now. */
+  readonly value: T;
+  /** Record an operator edit: updates the display AND the submitted value. */
+  set(next: T): void;
+}
+
+/** Wire one input node into its view's form scope.
+ *
+ *  @param name  Thunk reading the node's `name` prop. A field with an empty name registers
+ *               nothing (the server validator requires one, so this only guards a bare mount).
+ *  @param seed  Thunk reading the node's published `value`, already coerced to the display
+ *               type `T`. Must be a primitive — re-seeding compares it with `!==`.
+ *  @param toScope  Maps the displayed value to the value actually submitted. Defaults to
+ *               identity. `number` uses it to hold raw text while posting a parsed number, so
+ *               a half-typed "1." is never round-tripped through a numeric coercion.
+ */
+export function pluginField<T>(
+  name: () => string,
+  seed: () => T,
+  toScope: (value: T) => unknown = (value) => value,
+): PluginField<T> {
+  // Context-absent (a bare PluginUIRenderer mount with no PluginUIRoot): the control still
+  // renders and edits locally, it just contributes no field — mirroring how PuiActionButton
+  // stays inert without a plugin id.
+  const scope = getContext<PluginFormScope | undefined>(PLUGIN_FORM_CONTEXT);
+
+  let lastName = name();
+  let lastSeed = seed();
+  let current = $state<T>(lastSeed);
+
+  const register = (key: string, value: T): void => {
+    if (key.length > 0) scope?.set(key, toScope(value));
+  };
+  const unregister = (key: string): void => {
+    if (key.length > 0) scope?.remove(key);
+  };
+
+  register(lastName, lastSeed);
+
+  $effect(() => {
+    const nextName = name();
+    const nextSeed = seed();
+    // A renamed field at the same tree position: retire the old key so it cannot keep
+    // contributing to submits, then adopt the new one.
+    if (nextName !== lastName) {
+      unregister(lastName);
+      lastName = nextName;
+      lastSeed = nextSeed;
+      current = nextSeed;
+      register(nextName, nextSeed);
+      return;
+    }
+    // Same field, genuinely new published value → re-seed. Unchanged → leave the edit alone.
+    if (nextSeed !== lastSeed) {
+      lastSeed = nextSeed;
+      current = nextSeed;
+      register(nextName, nextSeed);
+    }
+  });
+
+  onDestroy(() => unregister(lastName));
+
+  return {
+    get value() {
+      return current;
+    },
+    set(next: T) {
+      current = next;
+      register(lastName, next);
+    },
+  };
+}

--- a/ui/src/lib/plugin-ui/registry.ts
+++ b/ui/src/lib/plugin-ui/registry.ts
@@ -12,6 +12,10 @@ import PuiTimeSeries from "./PuiTimeSeries.svelte";
 import PuiBarChart from "./PuiBarChart.svelte";
 import PuiTimeline from "./PuiTimeline.svelte";
 import PuiActionButton from "./PuiActionButton.svelte";
+import PuiTextInput from "./PuiTextInput.svelte";
+import PuiSelect from "./PuiSelect.svelte";
+import PuiCheckbox from "./PuiCheckbox.svelte";
+import PuiNumberInput from "./PuiNumberInput.svelte";
 
 /** Whitelist of plugin UI node types. Unknown types fall through to UnknownNodeTile. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -29,4 +33,10 @@ export const PLUGIN_UI_REGISTRY: Record<string, Component<any>> = {
   "bar-chart": PuiBarChart,
   timeline: PuiTimeline,
   "action-button": PuiActionButton,
+  // Input nodes (issue #1961) — these contribute named fields to a `submit: true`
+  // action-button's body; none of them POSTs on its own.
+  "text-input": PuiTextInput,
+  select: PuiSelect,
+  checkbox: PuiCheckbox,
+  number: PuiNumberInput,
 };

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1689,6 +1689,29 @@ export interface DocAgentRun {
  *                     props: { bars: { label: string; value: number; tone?: Tone }[]; max?: number; orientation?: "horizontal" | "vertical" }
  *  - `timeline`     — recent discrete events.
  *                     props: { events: { at: string; label: string; caption?: string; tone?: Tone }[] }
+ *
+ *  Interactive node (issue #1209) — POSTs a plugin-authored body to one of THIS plugin's own
+ *  routes. The owning plugin id comes from context, never from props, which is what scopes the
+ *  request to the plugin's own namespace.
+ *
+ *  - `action-button` — props: { label: string; tone?: Tone; route: { method: "POST"; path: string };
+ *                              body?: unknown; confirm?: string; submit?: boolean }
+ *
+ *  Input nodes (issue #1961) — editable settings. These NEVER post on their own: each one
+ *  contributes a NAMED FIELD to the body of a `submit: true` action-button, so "POST a
+ *  plugin-authored body to your own route" stays the only network primitive. The field scope is
+ *  the whole published view, and on a key collision the FIELD wins over the button's static
+ *  `body`. Every input needs a `name` (`/^[A-Za-z0-9_.-]{1,64}$/`) unique across the view;
+ *  `value` seeds the field and re-seeds it only when the published value actually changes, so a
+ *  timer-driven re-publish never clobbers what the operator is typing.
+ *
+ *  - `text-input`   — props: { name: string; label?: string; value?: string; placeholder?: string;
+ *                              secret?: boolean }   → posts a string. `secret` MASKS ONLY.
+ *  - `select`       — props: { name: string; label?: string; value?: string;
+ *                              options: { value: string; label?: string }[] } → posts a string
+ *  - `checkbox`     — props: { name: string; label?: string; value?: boolean } → posts a boolean
+ *  - `number`       — props: { name: string; label?: string; value?: number; placeholder?: string }
+ *                     → posts a number, or null when empty/unparseable
  */
 export interface PluginUINode {
   type: string;


### PR DESCRIPTION
Closes #1961.

An operator could never **type** a plugin setting. Every interactive affordance was
`action-button`, whose POST body is fixed at publish time — a plugin could offer a *choice*
between values it already knew, but not a URL, a path or an id. And a plugin wanting durable
settings had to shadow `ctx.config` with a `ctx.state` overlay, so `config.json` stopped being
the truth while still looking like it.

Both halves land here, without growing a second network shape.

## Part 1 — input nodes

Four new nodes — `text-input`, `select`, `checkbox`, `number` — that **never POST on their own**.
Each contributes a **named field to the body of an `action-button` that opts in with
`submit: true`**, so "POST a plugin-authored body to your own route" stays the only primitive and
the button's existing namespace guard applies unchanged.

```ts
{ type: "text-input", props: { name: "relayUrl", label: "Relay URL", value: cfg.relayUrl } }
{ type: "action-button", props: { label: "Save", submit: true,
                                  route: { method: "POST", path: "config" },
                                  body: { section: "relay" } } }
// POSTs { section: "relay", relayUrl: "wss://…" }
```

Field scope is the published view; `PluginUIRoot` owns the map and the button reads a snapshot at
click time. Contract decisions, each pinned by a test:

- **Fields win** over a colliding static `body` key — the field is the live value.
- **`name`** must match `/^[A-Za-z0-9_.-]{1,64}$/` and be unique across the view; a duplicate makes
  the body non-deterministic, so the whole view is rejected (fail-open, like every other tree rule).
- **`value` re-seeds only when it actually changes.** A plugin re-publishing its panel on a timer
  cannot clobber what the operator is typing; a re-publish after a save does snap the field to the
  stored truth.
- **`select` always submits an offered option** — an absent/unknown seed falls back to the first.
- **`number` submits `null`**, never `NaN`. It renders as `type="text"` + `inputmode="decimal"` on
  purpose: a controlled numeric input reports a half-typed `"1."` as the empty string, and writing
  that back deletes the character just typed.
- **`secret` masks only** — the value still travels as plaintext JSON to the plugin's own route.

## Part 2 — `ctx.setConfig(patch)`

Shallow-merges into the plugin's own `config.json` and persists it, so the overlay pattern can be
deleted and `ctx.config` stays the single source.

- **Re-reads the file before merging**, so an operator's hand-edit made since boot survives.
- **Throws; never fails open.** A dropped `publishUI` is cosmetic; a silent config no-op is data
  loss. It refuses outright — leaving the file byte-identical — when `config.json` exists but is
  unparseable, so a half-edited file is never clobbered.
- **Atomic** (temp file + rename) and **serialized per plugin**, so concurrent patches cannot
  interleave their read-modify-write.
- `ctx.config` is mutated **in place**, so a plugin holding it from `register()` keeps a live view.

Deliberately **no core endpoint that writes an arbitrary plugin's config** and no generic host-side
settings editor: the plugin publishes its own fields and owns its own route, so it keeps validating
its own settings.

## Scope notes

- Only *config* becomes live. Editing plugin **code** still needs a restart (its module is cached);
  the stale "reconfiguring needs a restart" claims in `docs/plugins.md` and `src/plugins/manage.ts`
  are narrowed to say exactly that.
- `shepherd-buzz-bridge` is untouched — it lives in its own repo and drops its overlay separately
  (erwins-enkel/shepherd-buzz-bridge#1).

## Verification

`bun run lint` · `bun run typecheck` · `bun test ./test` (7926 pass, 0 fail) · `cd ui && bun run check`
(0 errors) · `bun run check:i18n` · full UI suite (4376 tests, 282 files) · branch-hygiene,
feature-catalog, announcement-versions and glossary gates.

The browser tests live in one `PuiFormInputs.browser.test.ts` rather than one file per component:
what is under test is the cross-component form-scope contract, and splitting it would triple the
scaffolding while leaving the contract visible nowhere.
