### PR TITLE
fix(api): read Codex rollouts in GET /api/sessions/:id/activity

### DIFF
--- a/src/codex-activity.ts
+++ b/src/codex-activity.ts
@@ -5,9 +5,14 @@ import { readTranscriptTail, type ActivityEntry } from "./activity";
 import { readActivitySignal, signalFrom, type SessionActivity } from "./activity-signal";
 import { snapshotFrom, type ActivitySnapshot } from "./stall";
 import { codexHome, listRolloutFiles } from "./codex-usage";
-import { readSessionMeta } from "./codex-session-id";
+import {
+  CODEX_ID_SKEW_MS,
+  findCodexRollout,
+  readSessionMeta,
+  type CodexRollout,
+} from "./codex-session-id";
 import { jsonlPathFor, readSessionUsage, type SessionUsage } from "./usage";
-import type { AgentProvider } from "./types";
+import type { AgentProvider, Session } from "./types";
 
 const CMD_MAX = 60;
 const DEFAULT_LIMIT = 30;
@@ -475,6 +480,100 @@ export async function reviewerUsage(
     }
   }
   return readSessionUsage(worktreePath, trackingId);
+}
+
+// ── Task-session transcript locating + reading (issue #1992) ────────────────
+//
+// The reviewer readers above resolve an `exec` spawn's rollout through
+// `CodexRolloutResolver` (unique-cwd, fail-safe). A TASK session is different in kind: it is
+// interactive (`source: "cli"`) and long-lived, so a restore/relaunch writes a NEW rollout under
+// the SAME worktree cwd and the unique-candidate rule would resolve nothing for the rest of the
+// session's life. Task sessions therefore use `findCodexRollout`'s newest-wins rule — the same one
+// `restore()` and the poller's id capture already rely on.
+
+/** How long a proven rollout path is reused before re-deriving. Bounds how long a just-restored
+ *  session can still be read from its PREVIOUS rollout; file CONTENT is re-read on every request
+ *  regardless, so live output is never stale. */
+const ROLLOUT_TTL_MS = 30_000;
+/** Miss backoff: the scan is sync FS work on the single event loop (a full miss reads every
+ *  rollout header), and the Activity tab polls every 5s. Capped well below the reviewer
+ *  resolver's 60s so a just-started session's tab fills within one cap at worst. */
+const ROLLOUT_MISS_BASE_MS = 2_000;
+const ROLLOUT_MISS_CAP_MS = 15_000;
+
+export interface CodexTranscriptLocatorDeps {
+  /** Injected for tests; production is `findCodexRollout` over the real `$CODEX_HOME`. */
+  find: (worktreePath: string, notBeforeMs: number) => CodexRollout | null;
+  now: () => number;
+}
+
+/**
+ * Where a Codex TASK session's rollout lives, with a positive TTL cache and a miss backoff so the
+ * Activity tab's 5s poll can't rescan `$CODEX_HOME` on every request. One instance per app (see
+ * `AppDeps.codexTranscripts`); pure process state, safe to lose on restart.
+ *
+ * NON-ISOLATED sessions always yield null: they run in the shared repo checkout, whose cwd is also
+ * used by sibling sessions, relaunches and the operator's own `codex` runs, so no rollout can be
+ * attributed to one row. `resolveCodexRestoreId` refuses restore for exactly this reason (#1175) —
+ * showing another session's conversation would be worse than showing nothing.
+ */
+export class CodexTranscriptLocator {
+  // Both maps are keyed by session id and hold two words per entry; they grow only with the number
+  // of distinct Codex sessions whose transcript was read since boot, so no eviction is warranted.
+  private hits = new Map<string, { path: string; at: number }>();
+  private misses = new Map<string, { nextAt: number; count: number }>();
+
+  constructor(
+    private deps: CodexTranscriptLocatorDeps = { find: findCodexRollout, now: () => Date.now() },
+  ) {}
+
+  /** The session's rollout path, or null when it is unresolvable (or being backed off). */
+  pathFor(s: Pick<Session, "id" | "worktreePath" | "createdAt" | "isolated">): string | null {
+    if (!s.isolated) return null;
+
+    const now = this.deps.now();
+    const hit = this.hits.get(s.id);
+    if (hit) {
+      if (now - hit.at < ROLLOUT_TTL_MS) return hit.path;
+      this.hits.delete(s.id); // expired → re-derive below (a restore may have moved the rollout)
+    }
+
+    const miss = this.misses.get(s.id);
+    if (miss && now < miss.nextAt) return null;
+
+    const found = this.deps.find(s.worktreePath, s.createdAt - CODEX_ID_SKEW_MS);
+    if (!found) {
+      const count = (miss?.count ?? 0) + 1;
+      const delay = Math.min(ROLLOUT_MISS_BASE_MS * 2 ** (count - 1), ROLLOUT_MISS_CAP_MS);
+      this.misses.set(s.id, { nextAt: now + delay, count });
+      return null;
+    }
+    this.misses.delete(s.id);
+    this.hits.set(s.id, { path: found.path, at: now });
+    return found.path;
+  }
+
+  /** Drop a session's cached resolution + backoff (tests; a caller that knows the rollout moved). */
+  reset(id: string): void {
+    this.hits.delete(id);
+    this.misses.delete(id);
+  }
+}
+
+/** Read + parse one Codex rollout into the same `ActivityEntry[]` the Claude reader produces.
+ *  The Codex peer of `sessionActivity` (`src/activity.ts`): missing/unreadable → [], never throws,
+ *  so a vanished rollout degrades the Activity tab to empty rather than 500ing it. */
+export async function codexSessionActivity(
+  path: string,
+  limit = DEFAULT_LIMIT,
+): Promise<ActivityEntry[]> {
+  try {
+    const file = Bun.file(path);
+    if (!(await file.exists())) return [];
+    return parseCodexActivity(await file.text(), limit);
+  } catch {
+    return [];
+  }
 }
 
 // ── Boot-time usage backfill ────────────────────────────────────────────────

