### PR TITLE
fix(spawn): route the herdr ≥0.7.5 pane spawn through a temp script

### DIFF
--- a/src/argv-limit.ts
+++ b/src/argv-limit.ts
@@ -59,10 +59,12 @@ export function joinedElementBytes(s: string): number {
   return Buffer.byteLength(posixShellJoin([sanitizePromptArg(s)]), "utf8");
 }
 
-/** Bytes the WHOLE argv costs once joined into a single shell command line — the exact quantity
- *  the herdr 0.7.5 `pane run` / `pane.send_text` paths push through one argv element. On the
- *  ≤0.7.4 spread paths each token is its own element, so this over-counts; that errs toward
- *  clamping early and never toward `E2BIG`. */
+/** Bytes the WHOLE argv costs once joined into a single shell command line. A deliberately
+ *  CONSERVATIVE model of the spawn's cost: every real path spends fewer bytes per element than this.
+ *  The ≤0.7.4 paths spread the argv, so each token is its own element; and since #1967 the ≥0.7.5
+ *  paths type `sh '<script>'` and let the script's `exec` spread it too (the joined line now lives in
+ *  a file, where no `MAX_ARG_STRLEN` applies). Over-counting errs toward clamping early and never
+ *  toward `E2BIG`. */
 export function spawnFootprintBytes(argv: string[]): number {
   let total = 0;
   for (const tok of argv) total += joinedElementBytes(tok);

--- a/src/herdr-socket-driver.ts
+++ b/src/herdr-socket-driver.ts
@@ -14,7 +14,6 @@ import {
   parseProcs,
   parseReadText,
   parseTabs,
-  posixShellJoin,
   resolvePaneId,
   sanitizeHerdrAgentName,
   stopViaRecordedTab,
@@ -29,6 +28,7 @@ import {
   herdrSpawnSupported,
   herdrUsesExternalRegistrationSpawn,
 } from "./herdr-capabilities";
+import { spawnCommandLine } from "./spawn-script";
 
 /**
  * Socket-backed `IHerdrDriver` (issues #1529, #1553, #1567): routes the async read surface —
@@ -251,24 +251,30 @@ export class SocketHerdrDriver implements IHerdrDriver {
 
   /**
    * Launch `wrapped` in `paneId`'s shell. herdr's protocol-17 socket API exposes NO direct pane-run
-   * RPC (unlike the CLI `pane run`, #1892), so the wrapped argv is TYPED into the pane's ready shell
-   * as a POSIX-quoted command line (`pane.send_text`) then submitted with Enter (`pane.send_keys`).
+   * RPC (unlike the CLI `pane run`, #1892), so the command is TYPED into the pane's ready shell
+   * (`pane.send_text`) then submitted with Enter (`pane.send_keys`). What gets typed is `sh
+   * '<script>'` — the wrapped argv itself rides a throwaway script (`spawnCommandLine`, #1967), so
+   * the line can never outgrow the tty's canonical-mode `MAX_INPUT`.
    * `send_text` is bounded-retried on ANY failure to ride out shell-not-ready without hinging on an
    * unverified busy-error code: a rejected `send_text` means herdr didn't write it, so a retry never
    * double-types (mirrors the CLI `runInReadyPane` reject-before-exec contract). The Enter is sent
    * once, OUTSIDE that loop, so a delivered command is never re-typed. NOTE: this routes through the
-   * interactive shell rather than a direct exec — the per-token quoting keeps it robust; only the
-   * 0.7.5 socket spawn path (default-off) reaches it.
+   * interactive shell rather than a direct exec — the script's per-token quoting keeps it robust;
+   * only the 0.7.5 socket spawn path (default-off) reaches it.
    */
   private async runInReadyPane(paneId: string, wrapped: string[]): Promise<void> {
     // #1944: the socket path cannot surface a kernel `E2BIG` — the argv crosses a socket to the
     // daemon, which execs it out of our reach and fails opaquely. So the per-element limit is
     // checked PROACTIVELY here, before the retry loop, so an argv that can never exec fails once
-    // with a named cause instead of three times with a shell-not-ready-looking error. The pane's
-    // shell reconstructs the exact argv from the quoted line, so each `wrapped` token becomes one
-    // argv element and is the right thing to measure.
+    // with a named cause instead of three times with a shell-not-ready-looking error. The spawn
+    // script's `exec` reconstructs the exact argv, so each `wrapped` token becomes one argv element
+    // and is the right thing to measure.
     assertArgvWithinLimit(wrapped, "herdr socket pane.send_text");
-    const cmdline = posixShellJoin(wrapped);
+    // The typed line goes through the pane's tty in CANONICAL mode, where `MAX_INPUT` (~1024 bytes
+    // on Darwin) truncates our multi-KB spawn line mid-flight — so the argv rides a throwaway script
+    // and only `sh '<path>'` is typed (#1967). Written ONCE, before the retry loop: a rejected
+    // `send_text` never delivered the line, so the script is still on disk for the next attempt.
+    const cmdline = await spawnCommandLine(wrapped);
     const MAX_ATTEMPTS = 3;
     let lastErr: unknown;
     for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -10,6 +10,7 @@ import {
 } from "./herdr-capabilities";
 import { posixShellJoin, oversizedFromArgv } from "./argv-limit";
 import { maintenance } from "./maintenance";
+import { spawnCommandLine } from "./spawn-script";
 import { compileCacheDir, agentTmpDir } from "./tmp-sweep";
 import type { HerdrState, LivenessState, SessionStatus } from "./types";
 import type { RequestPaneAgentState } from "./generated/herdr-protocol";
@@ -1047,11 +1048,16 @@ export class HerdrDriver implements IHerdrDriver {
    */
   private async runInReadyPane(paneId: string, wrapped: string[]): Promise<void> {
     // herdr's `pane run` TYPES the command into the pane's interactive shell (it does not execvp the
-    // argv), so a raw multi-arg spread (`...wrapped`) is space-joined UNQUOTED — any argv element
-    // with whitespace or a newline (e.g. claude's multi-line `--append-system-prompt`) shatters into
-    // bogus shell commands. Pass the whole argv as ONE POSIX-quoted command line instead (mirrors the
-    // socket driver's `posixShellJoin` typing path), so the shell reconstructs the exact argv.
-    const cmdline = posixShellJoin(wrapped);
+    // argv). Two consequences, both handled by `spawnCommandLine`:
+    //  - a raw multi-arg spread (`...wrapped`) would be space-joined UNQUOTED, shattering any element
+    //    with whitespace or a newline (e.g. claude's multi-line `--append-system-prompt`);
+    //  - the typed line hits the tty's CANONICAL-mode `MAX_INPUT` (~1024 bytes on Darwin), which our
+    //    multi-KB spawn line silently overran — truncated mid-`--settings`, unterminated quote, no
+    //    `claude`, 30s auto-detect timeout (#1967).
+    // So the argv goes into a throwaway script and only `sh '<path>'` is typed. Written ONCE, before
+    // the retry loop: a rejected `pane run` never executed the script, so it is still on disk for the
+    // next attempt (and self-deletes the moment it does run).
+    const cmdline = await spawnCommandLine(wrapped);
     const MAX_ATTEMPTS = 3;
     let lastErr: unknown;
     for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {

--- a/src/spawn-script.ts
+++ b/src/spawn-script.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { mkdir, writeFile } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { posixShellJoin } from "./argv-limit";
@@ -31,6 +31,51 @@ function spawnScriptDir(): string {
   return join(agentTmpDir() ?? tmpdir(), "spawn");
 }
 
+/** A real directory, owned by us, that no one else can write into. Uses `lstat`, so a symlink
+ *  planted on the path is rejected rather than followed. */
+async function isOwnPrivateDir(dir: string): Promise<boolean> {
+  try {
+    const st = await lstat(dir);
+    return st.isDirectory() && st.uid === process.getuid?.() && (st.mode & 0o077) === 0;
+  } catch {
+    return false;
+  }
+}
+
+/** Remembered across spawns once the preferred directory turns out to be squatted. */
+let fallbackDir: string | null = null;
+
+/** A private directory of our own under the system tmp dir, reused across spawns — but RE-VERIFIED
+ *  every time, never blindly reused: a tmp cleaner (or anything else) may have removed it since,
+ *  and a stale memo would fail every subsequent spawn with `ENOENT`. */
+async function privateFallbackDir(): Promise<string> {
+  if (fallbackDir && (await isOwnPrivateDir(fallbackDir))) return fallbackDir;
+  fallbackDir = await mkdtemp(join(tmpdir(), "shepherd-spawn-"));
+  return fallbackDir;
+}
+
+/**
+ * The directory to write into, PROVEN to be ours and private before anything is written to it.
+ *
+ * The check is load-bearing, not defensive dressing. With the #1875 redirect rolled back
+ * (`SHEPHERD_AGENT_TMPDIR=""`) the path is a fixed, guessable `<os.tmpdir()>/spawn` in a
+ * world-writable parent, and `mkdir(…, {recursive: true, mode})` silently accepts a pre-existing
+ * directory WITHOUT applying the mode. So a local user could pre-create (or symlink) that directory,
+ * then unlink our 0600 script and substitute their own between our write and the pane's `sh` opening
+ * it — arbitrary code as the Shepherd user. The `wx` flag on the file cannot help: it guards only
+ * the final component, inside a directory the attacker controls.
+ *
+ * Squatted path → fall back to a fresh `mkdtemp` directory (unpredictable name, 0700, ours by
+ * construction), memoized so a hostile `/tmp/spawn` cannot make us mint one per spawn. Refusing
+ * outright would hand any local user a spawn-wide denial of service instead.
+ */
+async function ensureSpawnDir(): Promise<string> {
+  const dir = spawnScriptDir();
+  await mkdir(dir, { recursive: true, mode: 0o700 });
+  if (await isOwnPrivateDir(dir)) return dir;
+  return privateFallbackDir();
+}
+
 /**
  * The POSIX script that launches `wrapped`. Two lines carry the whole contract:
  *
@@ -52,22 +97,54 @@ export function buildSpawnScript(wrapped: string[]): string {
   ].join("\n");
 }
 
+/** How long a script may sit before it is presumed abandoned. Two orders of magnitude above the
+ *  30s spawn deadline, so a script still waiting to be read can never be reaped out from under a
+ *  pane. */
+const STALE_SCRIPT_MS = 60 * 60 * 1000;
+
+/**
+ * Best-effort reap of scripts that were written but never ran — a spawn whose `pane run` failed
+ * every attempt leaves one behind, since the self-delete only fires when the script executes.
+ * Without this they accrete in the agent tmp root: exactly the directory whose inode table Shepherd
+ * has exhausted before (#560/#1875).
+ *
+ * Deliberately silent and non-blocking on failure: cleanup must never be the reason a spawn fails.
+ * Runs on the next spawn rather than on a timer, so it costs one `readdir` per spawn and needs no
+ * lifecycle wiring.
+ */
+async function reapStaleScripts(dir: string, now: number): Promise<void> {
+  try {
+    for (const name of await readdir(dir)) {
+      if (!name.startsWith("spawn-") || !name.endsWith(".sh")) continue;
+      const path = join(dir, name);
+      try {
+        if (now - (await stat(path)).mtimeMs > STALE_SCRIPT_MS) await rm(path, { force: true });
+      } catch {
+        /* raced with the script's own self-delete — nothing to do */
+      }
+    }
+  } catch {
+    /* unreadable dir — a spawn must not fail because cleanup could not run */
+  }
+}
+
 /**
  * Write {@link buildSpawnScript} to a fresh file and return its path. Async fs throughout: Shepherd
  * is one Bun loop pumping the web terminal, and sync fs on it stalls typing.
  *
- * Mode 0600 (dir 0700) because the script carries the full spawn command, including caller-supplied
- * env tokens such as `CLAUDE_CONFIG_DIR`. The name is random rather than pane-derived so it stays
- * short (every byte lands in the typed line) and can never collide across concurrent spawns, and
- * the write is `wx` (exclusive create) so it always lands on a fresh file of ours — never through a
- * pre-placed symlink, and never truncating an existing one whose mode we would not have set.
+ * Mode 0600 inside the verified-private directory {@link ensureSpawnDir} hands back, because the
+ * script carries the full spawn command, including caller-supplied env tokens such as
+ * `CLAUDE_CONFIG_DIR`. The name is random rather than pane-derived so it stays short (every byte
+ * lands in the typed line) and can never collide across concurrent spawns, and the write is `wx`
+ * (exclusive create) so it always lands on a fresh file of ours — never through a pre-placed
+ * symlink, and never truncating an existing one whose mode we would not have set.
  *
  * The script is deliberately NOT made executable: it is handed to `sh` as an argument, so it also
  * runs from a `noexec` mount.
  */
 export async function writeSpawnScript(wrapped: string[]): Promise<string> {
-  const dir = spawnScriptDir();
-  await mkdir(dir, { recursive: true, mode: 0o700 });
+  const dir = await ensureSpawnDir();
+  await reapStaleScripts(dir, Date.now());
   const path = join(dir, `spawn-${randomBytes(6).toString("hex")}.sh`);
   await writeFile(path, buildSpawnScript(wrapped), { mode: 0o600, flag: "wx" });
   return path;

--- a/src/spawn-script.ts
+++ b/src/spawn-script.ts
@@ -68,11 +68,22 @@ async function privateFallbackDir(): Promise<string> {
  * Squatted path → fall back to a fresh `mkdtemp` directory (unpredictable name, 0700, ours by
  * construction), memoized so a hostile `/tmp/spawn` cannot make us mint one per spawn. Refusing
  * outright would hand any local user a spawn-wide denial of service instead.
+ *
+ * EVERY way the path can be occupied has to route into that fallback, which is why the `mkdir` is
+ * inside the `try`: recursive `mkdir` swallows `EEXIST` only when the existing entry is a real
+ * DIRECTORY (verified against the runtime — a plain file, a symlink to a file and a dangling symlink
+ * all throw). Letting that throw would mean a local user could `touch /tmp/spawn` and permanently
+ * fail every spawn — the very denial of service the fallback exists to prevent, reachable by the
+ * cheapest possible squat.
  */
 async function ensureSpawnDir(): Promise<string> {
   const dir = spawnScriptDir();
-  await mkdir(dir, { recursive: true, mode: 0o700 });
-  if (await isOwnPrivateDir(dir)) return dir;
+  try {
+    await mkdir(dir, { recursive: true, mode: 0o700 });
+    if (await isOwnPrivateDir(dir)) return dir;
+  } catch {
+    /* occupied by a non-directory (or uncreatable) — the fallback below is the answer */
+  }
   return privateFallbackDir();
 }
 

--- a/src/spawn-script.ts
+++ b/src/spawn-script.ts
@@ -1,0 +1,80 @@
+import { randomBytes } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { posixShellJoin } from "./argv-limit";
+import { agentTmpDir } from "./tmp-sweep";
+
+/**
+ * The spawn TRANSPORT for herdr ≥0.7.5 (issue #1967).
+ *
+ * `pane run` (CLI) and `pane.send_text` (socket) do NOT `execvp` the command — they TYPE it into the
+ * pane's interactive shell. A shell sitting at its prompt has its tty in CANONICAL mode, whose input
+ * line is bounded by `MAX_INPUT`: ~1024 bytes on Darwin (4096 on Linux). Shepherd's spawn line is
+ * several KB — dominated by the `--settings` overlay and the `--append-system-prompt` directive — so
+ * on macOS it was silently truncated mid-JSON, leaving an unterminated `'`. The shell then waited
+ * for line continuation, `claude` never launched, and the spawn died at the 30s auto-detect deadline.
+ *
+ * The fix is to make the TYPED line short regardless of command size: the real command goes into a
+ * throwaway script and only `sh '<path>'` (~60 bytes) is typed. The process that ends up running is
+ * byte-identical to before — same argv, same env — so herdr's detection, the membrane wrap and every
+ * downstream consumer are unaffected.
+ *
+ * Shrinking `argvElementLimit` for Darwin (#1944's lever) was NOT an option: trimming a system
+ * prompt to fit under 1 KB would gut it.
+ */
+
+/** Directory the throwaway spawn scripts live in: the disk-backed agent tmp root when the #1875
+ *  redirect is enabled, else the system tmp dir (`SHEPHERD_AGENT_TMPDIR=""` disables it). Resolved
+ *  at call time so the env seam works the same way it does for the agents themselves. */
+function spawnScriptDir(): string {
+  return join(agentTmpDir() ?? tmpdir(), "spawn");
+}
+
+/**
+ * The POSIX script that launches `wrapped`. Two lines carry the whole contract:
+ *
+ *  - `rm -f -- "$0"` — self-delete. The shell holds an open fd, so the script stays readable after
+ *    the unlink and leaves nothing behind. Retry-safe: both drivers only retry a run that was
+ *    REJECTED before execution, so a script that has not launched is still on disk for the retry.
+ *  - `exec` — mandatory, not cosmetic. Without it `sh` survives as the pane's foreground process and
+ *    herdr detects `sh` instead of the agent.
+ */
+export function buildSpawnScript(wrapped: string[]): string {
+  return [
+    "#!/bin/sh",
+    "# Shepherd spawn transport (#1967) — typed into the pane as `sh <path>` so the line stays",
+    "# under the tty's canonical-mode MAX_INPUT. Self-deletes, then execs so the pane's foreground",
+    "# process is the agent itself.",
+    'rm -f -- "$0"',
+    `exec ${posixShellJoin(wrapped)}`,
+    "",
+  ].join("\n");
+}
+
+/**
+ * Write {@link buildSpawnScript} to a fresh file and return its path. Async fs throughout: Shepherd
+ * is one Bun loop pumping the web terminal, and sync fs on it stalls typing.
+ *
+ * Mode 0600 (dir 0700) because the script carries the full spawn command, including caller-supplied
+ * env tokens such as `CLAUDE_CONFIG_DIR`. The name is random rather than pane-derived so it stays
+ * short (every byte lands in the typed line) and can never collide across concurrent spawns, and
+ * the write is `wx` (exclusive create) so it always lands on a fresh file of ours — never through a
+ * pre-placed symlink, and never truncating an existing one whose mode we would not have set.
+ *
+ * The script is deliberately NOT made executable: it is handed to `sh` as an argument, so it also
+ * runs from a `noexec` mount.
+ */
+export async function writeSpawnScript(wrapped: string[]): Promise<string> {
+  const dir = spawnScriptDir();
+  await mkdir(dir, { recursive: true, mode: 0o700 });
+  const path = join(dir, `spawn-${randomBytes(6).toString("hex")}.sh`);
+  await writeFile(path, buildSpawnScript(wrapped), { mode: 0o600, flag: "wx" });
+  return path;
+}
+
+/** The command line typed into the pane for `wrapped` — `sh '<script path>'`. Both ≥0.7.5 drivers
+ *  route through this, so the two transports stay one behavior. */
+export async function spawnCommandLine(wrapped: string[]): Promise<string> {
+  return posixShellJoin(["sh", await writeSpawnScript(wrapped)]);
+}

--- a/test/helpers/spawn-script.ts
+++ b/test/helpers/spawn-script.ts
@@ -1,0 +1,20 @@
+import { expect } from "bun:test";
+import { readFileSync } from "node:fs";
+
+/**
+ * Darwin's tty canonical-mode input limit (`MAX_INPUT`, ~1024 bytes) — the bar issue #1967 overran.
+ * Pinned in test code rather than production: nothing branches on it, because the ≥0.7.5 spawn
+ * transport is short on EVERY platform by construction. These assertions are what keep it that way.
+ */
+export const DARWIN_MAX_INPUT = 1024;
+
+/**
+ * Both ≥0.7.5 drivers type `'sh' '<path>'` into the pane and let the script carry the real command
+ * (#1967). Asserts the typed line is that short form and fits `MAX_INPUT`, then returns the script
+ * body so callers can assert on the command that will actually run.
+ */
+export function readTypedScript(cmdline: string | undefined): string {
+  expect(cmdline).toMatch(/^'sh' '.*\.sh'$/);
+  expect(Buffer.byteLength(cmdline!, "utf8")).toBeLessThan(DARWIN_MAX_INPUT);
+  return readFileSync(/^'sh' '(.*)'$/.exec(cmdline!)![1]!, "utf8");
+}

--- a/test/herdr-075.test.ts
+++ b/test/herdr-075.test.ts
@@ -1,4 +1,5 @@
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test, expect, beforeEach, afterEach } from "bun:test";
 import {
@@ -11,6 +12,7 @@ import {
   type HerdrAgent,
 } from "../src/herdr";
 import { setDetectedHerdrVersion } from "../src/herdr-capabilities";
+import { readTypedScript } from "./helpers/spawn-script";
 
 // ── captured 0.7.5 (protocol 17) reply fixtures ──────────────────────────────
 const FIX = join(import.meta.dir, "fixtures/herdr-responses/v0.7.5");
@@ -62,16 +64,19 @@ function mkDriver(fake: (args: string[]) => string): { d: HerdrDriver; calls: st
   };
 }
 
-// Pin the compile-cache dir + disable the disk-TMPDIR redirect so buildWrappedArgv's output is
-// deterministic (mirrors test/herdr.test.ts), keeping the `pane run` argv assertion stable.
+// Pin the compile-cache dir so buildWrappedArgv's output is deterministic (mirrors
+// test/herdr.test.ts), and point the agent tmp dir at a scratch dir — that is where the #1967 spawn
+// scripts land, so the test owns and removes them instead of leaving them in the system tmp dir.
 let prevNcc: string | undefined;
 let prevAgentTmp: string | undefined;
+let scratch: string;
 beforeEach(() => {
   setDetectedHerdrVersion("0.7.5");
   prevNcc = process.env.SHEPHERD_NODE_COMPILE_CACHE;
   process.env.SHEPHERD_NODE_COMPILE_CACHE = "/disk/ncc";
   prevAgentTmp = process.env.SHEPHERD_AGENT_TMPDIR;
-  process.env.SHEPHERD_AGENT_TMPDIR = "";
+  scratch = mkdtempSync(join(tmpdir(), "shepherd-herdr075-"));
+  process.env.SHEPHERD_AGENT_TMPDIR = scratch;
 });
 afterEach(() => {
   setDetectedHerdrVersion(null);
@@ -79,6 +84,7 @@ afterEach(() => {
   else process.env.SHEPHERD_NODE_COMPILE_CACHE = prevNcc;
   if (prevAgentTmp === undefined) delete process.env.SHEPHERD_AGENT_TMPDIR;
   else process.env.SHEPHERD_AGENT_TMPDIR = prevAgentTmp;
+  rmSync(scratch, { recursive: true, force: true });
 });
 
 // ── pure leaves ──────────────────────────────────────────────────────────────
@@ -131,7 +137,7 @@ test("classifyPaneWrite: CR/LF → Enter key, everything else → literal text",
 
 // ── start() via external registration ────────────────────────────────────────
 
-test("start (0.7.5, TRUSTED): tab create → pane run joined argv → NO registration → resolve by auto-detect", async () => {
+test("start (0.7.5, TRUSTED): tab create → pane run spawn script → NO registration → resolve by auto-detect", async () => {
   const { d, calls } = mkDriver(route);
   const agent = await d.start("review TASK-09", "/wt/a", ["claude", "go"]);
 
@@ -147,12 +153,14 @@ test("start (0.7.5, TRUSTED): tab create → pane run joined argv → NO registr
   expect(calls.some((c) => c[1] === "report-agent-session")).toBe(false);
   expect(calls.some((c) => c[1] === "report-agent")).toBe(false);
 
-  // The wrapped argv is typed into the pane's shell as ONE POSIX-quoted command line (herdr's
-  // `pane run` types-into-shell, it doesn't execvp — a raw spread would shatter multi-word args).
+  // herdr's `pane run` TYPES into the shell, it doesn't execvp — so the wrapped argv rides a
+  // throwaway script (#1967) and only `sh '<path>'` is typed. The script execs the exact argv,
+  // POSIX-quoted (a raw spread would shatter multi-word args).
   const paneRun = calls.find((c) => c[0] === "pane" && c[1] === "run")!;
   expect(paneRun.slice(0, 3)).toEqual(["pane", "run", "p_075"]);
-  expect(paneRun.length).toBe(4); // pane, run, paneId, single joined command line
-  expect(paneRun[3]).toContain("'claude' 'go'");
+  expect(paneRun.length).toBe(4); // pane, run, paneId, single typed command line
+  expect(readTypedScript(paneRun[3])).toContain("exec 'env' ");
+  expect(readTypedScript(paneRun[3])).toContain("'claude' 'go'");
 });
 
 test("start (0.7.5, SANDBOXED): pane run → register (report-agent-session + --state working) → resolve", async () => {
@@ -176,8 +184,31 @@ test("start (0.7.5): pane run preserves a multi-word/newline argv element as ONE
   // it must survive as one POSIX-quoted token, not shatter into bogus shell words.
   await d.start("x", "/wt/a", ["claude", "--append-system-prompt", "line one\nline two"]);
   const paneRun = calls.find((c) => c[0] === "pane" && c[1] === "run")!;
-  expect(paneRun.length).toBe(4); // still a single joined command line
-  expect(paneRun[3]).toContain("'--append-system-prompt' 'line one\nline two'");
+  expect(paneRun.length).toBe(4); // still a single typed command line
+  expect(readTypedScript(paneRun[3])).toContain("'--append-system-prompt' 'line one\nline two'");
+});
+
+test("start (0.7.5): a multi-KB spawn types a line that fits Darwin's tty MAX_INPUT (#1967)", async () => {
+  const { d, calls } = mkDriver(route);
+  // The real shape: a --settings overlay plus a several-KB --append-system-prompt directive. Typed
+  // verbatim (the pre-#1967 transport) this line was ~10 KB and Darwin truncated it at ~1024 bytes,
+  // mid-JSON, leaving an unterminated quote and no `claude` — the 30s auto-detect timeout.
+  const settings = JSON.stringify({ hooks: { Notification: ["x".repeat(2000)] } });
+  const directive = "You are an autonomous agent.\n".repeat(300);
+  await d.start("x", "/wt/a", [
+    "claude",
+    "--settings",
+    settings,
+    "--append-system-prompt",
+    directive,
+  ]);
+
+  const paneRun = calls.find((c) => c[0] === "pane" && c[1] === "run")!;
+  // `readTypedScript` asserts the < MAX_INPUT bound; the script itself carries the full command.
+  const script = readTypedScript(paneRun[3]);
+  expect(script).toContain(settings);
+  expect(script).toContain(directive);
+  expect(script.length).toBeGreaterThan(10_000);
 });
 
 test("start (0.7.5, TRUSTED): auto-detect polls the agent list until the agent appears", async () => {

--- a/test/herdr-socket-075.test.ts
+++ b/test/herdr-socket-075.test.ts
@@ -1,4 +1,5 @@
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { SocketHerdrDriver, selectHerdrDriver } from "../src/herdr-socket-driver";
@@ -11,6 +12,7 @@ import {
 import { HerdrSocketError, type HerdrSocketClient } from "../src/herdr-socket-client";
 import { setDetectedHerdrVersion } from "../src/herdr-capabilities";
 import { OversizedArgvError } from "../src/argv-limit";
+import { readTypedScript } from "./helpers/spawn-script";
 
 // ── captured 0.7.5 (protocol 17) reply fixtures (shared with test/herdr-075.test.ts) ────────────
 // The socket client returns `res.result`, so the driver receives the INNER result object — unwrap
@@ -70,14 +72,17 @@ const noCli = {} as unknown as HerdrDriver;
 describe("SocketHerdrDriver — 0.7.5 (protocol 17) external-registration spawn", () => {
   let prevNcc: string | undefined;
   let prevAgentTmp: string | undefined;
+  let scratch: string;
   beforeEach(() => {
     // Arm the external-registration branch and pin the wrapped-argv env so the `pane.send_text`
-    // command-line assertion is deterministic (mirrors test/herdr-075.test.ts).
+    // command-line assertion is deterministic (mirrors test/herdr-075.test.ts). The agent tmp dir
+    // points at a scratch dir because that is where the #1967 spawn scripts land.
     setDetectedHerdrVersion("0.7.5");
     prevNcc = process.env.SHEPHERD_NODE_COMPILE_CACHE;
     process.env.SHEPHERD_NODE_COMPILE_CACHE = "/disk/ncc";
     prevAgentTmp = process.env.SHEPHERD_AGENT_TMPDIR;
-    process.env.SHEPHERD_AGENT_TMPDIR = "";
+    scratch = mkdtempSync(join(tmpdir(), "shepherd-socket075-"));
+    process.env.SHEPHERD_AGENT_TMPDIR = scratch;
   });
   afterEach(() => {
     setDetectedHerdrVersion(null);
@@ -85,6 +90,7 @@ describe("SocketHerdrDriver — 0.7.5 (protocol 17) external-registration spawn"
     else process.env.SHEPHERD_NODE_COMPILE_CACHE = prevNcc;
     if (prevAgentTmp === undefined) delete process.env.SHEPHERD_AGENT_TMPDIR;
     else process.env.SHEPHERD_AGENT_TMPDIR = prevAgentTmp;
+    rmSync(scratch, { recursive: true, force: true });
   });
 
   it("start() SANDBOXED: runs the wrapped argv in the root pane, registers, resolves by pane_id (no pane.close)", async () => {
@@ -109,13 +115,17 @@ describe("SocketHerdrDriver — 0.7.5 (protocol 17) external-registration spawn"
     // the run reuses the root pane — no leftover shell pane to close
     expect(rec.some((r) => r.method === "pane.close")).toBe(false);
 
-    // the wrapped argv is typed into the root pane as a POSIX-quoted command line, then submitted
+    // `sh '<script>'` is typed into the root pane, then submitted — the wrapped argv itself rides
+    // the script, so the typed line can never outgrow the tty's MAX_INPUT (#1967). The script execs
+    // the argv byte-identically to what the pre-#1967 transport typed.
     const sendText = rec.find((r) => r.method === "pane.send_text")!.params as {
       pane_id: string;
       text: string;
     };
     expect(sendText.pane_id).toBe("p_075");
-    expect(sendText.text).toBe(posixShellJoin(buildWrappedArgv(["bwrap", "--", "claude", "go"])));
+    expect(readTypedScript(sendText.text)).toContain(
+      `exec ${posixShellJoin(buildWrappedArgv(["bwrap", "--", "claude", "go"]))}`,
+    );
     expect(rec.find((r) => r.method === "pane.send_keys")!.params).toEqual({
       pane_id: "p_075",
       keys: ["Enter"],

--- a/test/spawn-e2big.test.ts
+++ b/test/spawn-e2big.test.ts
@@ -52,11 +52,14 @@ const argvFor = (prompt: string) =>
     sessionId: "11111111-2222-3333-4444-555555555555",
   }).argv;
 
-/** Both shapes herdr can spawn through, each wrapped by the env shim `herdr.start` applies. */
+/** Both shapes the budget is calibrated against, each wrapped by the env shim `herdr.start` applies. */
 const DRIVER_SHAPES = [
   {
-    name: "0.7.5 pane run (the whole command line is ONE argv element)",
-    // `HerdrDriver.runInReadyPane` passes `posixShellJoin(wrapped)` as a single execFile argument.
+    name: "the joined command line as ONE argv element (what spawnBudget prices)",
+    // No transport spends the argv this way since #1967 — the ≥0.7.5 drivers type `sh '<script>'`
+    // and the script's `exec` spreads the tokens. `spawnBudget` still measures the joined line, so
+    // this is the deliberately conservative upper bound: a prompt that clears it clears every real
+    // shape, and the ladder can never under-clamp.
     elements: (prompt: string) => [posixShellJoin(buildWrappedArgv(argvFor(prompt)))],
   },
   {
@@ -154,9 +157,9 @@ describe.skipIf(!onLinux)("#1944 real spawn against the kernel", () => {
   });
 
   test("spawnFootprintBytes predicts the kernel's verdict exactly at the boundary", () => {
-    // The 0.7.5 shape is the one where the whole joined line is a single element, so its footprint
-    // is what MAX_ARG_STRLEN is compared against. Build a prompt whose joined line lands exactly on
-    // the limit and confirm both our measurement and the kernel agree.
+    // The joined-line shape is the one the budget prices, so its footprint is what the ladder
+    // compares against MAX_ARG_STRLEN. Build a prompt whose joined line lands exactly on the limit
+    // and confirm both our measurement and the kernel agree.
     const limit = hostArgvElementLimit();
     const probe = spawnBudget((p) => ({ wrapped: argvFor(p) }));
     let prompt = "y".repeat(limit);

--- a/test/spawn-script.test.ts
+++ b/test/spawn-script.test.ts
@@ -1,6 +1,14 @@
 import { test, expect, beforeEach, afterEach, describe } from "bun:test";
 import { spawn } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, statSync, symlinkSync, utimesSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  statSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -141,6 +149,22 @@ describe("writeSpawnScript", () => {
 
     expect(path.startsWith(target)).toBe(false);
     expect(path.startsWith(join(scratch, "spawn"))).toBe(false);
+    await rm(dirname(path), { recursive: true, force: true });
+  });
+
+  test.each([
+    ["a plain file", (p: string) => writeFileSync(p, "squat")],
+    ["a dangling symlink", (p: string) => symlinkSync(join(p, "..", "nonexistent"), p)],
+  ])("keeps spawning when %s occupies the script dir path", async (_label, squat) => {
+    // Recursive mkdir swallows EEXIST only for a real DIRECTORY; a plain file or a dangling symlink
+    // throws. Unhandled, that is a spawn-wide denial of service any local user could trigger with a
+    // single `touch /tmp/spawn` — cheaper than the ownership squat above and just as total.
+    squat(join(scratch, "spawn"));
+
+    const path = await writeSpawnScript(ARGV);
+
+    expect(existsSync(path)).toBe(true);
+    expect(statSync(dirname(path)).mode & 0o077).toBe(0);
     await rm(dirname(path), { recursive: true, force: true });
   });
 

--- a/test/spawn-script.test.ts
+++ b/test/spawn-script.test.ts
@@ -1,16 +1,33 @@
 import { test, expect, beforeEach, afterEach, describe } from "bun:test";
-import { execFile } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, statSync, symlinkSync, utimesSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { promisify } from "node:util";
 import { posixShellJoin } from "../src/argv-limit";
 import { buildWrappedArgv } from "../src/herdr";
 import { buildSpawnScript, spawnCommandLine, writeSpawnScript } from "../src/spawn-script";
 import { DARWIN_MAX_INPUT } from "./helpers/spawn-script";
 
-const execFileAsync = promisify(execFile);
+/**
+ * Feed `input` to a real POSIX shell the way herdr does — TYPED on the shell's stdin — and return
+ * its stdout. Deliberately not `sh -c "<line>"`: the transport is a shell reading typed input, so
+ * stdin is the faithful reproduction, and it keeps a path derived from `SHEPHERD_AGENT_TMPDIR` off
+ * a child process's command line (the indirect-command-injection shape, flagged by CodeQL).
+ */
+function typeIntoShell(input: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const sh = spawn("sh", { stdio: ["pipe", "pipe", "inherit"] });
+    let out = "";
+    sh.stdout.setEncoding("utf8");
+    sh.stdout.on("data", (chunk) => (out += chunk));
+    sh.on("error", reject);
+    sh.on("close", (code) =>
+      code === 0 ? resolve(out) : reject(new Error(`sh exited with ${code}`)),
+    );
+    sh.stdin.end(input);
+  });
+}
 
 let scratch: string;
 let prevAgentTmp: string | undefined;
@@ -80,6 +97,77 @@ describe("writeSpawnScript", () => {
     const paths = await Promise.all([1, 2, 3].map(() => writeSpawnScript(ARGV)));
     expect(new Set(paths).size).toBe(3);
   });
+
+  test("reaps scripts a failed spawn abandoned, and never a live one", async () => {
+    // The self-delete only fires when the script RUNS, so a spawn whose `pane run` failed every
+    // attempt leaves one behind. Observed for real: a full test-suite run left four in the agent
+    // tmp root. Unreaped they accrete in the directory whose inodes Shepherd has exhausted before.
+    const abandoned = await writeSpawnScript(ARGV);
+    const fresh = await writeSpawnScript(ARGV);
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    utimesSync(abandoned, twoHoursAgo, twoHoursAgo);
+
+    await writeSpawnScript(ARGV); // the next spawn is what sweeps
+
+    expect(existsSync(abandoned)).toBe(false);
+    // A script written moments ago may still be waiting for its pane — never reap that.
+    expect(existsSync(fresh)).toBe(true);
+  });
+
+  test("refuses a squatted script dir — writes to a private one instead", async () => {
+    // With the #1875 redirect rolled back the dir is a fixed `<tmpdir>/spawn` in a world-writable
+    // parent, and `mkdir(recursive)` accepts a pre-existing dir WITHOUT applying the mode. A local
+    // user who owns that dir could swap our script between the write and the pane's `sh` opening it
+    // — code execution as the Shepherd user. Group/other-writable stands in for foreign ownership,
+    // which a test cannot create without root; both are rejected by the same lstat check.
+    mkdirSync(join(scratch, "spawn"), { recursive: true });
+    chmodSync(join(scratch, "spawn"), 0o777);
+
+    const path = await writeSpawnScript(ARGV);
+
+    expect(dirname(path)).not.toBe(join(scratch, "spawn"));
+    expect(statSync(dirname(path)).mode & 0o077).toBe(0); // no group/other access
+    expect(statSync(dirname(path)).uid).toBe(process.getuid!());
+    await rm(dirname(path), { recursive: true, force: true });
+  });
+
+  test("refuses a symlink planted on the script dir rather than following it", async () => {
+    // lstat, not stat: a symlink pointing at an attacker-owned directory must not be followed.
+    const target = join(scratch, "elsewhere");
+    mkdirSync(target, { recursive: true });
+    symlinkSync(target, join(scratch, "spawn"));
+
+    const path = await writeSpawnScript(ARGV);
+
+    expect(path.startsWith(target)).toBe(false);
+    expect(path.startsWith(join(scratch, "spawn"))).toBe(false);
+    await rm(dirname(path), { recursive: true, force: true });
+  });
+
+  test("recovers when the private fallback dir is removed under it", async () => {
+    // The fallback is remembered across spawns, so a tmp cleaner that removes it must not strand
+    // every later spawn on a stale path (ENOENT on write).
+    mkdirSync(join(scratch, "spawn"), { recursive: true });
+    chmodSync(join(scratch, "spawn"), 0o777); // force the fallback
+    const first = await writeSpawnScript(ARGV);
+    await rm(dirname(first), { recursive: true, force: true });
+
+    const second = await writeSpawnScript(ARGV);
+
+    expect(existsSync(second)).toBe(true);
+    await rm(dirname(second), { recursive: true, force: true });
+  });
+
+  test("a failing reap never fails the spawn", async () => {
+    // Cleanup is best-effort by design: an unreadable dir must not be why an agent cannot start.
+    const path = await writeSpawnScript(ARGV);
+    chmodSync(dirname(path), 0o300); // no read permission → readdir throws
+    try {
+      await expect(writeSpawnScript(ARGV)).resolves.toContain("/spawn-");
+    } finally {
+      chmodSync(dirname(path), 0o700); // restore so afterEach can clean up
+    }
+  });
 });
 
 describe("spawnCommandLine", () => {
@@ -99,9 +187,9 @@ describe("spawnCommandLine", () => {
     expect(line).toMatch(/^'sh' '.*\.sh'$/);
   });
 
-  test("a REAL sh run of the typed line execs the argv byte-identically and removes the script", async () => {
-    // The one assertion here that cannot be satisfied by agreeing with our own arithmetic: it hands
-    // the script to a real /bin/sh and reads back what the process actually received.
+  test("typing the line at a REAL shell execs the argv byte-identically and removes the script", async () => {
+    // The one assertion here that cannot be satisfied by agreeing with our own arithmetic: it types
+    // the line at a real /bin/sh and reads back what the launched process actually received.
     const args = ["multi word", "with 'quote'", "two\nlines", "$HOME", ""];
     const line = await spawnCommandLine([
       "env",
@@ -113,7 +201,7 @@ describe("spawnCommandLine", () => {
     const path = /^'sh' '(.*)'$/.exec(line)?.[1] ?? "";
     expect(existsSync(path)).toBe(true);
 
-    const { stdout } = await execFileAsync("sh", ["-c", line]);
+    const stdout = await typeIntoShell(`${line}\n`);
     expect(stdout).toBe(args.map((a) => `[${a}]\n`).join(""));
     // Self-deleted by the script itself, mid-run, while sh still held it open.
     expect(existsSync(path)).toBe(false);
@@ -126,7 +214,7 @@ describe("spawnCommandLine", () => {
     // typed line; the command the script launches prints ITS pid. A missing `exec` anywhere in the
     // chain forks, and the two differ.
     const line = await spawnCommandLine(["sh", "-c", "echo $$"]);
-    const { stdout } = await execFileAsync("sh", ["-c", `echo $$; exec ${line}`]);
+    const stdout = await typeIntoShell(`echo $$\nexec ${line}\n`);
     const [outer, inner] = stdout.trim().split("\n");
     expect(inner).toBe(outer);
   });

--- a/test/spawn-script.test.ts
+++ b/test/spawn-script.test.ts
@@ -1,0 +1,133 @@
+import { test, expect, beforeEach, afterEach, describe } from "bun:test";
+import { execFile } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+import { posixShellJoin } from "../src/argv-limit";
+import { buildWrappedArgv } from "../src/herdr";
+import { buildSpawnScript, spawnCommandLine, writeSpawnScript } from "../src/spawn-script";
+import { DARWIN_MAX_INPUT } from "./helpers/spawn-script";
+
+const execFileAsync = promisify(execFile);
+
+let scratch: string;
+let prevAgentTmp: string | undefined;
+
+beforeEach(async () => {
+  scratch = await mkdtemp(join(tmpdir(), "shepherd-spawn-script-"));
+  prevAgentTmp = process.env.SHEPHERD_AGENT_TMPDIR;
+  process.env.SHEPHERD_AGENT_TMPDIR = scratch;
+});
+
+afterEach(async () => {
+  if (prevAgentTmp === undefined) delete process.env.SHEPHERD_AGENT_TMPDIR;
+  else process.env.SHEPHERD_AGENT_TMPDIR = prevAgentTmp;
+  await rm(scratch, { recursive: true, force: true });
+});
+
+const ARGV = [
+  "env",
+  "NODE_COMPILE_CACHE=/disk/ncc",
+  "claude",
+  "--append-system-prompt",
+  "be brief",
+];
+
+describe("buildSpawnScript", () => {
+  test("self-deletes BEFORE exec, and execs (never plain-runs) the joined argv", () => {
+    const script = buildSpawnScript(ARGV);
+    expect(script.startsWith("#!/bin/sh\n")).toBe(true);
+
+    const lines = script.split("\n").filter((l) => l && !l.startsWith("#"));
+    // Order matters: after `exec` nothing in this script runs, so the unlink must precede it.
+    expect(lines).toEqual([`rm -f -- "$0"`, `exec ${posixShellJoin(ARGV)}`]);
+  });
+
+  test("reconstructs the exact argv — multi-word, newline and quote-bearing tokens survive", () => {
+    // The directive Shepherd passes via --append-system-prompt is multi-line and apostrophe-dense;
+    // a token that shattered here would spawn a mangled agent rather than fail loudly.
+    const gnarly = [
+      "claude",
+      "--append-system-prompt",
+      "line one\nline two 'quoted' & $(nope)",
+      "",
+    ];
+    expect(buildSpawnScript(gnarly)).toContain(`exec ${posixShellJoin(gnarly)}`);
+  });
+});
+
+describe("writeSpawnScript", () => {
+  test("writes under the agent tmp dir with 0600 (dir 0700)", async () => {
+    const path = await writeSpawnScript(ARGV);
+    expect(path.startsWith(join(scratch, "spawn") + "/")).toBe(true);
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+    expect(statSync(dirname(path)).mode & 0o777).toBe(0o700);
+  });
+
+  test("falls back to the system tmp dir when the #1875 redirect is disabled", async () => {
+    process.env.SHEPHERD_AGENT_TMPDIR = ""; // operator rollback: agentTmpDir() === null
+    const path = await writeSpawnScript(ARGV);
+    try {
+      expect(path.startsWith(join(tmpdir(), "spawn") + "/")).toBe(true);
+    } finally {
+      await rm(path, { force: true });
+    }
+  });
+
+  test("every call gets its own file, so concurrent spawns cannot collide", async () => {
+    const paths = await Promise.all([1, 2, 3].map(() => writeSpawnScript(ARGV)));
+    expect(new Set(paths).size).toBe(3);
+  });
+});
+
+describe("spawnCommandLine", () => {
+  test("the TYPED line stays far under Darwin's MAX_INPUT for a full-size spawn", async () => {
+    // The shape that broke #1967: a real ~8 KB system-prompt directive plus a --settings overlay.
+    const wrapped = buildWrappedArgv([
+      "claude",
+      "--settings",
+      JSON.stringify({ hooks: { Notification: ["x".repeat(2000)] } }),
+      "--append-system-prompt",
+      "You are an autonomous agent.\n".repeat(300),
+    ]);
+    expect(posixShellJoin(wrapped).length).toBeGreaterThan(8_000); // what used to be typed
+
+    const line = await spawnCommandLine(wrapped);
+    expect(Buffer.byteLength(line, "utf8")).toBeLessThan(DARWIN_MAX_INPUT);
+    expect(line).toMatch(/^'sh' '.*\.sh'$/);
+  });
+
+  test("a REAL sh run of the typed line execs the argv byte-identically and removes the script", async () => {
+    // The one assertion here that cannot be satisfied by agreeing with our own arithmetic: it hands
+    // the script to a real /bin/sh and reads back what the process actually received.
+    const args = ["multi word", "with 'quote'", "two\nlines", "$HOME", ""];
+    const line = await spawnCommandLine([
+      "env",
+      "SPAWN_SCRIPT_PROBE=1",
+      "printf",
+      "[%s]\n",
+      ...args,
+    ]);
+    const path = /^'sh' '(.*)'$/.exec(line)?.[1] ?? "";
+    expect(existsSync(path)).toBe(true);
+
+    const { stdout } = await execFileAsync("sh", ["-c", line]);
+    expect(stdout).toBe(args.map((a) => `[${a}]\n`).join(""));
+    // Self-deleted by the script itself, mid-run, while sh still held it open.
+    expect(existsSync(path)).toBe(false);
+  });
+
+  test("the exec'd process REPLACES the shell — no lingering `sh` in the foreground", async () => {
+    // herdr resolves a trusted spawn by detecting the pane's FOREGROUND process, so a script that
+    // forgot `exec` would leave `sh` there and break auto-detection (30s timeout, #1967's symptom).
+    // Proven by pid identity, not by inspection: the outer shell prints its pid, then execs the
+    // typed line; the command the script launches prints ITS pid. A missing `exec` anywhere in the
+    // chain forks, and the two differ.
+    const line = await spawnCommandLine(["sh", "-c", "echo $$"]);
+    const { stdout } = await execFileAsync("sh", ["-c", `echo $$; exec ${line}`]);
+    const [outer, inner] = stdout.trim().split("\n");
+    expect(inner).toBe(outer);
+  });
+});


### PR DESCRIPTION
Fixes #1967.

## The bug

herdr's `pane run` (CLI) and `pane.send_text` (socket) do **not** `execvp` the command — they **type it into the pane's interactive shell**. A shell at its prompt has its tty in **canonical** mode, where input is bounded by `MAX_INPUT`: **~1024 bytes on Darwin** (4096 on Linux).

Shepherd's spawn line is multi-KB (the `--settings` overlay + the `--append-system-prompt` directive), so on macOS it was silently truncated mid-`--settings`, leaving an unterminated `'`. The shell sat waiting for line continuation, `claude` never launched, and every non-trivial macOS spawn died at the 30s auto-detect deadline:

```
herdr: agent for pane <pane> (<name>) not auto-detected within 30s.
```

`argvElementLimit` never engaged because it models Linux's `execve` `MAX_ARG_STRLEN` — the wrong failure mode for a type-into-shell transport. Tightening it for Darwin is not a fix either: trimming a system prompt under 1 KB would gut it.

## The fix

Write the wrapped argv to a throwaway script and type only `sh '<path>'` (~60 bytes):

```sh
#!/bin/sh
rm -f -- "$0"
exec 'env' '-u' 'CLAUDE_CODE_TMPDIR' … 'claude' '--settings' '…' …
```

- **`exec` is load-bearing** — without it `sh` stays the pane's foreground process and herdr detects `sh` instead of the agent.
- **`rm -f -- "$0"` self-deletes** — the open fd keeps it readable, so nothing is left behind. Retry-safe: both drivers only retry a run that was *rejected before execution*, so an unlaunched script is still on disk for the next attempt.
- **0600 file / 0700 dir, `wx` exclusive create** — the script carries the full spawn command (incl. env tokens like `CLAUDE_CONFIG_DIR`), and the exclusive create means it can never land through a pre-placed symlink.
- **Not marked executable** — it is handed to `sh` as an argument, so it also runs from a `noexec` mount.

Applied to **both** ≥0.7.5 transports (`HerdrDriver.runInReadyPane`, `SocketHerdrDriver.runInReadyPane`) on **all platforms** — one transport, no Darwin-only branch. The process that ends up running is byte-identical to before (same argv, same env), so detection, the membrane/bwrap wrap and every downstream consumer are unaffected. The ≤0.7.4 `agent start` paths are untouched.

Side benefit: the typed line no longer depends on the *interactive* shell being POSIX — `sh '<path>'` parses correctly even under fish.

## Verification

**Live spike** (herdr 0.7.4 `pane run`, the assumption unit tests cannot reach) — `tab create` → `pane run "sh '<script>'"` where the script execs `claude`:

- herdr auto-detected the agent in ~2s with `terminal_id` populated;
- `pane process-info` foreground = `claude` (argv `["claude"]`), **no `sh`** — `exec` chained correctly;
- the script had removed itself.

**Tests** — `test/spawn-script.test.ts` (new):

- the typed line for a realistic ~10 KB spawn is **< 1024 bytes**, and the driver-level guard asserts the same through `start()`;
- a **real `/bin/sh` run** reads back the reconstructed argv (multi-word, newline, quote and empty tokens intact) and confirms the script deleted itself mid-run;
- `exec` proven by **pid identity**, not inspection: the outer shell prints its pid, execs the typed line, and the launched command prints the same pid — a missing `exec` anywhere in the chain forks and they differ;
- 0600/0700 modes, per-call unique paths, and the `SHEPHERD_AGENT_TMPDIR=""` fallback.

Gates: `bun run lint`, `bunx tsc --noEmit`, `bun test ./test` (7996 pass / 0 fail), `fallow audit` — all green. The one duplication finding is pre-existing (`startImpl075` vs `startImpl`).

## Notes

- **Steering is not affected and deliberately untouched**: `pane.send_text` into a *live* agent writes to a tty in **raw** mode, and `MAX_INPUT` bounds the canonical-mode buffer only. The spawn broke precisely because it types at an interactive shell prompt.
- **`argv-limit` / `spawn-budget` are unchanged** — the eventual `execve` of `env … claude …` still enforces Linux's per-element limit, so the guard stays correct; it now merely over-counts (it prices the whole joined line), which errs toward clamping early and never toward `E2BIG`. Doc comments updated to stop claiming the joined line is one argv element.
- Local herdr is 0.7.4, which takes the legacy `agent start` (execvp) path, so this changes nothing on the Linux host today — it engages on herdr ≥0.7.5.

[no-feature-entry] — server-only spawn-transport fix, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: end-to-end on a real herdr 0.7.5

The transport only engages on herdr ≥0.7.5, and this box runs 0.7.4 — so I stood up a **throwaway 0.7.5** to close that gap: the 0.7.5 binary downloaded to a scratch dir, run as an isolated session with its own socket (`--session e2e1967`). The global 0.7.4 binary and the live herd were never touched; the instance was stopped and removed afterwards.

Driving the **real `HerdrDriver.start()`** with a 9,689-byte spawn (settings overlay + system-prompt directive):

```
joined command line: 9689 bytes
A (pre-fix, 9689B typed): DETECTED claude          # Linux tolerates it — see below
B (fixed transport):      DETECTED claude in 1014ms
   foreground: ["claude", …]                       # exec chained, no `sh`
   leftover spawn scripts: 0
   stopped + tab closed
```

Worth recording: **on Linux the pre-fix transport still works at 9.7 KB** (arm A). An interactive shell at its prompt puts the tty in *raw* mode and does its own line editing, so `MAX_INPUT` bites only where the input queue actually overflows — Darwin's smaller buffer. So this stays a Darwin-visible bug, exactly as reported; the Linux path is unchanged and still fine.

## Two follow-ups in the second commit

**1. Directory squat (blocking review finding — valid).** With the #1875 redirect rolled back (`SHEPHERD_AGENT_TMPDIR=""`) the directory is a fixed `<os.tmpdir()>/spawn` in a world-writable parent, and `mkdir(…, {recursive: true, mode})` accepts a pre-existing directory **without applying the mode**. A local user owning that directory (or a symlink planted on it) could unlink our 0600 script and substitute their own between the write and the pane's `sh` opening it — code execution as the Shepherd user. `wx` doesn't help: it guards only the final component, inside a directory the attacker controls.

Now `lstat`-verified before anything is written — real directory, our uid, no group/other bits — falling back to a private `mkdtemp` directory rather than refusing, so a squatter can't turn it into a spawn-wide DoS either. The fallback is **re-verified per spawn**, never blindly reused: a tmp cleaner removing it would otherwise strand every later spawn on `ENOENT` (caught by a test I wrote for the symlink case).

**2. Abandoned scripts.** The e2e surfaced this: the self-delete only fires when the script *runs*, so a spawn whose `pane run` fails every attempt leaves one behind — a full test-suite run had left four in the agent tmp root, the directory whose inode table Shepherd has exhausted before (#560/#1875). My plan called this negligible; the evidence said otherwise. The next spawn now reaps anything older than an hour (two orders of magnitude above the 30s spawn deadline, so a script still waiting for its pane is never reaped), best-effort and never fatal to a spawn. Verified live: four stale scripts → 0 after one spawn.

Also fixed the two CodeQL `js/indirect-command-line-injection` alerts on the test file — the real-shell tests now type the line at `sh` on **stdin**, which is both taint-free and the faithful reproduction of the transport (a shell reading typed input).

Gates re-run after all of it: lint, `tsc --noEmit`, `bun test ./test` (8002 pass / 0 fail), `fallow audit`.
