### PR TITLE
feat(sessions): per-session interrupt (POST /api/sessions/:id/interrupt)

### DIFF
--- a/docs/external-task-api.md
+++ b/docs/external-task-api.md
@@ -126,6 +126,15 @@ Once a task exists, an external agent can also drive it:
 
 - `POST /api/sessions/:id/reply` — send follow-up text to the live agent
   (`{ "text": "..." }`).
+- `POST /api/sessions/:id/interrupt` — interrupt that one session: a lone ESC to
+  its pane and nothing else (no body). The per-session counterpart to the
+  fleet-wide `POST /api/halt`, and composable with `/reply`, so cancel-then-re-prompt
+  is interrupt → reply. Unlike `/api/halt` it does not skip sessions that aren't
+  currently working (the caller named its target) and it is serialized against
+  other steers, so an interrupt issued before a reply always lands first; a
+  wedged send can therefore delay it, and `/api/halt` stays the un-queued escape
+  hatch. `200 {"ok":true}` when the ESC landed, `404 {"error":"not found"}` for an
+  unknown id, a dead pane, or an undeliverable send.
 - `POST /api/broadcast` — send the same text to many sessions at once.
 - `DELETE /api/sessions/:id` — archive (end) the session.
 - `GET /api/sessions` — list active sessions; `GET /api/sessions/:id/diff`,

--- a/src/server.ts
+++ b/src/server.ts
@@ -2571,6 +2571,19 @@ async function handleSessionReply({ req, parts, deps }: Ctx): Promise<Response |
   return ok ? json({ ok: true }) : json({ error: "not found" }, 404);
 }
 
