### PR TITLE
feat(ui): per-session stop on the session-card menu (#1995)

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3519,5 +3519,11 @@
   "feat_newtask_keymap_body": "Halte in „Neue Aufgabe\" kurz ⌘ (Strg unter Windows/Linux) — jedes Bedienelement zeigt sein Kürzel direkt an seinem Platz, Loslassen blendet wieder aus. ? öffnet die vollständige Tastenkarte.",
   "diagnostics_hint_tailscale_serve_denied": "Tailscale verweigert Shepherd die serve-Konfiguration, dadurch lässt sich keine Live-Vorschau veröffentlichen — führe einmalig sudo tailscale set --operator=$USER aus und öffne die Vorschau erneut.",
   "feat_fast_repo_switch_title": "Repo wechseln, ohne die Tastatur zu verlassen",
-  "feat_fast_repo_switch_body": "Tippe auf dem Handy beim Schreiben auf den Repo-Namen in der Kopfzeile von „Neue Aufgabe“ — die Repo-Liste öffnet sich sofort, und nach der Auswahl landest du direkt wieder in deiner Beschreibung, die Tastatur bleibt oben. Zwei Tipps statt fünf."
+  "feat_fast_repo_switch_body": "Tippe auf dem Handy beim Schreiben auf den Repo-Namen in der Kopfzeile von „Neue Aufgabe“ — die Repo-Liste öffnet sich sofort, und nach der Auswahl landest du direkt wieder in deiner Beschreibung, die Tastatur bleibt oben. Zwei Tipps statt fünf.",
+  "cardmenu_stop": "Agent stoppen",
+  "cardmenu_stop_title": "Sendet Esc an diese Sitzung — bricht nur den laufenden Zug ab",
+  "cardmenu_stop_toast": "{name} gestoppt",
+  "cardmenu_stop_failed": "{name} konnte nicht gestoppt werden — läuft möglicherweise nicht mehr",
+  "feat_session_stop_title": "Einzelnen Agenten stoppen, ohne ihn zu öffnen",
+  "feat_session_stop_body": "Rechtsklick (oder langes Tippen) auf die Karte einer arbeitenden Sitzung, dann „Agent stoppen\" — das schickt ein einzelnes Esc nur an diese Sitzung. So brichst du einen entgleisten Zug ab, ohne die ganze Herde anzuhalten oder ins Terminal zu wechseln."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3519,5 +3519,11 @@
   "feat_newtask_keymap_body": "In New Task, hold ⌘ (Ctrl on Windows/Linux) for a moment and every control shows its shortcut right where it sits — release to dismiss. Press ? for the full key card.",
   "diagnostics_hint_tailscale_serve_denied": "Tailscale refuses Shepherd's serve config, so no live preview can be published — run sudo tailscale set --operator=$USER once, then reopen the preview.",
   "feat_fast_repo_switch_title": "Switch repo without leaving the keyboard",
-  "feat_fast_repo_switch_body": "On a phone, tap the repo name in the New Task header while you're typing — the repo list opens straight away, and picking one drops you right back into your description with the keyboard still up. Two taps instead of five."
+  "feat_fast_repo_switch_body": "On a phone, tap the repo name in the New Task header while you're typing — the repo list opens straight away, and picking one drops you right back into your description with the keyboard still up. Two taps instead of five.",
+  "cardmenu_stop": "Stop agent",
+  "cardmenu_stop_title": "Send Esc to this session — stops the current turn, nothing else",
+  "cardmenu_stop_toast": "Stopped {name}",
+  "cardmenu_stop_failed": "Couldn't stop {name} — it may no longer be running",
+  "feat_session_stop_title": "Stop one agent without opening it",
+  "feat_session_stop_body": "Right-click (or long-press) a working session's card and pick Stop agent — it sends a single Esc to just that session, so you can cut one runaway turn short without halting the whole herd or switching to its terminal."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -945,6 +945,15 @@ export async function replySession(id: string, text: string): Promise<void> {
   if (!r.ok) throw await failed(r, "reply");
 }
 
+/** Interrupt ONE session: a lone ESC to its pane, nothing else (#1993). No body — the
+ *  id IS the target. The server answers 404 for an unknown id or a dead/unlisted pane,
+ *  which is a NORMAL outcome here (the caller's card can be a tick stale), so callers
+ *  must catch and surface it as a toast rather than let it crash. */
+export async function interruptSession(id: string): Promise<void> {
+  const r = await fetch(`/api/sessions/${id}/interrupt`, { method: "POST" });
+  if (!r.ok) throw await failed(r, "interrupt");
+}
+
 /** A next-prompt recommendation: the suggested prompt, or a stable error code the
  *  RecommendDialog maps to a localized message. Never throws — the dialog needs a
  *  distinct error state, not a crash. */

--- a/ui/src/lib/components/CardMenu.browser.test.ts
+++ b/ui/src/lib/components/CardMenu.browser.test.ts
@@ -137,3 +137,29 @@ describe("CardMenu merge action", () => {
     }
   });
 });