--- a/src/codex-session-id.ts
+++ b/src/codex-session-id.ts
@@ -26,16 +26,34 @@ export interface SessionMetaHeader {
   source: string | null;
 }
 
+/** A resolved interactive rollout: its Codex-native id AND the file it lives in. */
+export interface CodexRollout {
+  id: string;
+  path: string;
+}
+
+/** Generous negative clock-skew allowance when filtering rollout files by mtime against a session's
+ *  `createdAt` — a rollout is written just after spawn, so its mtime is >= createdAt on the same
+ *  machine; this only guards against tiny FS/clock jitter so a legit rollout is never excluded.
+ *  Lives here, with the scan, because every caller's window MUST agree: the id the resume path
+ *  captures and the rollout the transcript readers show have to be the same conversation. */
+export const CODEX_ID_SKEW_MS = 5 * 60_000;
+
 /**
  * The newest interactive (`source === "cli"`) rollout whose recorded cwd equals `worktreePath`,
  * among rollouts modified at/after `notBeforeMs`; null if none. The scan is UNBOUNDED over that
  * mtime window (callers must not cap it) so a busy machine can't push the target rollout out of view.
+ *
+ * "Newest wins" is the right rule for an interactive session precisely because it is long-lived: a
+ * restore/relaunch writes a NEW rollout under the SAME worktree cwd (which is why `restore()`
+ * re-derives instead of trusting the persisted id), so the freshest match is the conversation the
+ * pane is actually running. Callers wanting a rollout id only should use `findCodexSessionId`.
  */
