### PR TITLE
feat(ui): switch repo mid-compose in two taps, keyboard up

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3517,5 +3517,7 @@
   "keymap_mode_research_short": "RECH.",
   "feat_newtask_keymap_title": "⌘ halten zeigt alle Tastenkürzel",
   "feat_newtask_keymap_body": "Halte in „Neue Aufgabe\" kurz ⌘ (Strg unter Windows/Linux) — jedes Bedienelement zeigt sein Kürzel direkt an seinem Platz, Loslassen blendet wieder aus. ? öffnet die vollständige Tastenkarte.",
-  "diagnostics_hint_tailscale_serve_denied": "Tailscale verweigert Shepherd die serve-Konfiguration, dadurch lässt sich keine Live-Vorschau veröffentlichen — führe einmalig sudo tailscale set --operator=$USER aus und öffne die Vorschau erneut."
+  "diagnostics_hint_tailscale_serve_denied": "Tailscale verweigert Shepherd die serve-Konfiguration, dadurch lässt sich keine Live-Vorschau veröffentlichen — führe einmalig sudo tailscale set --operator=$USER aus und öffne die Vorschau erneut.",
+  "feat_fast_repo_switch_title": "Repo wechseln, ohne die Tastatur zu verlassen",
+  "feat_fast_repo_switch_body": "Tippe auf dem Handy beim Schreiben auf den Repo-Namen in der Kopfzeile von „Neue Aufgabe“ — die Repo-Liste öffnet sich sofort, und nach der Auswahl landest du direkt wieder in deiner Beschreibung, die Tastatur bleibt oben. Zwei Tipps statt fünf."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3517,5 +3517,7 @@
   "keymap_mode_research_short": "RSCH.",
   "feat_newtask_keymap_title": "Hold ⌘ to see every shortcut",
   "feat_newtask_keymap_body": "In New Task, hold ⌘ (Ctrl on Windows/Linux) for a moment and every control shows its shortcut right where it sits — release to dismiss. Press ? for the full key card.",