+
+describe("CardMenu stop action", () => {
+  it("renders the Stop agent item only when onstop is provided", async () => {
+    const { rerender } = await render(CardMenu, { props: base() });
+    // no onstop → no Stop item (a non-working session never offers it)
+    expect(page.getByRole("menuitem", { name: m.cardmenu_stop() }).query()).toBeNull();
+
+    await rerender(base({ onstop: vi.fn() }));
+    await expect
+      .element(page.getByRole("menuitem", { name: m.cardmenu_stop() }))
+      .toBeInTheDocument();
+  });
+
+  it("fires onstop on the FIRST click (no two-step arm) and takes no danger/armed wash", async () => {
+    const onstop = vi.fn();
+    render(CardMenu, { props: base({ onstop }) });
+
+    const item = page.getByRole("menuitem", { name: m.cardmenu_stop() });
+    // it must not read as the fleet e-stop: no armed wash, no danger colour
+    await expect.element(item).not.toHaveClass(/\barmed\b/);
+    await expect.element(item).not.toHaveClass(/\bdanger\b/);
+
+    await item.click();
+    expect(onstop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/lib/components/CardMenu.svelte
+++ b/ui/src/lib/components/CardMenu.svelte
@@ -12,6 +12,7 @@
     resumable,
     opener,
     onmergepr,
+    onstop,
     onresume,
     onrename,
     onrelaunch,
@@ -32,6 +33,11 @@
     // eligible to merge). Positive but consequential, so it arms amber (not the red danger wash) —
     // the parent's handler closes over the session id + runs the merge, like the badge menu.
     onmergepr?: () => void;
+    // when provided, a "Stop agent" item appears (the session is working) — a lone ESC to its
+    // pane (#1995). Deliberately a plain, unarmed row: this is the per-session counterpart of
+    // pressing Esc in the terminal, NOT the fleet e-stop (which arms red and chips its count),
+    // and it is reversible — the operator can steer the session again immediately.
+    onstop?: () => void;
     onresume?: () => void;
     onrename?: () => void;
     // when provided, a two-step armed Relaunch item appears between Resume and
@@ -180,6 +186,18 @@
       <span class="cm-icon" aria-hidden="true">⇥</span>{mergeArmed
         ? m.prbadge_confirm_merge()
         : m.prbadge_merge()}
+    </button>
+  {/if}
+  {#if onstop}
+    <button
+      class="cm-item"
+      type="button"
+      role="menuitem"
+      tabindex="-1"
+      title={m.cardmenu_stop_title()}
+      onclick={onstop}
+    >
+      <span class="cm-icon" aria-hidden="true">⎋</span>{m.cardmenu_stop()}
     </button>
   {/if}
   {#if resumable && onresume}

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -24,11 +24,13 @@ vi.mock("$lib/api", async (importOriginal) => {
       async () => ({ ok: true }) as { ok: boolean; reason?: "unsupported" | "no-run" },
     ),
     mergePr: vi.fn(async () => ({ state: "merged" }) as never),
+    interruptSession: vi.fn(async () => {}),
   };
 });
 
 const { reviews, planGates, repoConfig } = await import("$lib/reviews.svelte");
-const { releasePlanGate, reviewPlan, resumeQuota, retryCi, mergePr } = await import("$lib/api");
+const { releasePlanGate, reviewPlan, resumeQuota, retryCi, mergePr, interruptSession } =
+  await import("$lib/api");
 const { toasts } = await import("$lib/toasts.svelte");
 
 function session(partial: Partial<Session> & { id: string }): Session {
@@ -135,6 +137,7 @@ beforeEach(() => {
   vi.mocked(mergePr)
     .mockReset()
     .mockResolvedValue({ state: "merged" } as never);
+  vi.mocked(interruptSession).mockReset().mockResolvedValue(undefined);
 });
 
 function loadPreviewMode(repoPath: string, mode: "ask" | "inline" | "tab" = "ask") {
@@ -1303,5 +1306,86 @@ describe("UnitRow awaits-operator attention wash", () => {
     const bg = getComputedStyle(unit).backgroundColor;
     expect(bg).not.toBe(resolvedBackgroundColor("var(--color-sel)"));
     expect(bg).not.toBe("rgba(0, 0, 0, 0)");
+  });
+});
+
+describe("UnitRow stop agent action", () => {
+  function openMenu(rowName: string) {
+    page
+      .getByRole("button", { name: m.unit_open_aria({ name: rowName }) })
+      .element()
+      .dispatchEvent(
+        new MouseEvent("contextmenu", { button: 2, clientX: 40, clientY: 40, bubbles: true }),
+      );
+  }
+
+  it("offers Stop agent on a running row and interrupts that session id, toasting the outcome", async () => {
+    render(UnitRow, {
+      session: session({ id: "run-row", name: "run row", status: "running" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+    });
+
+    openMenu("run row");
+    // one click, no arm — the item fires straight away
+    await page.getByRole("menuitem", { name: m.cardmenu_stop() }).click();
+
+    expect(interruptSession).toHaveBeenCalledWith("run-row");
+    // The toast container isn't mounted in an isolated row render — assert on the store.
+    await vi.waitFor(() =>
+      expect(toasts.items.some((t) => t.text === m.cardmenu_stop_toast({ name: "run row" }))).toBe(
+        true,
+      ),
+    );
+  });
+
+  it("offers Stop agent on a blocked row flagged working (display-running)", async () => {
+    render(UnitRow, {
+      session: session({ id: "wb-row", name: "wb row", status: "blocked" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+      workingBlocked: { "wb-row": true },
+      onrename: vi.fn(),
+    });
+
+    openMenu("wb row");
+    await expect
+      .element(page.getByRole("menuitem", { name: m.cardmenu_stop() }))
+      .toBeInTheDocument();
+  });
+
+  it("does not offer Stop agent on an idle row", async () => {
+    render(UnitRow, {
+      session: session({ id: "idle-row", name: "idle row", status: "idle" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+      onrename: vi.fn(), // something else to open the menu with
+    });
+
+    openMenu("idle row");
+    await expect.element(page.getByText(m.cardmenu_rename())).toBeInTheDocument();
+    await expect.element(page.getByText(m.cardmenu_stop())).not.toBeInTheDocument();
+  });
+
+  it("a 404 (dead pane) surfaces the failure toast instead of throwing", async () => {
+    vi.mocked(interruptSession).mockRejectedValue(new Error("interrupt failed (404)"));
+    render(UnitRow, {
+      session: session({ id: "dead-row", name: "dead row", status: "running" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+    });
+
+    openMenu("dead row");
+    await page.getByRole("menuitem", { name: m.cardmenu_stop() }).click();
+
+    await vi.waitFor(() =>
+      expect(
+        toasts.items.some((t) => t.text === m.cardmenu_stop_failed({ name: "dead row" })),
+      ).toBe(true),
+    );
   });
 });

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -26,6 +26,7 @@
     resumeQuota,
     retryCi,
     mergePr,
+    interruptSession,
   } from "$lib/api";
   import { prMergeAvailable } from "./pr-badge";
   import CardMenu from "./CardMenu.svelte";
@@ -586,6 +587,16 @@
   // disagree. The merge endpoint is session-scoped, so no parent callback is needed; the server
   // re-validates on merge (a stale-eligibility merge fails harmlessly → toast).
   const mergeable = $derived(prMergeAvailable(git));
+  // Stop agent: offered only while the row reads as WORKING. dStatus (not raw status) is the gate
+  // on purpose — a working-while-blocked session is mid-turn and shows the amber working pip, so
+  // it is stoppable too. Everything else (idle / blocked-not-working / done / archived) has no turn
+  // to cut short, and its pane may well be gone. Like Merge PR the endpoint is session-scoped, so
+  // no parent callback is threaded — the row calls it and toasts the outcome itself.
+  const stoppable = $derived(dStatus === "running");
+  // Resolved here rather than as a ternary in the <CardMenu> tag: UnitRow's template sits at its
+  // grandfathered complexity cap (#855), and every inline conditional in the markup counts against
+  // it. undefined is what hides the menu item.
+  const onStop = $derived(stoppable ? stopFromMenu : undefined);
   let hitEl = $state<HTMLButtonElement>();
   let elapsedEl = $state<HTMLSpanElement>();
   let menu = $state<{ x: number; y: number; opener: HTMLElement } | null>(null);
@@ -593,6 +604,7 @@
   // swallow the trailing tap). No-ops when nothing to offer or one is already open.
   const hasMenu = $derived(
     mergeable ||
+      stoppable ||
       resumable ||
       !!ondecommission ||
       !!onrename ||
@@ -649,6 +661,25 @@
         }),
         { alert: true, key: `pr-merge:${session.id}` },
       );
+    }
+  }
+  // "Stop agent" — a lone ESC to this session's pane (#1995). One click, no arm: it is exactly what
+  // pressing Esc in the terminal does, and it is reversible (the operator can steer again at once).
+  // Both outcomes toast, keyed per session so repeated taps collapse into one: a success is
+  // otherwise invisible from a card you are not watching, and a 404 (the pane died between render
+  // and click) is a NORMAL result, so it surfaces as an alert toast, never an unhandled rejection.
+  async function stopFromMenu() {
+    menu = null;
+    try {
+      await interruptSession(session.id);
+      toasts.info(m.cardmenu_stop_toast({ name: session.name }), {
+        key: `session-interrupt:${session.id}`,
+      });
+    } catch {
+      toasts.info(m.cardmenu_stop_failed({ name: session.name }), {
+        alert: true,
+        key: `session-interrupt:${session.id}`,
+      });
     }
   }
   function decommissionFromMenu() {
@@ -961,6 +992,7 @@
     {resumable}
     opener={menu.opener}
     onmergepr={mergeable ? mergeFromMenu : undefined}
+    onstop={onStop}
     onresume={resumeFromMenu}
     onrename={onrename ? renameFromMenu : undefined}
     onrelaunch={relaunchable ? relaunchFromMenu : undefined}

--- a/ui/src/lib/feature-announcements/entries/v1.47.0-session-stop.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.47.0-session-stop.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "session-stop",
+  sinceVersion: "1.47.0",
+  titleKey: "feat_session_stop_title",
+  bodyKey: "feat_session_stop_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
Closes #1995.

#1993 shipped `POST /api/sessions/:id/interrupt` (a lone ESC to one pane, 200/404, no body) but nothing in the UI called it. The gap the parent issue named — no per-session stop for a session you are **not** focused on / attached to — is now closed.

## What it does

Right-click (or long-press) a **working** session's card → **Stop agent**. One click sends a single ESC to just that session's pane.

```
┌─ card menu ─────────┐
│ ⇥  Merge PR         │
│ ⎋  Stop agent       │  ← new
│ ↻  Resume session   │
│ ✎  Rename           │
│ ♻  Relaunch         │
│ ✕  Decommission     │
└─────────────────────┘
```

## Decisions (settled with the operator before implementing)

- **CardMenu only.** It is already the per-session action surface, so no new chrome lands on every row, and the missing surface (an unfocused session) is exactly what a card menu addresses. Desktop Esc-in-terminal and the mobile `SteerBar` `ControlBar include={["cancel"]}` already cover the attached pane.
- **It must not read as an e-stop.** The fleet halt (`GearHaltHero`) is an amber ■ hero with a live `N WORKING` chip and a two-step red arm. This is a plain neutral `.cm-item` with an `⎋` (Esc-key) glyph — no wash, no arm, no chip. A test asserts the item carries neither the `armed` nor the `danger` class.
- **One click, no arm.** It is one ESC to one pane and it is reversible — the operator can steer the session again immediately. Arms stay reserved for the irreversible items (Relaunch, Decommission) and for the fleet e-stop.
- **Running only.** Gated on `displayStatus(session, workingBlocked) === "running"`, not raw status, so a working-while-blocked session (mid-turn behind a permission prompt, amber working pip) is stoppable too. Idle / blocked-not-working / done / archived rows have no turn to cut short.
- **Interrupt-only.** The endpoint is deliberately composable with `/reply`, so cancel-then-re-prompt stays interrupt → steer rather than a combined action.

## Failure handling

`interruptSession()` throws on non-ok; `UnitRow` catches. A 404 (the pane died between render and click) is a **normal** outcome, not a crash — both outcomes toast, keyed `session-interrupt:<id>` so repeated taps collapse into one. The success toast matters: a lone ESC to a card you are not watching is otherwise invisible.

## Notes

- Like Merge PR, the endpoint is session-scoped, so no parent callback is threaded — the row calls the API and toasts the outcome itself.
- `onstop` is resolved into a `$derived` rather than an inline ternary in the `<CardMenu>` tag: UnitRow's template sits at its grandfathered fallow complexity cap (#855), and an inline conditional in the markup tipped it over.
- EN + DE keys added (`check:i18n` parity) and one feature-announcement fragment (`v1.47.0-session-stop.ts`, version from `bun run next-version`).

## Verification

- `cd ui && bun run check` → 0 errors, `bun run check:i18n` → parity
- `cd ui && bun run test` → 288 files / 4513 tests pass (6 new: 2 CardMenu, 4 UnitRow)
- pre-push gates green: branch hygiene, feature catalog, announcement versions, glossary, fallow audit
- Rebased onto `origin/main` (7c80d7727) before pushing

🤖 Generated with [Claude Code](https://claude.com/claude-code)