### PR TITLE
fix(tailscale): latch a serve-config denial seen by unregister

### DIFF
--- a/src/tailscale.ts
+++ b/src/tailscale.ts
@@ -111,8 +111,10 @@ export interface TailscaleServeOpts {
 export class TailscaleServeService {
   private byId = new Map<string, { port: number; state: ServeState }>();
   private queue: Promise<void> = Promise.resolve();
-  /** Latched by a `register`/`reconcileStartup` mutation refused for lack of operator/root
-   *  rights; cleared only by a subsequent SUCCESSFUL `register` — not by a successful
+  /** Latched by ANY async mutation refused for lack of operator/root rights — `register`,
+   *  `unregister` and `reconcileStartup` alike, since all three write serve config (only the
+   *  sync `stopAll` skips it: the process is exiting and nothing reads this afterwards).
+   *  Cleared only by a subsequent SUCCESSFUL `register` — not by a successful
    *  unregister or reconcile, neither of which clears it. That asymmetry is deliberate and
    *  matches the hint the operator is given ("run `tailscale set --operator=…`, then reopen
    *  the preview"): reopening a preview is a register, so the row goes green exactly when
@@ -164,6 +166,11 @@ export class TailscaleServeService {
       try {
         await this.run(["serve", `--https=${entry.port}`, "off"]);
       } catch (err) {
+        // Symmetric with register/reconcileStartup: a teardown is a serve-config WRITE, so a
+        // refusal here is the same host-level verdict. Without this, rights revoked mid-run
+        // (operator hands the tailnet back to root after a successful register) go unnoticed
+        // until some later register fails, and Diagnostics reads green in the meantime.
+        if (isServeConfigDenied(err)) this.denied = true;
         console.warn(`[tailscale-serve] unregister failed for ${id} port ${entry.port}:`, err);
       }
       this.byId.delete(id);

--- a/test/tailscale.test.ts
+++ b/test/tailscale.test.ts
@@ -452,6 +452,43 @@ describe("TailscaleServeService.permissionDenied", () => {
     expect(svc.permissionDenied()).toBe(false);
   });
 
+  // The blind spot this closes: rights are revoked MID-RUN (`tailscale set --operator=`)
+  // after a successful register, so the first refusal Shepherd sees is a teardown. That
+  // denial used to be dropped on the floor, leaving Diagnostics green over a host whose
+  // serve-config writes are being refused.
+  test("latches true when an unregister is refused for lack of operator rights", async () => {
+    // Rights hold for the register and are gone by the `off` — a fixed `denyingRun` can't
+    // express this, since unregister early-returns unless a register seeded the entry.
+    const run: TailscaleRunner = async (args) => {
+      if (args.includes("off")) throw deniedError();
+      return { stdout: "" };
+    };
+    const svc = new TailscaleServeService({ base: 8001, count: 5, enabled: true, run });
+
+    await svc.register("s1", 8001);
+    expect(svc.permissionDenied()).toBe(false);
+
+    await svc.unregister("s1");
+
+    expect(svc.permissionDenied()).toBe(true);
+    // The slot is still released: this is a host-level verdict, not slot bookkeeping.
+    expect(svc.snapshot()).toEqual({});
+  });
+
+  test("stays false when an unregister fails for an unrelated reason", async () => {
+    const run: TailscaleRunner = async (args) => {
+      if (args.includes("off")) throw new Error("fake run failure on port 8001");
+      return { stdout: "" };
+    };
+    const svc = new TailscaleServeService({ base: 8001, count: 5, enabled: true, run });
+
+    await svc.register("s1", 8001);
+    await svc.unregister("s1");
+
+    expect(svc.permissionDenied()).toBe(false);
+    expect(svc.snapshot()).toEqual({});
+  });
+
   test("stays false when the service is disabled (no mutation is ever attempted)", async () => {
     const svc = new TailscaleServeService({
       base: 8001,


### PR DESCRIPTION
Closes #1998.

## What

`TailscaleServeService` latched a permission refusal (`isServeConfigDenied`) in two of its three async mutation paths — `register()` (latch + clear on success) and `reconcileStartup()` (latch) — but `unregister()` did neither; its catch only `console.warn`ed.

So a denial observed **only** by a teardown was dropped and `permissionDenied()` kept reporting `false`. The `tailscale` diagnostics row stayed green while serve-config writes were in fact being refused — the green-over-broken reading #1981 exists to close, reached by a different path.

Not a regression from #1981 (36ffdb6) — a gap in the coverage it added.

## When it bites

Rights have to be revoked *mid-run*, after at least one successful register: Shepherd boots with `--operator` set (reconcile + registers succeed, latch clear), an operator later runs `tailscale set --operator=` to hand the tailnet back to root, and the next preview teardown is refused. Until some later `register` is attempted and fails, Diagnostics reports `ok`. Nothing is corrupted; the report is stale in the optimistic direction.

## Decisions

- **A successful `unregister` does NOT clear the latch.** Latch-on-failure only. The asymmetry is deliberate and preserved: the operator hint says "run \`tailscale set --operator=…\`, then reopen the preview", and reopening a preview is a `register` — so the row greens exactly when the fix is proven on the path that was broken. Greening off a teardown is a weaker signal.
- **`stopAll()` (sync shutdown) is left alone.** Same structural gap, but the process is exiting and nothing reads the flag afterwards — latching there would be dead code.
- The `denied` field's doc comment now names all three latching paths and why `stopAll` is excluded.

The slot-release path is unchanged: `byId.delete(id)` and the `onChange(null, null)` fire still run after a failed `off`.

## Tests

Two added to the existing `permissionDenied` describe, reusing the `deniedError()` fixture:

- a denied `unregister` after a successful `register` latches `true` (and the slot is still released);
- an `unregister` failing for an unrelated reason leaves it `false`.

Both need a runner whose behavior differs between the two calls (`unregister` early-returns unless a `register` seeded the entry), so they discriminate on the `off` argv rather than using the fixed `denyingRun`.

Verified red-before/green-after: reverting just the one-line latch fails the first new test.

## Verification

`bun test ./test` 8131 pass / 0 fail · `bun run lint` clean · `bunx tsc --noEmit` clean · `bunx fallow audit --base origin/main` no issues in the 2 changed files.

[no-feature-entry] — server-internal fix, ships no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)