### PR TITLE
fix(skills): hand epic import to the operator, agents can't reach it

### DIFF
--- a/.claude/skills/shepherd-epic-authoring/SKILL.md
+++ b/.claude/skills/shepherd-epic-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shepherd-epic-authoring
-description: Author a Shepherd-recognized epic in an attended session — decompose work into child issues, create them, and mark the parent body with the structural epic marker (fenced dag / task-list), optionally wiring native sub-issue + blocked_by links via epic import. Use when asked to create an epic with sub-issues, promote an existing issue #N to an epic, split an issue into child issues, or make a body of work drainable as an epic — especially mid-session, where no injected epic guidance exists.
+description: Author a Shepherd-recognized epic in an attended session — decompose work into child issues, create them, mark the parent body with the structural epic marker (fenced dag / task-list), and hand the optional native sub-issue + blocked_by link import to the operator. Use when asked to create an epic with sub-issues, promote an existing issue #N to an epic, split an issue into child issues, or make a body of work drainable as an epic — especially mid-session, where no injected epic guidance exists.
 ---
 
 # Shepherd Epic Authoring
@@ -21,7 +21,7 @@ gap: invoke it whenever an epic ask arises, at spawn or mid-session. It is
 attended by default (unattended drains run with skills disabled unless the
 operator opts out of context trimming) and
 richer than the injected blocks: it drafts the whole tree, gates outward
-actions on approval, and wires native links.
+actions on approval, and hands the native-link import back to the operator.
 
 This skill is **self-contained**: it ships in the Shepherd repo and runs in
 _other_ operators' repos, so everything it needs is below.
@@ -58,14 +58,14 @@ If the system prompt carries an **`<epic-authoring-directive>`** with an epic-dr
 (`PUT …/api/sessions/<id>/epic-draft`), Shepherd's guided epic-draft flow is driving this session.
 In that mode the hard gate and the GitHub writes are **owned by the server**: follow ONLY the
 decomposition guidance below (Stage 1), emit the draft by PUTting it to that endpoint, then **STOP**.
-Do **not** perform Stages 3–5 (`gh issue create`/`gh issue edit`, the epic-import endpoint) — the
+Do **not** perform Stages 3–5 (`gh issue create`/`gh issue edit`, the import handoff) — the
 operator approves the draft in the UI and the server materializes it. The directive is authoritative;
 this skill only lends it the slicing/authoring guidance.
 
 ## Stages
 
 Work the stages in order; track one todo per stage. **Nothing outward (issue
-creation, body edits, epic import) happens before the Stage 2 approval gate.**
+creation, body edits) happens before the Stage 2 approval gate.**
 
 ### 0. Orient
 
