### PR TITLE
fix(api): resolve session activity under spawnAccountDir

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2226,8 +2226,13 @@ async function sessionUsageRead(id: string, deps: AppDeps): Promise<Response> {
 async function sessionActivityRead(id: string, deps: AppDeps): Promise<Response> {
   const s = deps.store.get(id);
   if (!s) return json({ error: "not found" }, 404);
-  // pre-feature session (no pinned id) → no transcript to read
-  const path = s.claudeSessionId ? jsonlPathFor(s.worktreePath, s.claudeSessionId) : "";
+  // pre-feature session (no pinned id) → no transcript to read.
+  // spawnAccountDir MUST be passed (#1990): a spawn-account session writes its JSONL under
+  // <account>/projects (see src/usage.ts) — omitting it resolves a nonexistent path, which
+  // sessionActivity() degrades to [], so the Activity tab silently shows nothing.
+  const path = s.claudeSessionId
+    ? jsonlPathFor(s.worktreePath, s.claudeSessionId, s.spawnAccountDir)
+    : "";
   return json(path ? await sessionActivity(path) : []);
 }
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -20,6 +20,7 @@ import { WorktreeMgr } from "../src/worktree";
 import type { GitForge } from "../src/forge/types";
 import { config, USAGE_HISTORY_RETENTION_MS } from "../src/config";
 import { ACTIVE_LABEL } from "../src/drain-core";
+import { dashify } from "../src/usage";
 
 // Create a real tmp dir inside config.repoRoot so validation passes
 let tmpRoot: string;
@@ -512,6 +513,57 @@ test("GET /api/sessions/:id/activity returns [] for a session w/o JSONL", async 
   const res = await app.fetch(new Request(`http://x/api/sessions/${created.id}/activity`));
   expect(res.status).toBe(200);
   expect(await res.json()).toEqual([]);
+});
+
+// #1990: a session spawned into a swap/pool account writes its JSONL under
+// <spawnAccountDir>/projects, so the endpoint MUST resolve through that dir. The fixture is
+// written there and NOWHERE else (config.claudeProjectsDir points at an empty dir), so a
+// non-empty response is reachable through exactly one path — asserting only "entries came
+// back" would fail open, since a missing file degrades to [].
+test("GET /api/sessions/:id/activity resolves the transcript under spawnAccountDir", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  const worktreePath = "/wt-activity";
+  const claudeSessionId = "c0ffee00-0000-4000-8000-000000000099";
+  const accountDir = join(tmpRoot, "swap-account");
+  const emptyProjects = join(tmpRoot, "empty-projects");
+  mkdirSync(emptyProjects, { recursive: true });
+  const transcriptDir = join(accountDir, "projects", dashify(worktreePath));
+  mkdirSync(transcriptDir, { recursive: true });
+  writeFileSync(
+    join(transcriptDir, `${claudeSessionId}.jsonl`),
+    JSON.stringify({
+      type: "assistant",
+      timestamp: "2026-08-01T10:00:00.000Z",
+      message: {
+        role: "assistant",
+        model: "claude-opus-5",
+        content: [
+          { type: "tool_use", id: "tu-1", name: "Edit", input: { file_path: "/a/server.ts" } },
+        ],
+      },
+    }) + "\n",
+  );
+
+  const origProjectsDir = config.claudeProjectsDir;
+  config.claudeProjectsDir = emptyProjects;
+  try {
+    const s = deps.store.create({ ...USAGE_SESSION, worktreePath, claudeSessionId });
+    deps.store.setSpawnIdentity(s.id, "term_u", accountDir);
+
+    const res = await app.fetch(new Request(`http://x/api/sessions/${s.id}/activity`));
+    expect(res.status).toBe(200);
+    expect((await res.json()).map((e: { tool: string }) => e.tool)).toEqual(["Edit"]);
+
+    // Negative control: same worktree + transcript id, but no spawn account → resolves the
+    // server's own (empty) projects dir. Pins the direction — a "search both dirs" read fails.
+    const own = deps.store.create({ ...USAGE_SESSION, worktreePath, claudeSessionId });
+    const ownRes = await app.fetch(new Request(`http://x/api/sessions/${own.id}/activity`));
+    expect(ownRes.status).toBe(200);
+    expect(await ownRes.json()).toEqual([]);
+  } finally {
+    config.claudeProjectsDir = origProjectsDir;
+  }
 });
 
 test("GET /api/sessions/:id/activity 404s for unknown id", async () => {


### PR DESCRIPTION
Fixes #1990.

## The bug

`sessionActivityRead()` in `src/server.ts` called `jsonlPathFor(s.worktreePath, s.claudeSessionId)` — two args. `projectsDirFor()` (`src/usage.ts`) roots a transcript under `<spawnAccountDir>/projects` whenever that column is set (claude-swap points `CLAUDE_CONFIG_DIR` there), so dropping the third argument resolved the server's own projects dir: a path that does not exist for such a session.

`sessionActivity()` degrades a missing file to `[]`, so the failure was silent — no throw, no log, no 5xx. `ActivityFeed.svelte` just rendered an empty tab. Per the issue, 209 of 258 live sessions carry a non-empty `spawnAccountDir`.

Every other consumer already threads the argument (`poller`, `recap`, `process-reaper`, `usage-snapshot`, `usage-breakdown`, `task-export`, `index`) — including `sessionDiffAnnotationsRead()` **immediately below** the broken call, whose comment already named this exact hazard. This one caller was the outlier.

## The fix

One argument, plus a comment recording why it is load-bearing so the next edit doesn't drop it again.

## The test is the real work

The endpoint returns a bare array and fails open, so asserting "entries came back" would pass against the default projects dir whenever a fixture also happens to sit there. The regression test pins the path by construction instead:

- `config.claudeProjectsDir` points at an empty temp dir (restored in `finally`).
- The JSONL fixture is written **only** under `<spawnAccountDir>/projects/<dashified worktree>/<id>.jsonl`, so a non-empty response is reachable through exactly one path on disk.
- Negative control in the same test: an otherwise identical session with `spawnAccountDir` left `NULL` still returns `[]` — that pins the direction, so a hypothetical "search both dirs" read would not pass either.

Confirmed the test binds: it fails against the pre-fix line (`[]` vs `["Edit"]`) and passes after it.

## Scope

Deliberately fix + test only. No warn-log and no DTO reshape to distinguish "no activity yet" from "transcript not found" — the endpoint keeps its fail-open contract and bare-array wire shape.

Not fixed here: `sessionActivityRead()` has no Codex branch, so a Codex session's Activity tab is empty for a *different* reason (its rollout lives outside `~/.claude/projects` and needs `CodexRolloutResolver`, which isn't wired into `AppDeps` for this handler). Pre-existing and distinct from #1990 — filed as a follow-up.

## Verification

`bun test ./test` → 8084 pass / 0 fail · `bun run lint` clean · `bunx tsc --noEmit` clean · `fallow audit --base origin/main` → no issues in the 2 changed files. Server-only change, so no UI half, no i18n keys, no feature-catalog entry (ships as `fix:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)