-export function findCodexSessionId(
+export function findCodexRollout(
   worktreePath: string,
   notBeforeMs: number,
   home = codexHome(),
-): string | null {
+): CodexRollout | null {
   const target = normalize(worktreePath);
   // listRolloutFiles is newest-first by mtime, so the first cwd+cli match is the newest one — and the
   // first file older than the window means every remaining file is too: stop rather than scan the tail.
@@ -43,9 +61,18 @@ export function findCodexSessionId(
     if (mtimeMs < notBeforeMs) break;
     const meta = readSessionMeta(path);
     if (!meta || meta.source !== "cli" || !meta.id) continue;
-    if (normalize(meta.cwd) === target) return meta.id;
+    if (normalize(meta.cwd) === target) return { id: meta.id, path };
   }
   return null;
+}
+
+/** {@link findCodexRollout}'s id alone — the resume/seed callers' view. */
+export function findCodexSessionId(
+  worktreePath: string,
+  notBeforeMs: number,
+  home = codexHome(),
+): string | null {
+  return findCodexRollout(worktreePath, notBeforeMs, home)?.id ?? null;
 }
 
 /** Parse line 1 of a rollout jsonl (the `session_meta` record). Tolerant: null on any read/parse

--- a/src/server.ts
+++ b/src/server.ts
@@ -98,6 +98,7 @@ import { computeDiff, toSessionDiff } from "./diff";
 import { buildDiffNotes } from "./diff-annotations";
 import { resolveDiffBase } from "./diff-base";
 import { readSessionUsage, jsonlPathFor, type SessionUsageRollup } from "./usage";
+import { CodexTranscriptLocator, codexSessionActivity } from "./codex-activity";
 import { buildUsageBreakdown } from "./usage-breakdown";
 import { buildUsageTimeline } from "./usage-timeline";
 import { isApiKeyMode } from "./spawn-auth";
@@ -277,6 +278,10 @@ export interface AppDeps {
    *  `index.ts` injects explicit singletons so production shares one instance. */
   learnings?: LearningsService;
   repoConfig?: RepoConfigService;
+  /** Locates a Codex session's rollout for the transcript reads (issue #1992), with the TTL cache
+   *  + miss backoff that keeps the Activity tab's 5s poll off the `$CODEX_HOME` tree. Optional for
+   *  the same reason as the two above — the `codexTranscripts(deps)` accessor lazily builds one. */
+  codexTranscripts?: CodexTranscriptLocator;
   /** Server-side plugin registry (issue #1124); absent → `/api/plugins/*` 404s and the
    *  Settings → Plugins panel stays hidden (the zero-plugin invariant). */
   pluginRegistry?: PluginRegistry;
@@ -666,6 +671,9 @@ function learnings(deps: AppDeps): LearningsService {
 }
 function repoConfigSvc(deps: AppDeps): RepoConfigService {
   return (deps.repoConfig ??= new RepoConfigService(deps.store));
+}
+function codexTranscripts(deps: AppDeps): CodexTranscriptLocator {
+  return (deps.codexTranscripts ??= new CodexTranscriptLocator());
 }
 
 /**
@@ -2226,6 +2234,15 @@ async function sessionUsageRead(id: string, deps: AppDeps): Promise<Response> {
 async function sessionActivityRead(id: string, deps: AppDeps): Promise<Response> {
   const s = deps.store.get(id);
   if (!s) return json({ error: "not found" }, 404);
+  // Provider dispatch (#1992): a Codex session writes no ~/.claude/projects JSONL at all, so
+  // resolving one would yield a path that never exists — which degrades to [] and leaves the
+  // Activity tab silently empty. Its transcript is a rollout under $CODEX_HOME, located by the
+  // session's launch-unique worktree cwd (null for a non-isolated session: the shared checkout
+  // cwd can't be attributed to one row, same stance `restore()` takes — see the locator).
+  if ((s.agentProvider ?? "claude") === "codex") {
+    const rollout = codexTranscripts(deps).pathFor(s);
+    return json(rollout ? await codexSessionActivity(rollout) : []);
+  }
   // pre-feature session (no pinned id) → no transcript to read.
   // spawnAccountDir MUST be passed (#1990): a spawn-account session writes its JSONL under
   // <account>/projects (see src/usage.ts) — omitting it resolves a nonexistent path, which

--- a/src/service.ts
+++ b/src/service.ts
@@ -14,7 +14,7 @@ import {
   visualBlockLanguageLine,
   type OperatorLanguage,
 } from "./operator-language";
-import { findCodexSessionId } from "./codex-session-id";
+import { CODEX_ID_SKEW_MS, findCodexSessionId } from "./codex-session-id";
 import type {
   AgentProvider,
   CreateSessionInput,
@@ -119,11 +119,6 @@ export class RestoreError extends Error {
     this.name = "RestoreError";
   }
 }
-
-/** Generous negative clock-skew allowance when filtering Codex rollout files by mtime against a
- *  session's `createdAt` — a rollout is written just after spawn, so its mtime is >= createdAt on the
- *  same machine; this only guards against tiny FS/clock jitter so a legit rollout is never excluded. */
-const CODEX_ID_SKEW_MS = 5 * 60_000;
 
 /** Thrown by create() when an AUTONOMOUS (auto) spawn is refused because the originating issue's
  *  author is untrusted or its trust cannot be established (fail-closed). The drain's spawn catch

--- a/test/codex-activity.test.ts
+++ b/test/codex-activity.test.ts
@@ -5,6 +5,8 @@ import {
   parseCodexUsage,
   parseCodexActivity,
   readCodexTranscriptSignals,
+  codexSessionActivity,
+  CodexTranscriptLocator,
 } from "../src/codex-activity";
 
 const FIXTURE_PATH = join(import.meta.dir, "fixtures/codex-activity/rollout-role-exec.jsonl");
@@ -128,5 +130,142 @@ describe("readCodexTranscriptSignals", () => {
     const r = readCodexTranscriptSignals(join(import.meta.dir, "fixtures/does-not-exist.jsonl"));
     expect(r.snapshot).toBeNull();
     expect(r.activity).toBeNull();
+  });
+});
+
+describe("codexSessionActivity", () => {
+  test("reads + parses a rollout into the same entries parseCodexActivity yields", async () => {
+    expect(await codexSessionActivity(FIXTURE_PATH, -1)).toEqual(parseCodexActivity(FIXTURE, -1));
+  });
+
+  test("missing file → [] (the Activity tab degrades, never 500s)", async () => {
+    expect(await codexSessionActivity(join(import.meta.dir, "fixtures/nope.jsonl"))).toEqual([]);
+  });
+
+  test("unreadable path (a directory) → [] rather than a throw", async () => {
+    expect(await codexSessionActivity(import.meta.dir)).toEqual([]);
+  });
+});
+
+describe("CodexTranscriptLocator", () => {
+  const SESSION = {
+    id: "sess-1",
+    worktreePath: "/wt/task-1",
+    createdAt: 10_000_000,
+    isolated: true,
+  };
+
+  /** Controllable clock + a spy-able finder — no filesystem in the loop. */
+  function harness(found: { id: string; path: string } | null) {
+    let now = 0;
+    let result = found;
+    const calls: Array<{ worktreePath: string; notBeforeMs: number }> = [];
+    const locator = new CodexTranscriptLocator({
+      now: () => now,
+      find: (worktreePath, notBeforeMs) => {
+        calls.push({ worktreePath, notBeforeMs });
+        return result;
+      },
+    });
+    return {
+      locator,
+      calls,
+      advance: (ms: number) => {
+        now += ms;
+      },
+      setResult: (r: { id: string; path: string } | null) => {
+        result = r;
+      },
+    };
+  }
+
+  const HIT = { id: "roll-a", path: "/codex/rollout-a.jsonl" };
+
+  test("resolves through find() and memoises — the 5s poll does not rescan", () => {
+    const h = harness(HIT);
+    expect(h.locator.pathFor(SESSION)).toBe(HIT.path);
+    h.advance(5_000);
+    expect(h.locator.pathFor(SESSION)).toBe(HIT.path);
+    h.advance(5_000);
+    expect(h.locator.pathFor(SESSION)).toBe(HIT.path);
+    expect(h.calls.length).toBe(1);
+  });
+
+  test("scans with the createdAt mtime floor, minus the clock-skew allowance", () => {
+    const h = harness(HIT);
+    h.locator.pathFor(SESSION);
+    expect(h.calls[0]).toEqual({
+      worktreePath: SESSION.worktreePath,
+      notBeforeMs: SESSION.createdAt - 5 * 60_000,
+    });
+  });
+
+  test("past the TTL it re-derives — a restore's NEW rollout is picked up", () => {
+    const h = harness(HIT);
+    expect(h.locator.pathFor(SESSION)).toBe(HIT.path);
+    const next = { id: "roll-b", path: "/codex/rollout-b.jsonl" };
+    h.setResult(next);
+    h.advance(29_000); // still inside the TTL → stale path, no rescan
+    expect(h.locator.pathFor(SESSION)).toBe(HIT.path);
+    h.advance(2_000); // 31s > TTL
+    expect(h.locator.pathFor(SESSION)).toBe(next.path);
+    expect(h.calls.length).toBe(2);
+  });
+
+  test("misses back off exponentially, capped, and clear on a later hit", () => {
+    const h = harness(null);
+    expect(h.locator.pathFor(SESSION)).toBeNull(); // scan 1 → backoff 2s
+    h.advance(1_000);
+    expect(h.locator.pathFor(SESSION)).toBeNull(); // inside backoff → no scan
+    expect(h.calls.length).toBe(1);
+    h.advance(1_000);
+    expect(h.locator.pathFor(SESSION)).toBeNull(); // scan 2 → backoff 4s
+    expect(h.calls.length).toBe(2);
+
+    // widen past the cap: 8s, 16s→capped 15s, …
+    for (const step of [4_000, 8_000, 15_000, 15_000]) {
+      h.advance(step);
+      expect(h.locator.pathFor(SESSION)).toBeNull();
+    }
+    expect(h.calls.length).toBe(6);
+
+    // a rollout finally appears: the next attempt after the cap resolves and drops the backoff
+    h.setResult(HIT);
+    h.advance(15_000);
+    expect(h.locator.pathFor(SESSION)).toBe(HIT.path);
+    h.setResult(null); // a hit is memoised, so no rescan can undo it inside the TTL
+    h.advance(1_000);
+    expect(h.locator.pathFor(SESSION)).toBe(HIT.path);
+    expect(h.calls.length).toBe(7);
+  });
+
+  test("non-isolated session → null without ever scanning (cwd is unattributable)", () => {
+    const h = harness(HIT);
+    expect(h.locator.pathFor({ ...SESSION, isolated: false })).toBeNull();
+    expect(h.calls.length).toBe(0);
+  });
+
+  test("reset() drops both the memoised hit and the backoff", () => {
+    const h = harness(HIT);
+    expect(h.locator.pathFor(SESSION)).toBe(HIT.path);
+    h.locator.reset(SESSION.id);
+    expect(h.locator.pathFor(SESSION)).toBe(HIT.path);
+    expect(h.calls.length).toBe(2);
+  });
+
+  test("caches per session id — two sessions never share a resolution", () => {
+    const h = harness(HIT);
+    expect(h.locator.pathFor(SESSION)).toBe(HIT.path);
+    const other = {
+      id: "sess-2",
+      worktreePath: "/wt/task-2",
+      createdAt: 20_000_000,
+      isolated: true,
+    };
+    const b = { id: "roll-b", path: "/codex/rollout-b.jsonl" };
+    h.setResult(b);
+    expect(h.locator.pathFor(other)).toBe(b.path);
+    expect(h.locator.pathFor(SESSION)).toBe(HIT.path);
+    expect(h.calls.length).toBe(2);
   });
 });