+// POST /api/sessions/:id/interrupt — interrupt ONE running session: a lone ESC to its pane and
+// nothing else (#1993). The per-session counterpart to the fleet-wide /api/halt, and composable
+// with /reply, so cancel-then-re-prompt is interrupt → reply rather than a combined endpoint.
+async function handleSessionInterrupt({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (!(req.method === "POST" && parts[2] && parts[3] === "interrupt")) return null;
+  // No body — the path id IS the target, so there is nothing to validate (mirrors handleHalt).
+  // interrupt() is non-throwing: unknown id, dead/unlisted pane, unreachable herdr and a rejected
+  // send all resolve false → 404 here, the same shape handleSessionReply uses.
+  return (await deps.service.interrupt(parts[2]))
+    ? json({ ok: true })
+    : json({ error: "not found" }, 404);
+}
+
 // POST /api/sessions/:id/recommend-prompt — analyze the session's recent terminal history via a
 // transient second agent (claude opus / codex gpt-5.5) and return a recommended next prompt.
 // 200 {prompt} on success; 422 {error} on an analysis failure; 503 when unwired.
@@ -3759,6 +3772,7 @@ async function handleSessions(ctx: Ctx): Promise<Response | null> {
     handleSessionWorktree,
     handleSessionDelete,
     handleSessionReply,
+    handleSessionInterrupt,
     handleSessionRecommend,
     handleSessionGo,
     handleSessionAnswerPlanQuestions,

--- a/src/service.ts
+++ b/src/service.ts
@@ -4491,6 +4491,62 @@ export class SessionService {
     return result;
   }
 
+  /**
+   * Interrupt ONE session (`POST /api/sessions/:id/interrupt`): send a lone ESC — the agent's
+   * interrupt key — to that session's pane and nothing else (no bracketed paste, no trailing CR).
+   * Composable with reply, so a caller wanting cancel-then-re-prompt does interrupt → reply rather
+   * than needing a combined endpoint (#1993). Same non-throwing boolean contract as reply(): false
+   * for an unknown id, a dead/unlisted pane, an unreachable herdr, or a send that rejects.
+   *
+   * Three things it deliberately does NOT copy from `haltAll`:
+   *
+   *  1. It goes THROUGH #serializeSteer. haltAll bypasses the FIFO because an e-stop must never
+   *     queue behind the very steers it exists to cancel, and it accepts the resulting race (an ESC
+   *     landing after a paste block has closed clears the composed input while that steer's trailing
+   *     CR submits the remnant). A targeted interrupt is a steer, not an e-stop, so that reasoning
+   *     does not transfer: serializing makes interrupt → reply ordering deterministic — the ESC can
+   *     never land inside or after a reply's paste block. The accepted cost is the mirror image of
+   *     haltAll's: an interrupt can queue behind a wedged send, since the serializer chain is
+   *     process-wide rather than per-pane. /api/halt stays the un-queued escape hatch.
+   *  2. It does NOT filter on `agentStatus === "working"`. haltAll filters because it is a sweep
+   *     that must not touch bystanders; a caller naming one session has already chosen its target.
+   *     A status check would also cost a second herdr round-trip and still race the send. ESC on an
+   *     idle pane merely clears any composed input.
+   *  3. It resolves the pane the way the REPLY route does, not the way haltAll does: `liveAgentFor`
+   *     + `adoptLiveResumeAgent`, so a herdr-restored pane (live terminalId ≠ stored herdrAgentId)
+   *     is interrupted at its live id and the stored id is healed — interrupt and a following reply
+   *     therefore address the same pane. operatorReply's isolated-Codex RESUME is deliberately not
+   *     inherited: resuming a dead pane in order to interrupt it is meaningless.
+   *
+   * No `reply` signal is recorded (that kind carries operator words and is mined by the learnings
+   * distiller; an interrupt has no payload to mine) and no event is emitted (`halt:done` exists
+   * because a fleet sweep's reach is otherwise invisible; a single-target interrupt's outcome is
+   * its HTTP status).
+   */
+  async interrupt(id: string): Promise<boolean> {
+    const s = this.deps.store.get(id);
+    if (!s) return false;
+    let agent: HerdrAgent | null;
+    try {
+      // liveAgentFor lets a herdr-unreachable error propagate; an interrupt that can't reach herdr
+      // is a "didn't land", not a 500 (matches operatorReplyTarget's catch).
+      agent = this.liveAgentFor(id);
+    } catch {
+      return false;
+    }
+    if (!agent) return false; // dead / unlisted pane — the ESC would go nowhere
+    const target = agent.terminalId;
+    // Heal a herdr-restored pane's stale stored id, exactly as operatorReply does — a no-op when
+    // the ids already match. Null means the row vanished mid-call: don't send.
+    if (!this.adoptLiveResumeAgent(s, agent)) return false;
+    try {
+      await this.#serializeSteer(() => this.deps.herdr.send(target, "\x1b"));
+    } catch {
+      return false; // pane died between list and send
+    }
+    return true;
+  }
+
   /** Terminal ids herdr currently lists as live. Empty when herdr can't be reached, so
    *  callers treat an unlisted agent as a dead pane (the steer won't land). */
   private liveTerminalIds(): Set<string> {

--- a/test/server-steers.test.ts
+++ b/test/server-steers.test.ts
@@ -109,3 +109,51 @@ test("POST /api/halt surfaces a herdr-unreachable failure as a 500 (not a fake s
   expect(res.status).toBe(500);
   expect((await res.json()).error).toBe("herdr down");
 });
+
+// ── POST /api/sessions/:id/interrupt — the per-session counterpart to /api/halt (#1993) ──
+
+/** makeApp over a stub service exposing only interrupt(), which records the ids it saw. */
+function interruptHarness(result: boolean) {
+  const seen: string[] = [];
+  const store = new SessionStore(":memory:");
+  const deps: AppDeps = {
+    store,
+    events: new EventHub(),
+    service: {
+      interrupt: async (id: string) => {
+        seen.push(id);
+        return result;
+      },
+    } as any,
+    usageLimits: { limits: () => ({}) } as any,
+  };
+  return { app: makeApp(deps), seen };
+}
+
+test("POST /api/sessions/:id/interrupt interrupts that one session", async () => {
+  const { app, seen } = interruptHarness(true);
+  // No body and no content-type: the path id IS the target, so there is nothing to validate.
+  const res = await app.fetch(
+    new Request("http://x/api/sessions/s1/interrupt", { method: "POST" }),
+  );
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true });
+  expect(seen).toEqual(["s1"]);
+});
+
+test("POST /api/sessions/:id/interrupt 404s when it didn't land (unknown id / dead pane)", async () => {
+  const { app, seen } = interruptHarness(false);
+  const res = await app.fetch(
+    new Request("http://x/api/sessions/gone/interrupt", { method: "POST" }),
+  );
+  expect(res.status).toBe(404);
+  expect((await res.json()).error).toBe("not found");
+  expect(seen).toEqual(["gone"]);
+});
+
+test("GET /api/sessions/:id/interrupt does not interrupt", async () => {
+  const { app, seen } = interruptHarness(true);
+  const res = await app.fetch(new Request("http://x/api/sessions/s1/interrupt"));
+  expect(res.status).toBe(404);
+  expect(seen).toEqual([]); // never reached the service
+});

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -8064,3 +8064,162 @@ test("#1144: a mid-batch throw still sweeps the ids already archived in that bat
   // `a` was already archived and its sweep deferred — it must still be swept.
   expect(sweeps).toEqual([new Set([a.id])]);
 });
