### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs-site/src/content/docs/operating.md
+++ b/docs-site/src/content/docs/operating.md
@@ -34,6 +34,18 @@ above) as well as a Tailscale **Service** front (e.g. `svc:shepherd` →
 — a non-Tailscale reverse proxy or custom-DNS name — still needs its hostname
 added to `SHEPHERD_ALLOWED_HOSTS`.
 
+`tailscaled` only accepts serve-config writes from `root` or the user named as its
+`--operator`. On a host where that isn't you, the HUD's own mapping usually
+survives from an earlier root-written setup while **every** live-preview
+registration is refused — so previews stay dark fleet-wide. The **Tailscale** row
+in Settings → Diagnose reports that case as its own warning (it is checked before
+the "is the HUD's port served?" test, precisely because that test would otherwise
+read `ok`). The one-time fix it names:
+
+```bash
+sudo tailscale set --operator=$USER   # then reopen the preview
+```
+
 Access control is layered: the network reach is gated by
 **tailnet membership**, and the app itself is gated by a **single-operator
 password**. The password is exchanged for an HMAC-signed session cookie that

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -87,6 +87,12 @@ the sweep's `/proc/<pid>/environ` reads near zero, **not** a safety floor.
 | `SHEPHERD_REAP_RUNAWAY_MIN_CPU` | `0.8` | CPU prefilter: fraction of one core, averaged over the process's whole lifetime, a candidate must have burned before it can be reaped. Clamped to `0.05`–`1` (a set-but-empty value clamps rather than dropping the gate) |
 | `SHEPHERD_REAP_RUNAWAY_MIN_AGE_S` | `300` | Minimum process age (seconds) before a candidate can be reaped — the floor that keeps a freshly restored session's briefly-archived row from being reaped. Clamped to a hard `60`s minimum (up to 24h) |
 
+## Critic deadline
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `SHEPHERD_REVIEW_TIMEOUT_MS` | `600000` (10 min) | Hard deadline for a single critic run (session critic **and** standalone PR critic): how long to wait for the verdict file before giving up and finalizing an `error` verdict. Clamped to `60000`–`3600000`. Env-only (deliberately not a UI knob) — raise it for a repo whose PRs genuinely outgrow the default, since the critic restarts from scratch on every retry and would otherwise die at the same wall each time |
+
 ## Main agent terminal renderer (research preview)
 
 Every spawned `claude` runs on Claude Code's **classic** renderer by default —

--- a/docs-site/src/content/docs/reference/glossary.md
+++ b/docs-site/src/content/docs/reference/glossary.md
@@ -27,6 +27,18 @@ large body of work split into smaller stories.)
 Shepherd's isolated, read-only review agent that inspects a PR's diff once CI is
 green and posts a verdict.
 
+### Plan gate
+
+A pre-execution checkpoint: the agent first researches the task and writes an
+implementation plan, which is adversarially reviewed and must be approved before
+any product code is written.
+
+### Autopilot
+
+Best-effort automation that drives a task autonomously through to an open pull
+request. Switched off, each step stays with the operator to discuss, iterate and
+approve; the per-task toggle overrides the repo's standing Autopilot default.
+
 ### Merge train
 
 Shepherd's queue that carries a ready PR through rebase and merge automatically,
@@ -79,6 +91,22 @@ An automated LLM pass Shepherd spawns alongside the main task agent — critic /
 PR-review, plan-gate, recap, rundown, or doc-agent. Its token spend is real
 overhead attributed back to the task, on top of the agent's own authoring.
 
