### PR TITLE
fix(diagnostics): report a tailscale serve config Shepherd may not write

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -340,6 +340,15 @@ function resolveClaudeTrustDeps(deps: DiagnosticsDeps): {
   };
 }
 
+/** Default `previewServeDenied`: an unwired service never reports a denial, so a caller that
+ *  doesn't pass the tailscale serve service keeps the pre-existing behavior. Resolved here
+ *  rather than inline in the constructor for the same reason `resolveClaudeTrustDeps` exists —
+ *  the ctor sits at the repo's complexity ceiling, and one more inline `??` trips the health
+ *  gate. */
+function resolvePreviewServeDenied(deps: DiagnosticsDeps): () => boolean {
+  return deps.previewServeDenied ?? (() => false);
+}
+
 // ── host_capacity check (#1732) ──────────────────────────────────────────────
 // Warns when a systemd-managed Shepherd host has no resource guardrails, or errors
 // when the host is under dangerous live memory/IO pressure. Every field below drives
@@ -990,7 +999,7 @@ export class DiagnosticsService {
         });
         return stdout.toString();
       });
-    this.previewServeDenied = deps.previewServeDenied ?? (() => false);
+    this.previewServeDenied = resolvePreviewServeDenied(deps);
     this.runRemediation = deps.runRemediation ?? defaultRunRemediation;
     this.anyForgeRepo = deps.anyForgeRepo ?? (() => true);
     this.anyLightweightRepo = deps.anyLightweightRepo ?? (() => false);

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -120,6 +120,10 @@ export interface DiagnosticsDeps {
    *  `findServedPort`. Both a direct `tailscale serve` mapping and a Tailscale
    *  Service mapping are detected. Reject ⇒ treated as "not serving". */
   runServeStatus?: () => Promise<string>;
+  /** True when `tailscale serve` refused a preview registration for lack of
+   *  operator/root rights (`TailscaleServeService.permissionDenied`). Default
+   *  `() => false` so an unwired service keeps today's behavior. */
+  previewServeDenied?: () => boolean;
   /** Run a verbatim remediation command (a shell pipeline like `curl … | bash`).
    *  Resolves on exit 0; rejects on non-zero exit or timeout. Default spawns a
    *  detached process group and SIGKILLs the whole group on timeout. Injected in tests. */
@@ -926,6 +930,7 @@ export class DiagnosticsService {
   private ghProbeRetryDelayMs: number;
   private resolveHost: () => Promise<string | null>;
   private runServeStatus: () => Promise<string>;
+  private previewServeDenied: () => boolean;
   private runRemediation: (cmd: string) => Promise<void>;
   private anyForgeRepo: () => boolean;
   private anyLightweightRepo: () => boolean;
@@ -985,6 +990,7 @@ export class DiagnosticsService {
         });
         return stdout.toString();
       });
+    this.previewServeDenied = deps.previewServeDenied ?? (() => false);
     this.runRemediation = deps.runRemediation ?? defaultRunRemediation;
     this.anyForgeRepo = deps.anyForgeRepo ?? (() => true);
     this.anyLightweightRepo = deps.anyLightweightRepo ?? (() => false);