@@ -82,10 +82,10 @@ git remote -v                      # is there a GitHub remote?
 gh auth status 2>/dev/null         # is gh usable?
 ```
 
-A working GitHub remote + `gh` ⇒ **GitHub-native** (issue creation + epic
-import available). Otherwise **local/lightweight**: programmatic creation and
-import are unavailable (import asserts a GitHub-native forge) — the deliverable
-becomes an importable markdown file instead (see Stage 3).
+A working GitHub remote + `gh` ⇒ **GitHub-native**: you can create issues, and
+the operator can run the link import (Stage 4). Otherwise **local/lightweight**:
+programmatic creation is unavailable and import has no forge to write to — the
+deliverable becomes an importable markdown file instead (see Stage 3).
 
 ### 1. Draft
 
@@ -143,30 +143,55 @@ Write the approved tree to an importable markdown file (e.g. `BACKLOG.md`) and
 tell the operator it's the manual reference / future-import source — say this
 explicitly rather than failing silently.
 
-### 4. Import (GitHub-native only)
+### 4. Hand import to the operator (GitHub-native only)
 
-The body marker alone already makes the epic recognized and drainable; import
-additionally wires **native sub-issue + `blocked_by` links**. It is **not**
-automatic — trigger it per parent:
+**You are already done with the epic.** The body marker **is** the recognition
+contract — with it in place the epic is recognized and drainable. Import is a
+separate, optional step that additionally wires **native sub-issue +
+`blocked_by` links**; it is not automatic, and **you cannot trigger it**.
 
-```bash
-curl -s -X POST -G "http://127.0.0.1:7330/api/epic/import" \
-  --data-urlencode "repo=$(git rev-parse --show-toplevel)" \
-  --data-urlencode "parent=<PARENT_NUM>"
-```
+**Do not call the import endpoint.** You reach the Shepherd server only through
+its restricted loopback ingress, which admits a short session-scoped allowlist
+(hooks, build queue, epic draft). The import route is repo-scoped, not
+session-scoped, so it is not on that allowlist — calling the main port instead
+lands on the operator auth gate and returns `{"error":"unauthorized"}` (401).
+That boundary is deliberate: import performs GitHub writes, which Shepherd keeps
+on the operator's side of the gate. **Never go looking for the operator password
+or an API token to get around it** — a 401 here is the system working.
 
-(`-G --data-urlencode` keeps the POST while URL-encoding the query, so a repo
-path containing a space or `&` can't break the request.)
+Instead, tell the operator import is pending and give them both paths:
 
-(Use your Shepherd server's host/port; `7330` is the default.) The response
-reports `subIssuesAdded` / `dependenciesAdded` / `unresolved`. Re-check any
-`unresolved` member numbers — they usually mean a typo'd or foreign issue
-reference in the parent body — fix the body and re-import.
+1. **In the UI (one click, always available).** Open the Backlog, expand the
+   parent issue's row, and press **Import structure** — the button appears on
+   the epic panel for a marker-derived epic. The same action is offered as a
+   remediation inside that panel's **Diagnose** modal.
+2. **From their own shell**, if they'd rather. OPERATOR-RUN — this needs the
+   operator's credentials, so print it for them, do not run it:
+
+   ```bash
+   curl -s -X POST -G "http://127.0.0.1:7330/api/epic/import" \
+     -H "Authorization: Bearer $SHEPHERD_TOKEN" \
+     --data-urlencode "repo=$(git rev-parse --show-toplevel)" \
+     --data-urlencode "parent=<PARENT_NUM>"
+   ```
+
+   Use your Shepherd server's host/port; `7330` is the default. The bearer
+   header only works if `SHEPHERD_TOKEN` is configured on that server — it is
+   optional and unset by default; without it, use the UI. The
+   `-G`/`--data-urlencode` form keeps the POST while URL-encoding the query, so
+   a repo path containing a space or `&` can't break the request.
+
+The response reports `subIssuesAdded` / `dependenciesAdded` / `unresolved`. Tell
+the operator that any `unresolved` member numbers usually mean a typo'd or
+foreign issue reference in the parent body — worth reporting back so the body can
+be fixed and import re-run.
 
 ### 5. Verify + hand off
 
-Confirm the parent now carries the marker (and, if imported, the native
-links). Then stop and point:
+Confirm the parent now carries the marker — re-read the body you just wrote
+(`gh issue view <PARENT_NUM> --json body`) and check the fence lists the real
+child numbers. Do **not** wait on import: it is the operator's step, so name it
+as pending rather than treating it as a precondition. Then stop and point:
 
 - **The epic itself is the deliverable — open NO pull request.** If this
   session was spawned on the issue being promoted, the parent-body marker is
@@ -175,17 +200,21 @@ links). Then stop and point:
   and its own PR; an agent cannot trigger that itself. Tell the operator the
   epic is ready to drain and name the **DAG roots** (children with no
   blockers) as the first ones to start.
+- **Import is the one thing still owed** (GitHub-native repos) — restate it as
+  an operator step, with the UI path from Stage 4, and note that it only wires
+  the native links: drain does not wait on it.
 
 ## Gate rules (reference)
 
 - **Outward actions are gated** on the Stage 2 approval — drafting is always
-  safe; creating, editing, and importing are not.
-- **GitHub-only operations:** `gh issue create` / `gh issue edit` and the epic
-  import endpoint require a GitHub-native forge; local/lightweight repos get
-  the markdown fallback.
+  safe; creating and editing are not.
+- **GitHub-only operations:** `gh issue create` / `gh issue edit` require a
+  GitHub-native forge; local/lightweight repos get the markdown fallback.
+- **Import is the operator's, never yours:** it is off the agent ingress
+  allowlist and 401s for you (Stage 4). Hand it over — never hunt for
+  credentials to force it through.
 - **Marker grammar:** members are `#<n>` lines inside the fenced dag block; an
   edge is `#<dependent> <- #<blocker>[, #<blocker>…]`; the task-list variant
   lists members only. Real numbers, one fence, marker mandatory.
 - **No PR:** when the ask is to author or promote an epic, stop once the
-  parent body carries the marker (and import, where available, reports no
-  `unresolved`).
+  parent body carries the marker and import has been handed to the operator.