-  "diagnostics_hint_tailscale_serve_denied": "Tailscale refuses Shepherd's serve config, so no live preview can be published — run sudo tailscale set --operator=$USER once, then reopen the preview."
+  "diagnostics_hint_tailscale_serve_denied": "Tailscale refuses Shepherd's serve config, so no live preview can be published — run sudo tailscale set --operator=$USER once, then reopen the preview.",
+  "feat_fast_repo_switch_title": "Switch repo without leaving the keyboard",
+  "feat_fast_repo_switch_body": "On a phone, tap the repo name in the New Task header while you're typing — the repo list opens straight away, and picking one drops you right back into your description with the keyboard still up. Two taps instead of five."
 }

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -3279,8 +3279,20 @@ describe("NewTask mobile sheets + shortcuts", () => {
     await expect.poll(() => document.querySelector(".ctx-sheet")).toBeTruthy();
     expect(chip().getAttribute("aria-expanded")).toBe("true");
 
-    // Change only the repo: chip + payload repoPath update; base re-derives. The chip
-    // tap already opened the repo panel — clicking the trigger here would close it.
+    // Branch FIRST: a repo pick ends the sheet's life, so the independent branch edit
+    // has to happen while the sheet is still up. (Input fallback or select — the mock
+    // lists main only.) The chip tap already opened the repo panel, so the branch
+    // control is behind it; the trigger toggle collapses the panel to reach it.
+    document.querySelector<HTMLButtonElement>(".ctx-sheet .rs-trigger")!.click();
+    await expect.poll(() => document.querySelector(".rs-panel")).toBeNull();
+    const branchCtl = document.querySelector<HTMLSelectElement | HTMLInputElement>(
+      ".ctx-sheet .ctx-branch-select",
+    )!;
+    branchCtl.value = "main";
+    branchCtl.dispatchEvent(new Event("change", { bubbles: true }));
+
+    // Now the repo: chip + payload repoPath update; base re-derives.
+    document.querySelector<HTMLButtonElement>(".ctx-sheet .rs-trigger")!.click();
     await expect
       .poll(() =>
         Array.from(document.querySelectorAll<HTMLLIElement>('[role="option"]')).find((el) =>
@@ -3292,27 +3304,9 @@ describe("NewTask mobile sheets + shortcuts", () => {
       .find((el) => el.textContent?.includes("bravo"))!
       .click();
     await expect.poll(() => chip().textContent).toContain("bravo");
-    // The aria-modal context sheet stays open and focus stays INSIDE it (the
-    // in-sheet trigger), never escaping to the prompt behind the sheet.
-    expect(document.querySelector(".ctx-sheet")).toBeTruthy();
-    await expect
-      .poll(() => document.querySelector(".ctx-sheet")?.contains(document.activeElement))
-      .toBe(true);
-
-    // Change only the branch (input fallback or select — the mock lists main only).
-    const branchCtl = document.querySelector<HTMLSelectElement | HTMLInputElement>(
-      ".ctx-sheet .ctx-branch-select",
-    )!;
-    branchCtl.value = "main";
-    branchCtl.dispatchEvent(new Event("change", { bubbles: true }));
-
-    // Close the sheet: focus returns to the chip.
-    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
-    // (dispatch on the sheet so the dialog action sees it)
-    document
-      .querySelector<HTMLElement>('[role="dialog"][aria-modal="true"].sheet')
-      ?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
-    await expect.poll(() => document.querySelector(".ctx-sheet")).toBeNull();
+    // The pick ends the flow: sheet gone, caret back in the prompt.
+    expect(document.querySelector(".ctx-sheet")).toBeNull();
+    expect(document.activeElement).toBe(document.querySelector("#nt-prompt"));
 
     typePrompt("mobile task");
     await expect
@@ -3347,13 +3341,15 @@ describe("NewTask mobile sheets + shortcuts", () => {
     filter.dispatchEvent(new Event("input", { bubbles: true }));
     await expect.poll(() => document.querySelectorAll('.ctx-sheet [role="option"]').length).toBe(1);
 
-    // …and picking collapses the panel while the sheet stays open, so the branch control
-    // is right back in view.
+    // …and picking ends the flow in one tap: sheet closed, caret back in the prompt.
+    // Asserted synchronously for the same reason as above — selectRepo flushSync's the
+    // unmount so the focus() lands in the tap's own call stack and the soft keyboard
+    // comes straight back. An `await tick()` there would fail these three.
     document.querySelector<HTMLLIElement>('.ctx-sheet [role="option"]')!.click();
+    expect(document.querySelector(".ctx-sheet")).toBeNull();
+    expect(document.querySelector(".rs-panel")).toBeNull();
+    expect(document.activeElement).toBe(document.querySelector("#nt-prompt"));
     await expect.poll(() => chip().textContent).toContain("bravo");
-    await expect.poll(() => document.querySelector(".rs-panel")).toBeNull();
-    expect(document.querySelector(".ctx-sheet")).toBeTruthy();
-    expect(document.querySelector(".ctx-sheet .ctx-branch-select")).toBeTruthy();
   });
 
   it("three-press Escape: repo panel → focus in-sheet trigger; sheet → focus chip", async () => {
@@ -4240,21 +4236,29 @@ describe("NewTask 7A keyboard-compose state", () => {
   const settle = () =>
     new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())));
 
-  async function mountMobile(extra: Record<string, unknown> = {}, coarse = true) {
+  const composeRepo = {
+    name: "compose-repo",
+    path: "/repo/compose",
+    display: "compose-repo",
+    realPath: "/repo/compose",
+  };
+  /** Second repo, so the compose-state repo switch has somewhere to go. */
+  const otherRepo = {
+    name: "other-repo",
+    path: "/repo/other",
+    display: "other-repo",
+    realPath: "/repo/other",
+  };
+
+  async function mountMobile(
+    extra: Record<string, unknown> = {},
+    coarse = true,
+    repos: RepoEntry[] = [composeRepo],
+  ) {
     mockPointer(coarse);
     await page.viewport(390, 844);
     const { fake, restore } = installFakeViewport(window.innerHeight);
-    mockListRepos.mockResolvedValue({
-      repos: [
-        {
-          name: "compose-repo",
-          path: "/repo/compose",
-          display: "compose-repo",
-          realPath: "/repo/compose",
-        },
-      ],
-      recentWindowDays: 30,
-    });
+    mockListRepos.mockResolvedValue({ repos, recentWindowDays: 30 });
     render(NewTask, { props: base({ initialRepoPath: "/repo/compose", ...extra }) });
     await expect.poll(() => document.querySelector(".ctx-chip")).toBeTruthy();
     return { fake, restore };
@@ -4554,5 +4558,119 @@ describe("NewTask 7A keyboard-compose state", () => {
     } finally {
       restore();
     }
+  });
+
+  // Switching repo mid-compose used to cost five taps and drop the soft keyboard twice:
+  // the context line was inert (tap 1 only blurred), a pick left the sheet open (tap 4
+  // dismissed it) and the prompt unfocused (tap 5). These pin the two-tap replacement.
+  describe("compose-state repo switching", () => {
+    const repoSeg = () => document.querySelector<HTMLButtonElement>(".ctx-seg-repo")!;
+    const engineSeg = () => document.querySelector<HTMLButtonElement>(".ctx-seg-engine")!;
+
+    async function mountTwoRepos() {
+      return mountMobile({ initialRepoPath: composeRepo.path }, true, [composeRepo, otherRepo]);
+    }
+
+    it("one tap on the repo segment opens the sheet, the repo panel and focuses the filter", async () => {
+      const { fake, restore } = await mountTwoRepos();
+      try {
+        await enterCompose(fake);
+        expect(repoSeg().getAttribute("aria-expanded")).toBe("false");
+        expect(repoSeg().getAttribute("aria-haspopup")).toBe("dialog");
+
+        repoSeg().click();
+
+        // Asserted synchronously — no await, no poll. openRepoPicker flushes both
+        // renders inside the click handler so the focus stays in the gesture's own call
+        // stack (a soft keyboard only rises for an in-stack focus()). An async hop here
+        // fails these rather than silently costing the keyboard on a real device.
+        expect(document.querySelector(".ctx-sheet")).toBeTruthy();
+        expect(document.querySelector(".ctx-sheet .rs-panel")).toBeTruthy();
+        expect(document.activeElement).toBe(document.querySelector(".ctx-sheet .rs-filter"));
+      } finally {
+        restore();
+      }
+    });
+
+    it("a repo pick closes the sheet and puts the caret back in the prompt", async () => {
+      const { fake, restore } = await mountTwoRepos();
+      try {
+        await enterCompose(fake);
+        promptField().value = "half a thought";
+        promptField().dispatchEvent(new Event("input", { bubbles: true }));
+        repoSeg().click();
+        await expect
+          .poll(() =>
+            Array.from(document.querySelectorAll<HTMLLIElement>('.ctx-sheet [role="option"]')).find(
+              (el) => el.textContent?.includes("other-repo"),
+            ),
+          )
+          .toBeTruthy();
+
+        Array.from(document.querySelectorAll<HTMLLIElement>('.ctx-sheet [role="option"]'))
+          .find((el) => el.textContent?.includes("other-repo"))!
+          .click();
+
+        // Synchronous again: selectRepo flushSync's the unmount so its focus() lands in
+        // the tap's own stack and the keyboard comes straight back. Caret at the end, so
+        // dictation resumes where it left off rather than at position 0.
+        expect(document.querySelector(".ctx-sheet")).toBeNull();
+        expect(document.activeElement).toBe(promptField());
+        expect(promptField().selectionStart).toBe("half a thought".length);
+      } finally {
+        restore();
+      }
+    });
+
+    it("the engine segment opens the engine sheet", async () => {
+      const { fake, restore } = await mountTwoRepos();
+      try {
+        await enterCompose(fake);
+        expect(engineSeg().getAttribute("aria-expanded")).toBe("false");
+
+        engineSeg().click();
+
+        await expect.poll(() => document.querySelector(".sheet .group")).toBeTruthy();
+        expect(document.querySelector(".ctx-sheet")).toBeNull();
+      } finally {
+        restore();
+      }
+    });
+
+    // The blur guards are the whole keyboard contract, and a bare `.click()` dispatches
+    // NO pointer events — every other test here would pass with the guards deleted. So
+    // these two drive real CDP input, where pointerdown's default focus action actually
+    // runs: unguarded, the focused element blurs mid-tap and the flow breaks outright.
+    it("real taps do not blur their field: the segment survives, the filter keeps focus", async () => {
+      const { fake, restore } = await mountTwoRepos();
+      try {
+        await enterCompose(fake);
+
+        // The guard is declared…
+        const down = new PointerEvent("pointerdown", { bubbles: true, cancelable: true });
+        repoSeg().dispatchEvent(down);
+        expect(down.defaultPrevented).toBe(true);
+
+        // …and it is what keeps the segment alive long enough to be clicked. Without it
+        // the pointerdown blurs the prompt, `composing` flips false, the whole .ctx-line
+        // unmounts before pointerup, and the click never lands on anything.
+        await page.elementLocator(repoSeg()).click();
+        await expect.poll(() => document.querySelector(".ctx-sheet")).toBeTruthy();
+
+        // Same story one level down: the option row is tabindex="-1", so an unguarded
+        // tap focuses it and blurs .rs-filter — retracting the keyboard before pick().
+        const filter = document.querySelector<HTMLInputElement>(".ctx-sheet .rs-filter")!;
+        expect(document.activeElement).toBe(filter);
+        const row = Array.from(
+          document.querySelectorAll<HTMLLIElement>('.ctx-sheet [role="option"]'),
+        ).find((el) => el.textContent?.includes("other-repo"))!;
+        const rowDown = new PointerEvent("pointerdown", { bubbles: true, cancelable: true });
+        row.dispatchEvent(rowDown);
+        expect(rowDown.defaultPrevented).toBe(true);
+        expect(document.activeElement).toBe(filter);
+      } finally {
+        restore();
+      }
+    });
   });
 });

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -1109,16 +1109,20 @@
 
   function selectRepo(path: string) {
     repoPath = path;
-    queueMicrotask(() => {
-      // Picking inside the mobile context sheet must keep focus INSIDE the open
-      // aria-modal sheet (land on the in-sheet trigger, same as the Escape
-      // contract); the prompt refocus is the desktop behavior.
-      if (activeSheet === "context") {
-        contextSheetEl?.querySelector<HTMLElement>(".rs-trigger")?.focus();
-      } else {
-        promptInput?.focus();
-      }
-    });
+    if (activeSheet === "context") {
+      // A repo pick is the whole point of opening this sheet, so it ends here: close
+      // and put the caret straight back in the prompt. Synchronous throughout —
+      // a soft keyboard only rises for a focus() inside the activating tap's own call
+      // stack (same constraint as openRepoPicker), so flushSync, never `await tick()`.
+      // Order is load-bearing: the flush runs the sheet's use:dialog destroy, which
+      // restores focus to the opener — we must take it back AFTER, or that restore wins.
+      activeSheet = null;
+      flushSync();
+      promptInput?.focus();
+      promptInput?.setSelectionRange(prompt.length, prompt.length);
+      return;
+    }
+    queueMicrotask(() => promptInput?.focus());
   }
 
   function cycleRepo(dir: 1 | -1) {
@@ -1540,20 +1544,51 @@
     <div class="chead">
       <span class="chead-title">{heading}</span>
       {#if mobile && composing}
-        <!-- Compose state: the chip compresses to one read-only context line —
-             repo · branch · engine · gate. Everything here is confirmed already;
-             editing any of it means leaving compose (Next →) first. -->
+        <!-- Compose state: the chip compresses to one context line — repo · branch ·
+             engine · gate — split into two buttons whose hit areas match what each
+             segment names. Switching repo mid-compose is the single most common edit
+             (it gates the repo's slash commands and issue list), so it must not cost a
+             trip out of compose and back: both segments open their sheet directly.
+
+             onpointerdown preventDefault, per `.compose-actions` below: without it the
+             pointerdown blurs the textarea, the keyboard retracts, the vv-synced overlay
+             re-inflates and the button slides out from under the finger before `click`
+             fires. onclick stays the activation path so Enter/VoiceOver still work. -->
         <span class="ctx-line">
-          <span aria-hidden="true">{projectIcons.iconFor(repoPath) ?? "▣"}</span>
-          <b>{selectedRepoName || m.reposelect_placeholder()}</b>
-          <span class="ctx-dim">
-            · {baseBranch} · {agentProvider === "codex"
-              ? m.agent_provider_codex()
-              : m.agent_provider_claude()} ·
-          </span>
-          <span class="es-gate" class:on={planGate}
-            >{planGate ? m.newtask_gate_on() : m.newtask_gate_off()}</span
+          <button
+            type="button"
+            class="ctx-seg ctx-seg-repo"
+            aria-haspopup="dialog"
+            aria-expanded={activeSheet === "context"}
+            aria-label={m.newtask_context_chip_aria({
+              repo: selectedRepoName || m.reposelect_placeholder(),
+              branch: baseBranch,
+            })}
+            onpointerdown={(e) => e.preventDefault()}
+            onclick={openRepoPicker}
           >
+            <span aria-hidden="true">{projectIcons.iconFor(repoPath) ?? "▣"}</span>
+            <b>{selectedRepoName || m.reposelect_placeholder()}</b>
+            <span class="ctx-dim">· {baseBranch}</span>
+            <span class="chev" aria-hidden="true">▾</span>
+          </button>
+          <!-- Named by its own content, exactly as `.engine-summary` is. -->
+          <button
+            type="button"
+            class="ctx-seg ctx-seg-engine"
+            aria-haspopup="dialog"
+            aria-expanded={activeSheet === "engine"}
+            onpointerdown={(e) => e.preventDefault()}
+            onclick={() => (activeSheet = "engine")}
+          >
+            <span class="ctx-dim"
+              >{agentProvider === "codex" ? m.agent_provider_codex() : m.agent_provider_claude()} ·
+            </span>
+            <span class="es-gate" class:on={planGate}
+              >{planGate ? m.newtask_gate_on() : m.newtask_gate_off()}</span
+            >
+            <span class="chev" aria-hidden="true">▾</span>
+          </button>
         </span>
       {:else if mobile}
         <!-- Combined repo·branch chip: one control naming both payload-critical values;
@@ -3143,7 +3178,9 @@
     .chead {
       min-height: 44px;
       box-sizing: border-box;
-      padding: 8px 6px 8px 16px;
+      /* No vertical padding: the chip / context segments are the header's tap targets
+         and stretch to fill the full 44px row themselves (a11y touch floor). */
+      padding: 0 6px 0 16px;
     }
     .chead-title {
       display: none;
@@ -3152,6 +3189,7 @@
       display: inline-flex;
       align-items: center;
       gap: 6px;
+      min-height: 44px;
       min-width: 0;
       max-width: 80vw;
       border: 1px solid var(--color-line);
@@ -3348,14 +3386,46 @@
     .card.composing .hero:focus-within {
       border-color: var(--color-amber);
     }
-    /* Read-only header context line (repo · branch · engine · gate). */
+    /* Header context line (repo · branch · engine · gate) — two tap targets. */
     .ctx-line {
       display: flex;
-      align-items: center;
-      gap: 6px;
+      align-items: stretch;
+      gap: 2px;
       min-width: 0;
       font-size: var(--fs-meta);
       color: var(--color-ink);
+    }
+    .ctx-seg {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      /* Fills `.chead`'s 44px row — the a11y touch floor. */
+      min-height: 44px;
+      border: 0;
+      background: none;
+      padding: 0 4px;
+      font: inherit;
+      font-size: var(--fs-meta);
+      color: inherit;
+      cursor: pointer;
+    }
+    /* The repo NAME absorbs all the shrink; the engine segment is short and fixed. */
+    .ctx-seg-repo {
+      min-width: 0;
+    }
+    /* Branch holds its ground so a long repo name can't squeeze `main` down to `m…`.
+       Capped so an unusually long branch still can't crowd out the name. */
+    .ctx-seg-repo .ctx-dim {
+      flex-shrink: 0;
+      max-width: 12ch;
+    }
+    .ctx-seg-engine {
+      flex-shrink: 0;
+    }
+    .ctx-seg .chev {
+      flex-shrink: 0;
+      color: var(--color-faint);
+      font-size: var(--fs-micro);
     }
     .ctx-line b {
       font-weight: 600;

--- a/ui/src/lib/components/RepoSelect.svelte
+++ b/ui/src/lib/components/RepoSelect.svelte
@@ -151,11 +151,14 @@
     }
   }
 
+  // Own state settles BEFORE onchange, which is allowed to tear this component down
+  // synchronously (NewTask's mobile context sheet closes on pick). Assigning after the
+  // call would write to a destroyed component.
   function pick(path: string) {
-    onchange(path);
     open = false;
     pickerFor = null;
     filter = "";
+    onchange(path);
   }
 
   $effect(() => {
@@ -284,6 +287,14 @@
           {/if}
           {@const r = row.repo}
           {@const identity = repoIdentity(r)}
+          <!-- onpointerdown preventDefault: the row is focusable (tabindex="-1"), so a
+               tap would focus it and blur `.rs-filter` BEFORE `click` reaches pick() —
+               on a phone that retracts the soft keyboard and re-inflates the visual
+               viewport mid-gesture. Guarding here keeps focus on the filter, which the
+               host can then hand straight back to its own field. `onclick` stays the
+               activation path (unlike SlashCommandMenu/IssueSearchMenu, which pick on
+               mousedown) so Enter/Space and VoiceOver are unaffected. It also covers the
+               nested emoji/sync buttons, which act on click and need no focus. -->
           <li
             id={`rs-opt-${i}`}
             class="rs-row"
@@ -293,6 +304,7 @@
             role="option"
             aria-selected={i === activeIdx}
             tabindex="-1"
+            onpointerdown={(e) => e.preventDefault()}
             onclick={() => pick(r.path)}
             onkeydown={(e) => {
               if (e.key === "Enter" || e.key === " ") pick(r.path);

--- a/ui/src/lib/feature-announcements/entries/v1.47.0-fast-repo-switch.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.47.0-fast-repo-switch.ts
@@ -1,0 +1,12 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "fast-repo-switch",
+  sinceVersion: "1.47.0",
+  titleKey: "feat_fast_repo_switch_title",
+  bodyKey: "feat_fast_repo_switch_body",
+  // No targetId: the only coachmark anchor in New Task ("nt-repo") is on the desktop
+  // context row, and this change is mobile-only — it would never resolve where it counts.
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
Switching repo in the New Task pane on a phone cost **5 taps** and dropped the soft keyboard twice. It now costs **2**, with the keyboard up the whole way.

From the walkthrough that prompted this:

> "I tap the top of the bar here, but that only gets me out of edit mode of the feature description. Then I tap again and now I have access to all of my repos. I pick the new repo, but that once again only brings me halfway… I've actually never used this [branch]. So I tap again, which closes the panel, but now I still can't type or dictate my feature because I need to tap again to go into the description field."

| # | Tap before | Why | After |
| - | - | - | - |
| 1 | header line | while composing the chip was swapped for a **read-only** `.ctx-line` — the tap only blurred | the real entry point |
| 2 | `.ctx-chip` | `openRepoPicker()` | folded into tap 1 |
| 3 | a repo row | `selectRepo()` kept the sheet open, parked focus on `.rs-trigger` | closes the sheet, refocuses the prompt |
| 4 | scrim / Esc | dismiss the still-open sheet | gone |
| 5 | the textarea | re-focus to raise the keyboard again | gone |

## What changed

**The compose-state header line is now two tap targets.** `repo · branch` opens the Repo & Branch sheet; `engine · gate` opens the Engine sheet — each hit area matching what its segment names. Both lifted to the 44px touch floor (`.ctx-chip` too, which sat at ~30px).

**A repo pick ends the flow.** `selectRepo()` closes the sheet and puts the caret back at the end of the prompt.

**Two pointerdown guards, one per tap.** Both the segments and `RepoSelect`'s option row would otherwise blur their field on pointerdown — the row is `tabindex="-1"`, so a tap focused it and blurred `.rs-filter` *before* `click` reached `pick()`. On a phone either one retracts the keyboard and re-inflates the visual viewport mid-gesture.

Everything on the tap path is synchronous — `flushSync`, not `await tick()` — because a soft keyboard only rises for a `focus()` inside the activating gesture's own call stack. Ordering is load-bearing: the flush runs the sheet's `use:dialog` destroy, which restores focus to the opener, so the prompt refocus must come after it.

`RepoSelect.pick()` now settles its own state before calling `onchange`, which may tear the component down synchronously. Behavior-neutral for both consumers.

**Base Branch is unchanged** — same place in the same sheet, reachable by collapsing the repo panel. Desktop is untouched: there is no sheet, so `selectRepo` keeps its existing `queueMicrotask` refocus.

## Verification

- 4505 UI tests + 8084 server tests green; `check`, `check:i18n`, lint, and the branch/feature/announcement/glossary/fallow gates all pass.
- **Mutation-tested** — each new test was confirmed to fail with its fix reverted, individually: drop the row guard → fails; drop the segment guard → fails; restore the old keep-sheet-open behavior → fails. A bare `.click()` dispatches no pointer events, so the two blur tests dispatch a real `PointerEvent` and assert `defaultPrevented`; without that the whole suite is blind to the guards.
- **Driven in a real browser at Pixel 5 width against live data**: both segments 44px, tap 1 opens the sheet with the filter focused, tap 2 closes it with the prompt refocused and the draft text intact, zero header/body overflow with the longest repo name.
- Confirmed via a controlled A/B that `preventDefault` on `pointerdown` does **not** block touch panning (68px vs 70px scrolled), so the option-row guard cannot break scrolling the repo list.

One visual fix came out of the browser pass: with a long repo name the branch was ellipsizing to `m…`, so the branch now holds its ground (capped at 12ch) and the repo name absorbs the shrink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)