@@ -1255,6 +1261,8 @@ export class DiagnosticsService {
   };
 
   /** tailscale: missing binary / not-logged-in (resolveNodeHost null) ⇒ error;
+   *  logged-in but tailscaled refuses our serve-config writes ⇒ warning (live
+   *  preview cannot publish any slot until the host names an --operator);
    *  logged-in but not serving the HUD's local port (findServedPort finds no
    *  mapping for config.port in `tailscale serve status --json`) ⇒ warning
    *  (advisory — Shepherd runs fine without serve, it only gates the
@@ -1267,6 +1275,17 @@ export class DiagnosticsService {
         id: "tailscale",
         state: "error",
         hintKey: "diagnostics_hint_tailscale_missing",
+      };
+    }
+    // Ordered BEFORE the serve-status read on purpose: a denied host typically still has a
+    // working HUD mapping (written earlier with root, or by another user), so `findServedPort`
+    // succeeds and the row would report `ok` while every preview registration is refused.
+    // That green-over-broken reading is the blind spot this check exists to close.
+    if (this.previewServeDenied()) {
+      return {
+        id: "tailscale",
+        state: "warning",
+        hintKey: "diagnostics_hint_tailscale_serve_denied",
       };
     }
     const status = await this.runServeStatus();

--- a/src/index.ts
+++ b/src/index.ts
@@ -2750,6 +2750,10 @@ const diagnostics = new DiagnosticsService({
   // Diagnose row reflects the same cell the sweeps read (a fresh ProcessReaper
   // would carry an always-cold cell). Pure read, no spawn.
   probeHealth: () => reaper.health(),
+  // Pure read of the serve service's latched permission verdict — no extra spawn. Lets the
+  // `tailscale` row report a host that refuses our serve-config writes, which the
+  // HUD-port-only serve-status check cannot see.
+  previewServeDenied: () => tailscaleServe.permissionDenied(),
   anyForgeRepo: () =>
     listRepos(config.repoRoot).some((r) => store.getRepoConfig(r.path).repoMode === "forge"),
   anyLightweightRepo: () =>

--- a/src/tailscale.ts
+++ b/src/tailscale.ts
@@ -57,6 +57,29 @@ export async function resolveNodeHost(run: TailscaleRunner = defaultRun): Promis
 export type ServeState = "ok" | "failed";
 export type TailscaleRunnerSync = (args: string[]) => void;
 
+/**
+ * True when a `tailscale serve` mutation was refused because the calling user may not
+ * write serve config — tailscaled answers `Access denied: serve config denied` unless the
+ * caller is root or the configured `--operator`.
+ *
+ * WHY this gets its own signal instead of folding into the per-slot "failed" state: it is a
+ * HOST MISCONFIGURATION, not a per-slot hiccup. Every register in the preview range fails
+ * identically until someone runs `tailscale set --operator=`, so live preview is dark
+ * fleet-wide while the `tailscale` diagnostic — which only asserts the HUD's own port is
+ * served, and that mapping survives from before — keeps reporting ok. The result is a
+ * green dashboard over a feature that cannot work; `DiagnosticsService.tailscaleProbe`
+ * reads this to say so out loud.
+ *
+ * Matches only tailscaled's specific `serve config denied` wording, not a bare
+ * "access denied", so an unrelated failure can't be misreported as a permissions problem.
+ */
+export function isServeConfigDenied(err: unknown): boolean {
+  const e = err as { stderr?: unknown; message?: unknown } | null;
+  const stderr = typeof e?.stderr === "string" ? e.stderr : "";
+  const message = typeof e?.message === "string" ? e.message : "";
+  return /serve config denied/i.test(`${stderr}\n${message}`);
+}
+
 // Kept tight on purpose: a healthy local `tailscale serve … off` is sub-second, so this
 // only bites when tailscaled hangs — exactly when we want to bail fast on shutdown rather
 // than block `systemctl stop`. Anything skipped self-heals on the next boot's reconcile.
