### PR TITLE
fix(plugin-ui): stop password managers autofilling plugin inputs

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -392,6 +392,14 @@ Contract details worth knowing before you build a panel:
   yours to validate in the route handler; the host does not clamp.
 - **`secret` masks, it does not protect.** The value still travels as plaintext JSON to your
   route (as does everything else); it only keeps a token off the screen.
+- **Autofill is off on every input node, and you need do nothing to get it.** A panel is a
+  configuration surface, so the host renders each control with `autocomplete` disabled, a
+  meaningless `name` (the value you receive is still keyed on the `name` you declared — the
+  rendered one is decorative), and the opt-out attributes 1Password, Bitwarden, LastPass,
+  Dashlane and Proton Pass honour. Without this a `secret` field beside a plain one looks
+  exactly like a sign-in form, and a manager fills the plain field with a stored **username** —
+  which is how an `npub` once landed in a field meant to hold an environment variable's name.
+  Do not try to re-implement this from plugin side; you cannot set attributes on host controls.
 - **`label` is verbatim plugin data**, never an i18n key. Omit it and the field's `name` becomes
   its accessible name.
 

--- a/ui/src/lib/plugin-ui/PuiCheckbox.svelte
+++ b/ui/src/lib/plugin-ui/PuiCheckbox.svelte
@@ -1,10 +1,17 @@
 <script lang="ts">
   // `checkbox` node (issue #1961): a boolean toggle contributing a named value to a
   // `submit: true` action-button's body. `label` is verbatim plugin DATA (never i18n).
+  //
+  // Carries the autofill guard's `name` + vendor opt-outs but NO `autocomplete` (issue #1978):
+  // the attribute does not apply to `type="checkbox"`, and a manager that toggles a
+  // "remember me" box is answering to the opt-outs, not to `autocomplete`.
   import type { PluginUINode } from "$lib/types";
+  import { noAutofill } from "./autofill";
   import { pluginField } from "./field.svelte";
 
   let { node }: { node: PluginUINode } = $props();
+
+  const guard = noAutofill();
 
   const p = $derived(node.props ?? {});
   const name = $derived(typeof p.name === "string" ? p.name : "");
@@ -19,6 +26,7 @@
 <label class="pui-check">
   <input
     class="pui-box"
+    {...guard}
     type="checkbox"
     aria-label={label ? null : name || null}
     checked={field.value}

--- a/ui/src/lib/plugin-ui/PuiFormInputs.browser.test.ts
+++ b/ui/src/lib/plugin-ui/PuiFormInputs.browser.test.ts
@@ -210,6 +210,84 @@ describe("plugin-ui input nodes", () => {
   });
 });
 