--- a/test/codex-session-id.test.ts
+++ b/test/codex-session-id.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { findCodexSessionId } from "../src/codex-session-id";
+import { findCodexRollout, findCodexSessionId } from "../src/codex-session-id";
 
 let home: string;
 let sessionsDir: string;
@@ -128,4 +128,26 @@ test("missing CODEX_HOME sessions dir → null (graceful)", () => {
   } finally {
     rmSync(empty, { recursive: true, force: true });
   }
+});
+
+// findCodexRollout is the same scan, surfacing the FILE as well as the id — the transcript
+// readers (issue #1992) need the path, the resume/seed callers only ever wanted the id.
+test("findCodexRollout returns the matching rollout's path alongside its id", () => {
+  writeRollout("rollout-old.jsonl", { session_id: "uuid-old", cwd: CWD, source: "cli" }, 1000);
+  writeRollout("rollout-new.jsonl", { session_id: "uuid-new", cwd: CWD, source: "cli" }, 2000);
+  expect(findCodexRollout(CWD, 0, home)).toEqual({
+    id: "uuid-new",
+    path: join(sessionsDir, "rollout-new.jsonl"),
+  });
+});
+
+test("findCodexSessionId is exactly findCodexRollout's id (no divergence)", () => {
+  writeRollout("rollout-exec.jsonl", { session_id: "uuid-exec", cwd: CWD, source: "exec" }, 3000);
+  writeRollout("rollout-cli.jsonl", { session_id: "uuid-cli", cwd: CWD, source: "cli" }, 2000);
+  expect(findCodexSessionId(CWD, 0, home)).toBe(findCodexRollout(CWD, 0, home)!.id);
+});
+
+test("findCodexRollout → null when nothing matches", () => {
+  writeRollout("rollout-other.jsonl", { session_id: "o", cwd: "/nope", source: "cli" }, 1000);
+  expect(findCodexRollout(CWD, 0, home)).toBeNull();
 });

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -8,6 +8,7 @@ import {
   statSync,
   readFileSync,
   writeFileSync,
+  utimesSync,
 } from "node:fs";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