--- a/.claude/skills/shepherd-onboarding/SKILL.md
+++ b/.claude/skills/shepherd-onboarding/SKILL.md
@@ -26,7 +26,7 @@ planning skill. Everything it needs is below.
 ## Stages
 
 Work the stages in order. Create a TodoWrite item per stage. **Nothing outward
-(issue creation, epic import) happens before the Stage 4 approval gate.**
+(issue creation, body edits) happens before the Stage 4 approval gate.**
 
 ### 0. Orient
 
@@ -49,10 +49,10 @@ git remote -v                      # is there a GitHub remote?
 gh auth status 2>/dev/null         # is gh usable?
 ```
 
-A working GitHub remote + `gh` ⇒ **GitHub-native** (issues + epic import available).
-Otherwise treat the repo as **local/lightweight**: programmatic issue creation and
-epic import are unavailable (epic import asserts a GitHub-native forge), so the
-backlog will be left as importable markdown (Stage 5).
+A working GitHub remote + `gh` ⇒ **GitHub-native**: you can create issues, and the
+operator can run the epic link import (Stage 5). Otherwise treat the repo as
+**local/lightweight**: programmatic issue creation is unavailable and epic import has
+no forge to write to, so the backlog will be left as importable markdown (Stage 5).
 
 **Intent source:**
 
@@ -171,7 +171,7 @@ dependencies, sized one-PR-each.
 
 Present the full draft — the proposed `CLAUDE.md` (as a diff for an existing repo)
 and the entire issue/epic tree — then **stop**. Use `AskUserQuestion` to confirm,
-amend, or abort. **Nothing is created or imported before this gate.** If the operator
+amend, or abort. **Nothing is created or edited before this gate.** If the operator
 amends, revise the draft and re-present.
 
 ### 5. Create (ordered)
@@ -192,29 +192,50 @@ Only after approval. **GitHub-native repos** — order matters, because the pare
 2. **Create the parent epic issue** with a body containing the `epic-dag` fence that
    references those captured child numbers (and a checklist if you like). Capture its
    number too.
-3. **Trigger import per parent** so the links are actually wired — imports are **not**
-   automatic on creation, and the endpoint requires a **GitHub-native forge**:
+3. **Hand the per-parent import to the operator.** The fence in the parent body is
+   what Shepherd recognizes, so the epic is drainable the moment step 2 lands;
+   import only additionally wires the **native sub-issue + `blocked_by` links**, is
+   **not** automatic on creation, and requires a **GitHub-native forge**.
 
-   ```bash
-   curl -s -X POST -G "http://127.0.0.1:7330/api/epic/import" \
-     --data-urlencode "repo=$(git rev-parse --show-toplevel)" \
-     --data-urlencode "parent=<PARENT_NUM>"
-   ```
+   **You cannot trigger it.** You reach the Shepherd server only through its
+   restricted loopback ingress, whose allowlist is session-scoped (hooks, build
+   queue, epic draft); the repo-scoped import route is not on it, and the main port
+   answers `{"error":"unauthorized"}` (401). That boundary is deliberate — import
+   performs GitHub writes, which stay on the operator's side of the gate. **Never
+   go hunting for the operator password or an API token to get around it.**
 
-   (`-G --data-urlencode` keeps the POST while URL-encoding the query, so a
-   repo path containing a space or `&` can't break the request.)
+   Give the operator both paths instead:
+   - **In the UI:** open the Backlog, expand the parent issue's row, and press
+     **Import structure** on the epic panel (also offered as a remediation inside
+     that panel's **Diagnose** modal).
+   - **From their own shell.** OPERATOR-RUN — needs their credentials, so print it
+     for them, don't run it:
 
-   (Use your Shepherd server's host/port; `7330` is the default.) The response
-   reports `subIssuesAdded` / `dependenciesAdded` / `unresolved`. Re-check any
-   `unresolved` member numbers.
+     ```bash
+     curl -s -X POST -G "http://127.0.0.1:7330/api/epic/import" \
+       -H "Authorization: Bearer $SHEPHERD_TOKEN" \
+       --data-urlencode "repo=$(git rev-parse --show-toplevel)" \
+       --data-urlencode "parent=<PARENT_NUM>"
+     ```
+
+     (Use your Shepherd server's host/port; `7330` is the default. The bearer
+     header only works if `SHEPHERD_TOKEN` is configured there — it's optional and
+     unset by default; without it, use the UI. `-G --data-urlencode` keeps the POST
+     while URL-encoding the query, so a repo path containing a space or `&` can't
+     break the request.)
+
+   The response reports `subIssuesAdded` / `dependenciesAdded` / `unresolved`; tell
+   the operator that any `unresolved` member numbers are worth reporting back, since
+   they usually mean a typo'd or foreign issue reference in the parent body.
 
 **Local/lightweight repos** — `forge.createIssue` and epic import are unavailable, so
 do **not** attempt programmatic creation or import. Write the approved tree to an
 importable markdown file (e.g. `BACKLOG.md`) and tell the operator it's the manual
 reference / future-import source. Say this explicitly rather than failing silently.
 
-**Completion criterion:** every approved issue exists (GitHub) with epic links wired
-and `unresolved` empty, or the markdown backlog is written (local).
+**Completion criterion:** every approved issue exists with its parent body carrying
+the `epic-dag` fence and the link import handed to the operator (GitHub), or the
+markdown backlog is written (local).
 
 ### 6. Point to first task
 
@@ -223,9 +244,11 @@ them, the smallest tracer-bullet. Tell the operator exactly how to start it in
 Shepherd — open a New Task on issue `#<n>`. Do **not** spawn the session yourself
 (Shepherd owns session creation; a skill in one session can't cleanly spawn another).
 
-For GitHub repos, first confirm the per-parent import actually wired the links
-(sub-issues + blocked-by present) before pointing. For local repos, point at the
-markdown backlog.
+For GitHub repos, first confirm the parent body actually carries the `epic-dag`
+fence with the real child numbers (`gh issue view <PARENT_NUM> --json body`) — that,
+not the import, is what makes it drainable. Restate the import as the one step still
+owed by the operator; don't wait on it. For local repos, point at the markdown
+backlog.
 
 If obvious tooling guardrails are missing (no lint/typecheck/test/CI), add a one-line
 nudge: run Shepherd's **Readiness** analyzer to score and install them.
@@ -235,10 +258,13 @@ to start it.
 
 ## Gate rules (reference)
 
-- **Outward actions are gated.** Issue creation and epic import are outward and
-  happen only after the Stage 4 approval. Drafting is always safe; creating is not.
-- **GitHub-only operations:** `gh issue create` and `POST /api/epic/import` require a
+- **Outward actions are gated.** Issue creation is outward and happens only after
+  the Stage 4 approval. Drafting is always safe; creating is not.
+- **GitHub-only operations:** `gh issue create` and the epic link import require a
   GitHub-native forge. Local/lightweight repos get the markdown backlog instead.
+- **Import is the operator's, never yours:** it is off the agent ingress allowlist
+  and 401s for you (Stage 5). Hand it over — never hunt for credentials to force it
+  through.
 - **epic-dag grammar:** members are `#<n>` lines inside a fenced ` ```epic-dag `
   block; an edge is `#<dependent> <- #<blocker>[, #<blocker>…]`. (A `- [ ] #<n>`
   checklist is also accepted as a member list with no edges.)