+### Host capacity
+
+Whether Shepherd's systemd service (or its slice) sets a memory or CPU ceiling —
+`MemoryHigh`, `MemoryMax`, or `CPUQuota`. Without one, a burst of concurrent
+sessions can consume all the host's RAM or CPU and starve the box; the
+Diagnostics check warns until a limit is set (see
+[Operating Shepherd](/operating/#host-tuning--resource-guardrails)).
+
+### herdr runtime hygiene
+
+Shepherd reconciles herdr's panes and processes against its own session model to
+spot leftovers. It counts panes with live leftover processes — not systemd's
+"Tasks" figure for the herdr service, which counts threads (each agent process
+spawns many), so a Tasks count in the thousands is normal and not by itself a
+process leak.
+
 ## Industry terms
 
 ### PR
@@ -90,6 +118,13 @@ into a branch. ([Wikipedia](https://en.wikipedia.org/wiki/Distributed_version_co
 
 Continuous integration — automatically building and testing every change so
 problems surface early. ([Wikipedia](https://en.wikipedia.org/wiki/Continuous_integration))
+
+### Inode
+
+A filesystem's record for one file or directory. A filesystem has a limited
+number of them, set when it is created — so it can run out of inodes while still
+having free space, and every new file then fails as though the disk were full.
+([Wikipedia](https://en.wikipedia.org/wiki/Inode))
 
 ### Telemetry
 


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc update — sync to recent source changes

## Changes

- **`docs-site/src/content/docs/reference/glossary.md`** — added the five terms that exist in
  the glossary registry (`ui/src/lib/glossary.ts` + `ui/messages/en.json`) but were missing
  from this page, which claims to be the full reference for the same definitions:
  **Plan gate** and **Autopilot** (`gloss_plan_gate_*`, `gloss_autopilot_*`), **Host capacity**
  (`gloss_host_capacity_*`, added in 5157a445), **herdr runtime hygiene**
  (`gloss_herdr_hygiene_*`, added in 78dc7ec0), and **Inode** (`gloss_inode_*`, added in
  2f864a2e). Wording follows the registry definitions; Host capacity links to the existing
  resource-guardrails section of Operating Shepherd.

- **`docs-site/src/content/docs/operating.md`** — documented the new Tailscale diagnostic
  state from 36ffdb68 ("report a tailscale serve config Shepherd may not write"): when
  `tailscaled` refuses serve-config writes from a non-root / non-`--operator` user, every
  live-preview registration fails fleet-wide while the HUD's own mapping keeps working. The
  **Tailscale** Diagnose row now warns on this ahead of its served-port check
  (`src/diagnostics.ts` `tailscaleProbe`, `src/tailscale.ts` `isServeConfigDenied`), with the
  one-time `sudo tailscale set --operator=$USER` fix (hint string
  `diagnostics_hint_tailscale_serve_denied`). Noted that reopening a preview is what clears
  it, matching the latch semantics (`TailscaleServeService.denied` is cleared only by a
  successful `register`).

- **`docs-site/src/content/docs/reference/configuration.md`** — added a **Critic deadline**
  section for `SHEPHERD_REVIEW_TIMEOUT_MS` (default `600000` ms, clamped to
  `60000`–`3600000`), introduced in bcbfda10 and read in `src/config.ts` (`reviewTimeoutMs`).
  The source comment marks it explicitly env-only / not UI-configurable, so the configuration
  reference is the only place it can be discovered.

No changes were needed in `docs/external-task-api.md` (already covers
`POST /api/sessions/:id/interrupt` from 780d95e9 and `GET /api/tasks/:key/export` from
f54479fb, and its `codex-pending-1267` marker still matches `src/task-export.ts`),
`docs/sandbox-security.md`, `docs/token-usage-analysis.md` (a dated historical report),
`docs-site/src/content/docs/index.md`, or `docs-site/src/content/docs/getting-started.md`
(the herdr ≥0.7.5 note still matches `HERDR_MIN_VERSION` / the protocol-17 spawn path).

## Uncertain / needs human judgment

- **`configuration.md` is not exhaustive despite its description.** `src/config.ts` reads
  many env vars this page never mentions — the whole per-role matrix
  (`SHEPHERD_CRITIC_*`, `SHEPHERD_PLANNER_*`, `SHEPHERD_RECAP_*`, `SHEPHERD_NAMER_*`,
  `SHEPHERD_DISTILLER_*`, `SHEPHERD_OPTIMIZER_*`, `SHEPHERD_MERGE_SUGGEST_*`,
  `SHEPHERD_RUNDOWN_*`, `SHEPHERD_AUTOPILOT_*`), plus `SHEPHERD_DEFAULT_MODEL`,
  `SHEPHERD_DEFAULT_EFFORT`, `SHEPHERD_DEFAULT_AGENT_PROVIDER`, `SHEPHERD_AUTH_MODE`,
  `SHEPHERD_SANDBOX_EXTRA_HOSTS`, `SHEPHERD_VAPID_*`, `SHEPHERD_REVIEW_CYCLES_CAP`,
  `SHEPHERD_PLAN_REVIEW_CYCLES_CAP`, `SHEPHERD_AUTOMERGE_REBASE_CAP`,
  `SHEPHERD_REDUCED_PUSH_MODE`, and others. Most are UI-configurable fresh-DB seeds, so the
  omission looks deliberate rather than stale — but the page's own framing ("every
  environment variable") disagrees. Deciding which of these should be listed is an editorial
  call I did not make.

- **`index.md` "Start here" list.** It does not link the Capture extension, Keyboard
  shortcuts, or the newer **House rules** page (added to `docs-site/scripts/sync-docs.mjs`
  PAGES in 7350ff64). The list may be a curated subset rather than a full index, so I left it
  alone.

- **`docs/sandbox-security.md` line references.** The prose cites exact line numbers
  (`src/sandbox.ts:436-438`, `:539`, `:564`, `src/service.ts:1879`, `src/autopilot.ts:42-47`,
  …). Several of those files have changed since the note was written, so some anchors are
  likely off by a few lines, but the described behavior still reads as accurate. I did not
  re-verify or renumber each one.

- **Codex transcript coverage.** 0bc0d246 made `GET /api/sessions/:id/activity` read Codex
  rollouts, and its commit message notes task-export's `codex-pending-1267` marker still has
  the Claude-only gap. `docs/external-task-api.md` documents the export marker correctly, but
  it says nothing about `/activity` being provider-aware now; whether that belongs in this
  page is a judgment call I left to a human.