### PR TITLE
fix(test): skip darwin lsof probe test when lsof is absent

### DIFF
--- a/test/has-executable.test.ts
+++ b/test/has-executable.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Unit tests for the PATH probe backing test skip-gates (test/has-executable.ts).
+ *
+ * Deliberately driven against the REAL `spawnSync`, never a stub: the bug this
+ * guards (#1977) WAS a wrong assumption about the real runtime's return shape,
+ * so a mocked spawn would have reproduced it just as happily.
+ */
+
+import { test, expect } from "bun:test";
+import { hasExecutable } from "./has-executable";
+
+test("false when the binary is absent from PATH", () => {
+  // The regression case: under Bun a missing binary yields `status: undefined`
+  // (Node: `null`), so a `status !== null` guard would return true here.
+  expect(hasExecutable("shepherd-no-such-binary-1977")).toBe(false);
+});
+
+test("true for a binary that exists", () => {
+  // POSIX guarantees `sh` on every host this suite runs on (Linux CI, macOS CI,
+  // contributor boxes). `stdio: "ignore"` gives it /dev/null on stdin, so `sh -v`
+  // reads EOF and exits instead of blocking.
+  expect(hasExecutable("sh")).toBe(true);
+});

--- a/test/has-executable.ts
+++ b/test/has-executable.ts
@@ -1,0 +1,29 @@
+/**
+ * Runtime-agnostic "is this binary on PATH?" probe for test skip-gates.
+ *
+ * Exists because the obvious spelling is a footgun. Node signals a failed spawn
+ * with `status: null`, so a guard written as `spawnSync(bin, …).status !== null`
+ * reads correctly — under Node. Bun leaves `status` **undefined** on ENOENT, so
+ * that same guard fails OPEN: it reports the binary as present and the gated
+ * suite runs anyway (#1977). CI never caught it because CI runners have the
+ * binaries; it only bites contributors on a host that doesn't.
+ */
+
+import { spawnSync } from "node:child_process";
+
+/**
+ * True iff `bin` resolves on PATH and is executable.
+ *
+ * Checks `error` (set to an ENOENT — or EACCES for a present-but-not-executable
+ * file — `Error` in BOTH runtimes) and treats `status` as non-null only via
+ * `!= null`, which covers Bun's `undefined` alongside Node's `null`.
+ *
+ * The probe argv is a fixed `-v` purely to give the process something harmless
+ * to do; the **exit code is deliberately not inspected**. `status != null` only
+ * asserts "the process actually ran", so this stays honest for binaries whose
+ * `-v` means something other than "print version" or exits non-zero.
+ */
+export function hasExecutable(bin: string): boolean {
+  const probe = spawnSync(bin, ["-v"], { stdio: "ignore" });
+  return !probe.error && probe.status != null;
+}

--- a/test/proc-probes-darwin.integration.test.ts
+++ b/test/proc-probes-darwin.integration.test.ts
@@ -1,10 +1,11 @@
 import { test, expect } from "bun:test";
-import { spawnSync, spawn, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { makeDarwinProbes } from "../src/proc-probes-darwin";
 import { scanListeningPortsByWorktree } from "../src/process-reaper";
+import { hasExecutable } from "./has-executable";
 
 // This test constructs the darwin backend EXPLICITLY and drives it against REAL
 // `lsof`, so it exercises the parser + cell + cwd↔port JOIN on the existing Linux
@@ -13,8 +14,10 @@ import { scanListeningPortsByWorktree } from "../src/process-reaper";
 // invocation), which is the actual residual risk across lsof vintages, not mere
 // parseability.
 
-const hasLsof = spawnSync("lsof", ["-v"], { stdio: "ignore" }).status !== null;
-const maybe = hasLsof ? test : test.skip;
+// `lsof` is not universally installed (e.g. a stock Arch box), so gate on it —
+// via the shared probe, NOT an inline `spawnSync(…).status !== null`, which fails
+// OPEN under Bun and made this suite run (and fail) without lsof (#1977).
+const maybe = hasExecutable("lsof") ? test : test.skip;
 
 /** Spawn a child that chdirs into `dir` and binds a listening TCP socket on an
  *  ephemeral loopback port, printing `PORT <n>`. Resolves once the port is known. */


### PR DESCRIPTION
Closes #1977

## Problem

`test/proc-probes-darwin.integration.test.ts` gates itself on `lsof` being installed, but the guard assumed Node's ENOENT sentinel:

```ts
const hasLsof = spawnSync("lsof", ["-v"], { stdio: "ignore" }).status !== null;
```

Bun leaves `status` **undefined** on ENOENT, so the guard **fails open** — it reports `lsof` as present, the darwin-only case runs, and the whole 8000-test `root-tests` lane reports `1 fail`, rejecting `git push` for a reason unrelated to whatever is being pushed. Invisible in CI, because the runners have `lsof`; it only bites contributors on a box without it (e.g. a stock Arch install).

Verified in-worktree rather than taken on faith:

```
$ bun -e '… spawnSync("definitely-not-a-real-binary-xyz", ["-v"], {stdio:"ignore"}) …'
status: undefined   error.code: ENOENT   status !== null: true   ← fails open
```

## Fix

Extract `hasExecutable(bin)` into `test/has-executable.ts`, checking `!r.error && r.status != null` — `error` is set to an ENOENT (or EACCES) `Error` in **both** runtimes, and `!= null` covers Bun's `undefined` alongside Node's `null`.

**Why a helper rather than the one-line inline fix.** CI runners have `lsof`, which is exactly why this shipped green — an inline top-level `const` is unreachable from any test, so CI could never catch a regression of it. `hasExecutable("<missing>") === false` is deterministic on every host, so the invariant becomes CI-enforceable. Follows the existing `test/egress-runner-gate.ts` + `.test.ts` precedent. The unit test drives the **real** `spawnSync`, never a stub: the bug *was* a wrong assumption about the real runtime's return shape, so a mock would have reproduced it just as happily.

| Case | Bun `status` | `error` | Old guard | New guard |
| --- | --- | --- | --- | --- |
| lsof present | `0` | — | true (run) ✅ | true (run) ✅ |
| lsof missing | `undefined` | ENOENT | true (run) ❌ **fails** | false (skip) ✅ |
| present, not executable | `undefined` | EACCES | true (run) ❌ | false (skip) ✅ |
| missing, under Node | `null` | ENOENT | false (skip) ✅ | false (skip) ✅ |

## Scope

A grep over `test/ src/ scripts/` finds exactly one `.status !== null` — this one. The sibling guards already fail *closed* and are untouched: `egress-runner.test.ts` probes via `command -v` in a shell (missing tool → status 1) and checks `unshare` with `status === 0` (`undefined === 0` is false); `proc-probes-darwin.macos.test.ts` gates on `process.platform`, not a subprocess.

Behaviour is a plain skip on every host — no CI-specific hard failure — matching how the existing macOS/egress gates behave.

## Verification

Reproduced the reported failure first, under a PATH containing only `bun/node/sh/bash/git/env`:

- **before** — `0 pass, 1 fail`, with `[proc-probes-darwin] lsof refresh failed: Executable not found in $PATH: "lsof"`
- **after** — `0 pass, 1 skip, 0 fail` ✅

Plus, guarding against over-correcting into a permanent skip:

- normal PATH (this box has `/usr/bin/lsof`): the suite still **runs and passes** — `1 pass, 0 skip` ✅
- `bun test ./test/has-executable.test.ts` → 2 pass ✅
- `bun test ./test` (full root lane) → **8064 pass, 13 skip, 0 fail** ✅
- `bun run lint`, `bunx tsc --noEmit`, prettier → clean ✅
- `bunx fallow audit --base origin/main --fail-on-issues` → no issues in 3 changed files ✅
- pre-push hook → all 7 lanes green ✅

[no-feature-entry] — test-only `fix`, ships no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)