--- a/test/skill-agent-reachability.test.ts
+++ b/test/skill-agent-reachability.test.ts
@@ -1,0 +1,57 @@
+import { test, expect, describe } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { isAgentIngressRoute } from "../src/server";
+
+/**
+ * #2009 — the shipped skills used to instruct the agent to `POST /api/epic/import` to wire an
+ * epic's native sub-issue + blocked_by links. No spawned agent can reach that route: agents talk
+ * to the server only through the restricted loopback ingress, whose allowlist is session-scoped,
+ * and the repo-scoped import route is not on it (the main port answers 401). Both skills now hand
+ * import to the operator instead.
+ *
+ * The assertion can't simply be "the path is absent" — the skills still SHOW it, inside the
+ * command they print for the operator to run. So each skill must mention the path exactly once,
+ * and that mention must sit under the `OPERATOR-RUN` sentinel marking it as the operator's to run.
+ * Re-introducing an agent-facing call (a second mention, or an unmarked one) fails here.
+ */
+const OPERATOR_RUN_SENTINEL = "OPERATOR-RUN";
+const IMPORT_PATH = "/api/epic/import";
+/** How far above the mention the sentinel may sit — enough for the fence + a lead-in line. */
+const SENTINEL_LOOKBACK_LINES = 6;
+
+const SKILLS = ["shepherd-epic-authoring", "shepherd-onboarding"] as const;
+
+function readSkill(name: string): string {
+  return readFileSync(join(import.meta.dir, "..", ".claude", "skills", name, "SKILL.md"), "utf8");
+}
+
+describe("skills never instruct an agent-unreachable epic import (#2009)", () => {
+  test("the ingress allowlist rejects the import route", () => {
+    // The fact the skill text depends on. If someone ever admits import here, this fails and the
+    // skills' Stage 4/5 handoff wording has to be revisited in the same change.
+    expect(isAgentIngressRoute("POST", ["api", "epic", "import"])).toBe(false);
+    // …and the session-scoped shape it can't take, for good measure.
+    expect(isAgentIngressRoute("POST", ["api", "sessions", "abc", "epic-import"])).toBe(false);
+  });
+
+  for (const name of SKILLS) {
+    describe(name, () => {
+      const lines = readSkill(name).split("\n");
+      const mentions = lines
+        .map((line, i) => ({ line, i }))
+        .filter(({ line }) => line.includes(IMPORT_PATH));
+
+      test("mentions the import path exactly once", () => {
+        expect(mentions.length).toBe(1);
+      });
+
+      test("that mention is marked OPERATOR-RUN", () => {
+        expect(mentions.length).toBe(1);
+        const at = mentions[0]!.i;
+        const preceding = lines.slice(Math.max(0, at - SENTINEL_LOOKBACK_LINES), at);
+        expect(preceding.some((l) => l.includes(OPERATOR_RUN_SENTINEL))).toBe(true);
+      });
+    });
+  }
+});