+
+// ── interrupt(): the per-session counterpart to haltAll (#1993) ──────────────────────
+
+/** Minimal SessionService over an in-memory store with a scripted herdr, for interrupt().
+ *  `agents` is what herdr.list() returns (or a thrower); `send` defaults to recording. */
+function interruptHarness(opts: {
+  agents: unknown[] | (() => never);
+  send?: (target: string, text: string) => Promise<void>;
+}) {
+  const sent: { target: string; text: string }[] = [];
+  const emitted: { e: string; d: unknown }[] = [];
+  const store = new SessionStore(":memory:");
+  const session = store.create({
+    name: "a",
+    prompt: "x",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/a",
+    worktreePath: "/wt/a",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_a",
+  });
+  const service = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: {
+      create: () => ({}) as any,
+      ensureBaseRef: async () => {},
+      remove: () => {},
+      branchExists: () => false,
+    } as any,
+    events: { emit: (e: string, d: unknown) => emitted.push({ e, d }) } as any,
+    herdr: {
+      start: async () => ({}) as any,
+      list: typeof opts.agents === "function" ? opts.agents : () => opts.agents,
+      stop: async () => {},
+      send:
+        opts.send ??
+        (async (target: string, text: string) => {
+          sent.push({ target, text });
+        }),
+    } as any,
+  });
+  return { service, store, session, sent, emitted };
+}
+
+const liveAgent = (terminalId: string, agentStatus = "working") => ({
+  terminalId,
+  agentStatus,
+  cwd: "/wt/a",
+  name: "a",
+});
+
+test("interrupt sends ONE lone ESC to the session's live pane — no paste markers, no CR", async () => {
+  const { service, session, sent, emitted } = interruptHarness({ agents: [liveAgent("term_a")] });
+
+  expect(await service.interrupt(session.id)).toBe(true);
+  // A lone ESC is the whole payload: routing this through sendSteerTo instead would wrap it in
+  // \x1b[200~ … \x1b[201~ and append a CR, submitting an empty prompt after the interrupt.
+  expect(sent).toEqual([{ target: "term_a", text: "\x1b" }]);
+  // Unlike haltAll, a single-target interrupt reports its outcome through the HTTP status, so it
+  // emits nothing (and certainly not halt:done, whose count would be a lie for one session).
+  expect(emitted).toEqual([]);
+});
+
+test("interrupt records no signal — `reply` is a distiller-mined kind and ESC has no payload", async () => {
+  const { service, store, session } = interruptHarness({ agents: [liveAgent("term_a")] });
+
+  expect(await service.interrupt(session.id)).toBe(true);
+  expect(store.listSignals("/r")).toEqual([]);
+});
+
+test("interrupt hits an idle pane too — a caller naming one session already picked its target", async () => {
+  const { service, session, sent } = interruptHarness({ agents: [liveAgent("term_a", "idle")] });
+
+  // Deliberately NOT haltAll's `agentStatus === "working"` filter: that exists so a fleet sweep
+  // can't touch bystanders. ESC on an idle pane just clears any composed input.
+  expect(await service.interrupt(session.id)).toBe(true);
+  expect(sent).toEqual([{ target: "term_a", text: "\x1b" }]);
+});
+
+test("interrupt returns false for an unknown session id and sends nothing", async () => {
+  const { service, sent } = interruptHarness({ agents: [liveAgent("term_a")] });
+
+  expect(await service.interrupt("nope")).toBe(false);
+  expect(sent).toEqual([]);
+});
+
+test("interrupt returns false for a dead pane (session live in store, agent unlisted)", async () => {
+  const { service, session, sent } = interruptHarness({ agents: [] });
+
+  expect(await service.interrupt(session.id)).toBe(false);
+  expect(sent).toEqual([]);
+});
+
+test("interrupt returns false (never throws) when herdr can't be listed", async () => {
+  const { service, session, sent } = interruptHarness({
+    agents: () => {
+      throw new Error("herdr down");
+    },
+  });
+
+  // Unlike haltAll — whose throw is load-bearing, because a swallowed failure would emit a
+  // success-looking halt:done{halted:0} — a single interrupt has an honest "didn't land" answer
+  // (404), matching reply()'s non-throwing boolean contract.
+  expect(await service.interrupt(session.id)).toBe(false);
+  expect(sent).toEqual([]);
+});
+
+test("interrupt returns false when the send rejects (pane died between list and send)", async () => {
+  const { service, session } = interruptHarness({
+    agents: [liveAgent("term_a")],
+    send: async () => {
+      throw new Error("agent_not_found");
+    },
+  });
+
+  expect(await service.interrupt(session.id)).toBe(false);
+});
+
+test("interrupt adopts a herdr-restored pane: sends to the LIVE terminalId and heals the row", async () => {
+  // Stored id is stale (herdr daemon restarted); matchAgents re-pairs by cwd. Resolving the way
+  // the REPLY route does — rather than haltAll's agent.terminalId with no adoption — keeps
+  // interrupt and a following reply pointed at the same pane.
+  const { service, store, session, sent } = interruptHarness({ agents: [liveAgent("term_new")] });
+
+  expect(await service.interrupt(session.id)).toBe(true);
+  expect(sent).toEqual([{ target: "term_new", text: "\x1b" }]);
+  expect(store.get(session.id)!.herdrAgentId).toBe("term_new");
+});
+
+test("interrupt queues behind an in-flight reply: paste, CR, then ESC", async () => {
+  // The concrete reason interrupt goes THROUGH #serializeSteer instead of bypassing it like
+  // haltAll: a bypassing ESC could land after the paste block closed but before the CR, clearing
+  // the composed input so the CR submits an empty prompt. Serialized, interrupt → reply ordering
+  // is deterministic.
+  const order: string[] = [];
+  let releaseFirst!: () => void;
+  const firstSendGate = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+  let sends = 0;
+  const { service, session } = interruptHarness({
+    agents: [liveAgent("term_a")],
+    send: async (_target: string, text: string) => {
+      if (++sends === 1) await firstSendGate; // hold the paste mid-flight
+      order.push(text);
+    },
+  });
+
+  const reply = service.reply(session.id, "hello");
+  const interrupt = service.interrupt(session.id);
+  releaseFirst();
+  expect(await reply).toBe(true);
+  expect(await interrupt).toBe(true);
+
+  expect(order).toEqual(["\x1b[200~hello\x1b[201~", "\r", "\x1b"]);
+});