+describe("plugin-ui autofill guard", () => {
+  // Issue #1978. What is verifiable here is the RENDERED CONTRACT — the attributes are present
+  // and correct. Reproducing the original fill would need a real password manager holding a
+  // saved credential for the origin, which this harness does not have, so these tests assert
+  // the guard is in place rather than that a filler was defeated.
+  beforeEach(() => {
+    mockFetch();
+  });
+
+  const OPT_OUTS: [string, string][] = [
+    ["data-1p-ignore", ""],
+    ["data-bwignore", ""],
+    ["data-lpignore", "true"],
+    ["data-form-type", "other"],
+    ["data-protonpass-ignore", ""],
+  ];
+
+  /** Every rendered control — the checkbox wears `.pui-box`, not `.pui-input`. */
+  function controls(container: HTMLElement) {
+    return [...container.querySelectorAll<HTMLInputElement | HTMLSelectElement>("input, select")];
+  }
+
+  /** One of each node type, in this DOM order: plain, secret, select, checkbox, number. */
+  function everyNodeType() {
+    return renderForm([
+      { type: "text-input", props: { name: "relayUrl" } },
+      { type: "text-input", props: { name: "token", secret: true } },
+      { type: "select", props: { name: "verbosity", options: [{ value: "quiet" }] } },
+      { type: "checkbox", props: { name: "relayEvents" } },
+      { type: "number", props: { name: "retries" } },
+    ]);
+  }
+
+  it("puts a non-guessable name and every vendor opt-out on all four node types", async () => {
+    const { container } = await everyNodeType();
+    const all = controls(container);
+    expect(all).toHaveLength(5);
+
+    for (const el of all) {
+      expect(el.getAttribute("name")).toMatch(/^pui-[0-9a-f]{8}$/);
+      for (const [attr, value] of OPT_OUTS) expect(el.getAttribute(attr)).toBe(value);
+    }
+    // Unique per instance — a shared token would let a heuristic correlate the fields again.
+    expect(new Set(all.map((el) => el.getAttribute("name"))).size).toBe(all.length);
+  });
+
+  it("says new-password on the secret field, off on the rest, nothing on the checkbox", async () => {
+    const { container } = await everyNodeType();
+    const [plain, secret, select, checkbox, number] = controls(container);
+
+    // Chromium ignores `off` on a password field by policy; `new-password` is the value it
+    // honours, and denying the sign-in reading is what protects the field NEXT to this one.
+    expect(secret.getAttribute("autocomplete")).toBe("new-password");
+    expect(plain.getAttribute("autocomplete")).toBe("off");
+    expect(select.getAttribute("autocomplete")).toBe("off");
+    expect(number.getAttribute("autocomplete")).toBe("off");
+    // The attribute does not apply to `type="checkbox"` — setting it would be dead markup.
+    expect(checkbox.getAttribute("autocomplete")).toBeNull();
+  });
+
+  it("never renders the plugin's own field name, yet still submits under it", async () => {
+    // The reported shape: a `secret` field beside a plain one whose name is a heuristic magnet.
+    const { container } = await renderForm([
+      { type: "text-input", props: { name: "buzzKey", label: "buzz key", secret: true } },
+      { type: "text-input", props: { name: "keyEnv", label: "key env var", value: "BUZZ_KEY" } },
+    ]);
+
+    const names = controls(container).map((el) => el.getAttribute("name"));
+    expect(names).not.toContain("buzzKey");
+    expect(names).not.toContain("keyEnv");
+
+    // The scrambled DOM name is decorative: the wire key is still the plugin's own `name`.
+    const [key] = controls(container) as HTMLInputElement[];
+    type(key, "nsec1-secret");
+    expect(await save(container)).toEqual({ buzzKey: "nsec1-secret", keyEnv: "BUZZ_KEY" });
+  });
+});
+
 describe("plugin-ui form scope re-seeding", () => {
   beforeEach(() => {
     mockFetch();

--- a/ui/src/lib/plugin-ui/PuiNumberInput.svelte
+++ b/ui/src/lib/plugin-ui/PuiNumberInput.svelte
@@ -9,9 +9,12 @@
   // the operator just typed. Holding the raw TEXT locally and mapping to a number only on the
   // way to the form scope keeps typing intact while still submitting a real JSON number.
   import type { PluginUINode } from "$lib/types";
+  import { noAutofill } from "./autofill";
   import { pluginField } from "./field.svelte";
 
   let { node }: { node: PluginUINode } = $props();
+
+  const guard = noAutofill();
 
   const p = $derived(node.props ?? {});
   const name = $derived(typeof p.name === "string" ? p.name : "");
@@ -37,8 +40,10 @@
   {#if label}<span class="pui-label">{label}</span>{/if}
   <input
     class="pui-input"
+    {...guard}
     type="text"
     inputmode="decimal"
+    autocomplete="off"
     {placeholder}
     aria-label={label ? null : name || null}
     value={field.value}

--- a/ui/src/lib/plugin-ui/PuiSelect.svelte
+++ b/ui/src/lib/plugin-ui/PuiSelect.svelte
@@ -5,10 +5,17 @@
   //
   // The seed is clamped to the offered set: an absent or unknown `value` falls back to the
   // FIRST option, so the value this field submits is always one the plugin itself listed.
+  //
+  // The autofill guard (issue #1978) matters here for a second reason: it also suppresses
+  // browser form-value RESTORATION, which sets a select's DOM value on reload WITHOUT firing
+  // `change` — leaving what the operator sees diverged from what the form scope would submit.
   import type { PluginUINode } from "$lib/types";
+  import { noAutofill } from "./autofill";
   import { pluginField } from "./field.svelte";
 
   let { node }: { node: PluginUINode } = $props();
+
+  const guard = noAutofill();
 
   function isObj(x: unknown): x is Record<string, unknown> {
     return !!x && typeof x === "object" && !Array.isArray(x);
@@ -40,6 +47,8 @@
   {#if label}<span class="pui-label">{label}</span>{/if}
   <select
     class="pui-input"
+    {...guard}
+    autocomplete="off"
     aria-label={label ? null : name || null}
     value={field.value}
     onchange={(e) => field.set(e.currentTarget.value)}

--- a/ui/src/lib/plugin-ui/PuiTextInput.svelte
+++ b/ui/src/lib/plugin-ui/PuiTextInput.svelte
@@ -6,10 +6,20 @@
   // `secret` renders a masked control so an operator can paste a token without it sitting on
   // screen. That is MASKING ONLY: the value still travels as plaintext JSON to the plugin's
   // own route, exactly like every other field.
+  //
+  // `secret` also says `autocomplete="new-password"` rather than `off` (issue #1978). Chromium
+  // ignores `off` on a password field by policy, and the fill this guards against is not on
+  // THIS control — it is the plain text-input beside it. Chrome does not fill a lone text box
+  // with a username; it fills one because a password box next to it made the pair look like a
+  // sign-in form. `new-password` denies that reading, so the neighbour stops being a username
+  // slot. See `autofill.ts` for the rest of the guard.
   import type { PluginUINode } from "$lib/types";
+  import { noAutofill } from "./autofill";
   import { pluginField } from "./field.svelte";
 
   let { node }: { node: PluginUINode } = $props();
+
+  const guard = noAutofill();
 
   const p = $derived(node.props ?? {});
   const name = $derived(typeof p.name === "string" ? p.name : "");
@@ -27,8 +37,9 @@
   {#if label}<span class="pui-label">{label}</span>{/if}
   <input
     class="pui-input"
+    {...guard}
     type={secret ? "password" : "text"}
-    autocomplete={secret ? "off" : null}
+    autocomplete={secret ? "new-password" : "off"}
     {placeholder}
     aria-label={label ? null : name || null}
     value={field.value}

--- a/ui/src/lib/plugin-ui/autofill.ts
+++ b/ui/src/lib/plugin-ui/autofill.ts
@@ -1,0 +1,59 @@
+// Autofill guard for every plugin-ui input node (issue #1978).
+//
+// A plugin panel is a CONFIGURATION surface: none of its fields is ever a credential the
+// browser should remember or replay. Left unguarded, a panel that puts a `secret: true` field
+// next to a plain one reproduces the exact shape a password manager hunts for — a password box
+// plus an adjacent text box — and fills the text box with the stored USERNAME. Observed in
+// buzz-bridge: an `npub1…` (the public half of the very credential whose secret half is the
+// key) landed in `key env var`, a field that holds the NAME of an environment variable, and the
+// plugin's own validator accepted it because an npub satisfies every POSIX name rule.
+//
+// No single lever covers every filler, so the guard is three layers:
+//
+//   1. `autocomplete` — the platform signal. Honoured unevenly, and Chromium ignores it
+//      outright on `type="password"`. Applied by each component, NOT returned here (see below).
+//   2. A non-guessable `name` — these controls used to render with NO name at all, which leaves
+//      a heuristic falling back to the label/placeholder text. A meaningless per-instance token
+//      gives it something stable and inert to latch onto instead.
+//   3. Per-manager opt-out attributes — the only thing 1Password / Bitwarden / LastPass /
+//      Dashlane / Proton Pass actually obey. Each vendor invented its own; there is no standard
+//      and no negotiation, so all five ship together.
+//
+// None of this is a spec guarantee — it is the documented behaviour of the fillers that exist.
+// A manager honouring none of these conventions is not defeated by anything the platform offers.
+
+/** The vendor opt-outs, one per password manager that publishes one. A bare HTML attribute
+ *  serialises as `=""`, so the empty values here are exactly what each vendor documents. */
+const IGNORE = {
+  "data-1p-ignore": "", // 1Password
+  "data-bwignore": "", // Bitwarden
+  "data-lpignore": "true", // LastPass
+  "data-form-type": "other", // Dashlane
+  "data-protonpass-ignore": "", // Proton Pass
+} as const;
+
+/** Attributes that make one plugin-ui control invisible to autofill.
+ *
+ *  Call ONCE per component instance, never inside `$derived`: the generated `name` must stay
+ *  frozen for the control's lifetime, and a plugin re-publishing its panel on a timer would
+ *  otherwise churn it on every render for nothing.
+ *
+ *  The rendered `name` is deliberately DECORATIVE — nothing reads it. The value a control
+ *  submits is keyed on the plugin's own `name` prop through the form scope (see
+ *  `field.svelte.ts`), so scrambling the DOM name costs the submit contract nothing.
+ *
+ *  `autocomplete` is deliberately NOT included. `PuiTextInput` needs `new-password` when the
+ *  field is `secret` and `off` otherwise — and `secret` is reactive, so a re-publish can flip
+ *  it — while `PuiCheckbox` needs none at all, the attribute not applying to `type="checkbox"`.
+ *  Each component states its own.
+ */
+export function noAutofill(): Record<string, string> {
+  // `getRandomValues`, NOT `randomUUID`: the latter is gated to secure contexts, so it is
+  // `undefined` over plain http and would throw here — crashing the whole panel for the sake
+  // of a name nothing reads. This one carries no such restriction, so no fallback branch is
+  // needed for a case that would otherwise be very easy to ship broken.
+  const token = [...crypto.getRandomValues(new Uint8Array(4))]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return { name: `pui-${token}`, ...IGNORE };
+}


### PR DESCRIPTION
Closes #1978

## The bug

`PuiTextInput` set `autocomplete="off"` only when `secret` was true, and no plugin-ui control rendered a `name` at all. A plugin panel that puts a `secret: true` field next to a plain one therefore reproduced the exact shape a password manager hunts for — password box plus adjacent text box — and the plain field got filled with the stored **username**.

Observed in buzz-bridge: an `npub1…` — the public half of the very nostr credential whose secret half is the key — landed in `key env var`, a field that holds the *name* of an environment variable. The plugin's own validator accepted it, because an npub is 63 alphanumerics starting with a letter and satisfies every POSIX variable-name rule. Fixed plugin-side in erwins-enkel/shepherd-buzz-bridge#7; this closes the invitation in the host renderer.

## The fix

Plugin panels are configuration surfaces — none of them ever wants autofill — so the guard is unconditional across all four input nodes rather than keyed on `secret`. Three layers, because no single one covers every filler:

| Control | `autocomplete` | `name` | vendor opt-outs |
| --- | --- | --- | --- |
| text-input (secret) | `new-password` | `pui-<8 hex>` | all five |
| text-input (plain) | `off` | `pui-<8 hex>` | all five |
| select | `off` | `pui-<8 hex>` | all five |
| number | `off` | `pui-<8 hex>` | all five |
| checkbox | — | `pui-<8 hex>` | all five |

Opt-outs are `data-1p-ignore`, `data-bwignore`, `data-lpignore="true"`, `data-form-type="other"`, `data-protonpass-ignore` — one per manager that publishes one. There is no standard, so all five ship together. `data-1p-ignore` was already an established convention in this repo.

Three points worth the reviewer's attention:

**Why `new-password` on the secret field rather than the `off` the issue suggested.** Chromium ignores `autocomplete="off"` on `type="password"` by stated policy, so the attribute the code set there was inert against Chrome. `new-password` is the value Chrome honours — and the point is not protecting the secret. Chrome does not fill a lone text box with a username; it fills one because a password box beside it made the pair read as a sign-in form, which is what turned the neighbour into a username slot. Denying that reading is a second line of defence aimed at exactly the reported field. Accepted cost: Chrome may occasionally offer "Suggest strong password" on a plugin token field — noise, dismissible, not a leak.

**The rendered `name` is deliberately decorative.** The controls had *no* `name`, which leaves a heuristic falling back to label/placeholder text; a meaningless per-instance token gives it something stable and inert instead. Nothing reads it — the submitted value is still keyed on the plugin's own `name` prop through the form scope. A test asserts both halves: no control's DOM `name` is the plugin-authored one, and the POST body is still keyed on it.

**The checkbox takes `name` + opt-outs but no `autocomplete`**, which per spec does not apply to `type="checkbox"`. Managers do toggle "remember me" boxes, so the other two layers still earn their place.

## The `PuiSelect` half of the issue

Treated as prevention-only, matching how the issue itself framed it — a lead, not a finding. `PuiSelect` gets the same guard, which also suppresses browser form-value **restoration**: a genuine way a select's DOM value diverges from the registered one *without* firing `change`, and a plausible mechanism for the reported `defaultChannelId: null`. No speculative submit-time reconcile was built against an undemonstrated bug. **The original `defaultChannelId` observation was not reproduced and is not claimed fixed.**

## Verification

`ui`: 4423 tests pass, `bun run check` clean (0 errors). Root: 8064 tests pass, `lint` + `typecheck` clean. Branch-hygiene, i18n-parity, glossary and feature-catalog gates pass; `fallow audit` reports dead code 0 / complexity 0 (duplication warn-only, and pre-existing — the clone groups are the prop-derivation preamble the four components have always shared).

Two limits stated plainly rather than papered over:

- **Heuristic, not spec.** `new-password` reliably stops the stored-password fill and is the standard way to break sign-in classification, but Chrome also has separate "username-first" flows. This ships on documented behaviour plus review.
- **Not reproducible in CI.** Demonstrating the original fill needs a real password manager holding a saved credential for the origin, which the browser-test harness does not have. The new tests therefore assert the *rendered contract* — the attributes are present and correct — which is the verifiable part.

One self-review catch worth flagging: the first cut used `crypto.randomUUID()`, which is gated to secure contexts and is `undefined` over plain http — it would have thrown at component init and crashed the whole plugin panel for the sake of a name nothing reads. Switched to `crypto.getRandomValues`, which carries no such restriction and needs no fallback branch.

No user-facing strings added (no i18n keys needed). `[no-feature-entry]` — a `fix` that ships no new UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)