@@ -564,6 +565,148 @@ test("GET /api/sessions/:id/activity resolves the transcript under spawnAccountD
   } finally {
     config.claudeProjectsDir = origProjectsDir;
   }
+});
+
+// ── Codex activity (#1992) ───────────────────────────────────────────────────────────────────
+// A Codex session writes NO ~/.claude/projects JSONL; its transcript is a rollout under
+// $CODEX_HOME, located by the session's launch-unique worktree cwd. Every fixture below is
+// written ONLY there (config.claudeProjectsDir points at an empty dir), so a non-empty body is
+// reachable through exactly one code path — asserting "entries came back" cannot fail open.
+
+const CODEX_WT = "/wt-codex";
+
+interface RolloutSpec {
+  name: string;
+  cwd?: string;
+  source?: string;
+  /** Becomes the entry's `summary`, so each rollout is identifiable in the response. */
+  cmd?: string;
+  /** Seconds; defaults to now (inside the session's createdAt − skew window). */
+  mtimeSec?: number;
+}
+
+/** Seed a temp $CODEX_HOME with rollout jsonl files (session_meta header + one tool call). */
+function seedCodexHome(rollouts: RolloutSpec[]): string {
+  const home = join(tmpRoot, `codex-home-${rollouts.map((r) => r.name).join("-")}`);
+  const sessions = join(home, "sessions");
+  mkdirSync(sessions, { recursive: true });
+  for (const r of rollouts) {
+    const lines = [
+      JSON.stringify({
+        timestamp: "2026-08-01T10:00:00.000Z",
+        type: "session_meta",
+        payload: { session_id: `id-${r.name}`, cwd: r.cwd ?? CODEX_WT, source: r.source ?? "cli" },
+      }),
+      JSON.stringify({
+        timestamp: "2026-08-01T10:00:20.000Z",
+        type: "response_item",
+        payload: {
+          type: "custom_tool_call",
+          call_id: `call-${r.name}`,
+          name: "exec",
+          input: `const r = await tools.exec_command({cmd:${JSON.stringify(r.cmd ?? "echo hi")},workdir:"${CODEX_WT}"});`,
+        },
+      }),
+    ];
+    const path = join(sessions, r.name);
+    writeFileSync(path, lines.join("\n") + "\n");
+    if (r.mtimeSec !== undefined) utimesSync(path, r.mtimeSec, r.mtimeSec);
+  }
+  return home;
+}
+
+/** Run `fn` with $CODEX_HOME seeded and claudeProjectsDir pointed at an empty dir, restoring both. */
+async function withCodexHome(rollouts: RolloutSpec[], fn: () => Promise<void>): Promise<void> {
+  const home = seedCodexHome(rollouts);
+  const emptyProjects = join(tmpRoot, "empty-projects-codex");
+  mkdirSync(emptyProjects, { recursive: true });
+  const prevHome = process.env.CODEX_HOME;
+  const prevProjects = config.claudeProjectsDir;
+  process.env.CODEX_HOME = home;
+  config.claudeProjectsDir = emptyProjects;
+  try {
+    await fn();
+  } finally {
+    if (prevHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prevHome;
+    config.claudeProjectsDir = prevProjects;
+  }
+}
+
+const CODEX_SESSION = {
+  ...USAGE_SESSION,
+  worktreePath: CODEX_WT,
+  agentProvider: "codex" as const,
+  claudeSessionId: "c0ffee00-0000-4000-8000-0000000000c0",
+};
+
+async function activityOf(app: ReturnType<typeof makeApp>, id: string) {
+  const res = await app.fetch(new Request(`http://x/api/sessions/${id}/activity`));
+  expect(res.status).toBe(200);
+  return (await res.json()) as Array<{ tool: string; summary: string }>;
+}
+
+test("GET /api/sessions/:id/activity reads a Codex session's rollout under $CODEX_HOME", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  await withCodexHome([{ name: "rollout-mine.jsonl", cmd: "bun test ./test" }], async () => {
+    const s = deps.store.create(CODEX_SESSION);
+    const entries = await activityOf(app, s.id);
+    expect(entries.map((e) => [e.tool, e.summary])).toEqual([["exec", "$ bun test ./test"]]);
+  });
+});
+
+test("GET /api/sessions/:id/activity: the SAME fixture yields [] for a claude session", async () => {
+  // Negative control pinning the dispatch direction — a reader that tries both providers, or one
+  // that ignores agentProvider, would surface the rollout here.
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  await withCodexHome([{ name: "rollout-mine.jsonl", cmd: "bun test ./test" }], async () => {
+    const s = deps.store.create({ ...CODEX_SESSION, agentProvider: "claude" as const });
+    expect(await activityOf(app, s.id)).toEqual([]);
+  });
+});
+
+test("GET /api/sessions/:id/activity: two cli rollouts share the cwd → the NEWER wins", async () => {
+  // The post-restore shape: a relaunch writes a new rollout under the same worktree cwd. This is
+  // why the read uses findCodexRollout's newest-wins rule and NOT CodexRolloutResolver, whose
+  // unique-candidate rule would resolve nothing here for the rest of the session's life.
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  const nowSec = Math.floor(Date.now() / 1000);
+  await withCodexHome(
+    [
+      { name: "rollout-before-restore.jsonl", cmd: "old run", mtimeSec: nowSec - 120 },
+      { name: "rollout-after-restore.jsonl", cmd: "new run", mtimeSec: nowSec - 10 },
+    ],
+    async () => {
+      const s = deps.store.create(CODEX_SESSION);
+      expect((await activityOf(app, s.id)).map((e) => e.summary)).toEqual(["$ new run"]);
+    },
+  );
+});
+
+test("GET /api/sessions/:id/activity: a non-isolated Codex session yields []", async () => {
+  // Its cwd is the shared repo checkout — also used by siblings, relaunches and the operator's own
+  // codex runs — so no rollout is attributable to this row. restore() refuses for the same reason.
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  await withCodexHome([{ name: "rollout-shared.jsonl", cmd: "someone else" }], async () => {
+    const s = deps.store.create({ ...CODEX_SESSION, isolated: false });
+    expect(await activityOf(app, s.id)).toEqual([]);
+  });
+});
+
+test("GET /api/sessions/:id/activity never adopts a reviewer's (source=exec) rollout", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  await withCodexHome(
+    [{ name: "rollout-reviewer.jsonl", source: "exec", cmd: "critic run" }],
+    async () => {
+      const s = deps.store.create(CODEX_SESSION);
+      expect(await activityOf(app, s.id)).toEqual([]);
+    },
+  );
 });
 
 test("GET /api/sessions/:id/activity 404s for unknown id", async () => {


### PR DESCRIPTION
Closes #1992.

## Problem

`sessionActivityRead()` resolved the transcript with `jsonlPathFor()` unconditionally — always a `~/.claude/projects`-shaped path. A Codex session writes none, so the path never existed, `sessionActivity()` degraded to `[]`, and the Activity tab was **silently empty**. Same user-visible symptom as #1990/#1991, different cause.

## Fix

Dispatch on `s.agentProvider`, the way the sibling `/usage` DTO in the same file already does. Codex reads its rollout under `$CODEX_HOME`.

**Deliberate deviation from the issue's fix sketch.** The issue proposes `CodexRolloutResolver`; that resolver resolves *only on a unique cwd candidate* (`selectCodexRollout` → `c.length === 1`, else `null`). That fail-safe rule is right for its callers — one-shot `source:"exec"` reviewer spawns. A **task** session is `source:"cli"` and long-lived: every restore/relaunch writes a NEW rollout under the SAME worktree cwd (which is why `resolveCodexRestoreId()` re-derives instead of trusting the persisted `providerSessionId`), so ≥2 candidates is the steady state and the resolver would return `null` for the rest of the session's life — bug unfixed. Verified against a real `$CODEX_HOME`: 7 `cli` rollouts sharing one cwd.

So the read uses `findCodexRollout()`'s **newest-wins** rule — the same one `restore()` and the poller's id capture already rely on — extracted from `findCodexSessionId()` so it returns the path as well as the id. `CODEX_ID_SKEW_MS` moves next to that scan (out of `service.ts`) because every caller's mtime window must agree: the id the resume path captures and the rollout the tab shows have to be the same conversation.

**Non-isolated Codex sessions still return `[]`.** Their cwd is the shared repo checkout, also used by sibling sessions, relaunches and the operator's own `codex` runs, so no rollout is attributable to one row. `resolveCodexRestoreId()` refuses restore for exactly this reason (#1175/#1476) — rendering another session's conversation would be worse than rendering nothing.

**`CodexTranscriptLocator`** caches the resolution (30 s TTL) and backs misses off (2 s → 15 s cap). The scan is sync FS work on the single Bun loop and `ActivityFeed.svelte` polls every 5 s; measured over a synthetic 1600-rollout tree: **3.2 ms** warm walk, **33 ms** on a full miss (reads every `session_meta` header). The TTL bounds how long a just-restored session can be read from its previous rollout; file *content* is re-read every request, so live output is never stale. The cap sits well below the reviewer resolver's 60 s so a just-started session's tab fills within one cap at worst.

## Tests

Endpoint tests seed a temp `$CODEX_HOME` with `config.claudeProjectsDir` pointed at an empty dir, so the fixture is reachable through exactly **one** code path — a "non-empty response" assertion alone would fail open, since a missing file degrades to `[]` (the #1991 lesson).

- Codex session resolves its rollout → parsed entries (asserts tool + summary)
- Same fixture, `agentProvider: "claude"` → `[]` — pins the dispatch direction
- **Two `cli` rollouts share the cwd → the newer wins** — the post-restore shape; this is the case the issue's resolver sketch would fail
- Non-isolated Codex → `[]`
- Only cwd match is `source:"exec"` (a reviewer spawn in the same worktree) → `[]`
- Locator unit tests against a fake clock: memoised hit, TTL re-derive, exponential miss backoff + cap + clear-on-hit, per-session isolation, `reset()`
- Claude path unchanged — the #1991 `spawnAccountDir` test and the existing activity tests pass untouched

`bun run lint`, `bunx tsc --noEmit`, `bun test ./test` (8102 pass), and all seven pre-push lanes green.

## Out of scope

The poller's activity signals / heat strip / stall detection, recap, process-reaper, and `/api/tasks/:key/export`'s `codex-pending-1267` marker (#1267) are Claude-only too — same root cause, separate issues. `findCodexRollout()` + the locator make each a small follow-up.

Server-only, no UI surface → `[no-feature-entry]`; no new user-facing strings → no i18n or glossary work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)