### PR DESCRIPTION
Closes #1993.

There was no way to interrupt **one** session: `POST /api/sessions/:id/reply` sends a bracket-pasted steer + CR (never an ESC), and `haltAll` (`POST /api/halt`) sweeps every working agent. An operator wanting to redirect one busy session could only type into its composer and hope, or stop the whole fleet.

This adds `POST /api/sessions/:id/interrupt` — a lone `\x1b` to that session's pane, nothing else. No body; `200 {ok:true}` when it lands, `404 {error:"not found"}` for an unknown id, dead/unlisted pane, unreachable herdr, or a rejected send. Composable with `/reply`, so cancel-then-re-prompt is interrupt → reply rather than a new combined endpoint.

## The three decisions the issue asked to make deliberately

Each is captured as a comment at the code that embodies it, and pinned by a test.

**1. It goes THROUGH `#serializeSteer`.** `haltAll` bypasses the FIFO because an e-stop must never queue behind the very steers it exists to cancel, and it accepts the resulting race: an ESC landing after a paste block has closed clears the composed input while that steer's trailing CR submits the remnant. A targeted interrupt is a steer, not an e-stop, so that reasoning does not transfer — serializing makes interrupt → reply ordering deterministic. The accepted cost is the mirror image: an interrupt can queue behind a wedged send, since the serializer chain is process-wide rather than per-pane. `/api/halt` stays the un-queued escape hatch.

**2. No `agentStatus === "working"` filter.** `haltAll` filters because a sweep must not touch bystanders; a caller naming one session already picked its target. A status check would cost a second herdr round-trip and still race the send. ESC on an idle pane merely clears composed input.

**3. Pane resolution matches the REPLY route, not `haltAll`** (the issue's "minor" `terminalId` vs `herdrAgentId` note): `liveAgentFor` + `adoptLiveResumeAgent`, so a herdr-restored pane is interrupted at its live `terminalId` and the stale stored id is healed — interrupt and a following reply address the same pane. `operatorReply`'s isolated-Codex **resume** is deliberately not inherited: resuming a dead pane in order to interrupt it is meaningless.

Also: no signal row (`reply` is a distiller-mined kind carrying operator words; an ESC has no payload to mine) and no event (`halt:done` exists because a fleet sweep's reach is otherwise invisible; a single-target interrupt's outcome is its HTTP status).

## Scope

Endpoint only. The UI stop button the issue names is filed as #1995 — the mobile `SteerBar` already exposes an Esc control for the *focused* session via the attached PTY socket, so the remaining gap is a control for non-focused sessions, which is a design question that does not block either caller. The buzz-bridge blocker (erwins-enkel/shepherd-buzz-bridge#14) consumes the HTTP route, which is what it names.

## Tests

`test/service.test.ts` (9): lone ESC with no paste markers and no CR; no signal recorded; idle pane still interrupted; unknown id; dead pane; `herdr.list()` throws → false, never throws; send rejects → false; herdr-restored pane adopts the live id and heals the row; and — the concrete assertion behind decision 1 — an interrupt issued while a reply is mid-flight lands strictly after that reply's CR (`paste, CR, ESC`).

`test/server-steers.test.ts` (3): 200 with the id reaching the service, 404 when it didn't land, and GET not interrupting.

Verified locally: `bun test ./test` (8109 tests, 0 fail), `bun run lint`, `bunx tsc --noEmit`, `bunx fallow audit --base origin/main --fail-on-issues` — all green.

[no-feature-entry] — server-only change, no user-facing UX ships here (see #1995).

🤖 Generated with [Claude Code](https://claude.com/claude-code)