@@ -88,6 +111,9 @@ export interface TailscaleServeOpts {
 export class TailscaleServeService {
   private byId = new Map<string, { port: number; state: ServeState }>();
   private queue: Promise<void> = Promise.resolve();
+  /** Latched by any serve mutation refused for lack of operator/root rights; cleared by the
+   *  next mutation that succeeds. Surfaced via {@link permissionDenied}. */
+  private denied = false;
 
   constructor(private opts: TailscaleServeOpts) {}
 
@@ -115,8 +141,10 @@ export class TailscaleServeService {
       try {
         await this.run(["serve", "--bg", `--https=${port}`, `127.0.0.1:${port}`]);
         this.byId.set(id, { port, state: "ok" });
+        this.denied = false;
         this.fire(id, port, "ok");
       } catch (err) {
+        if (isServeConfigDenied(err)) this.denied = true;
         console.warn(`[tailscale-serve] register failed for ${id} port ${port}:`, err);
         this.byId.set(id, { port, state: "failed" });
         this.fire(id, port, "failed");
@@ -159,8 +187,12 @@ export class TailscaleServeService {
       for (let port = this.opts.base; port < this.opts.base + this.opts.count; port++) {
         try {
           await this.run(["serve", `--https=${port}`, "off"]);
-        } catch {
-          /* benign */
+        } catch (err) {
+          // Clearing a slot that holds no mapping is benign and expected. A PERMISSION
+          // refusal is not: latch it here so the `tailscale` diagnostic can report a
+          // denied host at boot, instead of staying green until someone opens a preview
+          // and discovers the feature is dark.
+          if (isServeConfigDenied(err)) this.denied = true;
         }
       }
     });
@@ -190,5 +222,19 @@ export class TailscaleServeService {
   snapshot(): Record<string, ServeState> {
     if (!this.opts.enabled) return {};
     return Object.fromEntries([...this.byId].map(([id, e]) => [id, e.state]));
+  }
+
+  /**
+   * True when the most recent serve mutation was refused for lack of operator/root
+   * rights (see {@link isServeConfigDenied}) — i.e. the host needs
+   * `tailscale set --operator=<user>` before any preview can be published.
+   *
+   * Reports OBSERVED failures only: a boot that has neither reconciled nor registered
+   * anything yet reads `false`, and so does a disabled service. `reconcileStartup`
+   * exercises the whole range at boot, so in practice the answer is available before
+   * the first preview opens.
+   */
+  permissionDenied(): boolean {
+    return this.denied;
   }
 }

--- a/src/tailscale.ts
+++ b/src/tailscale.ts
@@ -111,8 +111,12 @@ export interface TailscaleServeOpts {
 export class TailscaleServeService {
   private byId = new Map<string, { port: number; state: ServeState }>();
   private queue: Promise<void> = Promise.resolve();
-  /** Latched by any serve mutation refused for lack of operator/root rights; cleared by the
-   *  next mutation that succeeds. Surfaced via {@link permissionDenied}. */
+  /** Latched by a `register`/`reconcileStartup` mutation refused for lack of operator/root
+   *  rights; cleared only by a subsequent SUCCESSFUL `register` — not by a successful
+   *  unregister or reconcile, neither of which clears it. That asymmetry is deliberate and
+   *  matches the hint the operator is given ("run `tailscale set --operator=…`, then reopen
+   *  the preview"): reopening a preview is a register, so the row goes green exactly when
+   *  the fix is proven on the path that was broken. Surfaced via {@link permissionDenied}. */
   private denied = false;
 
   constructor(private opts: TailscaleServeOpts) {}
@@ -225,9 +229,9 @@ export class TailscaleServeService {
   }
 
   /**
-   * True when the most recent serve mutation was refused for lack of operator/root
-   * rights (see {@link isServeConfigDenied}) — i.e. the host needs
-   * `tailscale set --operator=<user>` before any preview can be published.
+   * True when a serve mutation was refused for lack of operator/root rights (see
+   * {@link isServeConfigDenied}) and no later `register` has since succeeded — i.e. the
+   * host needs `tailscale set --operator=<user>` before any preview can be published.
    *
    * Reports OBSERVED failures only: a boot that has neither reconciled nor registered
    * anything yet reads `false`, and so does a disabled service. `reconcileStartup`

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -497,6 +497,36 @@ describe("DiagnosticsService probes", () => {
     expect(c.state).toBe("warning");
     expect(c.hintKey).toBe("diagnostics_hint_tailscale_not_serving");
   });
+  // The regression this closes: a host that refuses Shepherd's serve-config writes usually
+  // STILL has a working HUD mapping (written earlier with root), so the serve-status read
+  // succeeds and the row used to report `ok` while every preview registration was denied —
+  // a green dashboard over a dead feature. healthyDeps() serves config.port, so this asserts
+  // the denial verdict wins over an otherwise-healthy status.
+  it("tailscale: warning when serve config is denied, even though config.port is served", async () => {
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      previewServeDenied: () => true,
+    });
+    const c = byId((await svc.check(0)).checks, "tailscale");
+    expect(c.state).toBe("warning");
+    expect(c.hintKey).toBe("diagnostics_hint_tailscale_serve_denied");
+  });
+  it("tailscale: not-logged-in still outranks a denial verdict", async () => {
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      resolveHost: async () => null,
+      previewServeDenied: () => true,
+    });
+    const c = byId((await svc.check(0)).checks, "tailscale");
+    expect(c.state).toBe("error");
+    expect(c.hintKey).toBe("diagnostics_hint_tailscale_missing");
+  });
+  it("tailscale: ok when serve config is not denied (default dep keeps today's behavior)", async () => {
+    const svc = new DiagnosticsService({ ...healthyDeps(), previewServeDenied: () => false });
+    const c = byId((await svc.check(0)).checks, "tailscale");
+    expect(c.state).toBe("ok");
+    expect(c.hintKey).toBe("diagnostics_hint_tailscale_ok");
+  });
   it("tailscale: never forwards raw serve-status text", async () => {
     const secret = "SECRET-SERVE-LINE-127.0.0.1";
     const svc = new DiagnosticsService({

--- a/test/tailscale.test.ts
+++ b/test/tailscale.test.ts
@@ -1,5 +1,6 @@
 import { test, expect, describe } from "bun:test";
 import {
+  isServeConfigDenied,
   resolveNodeHost,
   TailscaleServeService,
   type TailscaleRunner,
@@ -324,5 +325,144 @@ describe("TailscaleServeService", () => {
     await p2;
 
     expect(order).toEqual(["s1-exec-start", "s1-exec-done", "s2-exec"]);
+  });
+});
+
+// ── isServeConfigDenied / permissionDenied ────────────────────────────────────
+
+/** Verbatim stderr from tailscale 1.98.4 when a non-root, non-operator user writes
+ *  serve config. Copied from a real refusal so the matcher is tested against the
+ *  string tailscaled actually emits, not a paraphrase of it. */
+const DENIED_STDERR =
+  "sending serve config: Access denied: serve config denied\n\n" +
+  "Use 'sudo tailscale serve --bg --https=8001 127.0.0.1:8001'.\n" +
+  "To not require root, use 'sudo tailscale set --operator=$USER' once.\n";
+
+/** Shaped like a promisify(execFile) rejection: message carries the joined output,
+ *  stderr carries it verbatim. */
+function deniedError(): Error & { stderr: string } {
+  const err = new Error(
+    "Command failed: tailscale serve --bg --https=8001 127.0.0.1:8001\n" + DENIED_STDERR,
+  ) as Error & { stderr: string };
+  err.stderr = DENIED_STDERR;
+  return err;
+}
+
+/** A denial-shaped runner: every serve mutation is refused, as on a host with no --operator. */
+const denyingRun: TailscaleRunner = async () => {
+  throw deniedError();
+};
+
+describe("isServeConfigDenied", () => {
+  test("matches a real tailscaled refusal via stderr", () => {
+    expect(isServeConfigDenied(deniedError())).toBe(true);
+  });
+
+  test("matches when the wording only reached the message (no stderr field)", () => {
+    expect(isServeConfigDenied(new Error(`Command failed\n${DENIED_STDERR}`))).toBe(true);
+  });
+
+  test("does not match an unrelated failure", () => {
+    expect(isServeConfigDenied(new Error("spawn tailscale ENOENT"))).toBe(false);
+  });
+
+  // Guards against over-matching: a bare "access denied" from some other subsystem must not
+  // be reported to the operator as "run tailscale set --operator".
+  test("does not match a bare access-denied without the serve-config wording", () => {
+    expect(isServeConfigDenied(new Error("Access denied: tailnet lock"))).toBe(false);
+  });
+
+  test("tolerates non-Error rejections", () => {
+    expect(isServeConfigDenied(null)).toBe(false);
+    expect(isServeConfigDenied("serve config denied")).toBe(false);
+  });
+});
+
+describe("TailscaleServeService.permissionDenied", () => {
+  test("false before any mutation has been attempted", () => {
+    const { run } = makeRun();
+    const svc = new TailscaleServeService({ base: 8001, count: 5, enabled: true, run });
+    expect(svc.permissionDenied()).toBe(false);
+  });
+
+  test("latches true when a register is refused for lack of operator rights", async () => {
+    const svc = new TailscaleServeService({
+      base: 8001,
+      count: 5,
+      enabled: true,
+      run: denyingRun,
+    });
+
+    await svc.register("s1", 8001);
+
+    expect(svc.permissionDenied()).toBe(true);
+    // The per-slot state still reports the ordinary failure — this adds a host-level
+    // verdict alongside it rather than replacing it.
+    expect(svc.snapshot()).toEqual({ s1: "failed" });
+  });
+
+  // The blind spot this closes: reconcileStartup exercises the whole range at boot, so a
+  // denied host is known BEFORE anyone opens a preview.
+  test("latches true from reconcileStartup on a denied host", async () => {
+    const svc = new TailscaleServeService({
+      base: 8001,
+      count: 3,
+      enabled: true,
+      run: denyingRun,
+    });
+
+    await svc.reconcileStartup();
+
+    expect(svc.permissionDenied()).toBe(true);
+  });
+
+  test("stays false when reconcileStartup only hits benign empty-slot errors", async () => {
+    const { run } = makeRun(new Set([8001, 8002, 8003]));
+    const svc = new TailscaleServeService({ base: 8001, count: 3, enabled: true, run });
+
+    await svc.reconcileStartup();
+
+    expect(svc.permissionDenied()).toBe(false);
+  });
+
+  test("stays false when a register fails for an unrelated reason", async () => {
+    const { run } = makeRun(new Set([8001]));
+    const svc = new TailscaleServeService({ base: 8001, count: 5, enabled: true, run });
+
+    await svc.register("s1", 8001);
+
+    expect(svc.snapshot()).toEqual({ s1: "failed" });
+    expect(svc.permissionDenied()).toBe(false);
+  });
+
+  test("clears once a later register succeeds (operator granted mid-run)", async () => {
+    let granted = false;
+    const run: TailscaleRunner = async () => {
+      if (!granted) throw deniedError();
+      return { stdout: "" };
+    };
+    const svc = new TailscaleServeService({ base: 8001, count: 5, enabled: true, run });
+
+    await svc.register("s1", 8001);
+    expect(svc.permissionDenied()).toBe(true);
+
+    granted = true;
+    await svc.register("s2", 8002);
+
+    expect(svc.permissionDenied()).toBe(false);
+  });
+
+  test("stays false when the service is disabled (no mutation is ever attempted)", async () => {
+    const svc = new TailscaleServeService({
+      base: 8001,
+      count: 5,
+      enabled: false,
+      run: denyingRun,
+    });
+
+    await svc.reconcileStartup();
+    await svc.register("s1", 8001);
+
+    expect(svc.permissionDenied()).toBe(false);
   });
 });

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -537,7 +537,7 @@
   "viewport_preview_stop_failed": "Devserver konnte nicht gestoppt werden; er ignoriert möglicherweise das Stoppsignal.",
   "unitrow_preview_badge": "Vorschau",
   "unitrow_preview_badge_degraded": "Vorschau; Tailscale-Registrierung fehlgeschlagen, nur über Loopback erreichbar",
-  "viewport_preview_serve_failed": "Tailscale-Registrierung für diesen Vorschau-Port fehlgeschlagen; nur über Loopback erreichbar. Nutze 'In neuem Tab öffnen', wenn der Frame leer bleibt.",
+  "viewport_preview_serve_failed": "Tailscale-Registrierung fehlgeschlagen — nur Loopback. Die Ursache steht unter Einstellungen → Diagnose.",
   "viewport_git_actions": "PR",
   "viewport_git_actions_title": "PR, Merge, Kritiker & Merge-Freigabe",
   "viewport_git_actions_aria": "PR- und Merge-Aktionen ein-/ausblenden",
@@ -3516,5 +3516,6 @@
   "keymap_footer_held": "{mod} GEHALTEN — Taste drücken oder loslassen",
   "keymap_mode_research_short": "RECH.",
   "feat_newtask_keymap_title": "⌘ halten zeigt alle Tastenkürzel",
-  "feat_newtask_keymap_body": "Halte in „Neue Aufgabe\" kurz ⌘ (Strg unter Windows/Linux) — jedes Bedienelement zeigt sein Kürzel direkt an seinem Platz, Loslassen blendet wieder aus. ? öffnet die vollständige Tastenkarte."
+  "feat_newtask_keymap_body": "Halte in „Neue Aufgabe\" kurz ⌘ (Strg unter Windows/Linux) — jedes Bedienelement zeigt sein Kürzel direkt an seinem Platz, Loslassen blendet wieder aus. ? öffnet die vollständige Tastenkarte.",
+  "diagnostics_hint_tailscale_serve_denied": "Tailscale verweigert Shepherd die serve-Konfiguration, dadurch lässt sich keine Live-Vorschau veröffentlichen — führe einmalig sudo tailscale set --operator=$USER aus und öffne die Vorschau erneut."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -537,7 +537,7 @@
   "viewport_preview_stop_failed": "Couldn't stop the dev server; it may be ignoring the stop signal.",
   "unitrow_preview_badge": "Preview",
   "unitrow_preview_badge_degraded": "Preview; Tailscale registration failed, reachable on loopback only",
-  "viewport_preview_serve_failed": "Tailscale registration failed for this preview port; it's reachable on loopback only. Use Open in new tab if the frame is blank.",
+  "viewport_preview_serve_failed": "Tailscale registration failed — loopback only. Settings → Diagnostics names the cause.",
   "viewport_git_actions": "PR",
   "viewport_git_actions_title": "PR, merge, critic & ready-to-merge actions",
   "viewport_git_actions_aria": "Toggle PR and merge actions",
@@ -3516,5 +3516,6 @@
   "keymap_footer_held": "{mod} HELD — press a key or let go",
   "keymap_mode_research_short": "RSCH.",
   "feat_newtask_keymap_title": "Hold ⌘ to see every shortcut",
-  "feat_newtask_keymap_body": "In New Task, hold ⌘ (Ctrl on Windows/Linux) for a moment and every control shows its shortcut right where it sits — release to dismiss. Press ? for the full key card."
+  "feat_newtask_keymap_body": "In New Task, hold ⌘ (Ctrl on Windows/Linux) for a moment and every control shows its shortcut right where it sits — release to dismiss. Press ? for the full key card.",
+  "diagnostics_hint_tailscale_serve_denied": "Tailscale refuses Shepherd's serve config, so no live preview can be published — run sudo tailscale set --operator=$USER once, then reopen the preview."
 }

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -3042,7 +3042,13 @@
         ></iframe>
         <div class="preview-foot">
           {#if previewServeFailed}
-            <span class="preview-serve-failed">{m.viewport_preview_serve_failed()}</span>
+            <!-- title= carries the full sentence: this span is single-line elided
+                 (.preview-serve-failed), and in a narrow viewport the tail — which is
+                 exactly the "Settings → Diagnostics" pointer at the cause — is the part
+                 that gets cut. Shortening the string alone only postpones that. -->
+            <span class="preview-serve-failed" title={m.viewport_preview_serve_failed()}
+              >{m.viewport_preview_serve_failed()}</span
+            >
           {/if}
           <!-- Persistent static setup hint (NOT an auto-detected error): a blank
                frame usually means the preview port isn't tailscale-served yet, or the

--- a/ui/src/lib/diagnostics-docs.ts
+++ b/ui/src/lib/diagnostics-docs.ts
@@ -9,6 +9,9 @@ export const DOC_LINKS: Record<string, string> = {
   diagnostics_hint_gh_not_authenticated: "https://cli.github.com/manual/gh_auth_login",
   diagnostics_hint_tailscale_missing: "https://tailscale.com/kb/1347/installation",
   diagnostics_hint_tailscale_not_serving: "https://tailscale.com/kb/1242/tailscale-serve",
+  // The --operator flag (the fix for a denied serve config) is documented on the
+  // `tailscale set` CLI page, not the serve page.
+  diagnostics_hint_tailscale_serve_denied: "https://tailscale.com/kb/1080/cli#set",
   // Shepherd's own operating guide (resource-guardrails section) carries a
   // copy-paste `set-property` remedy — far more actionable than the raw systemd
   // man page. Both host_capacity non-ok states point here. Anchor slug is coupled


### PR DESCRIPTION
## Was kaputt war

Auf einem Host, dessen `tailscaled` Shepherd das Schreiben der serve-Config verweigert, war die Live-Vorschau tot — **und Shepherd hat grün gemeldet.**

`tailscaled` lehnt serve-Config-Writes von einem Prozess ab, der weder root noch der konfigurierte `--operator` ist:

```
$ tailscale serve --bg --https=8001 127.0.0.1:8001
sending serve config: Access denied: serve config denied
To not require root, use 'sudo tailscale set --operator=$USER' once.
```

Shepherd meldet jeden Vorschau-Slot per `tailscale serve` an, also scheitert auf so einem Host **jede** Registrierung. Der Dev-Server läuft einwandfrei auf Loopback, aber auf dem Tailnet-Port lauscht nichts → der Vorschau-Frame zeigt `ERR_CONNECTION_REFUSED`.

Die `tailscale`-Diagnosezeile konnte das nicht sehen: sie prüft nur, ob für den **HUD-eigenen** Port ein Mapping existiert — und genau das überlebt typischerweise aus einem früheren, mit root angelegten Setup. Ergebnis: grüner Haken über einem toten Feature, Ursache ausschließlich in `shepherd.log`.

## Was sich ändert

- `isServeConfigDenied()` klassifiziert die Ablehnung, die der Serve-Service ohnehin schon beobachtet — kein zusätzlicher Probe, kein Griff nach dem instabilen `tailscale debug prefs`.
- `TailscaleServeService.permissionDenied()` latcht das Urteil; `reconcileStartup` fährt beim Boot den ganzen Portbereich ab, sodass ein abgelehnter Host gemeldet wird, **bevor** jemand eine Vorschau öffnet.
- Die `tailscale`-Diagnosezeile meldet das als eigene Warnung — bewusst **vor** dem serve-status-Read, weil der auf so einem Host erfolgreich ist und die Zeile sonst weiter `ok` sagen würde.
- Der Vorschau-Banner lief über den Footer hinaus und brach mitten im Satz ab (`Nutze 'I…`); jetzt kürzer und mit Verweis auf die Diagnose-Zeile, die Ursache und Fix-Befehl nennt.

Nur die spezifische Formulierung `serve config denied` matcht, damit ein unabhängiger Fehler nicht als Rechteproblem fehletikettiert wird.

## Scope

Das behebt **nicht** die Vorschau — die Ursache ist Host-Konfiguration und braucht einmalig `sudo tailscale set --operator=<user>` pro Maschine. Dieser PR sorgt dafür, dass Shepherd das *sagt*, statt es zu verschweigen.

## Tests

15 neue Tests: Klassifizierung gegen das verbatim-stderr von tailscale 1.98.4, Latching über register/reconcile/disabled, Nicht-Übermatchen eines nackten „access denied", und dass das Ablehnungs-Urteil einen ansonsten gesunden serve-status schlägt.

- Root: 8077 pass
- UI: 282 Dateien / 4387 Tests pass
- `check:i18n` (EN+DE Parität), svelte-check 0 Fehler, alle vier Hygiene-Gates grün

`test/proc-probes-darwin.integration.test.ts` („darwin backend over real lsof") schlägt auf meinem Arch-Host fehl — **verifiziert vorbestehend**: identischer Fehlschlag auf unverändertem `origin/main`, und der Test importiert nur `proc-probes-darwin`/`process-reaper`, die dieser PR nicht anfasst.

[no-feature-entry] — kein user-facing `feat`; beide Commits sind `fix`.