### PR DESCRIPTION
Closes #2009.

## What was wrong

`shepherd-epic-authoring` Stage 4 told the agent to `POST /api/epic/import` to wire an epic's native sub-issue + `blocked_by` links. No spawned agent can reach that route:

- Agents talk to the server only through the restricted loopback ingress, whose allowlist (`isAgentIngressRoute`, `src/server.ts`) admits three **session-scoped** families — `hooks`, `queue`, `epic-draft`.
- `/api/epic/import` is repo-scoped, so it can't even take that shape (the per-session UUID is what stands in for the agent's credential). Hitting the main port instead lands on `checkAuth` → `{"error":"unauthorized"}`.

The failure is loud, but the skill gave no recovery path — so an agent either gave up or went looking for the operator password to get around a boundary that exists precisely to stop that.

**`shepherd-onboarding` carried the identical unreachable curl** (Stage 5 step 3, its completion criterion, the Stage 6 verify sentence, and its Gate-rules bullet). Not named in the issue; found while researching it, fixed here.

## What changed

Option 1 from the issue — fix the skills; the ingress surface is untouched. Import performs GitHub writes, which is exactly what the epic-draft flow deliberately keeps server-side.

The import step is now a **handoff**, in both skills:

1. States the boundary and why a 401 there is the system working — plus an explicit **never hunt for the operator password or an API token** rule.
2. **UI path first:** Backlog → expand the epic parent's issue row → **Import structure** (`EpicPanel.svelte`, shown for a marker-derived epic), also offered as a remediation in that panel's **Diagnose** modal.
3. **Operator-run curl second**, marked `OPERATOR-RUN`, carrying the bearer header and the honest caveat that it only works when `SHEPHERD_TOKEN` is configured (optional, unset by default) — otherwise the UI is the path.
4. Makes the non-blocking part loud: the body marker **is** the recognition contract, so the epic is recognized and drainable already; import only wires the native links, and nothing waits on it. The downstream verify steps now check the marker rather than the wired links.

Gate-rules sections in both skills were realigned to match — no remaining claim that the agent creates, imports, or waits on import.

## Regression gate

`test/skill-agent-reachability.test.ts` (following the `test/epic-parse.test.ts` precedent of asserting skill-doc content):

- Asserts `isAgentIngressRoute("POST", ["api","epic","import"])` is `false` — the fact the skill text depends on. If the ingress is ever widened to admit import, this fails and forces the handoff wording to be revisited in the same change.
- Per skill: `/api/epic/import` occurs **exactly once** and that mention sits under the `OPERATOR-RUN` sentinel. "Assert absent" isn't available — the path legitimately survives inside the command printed for the operator — so the test asserts the shape instead. A re-introduced agent-facing call (a second mention, or an unmarked one) fails here.

## Verification

- `bun test ./test` — 8136 pass / 0 fail (includes the pre-existing `epic-parse` skill assertions and the new test).
- `bun run lint`, `bunx tsc --noEmit`, `bunx prettier --check` on the touched files — clean.
- `bunx fallow audit --base origin/main --fail-on-issues` — no issues in the 3 changed files.

UI half untouched. No i18n, glossary, or feature-catalog entry: nothing user-facing ships (`fix`, not `feat`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)