### PR TITLE
feat(learnings): re-target the flywheel from rules to gotchas

### DIFF
--- a/scripts/sweep-house-rules.ts
+++ b/scripts/sweep-house-rules.ts
@@ -1,0 +1,157 @@
+#!/usr/bin/env bun
+/**
+ * One-shot sweep of a repo's active house rules against the admission test (issue #2004).
+ *
+ * The flywheel now admits non-derivable repo FACTS, not behavioral rules (`src/learning-shape.ts`).
+ * The distiller's fails-the-admission-test DELETE criterion keeps the corpus honest from here on;
+ * this script is how the corpus that predates the re-target gets fixed in one pass, and how the
+ * resulting shrink of the injected `<shepherd-house-rules>` block is measured.
+ *
+ * Read-only by default. Nothing is retired without `--apply`, and every retirement is reversible
+ * through `POST /api/learnings/:id/restore` (the reason is stored as `not-a-gotcha`, so the sweep's
+ * retirements stay distinguishable from Wilson auto-retires, expired trials and merges).
+ *
+ *   scripts/sweep-house-rules.ts --repo /path/to/repo
+ *       Dry run: prints the admission test, every active rule, and the current block cost.
+ *
+ *   scripts/sweep-house-rules.ts --repo /path/to/repo --decisions drop.json
+ *       Dry run + projected before/after for the drops in `{"drop":[{"id":"…","why":"…"}]}`.
+ *
+ *   scripts/sweep-house-rules.ts --repo /path/to/repo --decisions drop.json --apply
+ *       Retires them and prints the measured before/after.
+ *
+ * Writes to the live DB directly (a second SQLite writer; WAL + busy_timeout make that safe — see
+ * store.ts). The running server holds no learnings cache, but it does not learn of the change
+ * either: the drawer refreshes on its next fetch. Snapshot first — note that even a dry run opens a
+ * full `SessionStore`, which runs this build's additive schema migrations against the file:
+ *   sqlite3 ~/.shepherd/shepherd.db "VACUUM INTO '/tmp/pre-sweep.db'"
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { SessionStore } from "../src/store";
+import { resolveDbPath } from "../src/backup-paths";
+import { LEARNING_ADMISSION_TEST, SWEEP_RETIRE_REASON } from "../src/learning-shape";
+import {
+  parseDecisions,
+  planSweep,
+  priceBlock,
+  type BlockCost,
+  type SweepDecision,
+  type SweepPlan,
+} from "../src/learning-sweep";
+
+/** Kept in step with `config.houseRulesBudgetChars`; config.ts is not imported here because loading
+ *  it runs forge/node-bin resolution side effects a CLI has no use for (same reason backup.ts keeps
+ *  its own path resolver). */
+const BUDGET_CHARS = Number(process.env.SHEPHERD_HOUSE_RULES_BUDGET_CHARS ?? 4000);
+
+interface Args {
+  repo: string;
+  decisions?: string;
+  apply: boolean;
+  db: string;
+}
+
+export function parseArgs(argv: string[]): Args {
+  const out: Partial<Args> = { apply: false, db: resolveDbPath() };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--apply") out.apply = true;
+    else if (a === "--repo") out.repo = argv[++i];
+    else if (a === "--decisions") out.decisions = argv[++i];
+    else if (a === "--db") out.db = argv[++i];
+    else throw new Error(`unknown argument: ${a}`);
+  }
+  if (!out.repo) throw new Error("--repo <path> is required");
+  if (out.apply && !out.decisions) throw new Error("--apply requires --decisions <file>");
+  return out as Args;
+}
+
+function fmt(c: BlockCost): string {
+  return `${c.injectedRules} injected · ${c.chars} chars · ~${c.tokens} est-tokens`;
+}
+
+/** Print the outcome. `done` is what was actually retired (null on a dry run) and `after` the cost
+ *  that goes with it — both passed in rather than read off the plan, so a run that aborts partway
+ *  reports what really happened instead of what it intended. */
+function report(plan: SweepPlan, done: SweepPlan["retire"] | null, after: BlockCost): void {
+  for (const r of plan.refused) console.log(`REFUSED  ${r.id}  (${r.reason})`);
+  const rows = done ?? plan.retire;
+  for (const r of rows) console.log(`${done ? "RETIRED" : "WOULD RETIRE"}  ${r.id}  ${r.rule}`);
+  console.log(`\nactive rules  ${plan.activeBefore} → ${plan.activeBefore - rows.length}`);
+  console.log(`block before  ${fmt(plan.before)}`);
+  console.log(`block after   ${fmt(after)}`);
+  const saved = plan.before.chars - after.chars;
+  const pct = plan.before.chars > 0 ? Math.round((saved / plan.before.chars) * 100) : 0;
+  console.log(
+    `saved         ${saved} chars (${pct}%) · ~${plan.before.tokens - after.tokens} est-tokens`,
+  );
+}
+
+function main(argv: string[]): number {
+  let args: Args;
+  try {
+    args = parseArgs(argv);
+  } catch (e) {
+    console.error(String(e instanceof Error ? e.message : e));
+    console.error(
+      "usage: sweep-house-rules.ts --repo <path> [--decisions <file>] [--apply] [--db <path>]",
+    );
+    return 2;
+  }
+  const store = new SessionStore(args.db);
+  const rules = store.listActiveLearnings(args.repo);
+  if (rules.length === 0) {
+    console.error(`no active house rules for ${args.repo} in ${args.db}`);
+    return 1;
+  }
+
+  if (!args.decisions) {
+    console.log(LEARNING_ADMISSION_TEST);
+    console.log(`\n${rules.length} active rules for ${args.repo}:\n`);
+    for (const r of rules) {
+      const scope = r.scopeGlobs.length ? ` [scope: ${r.scopeGlobs.join(",")}]` : "";
+      console.log(`${r.id}  (${r.status})${scope}\n  ${r.rule}\n`);
+    }
+    console.log(`block cost    ${fmt(planSweep(rules, [], BUDGET_CHARS).before)}`);
+    return 0;
+  }
+
+  let decisions: SweepDecision[];
+  try {
+    decisions = parseDecisions(JSON.parse(readFileSync(args.decisions, "utf8")));
+  } catch (e) {
+    console.error(`decisions file: ${String(e instanceof Error ? e.message : e)}`);
+    return 2;
+  }
+  const plan = planSweep(rules, decisions, BUDGET_CHARS);
+  if (!args.apply) {
+    report(plan, null, plan.after);
+    console.log("\n(dry run — pass --apply to retire)");
+    return 0;
+  }
+  // Retire one at a time and keep the successes: a rule that changed status between the plan and
+  // now returns null, and the report must then describe the partial state, not the intent.
+  const done: SweepPlan["retire"] = [];
+  let failed: string | null = null;
+  for (const r of plan.retire) {
+    if (store.retireLearning(r.id, SWEEP_RETIRE_REASON) === null) {
+      failed = r.id;
+      break;
+    }
+    done.push(r);
+  }
+  // Price the state that now exists, rather than trusting the projection.
+  report(plan, done, priceBlock(store.listActiveLearnings(args.repo), BUDGET_CHARS));
+  if (failed !== null) {
+    console.error(
+      `\nFAILED to retire ${failed} (no longer active?) — stopped, earlier drops stand`,
+    );
+    return 1;
+  }
+  return 0;
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -12,6 +12,12 @@ import { buildTransientAgentArgv } from "./transient-agent-argv";
 import { reapTransientByLabel } from "./transient-tab-reaper";
 import type { RoleEnvironment } from "./default-model";
 import { normalizeRule } from "./learning-rule";
+import {
+  LEARNING_ADMISSION_TEST,
+  LEARNING_FACT_SHAPE,
+  LEARNING_RULE_MAX_CHARS,
+  trimRuleToLimit,
+} from "./learning-shape";
 
 const PROPOSALS_FILE = ".shepherd-learnings.json";
 
@@ -451,7 +457,7 @@ export class DistillerService {
       have.add(key);
       this.deps.store.addLearning({
         repoPath: f.repoPath,
-        rule: r.rule.trim().slice(0, 240),
+        rule: trimRuleToLimit(r.rule),
         rationale: typeof r.rationale === "string" ? r.rationale : "",
         evidence,
         scopeGlobs: sanitizeScopeGlobs(r.scopeGlobs),
@@ -513,20 +519,29 @@ function isBlockedByPruneTombstone(
   );
 }
 
-function distillPrompt(): string {
+export function distillPrompt(): string {
   return [
-    "You are a code-review pattern analyst. Read `signals.json` in this directory.",
+    "You are a repo-gotcha analyst. Your job is NOT to write rules of conduct — it is to capture the",
+    "non-obvious FACTS about one repository that cost an agent real time when it does not know them.",
+    "Read `signals.json` in this directory.",
     "It is a JSON object with four fields:",
     "  `signals` — an array of past corrections, blocks, stalls, and critic findings for one repository;",
-    "  `existingRules` — all recorded/dismissed rules (do NOT ADD any of these — they are the dedup set);",
-    "  `activeRules` — currently-active house rules as {id, rule, promoted} objects. UPDATE/DELETE may target ONLY entries with promoted:false; promoted:true rules are mirrored in CLAUDE.md and may only be flagged ineffective.",
-    "  `proposedRules` — currently-proposed rules as {id, rule} objects (not yet active).",
+    "  `existingRules` — all recorded/dismissed entries (do NOT ADD any of these — they are the dedup set);",
+    "  `activeRules` — currently-active entries as {id, rule, promoted} objects. UPDATE/DELETE may target ONLY entries with promoted:false; promoted:true entries are mirrored in CLAUDE.md and may only be flagged ineffective.",
+    "  `proposedRules` — currently-proposed entries as {id, rule} objects (not yet active).",
+    "",
+    LEARNING_ADMISSION_TEST,
+    "",
+    LEARNING_FACT_SHAPE,
     "",
     "For each candidate finding, choose exactly ONE action:",
-    "  ADD    → emit in `rules`   (new guidance, not already in existingRules)",
+    "  ADD    → emit in `rules`   (passes the admission test, not already in existingRules)",
     "  UPDATE → emit in `updates` (same topic AND same target; richer wording — keep the most informative version)",
-    "  DELETE → emit in `deletes` (the finding directly CONTRADICTS that activeRule — emit any corrected rule as a separate ADD)",
-    "  NOOP   → emit nothing      (already fully covered by an existingRule or activeRule)",
+    "  DELETE → emit in `deletes` for EITHER reason: (a) the finding directly CONTRADICTS that activeRule",
+    "           (emit any corrected fact as a separate ADD), or (b) that activeRule FAILS the admission",
+    "           test above — it is judgement/process guidance, a restated standing directive, or a",
+    "           preference with no failure mode. Reason (b) needs no signal: judge the rule's own text.",
+    "  NOOP   → emit nothing      (fails the admission test, or already fully covered by an existingRule or activeRule)",
     "",
     "MULTI-VALUED GUARD: never UPDATE or DELETE a rule whose target (file / category / object) DIFFERS",
     "from the candidate, even if the topic is similar. A UI rule and a migration rule about the same",
@@ -549,7 +564,7 @@ function distillPrompt(): string {
     'glob patterns (e.g. "src/**", "ui/**/*.svelte") so the rule injects only for tasks touching',
     "those files. OMIT `scopeGlobs` (or use []) for general rules — do not invent a scope when unsure.",
     `Write your output as JSON to \`${PROPOSALS_FILE}\` in this directory, shaped exactly:`,
-    '{"rules":[{"rule":"<=160 char imperative","rationale":"why","evidence":["signalId",...],"scopeGlobs":["glob",...]}],"updates":[{"id":"activeRuleId","rule":"<=160 char imperative","rationale":"why"}],"deletes":[{"id":"activeRuleId","reason":"why"}],"ineffective":[{"id":"activeRuleId","evidence":["signalId",...]}],"reaffirm":[{"id":"proposedRuleId","evidence":["signalId",...]}]}',
+    `{"rules":[{"rule":"<=${LEARNING_RULE_MAX_CHARS} char fact line (see SHAPE)","rationale":"why this is not derivable from the repo","evidence":["signalId",...],"scopeGlobs":["glob",...]}],"updates":[{"id":"activeRuleId","rule":"<=${LEARNING_RULE_MAX_CHARS} char fact line","rationale":"why"}],"deletes":[{"id":"activeRuleId","reason":"contradicted | fails-admission-test, plus one sentence"}],"ineffective":[{"id":"activeRuleId","evidence":["signalId",...]}],"reaffirm":[{"id":"proposedRuleId","evidence":["signalId",...]}]}`,
     'If nothing applies, write {"rules":[],"updates":[],"deletes":[],"ineffective":[],"reaffirm":[]}. Do not write anything else.',
   ].join("\n");
 }

--- a/src/learning-shape.ts
+++ b/src/learning-shape.ts
@@ -47,9 +47,10 @@ export const LEARNING_FACT_SHAPE = [
   "SHAPE — write each qualifying finding as ONE self-contained line carrying all three parts:",
   "  <the fact — what is true, naming the artifact> — <why it bites — the failure it causes> ; <how to apply it>",
   "Only this line is ever shown to a future agent, so it must stand alone. State the fact, not an",
-  'exhortation: prefer "`refs/stash` is one stack shared by every worktree of the repo, so a bare',
-  "`git stash pop` can take another session's entry — use `git stash create` + `apply <sha>`\" over",
-  '"never use git stash".',
+  "exhortation: prefer \"a column added by ALTER is missing from `update()`'s whitelist, so writes",
+  'to it are dropped with no error — add a dedicated setter beside the migration" over "remember',
+  'to add a setter". (Illustrative shape only — never propose an entry that merely restates a',
+  "directive the agent is already handed every session; see the REJECT list above.)",
 ].join("\n");
 
 /** Hard cap on stored rule text — the width every entry point trims to. */

--- a/src/learning-shape.ts
+++ b/src/learning-shape.ts
@@ -1,0 +1,76 @@
+/**
+ * What the learnings flywheel is allowed to admit (issue #2004).
+ *
+ * The flywheel was built to manufacture imperative behavioral rules, distil them, rank them and
+ * inject up to `SHEPHERD_HOUSE_RULES_BUDGET_CHARS` of them into every spawn's system prompt. That
+ * made sense when models needed to be told how to work. It stopped making sense when the same
+ * guidance began competing with the system prompt and the operator's actual request for attention —
+ * the conflicting-instruction failure Anthropic describes in "The new rules of context engineering
+ * for Claude 5 generation models" (they deleted over 80% of Claude Code's system prompt on the
+ * strength of it).
+ *
+ * So the flywheel is re-targeted, at ADMISSION, from rules to gotchas: what is TRUE about this repo
+ * that an agent cannot work out for itself, why getting it wrong hurts, and how to apply it. The
+ * test below is the single source of truth for that, shared verbatim by the distiller prompt
+ * (proposal + delete), the optimizer prompt (rewrite) and the sweep tooling (retire) so the three
+ * cannot drift apart.
+ *
+ * It is INSTRUCTION, not a gate — no regex can tell a fact from a platitude. The corrective loops are
+ * the distiller's fails-the-test DELETE criterion (which keeps sweeping the active set every run) and
+ * the operator's approve click, which sees the same criterion restated in the drawer.
+ */
+
+/** Agent-facing prompt text, so fixed English — same precedent as the distiller/critic prompts. */
+export const LEARNING_ADMISSION_TEST = [
+  "ADMISSION TEST — a candidate qualifies only when ALL THREE hold:",
+  "  1. NON-DERIVABLE — an agent could not learn it by reading the repo, its README/CLAUDE.md, or",
+  "     `--help`, in the session where it needs it.",
+  "  2. CONSEQUENTIAL AND QUIET — getting it wrong causes a concrete failure that is silent, delayed,",
+  '     or expensive to undo. "the linter catches it" is a REJECT.',
+  "  3. ATTACHED TO AN ARTIFACT — it names the file, flag, endpoint, table, field or invariant it",
+  "     applies to, so a reviewer can check it against the code.",
+  "",
+  "REJECT outright — do not propose, and DELETE if already active — when the candidate is:",
+  "  - general engineering judgement or process a capable model already follows unprompted:",
+  "    scope discipline, verify-before-claiming, ask-before-destructive, deliver-findings-first,",
+  "    don't-build-what-wasn't-asked, finish-what-you-started;",
+  "  - a restatement of a directive the agent is already given every session (worktree/stash safety,",
+  "    tmpfs, untrusted content, one-PR-per-session, plan gate, build queue) or of the repo's CLAUDE.md;",
+  '  - a preference with no failure mode ("prefer X over Y");',
+  "  - broad enough to apply to any repository — that is not a fact about THIS one.",
+].join("\n");
+
+/** How a qualifying finding must be written. The injected block renders the `rule` line ONLY
+ *  (`renderHouseRulesBlock` in house-rules.ts) — the rationale never reaches the agent — so the
+ *  fact, its consequence and its application all have to survive in that one line. */
+export const LEARNING_FACT_SHAPE = [
+  "SHAPE — write each qualifying finding as ONE self-contained line carrying all three parts:",
+  "  <the fact — what is true, naming the artifact> — <why it bites — the failure it causes> ; <how to apply it>",
+  "Only this line is ever shown to a future agent, so it must stand alone. State the fact, not an",
+  'exhortation: prefer "`refs/stash` is one stack shared by every worktree of the repo, so a bare',
+  "`git stash pop` can take another session's entry — use `git stash create` + `apply <sha>`\" over",
+  '"never use git stash".',
+].join("\n");
+
+/** Hard cap on stored rule text — the width every entry point trims to. */
+export const LEARNING_RULE_MAX_CHARS = 240;
+
+/** Trim rule text to {@link LEARNING_RULE_MAX_CHARS} at a WORD boundary.
+ *
+ *  The blunt `slice(0, 240)` this replaces cut mid-word, and a fact line loses its point when the
+ *  consequence is the part that falls off — the live corpus already carried "…leaks into execution
+ *  across consumers when one site " as a truncated fragment. Fact-shaped entries run longer than the
+ *  imperatives the flywheel used to emit, so the cut matters more, not less. Falls back to a hard
+ *  slice when the overlong text has no space to break on. */
+export function trimRuleToLimit(rule: string): string {
+  const text = rule.trim();
+  if (text.length <= LEARNING_RULE_MAX_CHARS) return text;
+  const cut = text.slice(0, LEARNING_RULE_MAX_CHARS);
+  const lastSpace = cut.lastIndexOf(" ");
+  return (lastSpace > 0 ? cut.slice(0, lastSpace) : cut).trimEnd();
+}
+
+/** Stored in `retiredReason` by the sweep (issue #2004) so a retirement carries WHY it happened —
+ *  distinct from `auto-retire` (Wilson-scored underperformance), `trial-expired`, `superseded` and
+ *  `merged`. Reversible through `POST /api/learnings/:id/restore`. */
+export const SWEEP_RETIRE_REASON = "not-a-gotcha";

--- a/src/learning-sweep.ts
+++ b/src/learning-sweep.ts
@@ -1,0 +1,131 @@
+/**
+ * Pure planning + pricing for the one-shot house-rules sweep (issue #2004).
+ *
+ * The flywheel's admission criteria were re-targeted from behavioral rules to non-derivable repo
+ * facts (see `src/learning-shape.ts`). Going forward the distiller's fails-the-admission-test DELETE
+ * criterion drains the active set on its own daily run; this module exists for the one-shot that
+ * fixes TODAY's corpus, and for measuring what that costs the injected block.
+ *
+ * No store, no fs, no clock of its own — `scripts/sweep-house-rules.ts` is the only I/O — so the
+ * arithmetic the sweep reports is unit-testable against fixtures.
+ *
+ * Pricing deliberately reuses the spawn path end to end: `planHouseRulesInjection` decides what
+ * would inject, `renderHouseRulesBlock` renders exactly what a spawn would carry, and
+ * `measurePromptBlocks` (the #1999 meter) prices it. So the numbers reported here are the meter's
+ * numbers in the meter's units, not a parallel estimate. One caveat worth stating: with no session
+ * there are no target paths, so scope-gated rules never inject — same as the drawer's cross-repo
+ * overview. The delta is therefore the Always-rule baseline, and a scoped rule's retirement shows up
+ * in the rule count, not in the chars.
+ */
+
+import type { Learning } from "./types";
+import { planHouseRulesInjection, renderHouseRulesBlock, HOUSE_RULES_TAG } from "./house-rules";
+import { measurePromptBlocks } from "./prompt-budget";
+
+/** One operator/agent decision: retire this rule, for this stated reason. */
+export interface SweepDecision {
+  id: string;
+  why: string;
+}
+
+/** Why a decision could not be applied. `promoted` rules are refused for the same reason the
+ *  distiller may not delete them — their text is mirrored verbatim in the repo's CLAUDE.md, so
+ *  retiring the row silently desyncs the two. */
+export type SweepRefusal = "not-found" | "not-active" | "promoted";
+
+/** What the injected `<shepherd-house-rules>` block costs, in the meter's units. */
+export interface BlockCost {
+  /** Rules that would actually inject (Always-rules; see the module note on scope gating). */
+  injectedRules: number;
+  chars: number;
+  bytes: number;
+  /** ESTIMATE — see `estimateTokens` in prompt-budget.ts. */
+  tokens: number;
+}
+
+export interface SweepPlan {
+  retire: { id: string; rule: string; why: string }[];
+  refused: { id: string; reason: SweepRefusal }[];
+  /** Rules the repo has now (active + promoted), and what remains after the retirements. */
+  activeBefore: number;
+  activeAfter: number;
+  before: BlockCost;
+  after: BlockCost;
+}
+
+/** Price the block that `rules` would produce at spawn. An empty injection set renders to `null`
+ *  (no block at all), which costs nothing — not the bare tag overhead. */
+export function priceBlock(rules: Learning[], budgetChars: number, now?: number): BlockCost {
+  const plan = planHouseRulesInjection(rules, budgetChars, now ?? Date.now());
+  const text = renderHouseRulesBlock(plan.injected);
+  if (text === null) return { injectedRules: 0, chars: 0, bytes: 0, tokens: 0 };
+  const measured = measurePromptBlocks([{ name: HOUSE_RULES_TAG, text }]);
+  return {
+    injectedRules: plan.injected.length,
+    chars: measured.totalChars,
+    bytes: measured.totalBytes,
+    tokens: measured.totalTokens,
+  };
+}
+
+/**
+ * Resolve `decisions` against the repo's current active+promoted `rules` and price the before/after
+ * block. Pure: decides nothing on its own and mutates nothing — the caller applies `retire`.
+ *
+ * A decision naming an unknown id, an already-retired rule or a promoted rule is refused rather
+ * than silently dropped, so a stale decisions file is visible instead of quietly under-applying.
+ * Duplicate ids collapse to one retirement.
+ */
+export function planSweep(
+  rules: Learning[],
+  decisions: SweepDecision[],
+  budgetChars: number,
+  now?: number,
+): SweepPlan {
+  const byId = new Map(rules.map((r) => [r.id, r]));
+  const retire: SweepPlan["retire"] = [];
+  const refused: SweepPlan["refused"] = [];
+  const seen = new Set<string>();
+  for (const d of decisions) {
+    if (seen.has(d.id)) continue;
+    seen.add(d.id);
+    const rule = byId.get(d.id);
+    if (!rule) {
+      refused.push({ id: d.id, reason: "not-found" });
+      continue;
+    }
+    if (rule.status === "promoted") {
+      refused.push({ id: d.id, reason: "promoted" });
+      continue;
+    }
+    if (rule.status !== "active") {
+      refused.push({ id: d.id, reason: "not-active" });
+      continue;
+    }
+    retire.push({ id: rule.id, rule: rule.rule, why: d.why });
+  }
+  const retiring = new Set(retire.map((r) => r.id));
+  const remaining = rules.filter((r) => !retiring.has(r.id));
+  return {
+    retire,
+    refused,
+    activeBefore: rules.length,
+    activeAfter: remaining.length,
+    before: priceBlock(rules, budgetChars, now),
+    after: priceBlock(remaining, budgetChars, now),
+  };
+}
+
+/** Parse a decisions file body: `{"drop":[{"id":"…","why":"…"}]}`. Throws on any shape it cannot
+ *  trust — applying a half-understood file against the live corpus is worse than refusing to run. */
+export function parseDecisions(raw: unknown): SweepDecision[] {
+  if (typeof raw !== "object" || raw === null || !Array.isArray((raw as { drop?: unknown }).drop)) {
+    throw new Error('decisions file must be {"drop":[{"id":"…","why":"…"}]}');
+  }
+  return (raw as { drop: unknown[] }).drop.map((entry, i) => {
+    const e = entry as { id?: unknown; why?: unknown };
+    if (typeof e?.id !== "string" || !e.id.trim()) throw new Error(`drop[${i}]: missing id`);
+    if (typeof e.why !== "string" || !e.why.trim()) throw new Error(`drop[${i}]: missing why`);
+    return { id: e.id.trim(), why: e.why.trim() };
+  });
+}

--- a/src/learnings-service.ts
+++ b/src/learnings-service.ts
@@ -2,6 +2,7 @@ import type { SessionStore } from "./store";
 import type { EventHub } from "./events";
 import type { EvidenceItem, Learning, SignalKind } from "./types";
 import { planHouseRulesInjection, prioritize } from "./house-rules";
+import { trimRuleToLimit } from "./learning-shape";
 
 /** Flatten + clip a signal payload to a one-line evidence excerpt for the drawer. */
 function evidenceExcerpt(payload: string, max = 140): string {
@@ -111,13 +112,13 @@ export class LearningsService {
 
   /**
    * Approve (→active) or dismiss a proposed rule. On approve, an edited rule is
-   * normalized to addLearning's contract (trim + 240 cap); an empty edit falls
+   * normalized to addLearning's contract (word-boundary trim to the rule cap); an empty edit falls
    * back to the stored rule. Returns null (no emit) when the rule isn't found.
    */
   setStatus(id: string, action: "approve" | "dismiss", ruleEdit?: string): Learning | null {
     let rule: string | undefined;
     if (action === "approve" && typeof ruleEdit === "string") {
-      const trimmed = ruleEdit.trim().slice(0, 240);
+      const trimmed = trimRuleToLimit(ruleEdit);
       if (trimmed) rule = trimmed;
     }
     const status = action === "approve" ? "active" : "dismissed";

--- a/src/optimizer.ts
+++ b/src/optimizer.ts
@@ -77,7 +77,15 @@ export interface OptimizerDeps {
 /**
  * Operator-triggered LLM pass that rewrites flagged ("not working") house rules using
  * their failure evidence, applies the rewrites in place (clearing the flag), and opens a
- * CLAUDE.md sync PR for any revised *promoted* rule. A faithful sibling of
+ * CLAUDE.md sync PR for any revised *promoted* rule.
+ *
+ * An OMITTED target (the agent judged it unrewritable — since #2004 that includes failing the
+ * admission test) is left flagged and unchanged, and nothing here retires it. Note this is NOT
+ * self-draining under `autoOptimizeFlagged`: `runAutoRetire` skips retirement while
+ * `autoOptimizedAt` is null and only `reviseLearning` stamps it, so an omitted target is
+ * re-enqueued for `optimizeOne` on every sweep. What actually drains a fails-the-test entry is
+ * the distiller's DELETE criterion (non-promoted active rules) — or plain auto-retire in a repo
+ * with `autoOptimizeFlagged` off. A faithful sibling of
  * {@link DistillerService} — same inflight/queue/tick/finalize/health shape and the same
  * shared read-only transient-agent contract. NEVER runs on a timer inside the service.
  */
@@ -377,8 +385,8 @@ export function optimizePrompt(): string {
     "Optionally refine the rationale. Preserve each target's `id` EXACTLY; do not invent ids or",
     "add targets. OMIT a target when it cannot be restated as a fact — including when it fails the",
     "admission test outright (judgement/process guidance, a restated standing directive, or a",
-    "preference with no failure mode). Omitting leaves it flagged, which is the correct outcome:",
-    "the lifecycle retires it. Do not rescue such an entry by making it a sterner instruction.",
+    "preference with no failure mode). Omitting leaves it flagged and unchanged, which is the",
+    "correct outcome; do not rescue such an entry by making it a sterner instruction.",
     `Write your output as JSON to \`${OUTPUT_FILE}\` in this directory, shaped exactly:`,
     `{"revisions": [{"id": "<id>", "rule": "<=${LEARNING_RULE_MAX_CHARS} char fact line", "rationale": "why (optional)"}]}`,
     "Write nothing else.",

--- a/src/optimizer.ts
+++ b/src/optimizer.ts
@@ -10,6 +10,11 @@ import { apiKeyFailClosed, apiKeyPassthroughEnv } from "./spawn-auth";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
 import { reapTransientByLabel } from "./transient-tab-reaper";
 import type { RoleEnvironment } from "./default-model";
+import {
+  LEARNING_ADMISSION_TEST,
+  LEARNING_FACT_SHAPE,
+  LEARNING_RULE_MAX_CHARS,
+} from "./learning-shape";
 
 const INPUT_FILE = "input.json";
 const OUTPUT_FILE = "optimized.json";
@@ -356,18 +361,26 @@ function coerceRevision(e: {
   return { id, rule: e.rule, rationale };
 }
 
-function optimizePrompt(): string {
+export function optimizePrompt(): string {
   return [
-    `You are a house-rule editor. Read \`${INPUT_FILE}\` in this directory.`,
+    `You are a repo-gotcha editor. Read \`${INPUT_FILE}\` in this directory.`,
     'It is a JSON object `{ "targets": [{ "id", "rule", "rationale", "failures": [{ "kind", "payload" }] }] }`.',
-    "Each target is a standing house rule for one repository that FAILED to prevent a mistake;",
+    "Each target is a standing entry for one repository that FAILED to prevent a mistake;",
     "`failures` are the signals (critic findings / blocks / corrections) showing it failing.",
-    "For each target, produce a STRONGER, more specific imperative rewrite (<=160 chars) that",
-    "would have prevented those failures — keep the same intent, make it concrete and actionable.",
+    "",
+    LEARNING_ADMISSION_TEST,
+    "",
+    LEARNING_FACT_SHAPE,
+    "",
+    "For each target, recover the underlying FACT its failures point at and restate the entry in the",
+    `shape above (<=${LEARNING_RULE_MAX_CHARS} chars) so an agent that reads it once cannot repeat those failures.`,
     "Optionally refine the rationale. Preserve each target's `id` EXACTLY; do not invent ids or",
-    "add targets. If a rule genuinely cannot be improved, omit it.",
+    "add targets. OMIT a target when it cannot be restated as a fact — including when it fails the",
+    "admission test outright (judgement/process guidance, a restated standing directive, or a",
+    "preference with no failure mode). Omitting leaves it flagged, which is the correct outcome:",
+    "the lifecycle retires it. Do not rescue such an entry by making it a sterner instruction.",
     `Write your output as JSON to \`${OUTPUT_FILE}\` in this directory, shaped exactly:`,
-    '{"revisions": [{"id": "<id>", "rule": "<=160 char imperative", "rationale": "why (optional)"}]}',
+    `{"revisions": [{"id": "<id>", "rule": "<=${LEARNING_RULE_MAX_CHARS} char fact line", "rationale": "why (optional)"}]}`,
     "Write nothing else.",
   ].join("\n");
 }

--- a/src/promote.ts
+++ b/src/promote.ts
@@ -1,8 +1,7 @@
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { promisify } from "node:util";
 import type { Options } from "prettier";
 import type { SessionStore } from "./store";
@@ -43,41 +42,19 @@ export class Promoter {
     this.git = deps.git ?? defaultGit;
     this.readClaudeMd =
       deps.readClaudeMd ?? ((p) => (existsSync(p) ? readFileSync(p, "utf8") : ""));
-    // Ensure the parent dir exists before writing — harmless for worktree paths (the dir is
-    // already there), and lets the global write (issue #872) create ~/.claude if absent.
-    this.writeClaudeMd =
-      deps.writeClaudeMd ??
-      ((p, c) => {
-        mkdirSync(dirname(p), { recursive: true });
-        writeFileSync(p, c);
-      });
+    this.writeClaudeMd = deps.writeClaudeMd ?? ((p, c) => writeFileSync(p, c));
   }
 
-  /** Write a single cross-repo rule into the user-global `~/.claude/CLAUDE.md` (issue #872).
-   *  No forge/branch/PR — a direct, operator-confirmed write to the home-dir file. Reads the
-   *  existing Shepherd-owned block, unions the rule in (dedup, order-preserving) and rewrites.
-   *  Idempotent: a no-op (no write) when the rule is already present. `homedir()` is the server
-   *  process's home — see the issue's home-dir-trust caveat. */
-  async promoteGlobal(rule: string): Promise<PromoteResult> {
-    const path = join(homedir(), ".claude", "CLAUDE.md");
-    try {
-      const current = this.readClaudeMd(path);
-      // Dedup in *sanitized* space: extractLearningsBlockRules returns the stored rules in
-      // their already-sanitized form, while `rule` is raw — comparing them raw would miss a
-      // rule that sanitize alters (leading marker / collapsible whitespace), writing a
-      // duplicate bullet and defeating the `next === current` no-op on re-promote.
-      const rules = [...new Set([...extractLearningsBlockRules(current), rule].map(sanitizeRule))];
-      const next = upsertLearningsBlock(current, rules);
-      if (next === current) return { ok: true, url: "" };
-      this.writeClaudeMd(path, next);
-      return { ok: true, url: "" };
-    } catch (err) {
-      // Don't leak raw fs stderr (EACCES/EROFS on the home dir) to the client; log it
-      // server-side and return a structured result, matching the PR-promote path.
-      console.warn(`[promote-global] failed:`, err);
-      return { ok: false, error: "global promote failed", status: 500 };
-    }
-  }
+  /* Promote-to-GLOBAL (`~/.claude/CLAUDE.md`, issue #872) was removed here in #2004 (the Claude-5
+   * context-engineering epic). Three reasons, recorded so it isn't re-added by reflex:
+   *   - Claude's own auto-memory now owns that file, written by the model that reads it. A second
+   *     writer duplicates the channel.
+   *   - A rule promoted there is resident in EVERY session of EVERY repo — the widest blast radius
+   *     available, for exactly the class of standing instruction this epic is cutting back.
+   *   - It was the one write in the flywheel with no review gate: no PR, no approval, straight to
+   *     the operator's home dir.
+   * The per-repo promotes below keep their PR, so a rule still reaches a CLAUDE.md — reviewably,
+   * and scoped to the repo whose gotcha it actually is. */
 
   async resyncPromoted(repoPath: string): Promise<PromoteResult> {
     // Claim inflight slot synchronously — repo path can't collide with a learning id.
@@ -120,8 +97,8 @@ export class Promoter {
         return { ok: false, error: "worktree creation failed", status: 500 };
       }
       try {
-        // Dedup in sanitized space (matches promoteGlobal): two stored rules that collapse to
-        // the same sanitized bullet must not both survive into the block.
+        // Dedup in sanitized space: two stored rules that collapse to the same sanitized bullet
+        // must not both survive into the block.
         const rules = [...new Set(promoted.map((l) => sanitizeRule(l.rule)))];
         const claudePath = join(wt.worktreePath, "CLAUDE.md");
         const current = this.readClaudeMd(claudePath);
@@ -269,8 +246,8 @@ export class Promoter {
     const promoted = this.deps.store
       .listLearnings(learning.repoPath, { status: "promoted" })
       .map((l) => l.rule);
-    // Dedup in sanitized space (matches promoteGlobal): a stored rule and the newly-promoted
-    // one that collapse to the same sanitized bullet must dedup, not emit a duplicate.
+    // Dedup in sanitized space: a stored rule and the newly-promoted one that collapse to the
+    // same sanitized bullet must dedup, not emit a duplicate.
     const rules = [...new Set([...promoted, learning.rule].map(sanitizeRule))];
     // Best-effort prettier-stabilize the block against this target's config (#935).
     const next = await formatLearningsBlockForTarget(
@@ -340,23 +317,6 @@ export function upsertLearningsBlock(content: string, rules: string[]): string {
   }
   const sep = content.length === 0 ? "" : content.endsWith("\n") ? "\n" : "\n\n";
   return content + sep + body + "\n";
-}
-
-/** Parse the rules out of the managed `shepherd:learnings` block — the inverse of
- *  `upsertLearningsBlock`, used to accumulate across successive global promotes (#872).
- *  Returns `[]` when no block is present. Tolerant of CRLF and leading whitespace; only
- *  `- <rule>` bullets are returned — non-bullet/prose lines inside the block are ignored
- *  (the block is Shepherd-owned and rewritten in full, so hand-edits aren't preserved). */
-export function extractLearningsBlockRules(content: string): string[] {
-  const start = content.indexOf(LEARNINGS_START);
-  const end = content.indexOf(LEARNINGS_END);
-  if (start === -1 || end === -1 || end <= start) return [];
-  return content
-    .slice(start + LEARNINGS_START.length, end)
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line.startsWith("- "))
-    .map((line) => line.slice(2).trim());
 }
 
 /** Best-effort: re-format the managed `shepherd:learnings` block to match the target repo's

--- a/src/server.ts
+++ b/src/server.ts
@@ -510,11 +510,10 @@ export interface AppDeps {
     /** Async (MergeSuggestService.mergeNow); the trigger route fires it and forgets. */
     mergeNow: (repoPath: string) => Promise<void>;
   };
-  /** Promote a curated rule into the repo's CLAUDE.md via an auto-opened PR, or a cross-repo
-   *  recurrence rule into the user-global ~/.claude/CLAUDE.md directly (#872). */
+  /** Promote a curated rule into the repo's CLAUDE.md via an auto-opened PR. (The user-global
+   *  ~/.claude/CLAUDE.md write that lived alongside it was dropped in #2004 — see promote.ts.) */
   promoter?: {
     promote: (id: string) => Promise<import("./promote").PromoteResult>;
-    promoteGlobal: (rule: string) => Promise<import("./promote").PromoteResult>;
   };
   /** PR-gated AI doc agent (issue #882). Optional + flag-gated (config.docAgentEnabled); the route
    *  404s when the flag is off or the service is unwired. Wired to DocAgentService in index.ts. */
@@ -1879,30 +1878,7 @@ function handleMergeSuggestionPost(
 ): Promise<Response> | null {
   if (parts[2] === "merge" && !parts[3]) return handleMergeApply(req, deps);
   if (parts[2] === "merge-dismiss") return handleMergeDismiss(req, deps);
-  if (parts[2] === "promote-global") return handleMergePromoteGlobal(req, deps);
   return null;
-}
-
-/** POST /api/learnings/promote-global — write a cross-repo recurrence rule into the user-global
- *  ~/.claude/CLAUDE.md (issue #872), body {suggestionId}. Explicit, operator-confirmed; no PR.
- *  Marks the suggestion `applied` so it leaves the band and isn't re-suggested (the cross dedup
- *  set includes `applied`). 409 on a stale re-post, mirroring handleMergeApply. */
-async function handleMergePromoteGlobal(req: Request, deps: AppDeps): Promise<Response> {
-  const body = (await req.json().catch(() => ({}))) as { suggestionId?: unknown };
-  const id = typeof body.suggestionId === "string" ? body.suggestionId : "";
-  if (!id) return json({ error: "suggestionId required" }, 400);
-  const sug = deps.store.getMergeSuggestion(id);
-  if (!sug) return json({ error: "not found" }, 404);
-  if (sug.kind !== "cross") return json({ error: "not a cross-repo suggestion" }, 400);
-  if (sug.status !== "pending") return json({ error: "already resolved" }, 409);
-  if (!deps.promoter) return json({ error: "promote unavailable" }, 503);
-  const res = await deps.promoter.promoteGlobal(sug.mergedRule);
-  if (!res.ok) return json({ error: res.error }, res.status);
-  // Promoter-orchestrated (separate service): the suggestion bookkeeping stays inline; only
-  // the recurring emit tail unifies through the learnings service (#1092).
-  deps.store.setMergeSuggestionStatus(id, "applied");
-  learnings(deps).emitPending();
-  return json({ ok: true });
 }
 
 /** POST /api/learnings/merge-dismiss — dismiss a merge suggestion (intra or cross), body

--- a/src/store.ts
+++ b/src/store.ts
@@ -67,6 +67,7 @@ import { sanitizeScopeGlobs } from "./house-rules";
 import type { EpicRun } from "./epic-core";
 import type { EpicLandingState } from "./completed-epic";
 import { normalizeRule } from "./learning-rule";
+import { trimRuleToLimit } from "./learning-shape";
 import type { GitState } from "./forge/types";
 
 /** Tolerantly parse a persisted JSON column, falling back to `fallback` on any error. */
@@ -4484,7 +4485,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
   reviseLearning(id: string, rule: string, rationale?: string): Learning | null {
     const cur = this.getLearning(id);
     if (!cur || (cur.status !== "active" && cur.status !== "promoted")) return null;
-    const text = rule.trim().slice(0, 240);
+    const text = trimRuleToLimit(rule);
     if (!text) return null;
     const resolvedRationale = rationale !== undefined ? rationale : cur.rationale;
     const now = Date.now();
@@ -4507,7 +4508,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
   mergeLearning(id: string, rule: string, rationale?: string): Learning | null {
     const cur = this.getLearning(id);
     if (!cur || cur.status !== "active") return null;
-    const text = rule.trim().slice(0, 240);
+    const text = trimRuleToLimit(rule);
     if (!text) return null;
     const resolvedRationale = rationale !== undefined ? rationale : cur.rationale;
     const now = Date.now();

--- a/test/distiller.test.ts
+++ b/test/distiller.test.ts
@@ -1,5 +1,15 @@
 import { test, expect, beforeEach, afterEach, spyOn } from "bun:test";
-import { DistillerService, DISTILL_LABEL, type DistillerDeps } from "../src/distiller";
+import {
+  DistillerService,
+  DISTILL_LABEL,
+  distillPrompt,
+  type DistillerDeps,
+} from "../src/distiller";
+import {
+  LEARNING_ADMISSION_TEST,
+  LEARNING_FACT_SHAPE,
+  LEARNING_RULE_MAX_CHARS,
+} from "../src/learning-shape";
 import { SessionStore } from "../src/store";
 import { config } from "../src/config";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
@@ -1373,4 +1383,32 @@ test("tab baseline: repeated distill runs (success + timeout) leave zero open ta
     expect(openTabs.size).toBe(0);
   }
   expect(n).toBe(6); // six real spawns happened; all six tabs were closed
+});
+
+// ── admission test wiring (#2004) ────────────────────────────────────────────
+// The re-target lives entirely in prompt text, so these are the only regression guard against a
+// future edit quietly restoring rule-manufacturing.
+
+test("distill prompt carries the shared admission test + fact shape", () => {
+  const p = distillPrompt();
+  expect(p).toContain(LEARNING_ADMISSION_TEST);
+  expect(p).toContain(LEARNING_FACT_SHAPE);
+  expect(p).toContain("repo-gotcha analyst");
+  // DELETE must cover an active rule that merely FAILS the test — not only a contradicted one.
+  expect(p).toContain("FAILS the admission");
+  expect(p).toContain(String(LEARNING_RULE_MAX_CHARS));
+  expect(p).not.toContain("160 char imperative");
+});
+
+test("an over-long proposed rule is trimmed at a word boundary", async () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r", 3);
+  const long = "word ".repeat(80).trim(); // 399 chars, spaces throughout
+  const { deps } = mkDeps(store, { rules: [{ rule: long, rationale: "x", evidence: [] }] });
+  const d = new DistillerService(deps as any);
+  await d.distillNow("/r");
+  await d.tick();
+  const [stored] = store.listLearnings("/r");
+  expect(stored!.rule.length).toBeLessThanOrEqual(LEARNING_RULE_MAX_CHARS);
+  expect(stored!.rule.endsWith("word")).toBe(true); // no mid-word cut
 });

--- a/test/learning-sweep.test.ts
+++ b/test/learning-sweep.test.ts
@@ -1,0 +1,111 @@
+import { test, expect } from "bun:test";
+import { planSweep, parseDecisions, priceBlock } from "../src/learning-sweep";
+import { renderHouseRulesBlock } from "../src/house-rules";
+import type { Learning } from "../src/types";
+
+function mk(id: string, rule: string, over: Partial<Learning> = {}): Learning {
+  return {
+    id,
+    repoPath: "/r",
+    rule,
+    rationale: "",
+    evidence: [],
+    status: "active",
+    evidenceCount: 0,
+    ineffectiveCount: 0,
+    helpfulCount: 0,
+    injectedCount: 0,
+    lastUsedAt: null,
+    lastEvidenceAt: null,
+    distinctKinds: 0,
+    distinctSessions: 0,
+    trialedAt: null,
+    reTrialBlockedAt: null,
+    retiredAt: null,
+    retiredReason: null,
+    mergedIntoId: null,
+    prUrl: null,
+    scopeGlobs: [],
+    createdAt: 1,
+    updatedAt: 1,
+    ...over,
+  } as Learning;
+}
+
+test("priceBlock matches the block a spawn would actually carry", () => {
+  const rules = [mk("a", "fact one"), mk("b", "fact two")];
+  const cost = priceBlock(rules, 4000, 1000);
+  expect(cost.injectedRules).toBe(2);
+  expect(cost.chars).toBe(renderHouseRulesBlock(rules)!.length);
+  expect(cost.tokens).toBe(Math.ceil(cost.chars / 4));
+});
+
+test("an empty set costs nothing — not the bare tag overhead", () => {
+  expect(priceBlock([], 4000, 1000)).toEqual({
+    injectedRules: 0,
+    chars: 0,
+    bytes: 0,
+    tokens: 0,
+  });
+});
+
+test("planSweep prices before/after and shrinks the block by the dropped rules", () => {
+  const rules = [mk("a", "keep this fact"), mk("b", "drop this platitude")];
+  const plan = planSweep(rules, [{ id: "b", why: "judgement guidance" }], 4000, 1000);
+  expect(plan.retire).toEqual([
+    { id: "b", rule: "drop this platitude", why: "judgement guidance" },
+  ]);
+  expect(plan.refused).toEqual([]);
+  expect(plan.activeBefore).toBe(2);
+  expect(plan.activeAfter).toBe(1);
+  expect(plan.after.chars).toBe(plan.before.chars - "- drop this platitude\n".length);
+  expect(plan.after.injectedRules).toBe(1);
+});
+
+test("a promoted rule is refused — its text is mirrored in CLAUDE.md", () => {
+  const rules = [mk("a", "mirrored", { status: "promoted" })];
+  const plan = planSweep(rules, [{ id: "a", why: "x" }], 4000, 1000);
+  expect(plan.retire).toEqual([]);
+  expect(plan.refused).toEqual([{ id: "a", reason: "promoted" }]);
+  expect(plan.after.chars).toBe(plan.before.chars); // nothing dropped → nothing saved
+});
+
+test("an unknown id is refused, not silently ignored", () => {
+  const plan = planSweep([mk("a", "x")], [{ id: "zz", why: "y" }], 4000, 1000);
+  expect(plan.refused).toEqual([{ id: "zz", reason: "not-found" }]);
+});
+
+test("a duplicate decision retires once", () => {
+  const plan = planSweep(
+    [mk("a", "x"), mk("b", "y")],
+    [
+      { id: "a", why: "one" },
+      { id: "a", why: "again" },
+    ],
+    4000,
+    1000,
+  );
+  expect(plan.retire.map((r) => r.id)).toEqual(["a"]);
+  expect(plan.refused).toEqual([]);
+  expect(plan.activeAfter).toBe(1);
+});
+
+test("scope-gated rules never inject, so they move the count but not the chars", () => {
+  const rules = [mk("a", "always fact"), mk("b", "scoped fact", { scopeGlobs: ["ui/**"] })];
+  const plan = planSweep(rules, [{ id: "b", why: "not a gotcha" }], 4000, 1000);
+  expect(plan.before.injectedRules).toBe(1);
+  expect(plan.after.chars).toBe(plan.before.chars);
+  expect(plan.activeAfter).toBe(1);
+});
+
+test("parseDecisions accepts the documented shape and rejects everything else", () => {
+  expect(parseDecisions({ drop: [{ id: " a ", why: " because " }] })).toEqual([
+    { id: "a", why: "because" },
+  ]);
+  expect(parseDecisions({ drop: [] })).toEqual([]);
+  expect(() => parseDecisions({})).toThrow(/must be/);
+  expect(() => parseDecisions(null)).toThrow(/must be/);
+  expect(() => parseDecisions({ drop: [{ id: "a" }] })).toThrow(/missing why/);
+  expect(() => parseDecisions({ drop: [{ why: "b" }] })).toThrow(/missing id/);
+  expect(() => parseDecisions({ drop: [{ id: "  ", why: "b" }] })).toThrow(/missing id/);
+});

--- a/test/merge-suggest.test.ts
+++ b/test/merge-suggest.test.ts
@@ -214,8 +214,9 @@ test("cross: a group promoted to global (applied) is NOT re-suggested on a later
   await svc.tick();
   const cross = store.listMergeSuggestions({ kind: "cross", status: "pending" });
   expect(cross.length).toBe(1);
-  // Simulate promote-global: mark applied. The member rules stay ACTIVE (no retire), so the
-  // dedup set must include `applied` or the same group re-appears next pass.
+  // A cross suggestion marked applied (the promote-global route that did this was removed in
+  // #2004; the store transition remains). Member rules stay ACTIVE (no retire), so the dedup
+  // set must include `applied` or the same group re-appears next pass.
   store.setMergeSuggestionStatus(cross[0]!.id, "applied");
 
   // Change the global active set so the cross pass isn't gated out by an unchanged signature —

--- a/test/optimizer.test.ts
+++ b/test/optimizer.test.ts
@@ -1,5 +1,15 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
-import { OptimizerService, OPTIMIZE_LABEL, type OptimizerTarget } from "../src/optimizer";
+import {
+  OptimizerService,
+  OPTIMIZE_LABEL,
+  optimizePrompt,
+  type OptimizerTarget,
+} from "../src/optimizer";
+import {
+  LEARNING_ADMISSION_TEST,
+  LEARNING_FACT_SHAPE,
+  LEARNING_RULE_MAX_CHARS,
+} from "../src/learning-shape";
 import { SessionStore } from "../src/store";
 import { HerdrUnavailableError } from "../src/herdr";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
@@ -548,4 +558,16 @@ test("reapOrphans is a no-op when herdr is unavailable (optimizer)", async () =>
   } as never);
   expect(() => svc.reapOrphans()).not.toThrow();
   expect(closes).toBe(0);
+});
+
+// ── admission test wiring (#2004) ────────────────────────────────────────────
+
+test("optimize prompt carries the shared admission test + fact shape", () => {
+  const p = optimizePrompt();
+  expect(p).toContain(LEARNING_ADMISSION_TEST);
+  expect(p).toContain(LEARNING_FACT_SHAPE);
+  // A rule that fails the test must be dropped, not rewritten into a sterner instruction.
+  expect(p).toContain("OMIT a target when it cannot be restated as a fact");
+  expect(p).toContain(String(LEARNING_RULE_MAX_CHARS));
+  expect(p).not.toContain("160 char imperative");
 });

--- a/test/promote.test.ts
+++ b/test/promote.test.ts
@@ -359,7 +359,8 @@ test("Promoter.resyncPromoted dedups two promoted rules that collapse to one san
   });
   const res = await p.resyncPromoted("/repo-dup");
   expect(res.ok).toBe(true);
-  expect(extractLearningsBlockRules(written)).toEqual(["\\- dash"]); // exactly one bullet
+  expect(written.match(/^- /gm)?.length).toBe(1); // exactly one bullet
+  expect(written).toContain("\\- dash");
 });
 
 test("Promoter.resyncPromoted is a no-op when CLAUDE.md already has the current block", async () => {
@@ -534,115 +535,6 @@ test("Promoter.resyncPromoted returns 400 with lightweight message for local for
   }
   expect(openPrCalled).toBe(false);
   expect(worktreeCreated).toBe(false);
-});
-
-// --- extractLearningsBlockRules + promoteGlobal (issue #872) ---
-
-import { extractLearningsBlockRules } from "../src/promote";
-
-test("extractLearningsBlockRules returns [] when there is no managed block", () => {
-  expect(extractLearningsBlockRules("# Repo\n\nhello\n")).toEqual([]);
-  expect(extractLearningsBlockRules("")).toEqual([]);
-});
-
-test("extractLearningsBlockRules parses bullets and round-trips upsertLearningsBlock", () => {
-  const content = upsertLearningsBlock("# Repo\n", ["use bun", "rebase onto main"]);
-  expect(extractLearningsBlockRules(content)).toEqual(["use bun", "rebase onto main"]);
-});
-
-test("extractLearningsBlockRules tolerates CRLF + leading whitespace and ignores prose", () => {
-  const block = [
-    LEARNINGS_START,
-    "  - indented rule",
-    "- normal rule",
-    "some prose line", // no bullet → ignored (block is Shepherd-owned)
-    "",
-    LEARNINGS_END,
-  ].join("\r\n");
-  const content = "# Repo\r\n\r\n" + block + "\r\n";
-  expect(extractLearningsBlockRules(content)).toEqual(["indented rule", "normal rule"]);
-});
-
-/** Promoter wired only for global writes: store/worktree/forge are unused by promoteGlobal.
- *  Injected CLAUDE.md IO operates on `state` so the real ~/.claude is never touched. */
-function globalPromoter(state: { content: string; writes: string[] }) {
-  return new Promoter({
-    store: new SessionStore(":memory:"),
-    worktree: {
-      create: () => {
-        throw new Error("worktree unused by promoteGlobal");
-      },
-      remove: () => {},
-    },
-    resolveForge: () => null,
-    git: async () => {},
-    readClaudeMd: () => state.content,
-    writeClaudeMd: (_p, c) => {
-      state.content = c;
-      state.writes.push(c);
-    },
-  });
-}
-
-test("promoteGlobal writes a fresh block when the global file is empty", async () => {
-  const state = { content: "", writes: [] as string[] };
-  const res = await globalPromoter(state).promoteGlobal("always rebase onto main");
-  expect(res.ok).toBe(true);
-  expect(state.writes.length).toBe(1);
-  expect(extractLearningsBlockRules(state.writes[0]!)).toEqual(["always rebase onto main"]);
-});
-
-test("promoteGlobal accumulates onto the existing block (dedup, order-preserving)", async () => {
-  const existing = upsertLearningsBlock("# Global\n\nintro\n", ["rule a"]);
-  const state = { content: existing, writes: [] as string[] };
-  const res = await globalPromoter(state).promoteGlobal("rule b");
-  expect(res.ok).toBe(true);
-  expect(extractLearningsBlockRules(state.writes[0]!)).toEqual(["rule a", "rule b"]);
-  expect(state.writes[0]).toContain("intro"); // content outside the block is preserved
-});
-
-test("promoteGlobal is an idempotent no-op when the rule is already present", async () => {
-  const existing = upsertLearningsBlock("", ["rule a"]);
-  const state = { content: existing, writes: [] as string[] };
-  const res = await globalPromoter(state).promoteGlobal("rule a");
-  expect(res.ok).toBe(true);
-  expect(state.writes.length).toBe(0); // already current → nothing written
-});
-
-test("promoteGlobal re-promote of a sanitize-altered rule is an idempotent no-op", async () => {
-  // The stored block holds the *sanitized* form ("\- dash"); the incoming raw "- dash" must
-  // dedup against it, not write a second bullet. (Plain "rule a" wouldn't catch this — sanitize
-  // leaves it unchanged.)
-  const existing = upsertLearningsBlock("", ["- dash"]);
-  expect(extractLearningsBlockRules(existing)).toEqual(["\\- dash"]);
-  const state = { content: existing, writes: [] as string[] };
-  const res = await globalPromoter(state).promoteGlobal("- dash");
-  expect(res.ok).toBe(true);
-  expect(state.writes.length).toBe(0); // already current → no duplicate bullet, no write
-});
-
-test("promoteGlobal returns a structured 500 (not a throw) on an fs failure", async () => {
-  const p = new Promoter({
-    store: new SessionStore(":memory:"),
-    worktree: {
-      create: () => {
-        throw new Error("unused");
-      },
-      remove: () => {},
-    },
-    resolveForge: () => null,
-    git: async () => {},
-    writeClaudeMd: () => {},
-    readClaudeMd: () => {
-      throw new Error("EACCES: permission denied, open '/root/.claude/CLAUDE.md'");
-    },
-  });
-  const res = await p.promoteGlobal("a rule");
-  expect(res.ok).toBe(false);
-  if (!res.ok) {
-    expect(res.status).toBe(500);
-    expect(res.error).toBe("global promote failed"); // no raw fs stderr leaked
-  }
 });
 
 // ── formatLearningsBlockForTarget (#935: prettier-stable under proseWrap:"always") ───────────

--- a/test/server-learnings.test.ts
+++ b/test/server-learnings.test.ts
@@ -46,7 +46,6 @@ function harness(promoter?: AppDeps["promoter"]): {
 test("promote success → 200 with url and emits learnings:update", async () => {
   const stub: AppDeps["promoter"] = {
     promote: async (): Promise<PromoteResult> => ({ ok: true, url: "https://pr/7" }),
-    promoteGlobal: async (): Promise<PromoteResult> => ({ ok: true, url: "" }),
   };
   const { app, emitted } = harness(stub);
 
@@ -65,7 +64,6 @@ test("promote error → propagates status code from service", async () => {
       error: "only active rules can be promoted",
       status: 409,
     }),
-    promoteGlobal: async (): Promise<PromoteResult> => ({ ok: true, url: "" }),
   };
   const { app } = harness(stub);
 
@@ -87,7 +85,7 @@ test("promote with no promoter dep → 503", async () => {
   expect(await res.json()).toEqual({ error: "promote unavailable" });
 });
 
-// ── POST /api/learnings/promote-global (issue #872) ───────────────────────────
+// ── promote-global is GONE (issue #2004) ─────────────────────────────────────
 
 /** Harness exposing the store so a cross suggestion can be seeded + re-read. */
 function globalHarness(promoter?: AppDeps["promoter"]): {
@@ -126,19 +124,9 @@ function seedCross(store: SessionStore) {
   });
 }
 
-const okGlobal: AppDeps["promoter"] = {
-  promote: async (): Promise<PromoteResult> => ({ ok: true, url: "" }),
-  promoteGlobal: async (): Promise<PromoteResult> => ({ ok: true, url: "" }),
-};
-
-test("promote-global success → marks suggestion applied + emits learnings:update", async () => {
-  let promotedRule = "";
+test("POST /api/learnings/promote-global is gone — a pending suggestion is left untouched", async () => {
   const { app, store, emitted } = globalHarness({
     promote: async (): Promise<PromoteResult> => ({ ok: true, url: "" }),
-    promoteGlobal: async (rule: string): Promise<PromoteResult> => {
-      promotedRule = rule;
-      return { ok: true, url: "" };
-    },
   });
   const sug = seedCross(store);
   const res = await app.fetch(
@@ -146,94 +134,11 @@ test("promote-global success → marks suggestion applied + emits learnings:upda
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ suggestionId: sug.id }),
-    }),
-  );
-  expect(res.status).toBe(200);
-  expect(await res.json()).toEqual({ ok: true });
-  expect(promotedRule).toBe("always rebase onto main");
-  expect(store.getMergeSuggestion(sug.id)!.status).toBe("applied");
-  expect(emitted.some(([event]) => event === "learnings:update")).toBe(true);
-});
-
-test("promote-global on an already-applied suggestion → 409 (stale re-post, no re-write)", async () => {
-  let calls = 0;
-  const { app, store } = globalHarness({
-    promote: async (): Promise<PromoteResult> => ({ ok: true, url: "" }),
-    promoteGlobal: async (): Promise<PromoteResult> => {
-      calls++;
-      return { ok: true, url: "" };
-    },
-  });
-  const sug = seedCross(store);
-  store.setMergeSuggestionStatus(sug.id, "applied");
-  const res = await app.fetch(
-    new Request("http://x/api/learnings/promote-global", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ suggestionId: sug.id }),
-    }),
-  );
-  expect(res.status).toBe(409);
-  expect(calls).toBe(0);
-});
-
-test("promote-global with unknown suggestionId → 404", async () => {
-  const { app } = globalHarness(okGlobal);
-  const res = await app.fetch(
-    new Request("http://x/api/learnings/promote-global", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ suggestionId: "nope" }),
     }),
   );
   expect(res.status).toBe(404);
-});
-
-test("promote-global on an intra suggestion → 400", async () => {
-  const { app, store } = globalHarness(okGlobal);
-  const sug = store.addMergeSuggestion({
-    kind: "intra",
-    repoPath: "/r",
-    targetId: "t",
-    sourceIds: ["a"],
-    mergedRule: "merged",
-    mergedRationale: "",
-    repoPaths: null,
-    signature: "intra-sig",
-  });
-  const res = await app.fetch(
-    new Request("http://x/api/learnings/promote-global", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ suggestionId: sug.id }),
-    }),
-  );
-  expect(res.status).toBe(400);
-});
-
-test("promote-global with missing suggestionId → 400", async () => {
-  const { app } = globalHarness(okGlobal);
-  const res = await app.fetch(
-    new Request("http://x/api/learnings/promote-global", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({}),
-    }),
-  );
-  expect(res.status).toBe(400);
-});
-
-test("promote-global with no promoter dep → 503 (after suggestion validated)", async () => {
-  const { app, store } = globalHarness(undefined);
-  const sug = seedCross(store);
-  const res = await app.fetch(
-    new Request("http://x/api/learnings/promote-global", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ suggestionId: sug.id }),
-    }),
-  );
-  expect(res.status).toBe(503);
+  expect(store.getMergeSuggestion(sug.id)!.status).toBe("pending");
+  expect(emitted.some(([event]) => event === "learnings:update")).toBe(false);
 });
 
 // ── optimizer routes ─────────────────────────────────────────────────────────

--- a/test/store-learnings.test.ts
+++ b/test/store-learnings.test.ts
@@ -885,9 +885,9 @@ test("mergeSuggestionSignatures: cross includes 'applied' so a promoted group is
     repoPaths: ["/r1", "/r2"],
     signature: "cross-sig-1",
   });
-  // Before promote it is pending → already in the dedup set.
+  // Before it is applied it is pending → already in the dedup set.
   expect(s.mergeSuggestionSignatures({ kind: "cross" }).has("cross-sig-1")).toBe(true);
-  // promote-global marks it applied; cross members stay active, so 'applied' MUST still dedup.
+  // Once applied, cross members stay active, so 'applied' MUST still dedup.
   s.setMergeSuggestionStatus(sug.id, "applied");
   expect(s.mergeSuggestionSignatures({ kind: "cross" }).has("cross-sig-1")).toBe(true);
 });

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1885,7 +1885,7 @@
   "learnings_merge_failed": "Regeln konnten nicht zusammengeführt werden",
   "learnings_actions_help": "Die Repo-Buttons starten manuelle Wartungsläufe: „Zusammenführungen vorschlagen“ sucht nahezu doppelte Regeln und gruppiert sie, damit du jede Gruppe zu einer Regel zusammenfassen kannst, deren Bilanz erhalten bleibt; „Jetzt destillieren“ wertet jüngste Sessions auf Signale aus und schlägt neue Regeln vor, ohne auf den Zeitplan zu warten.",
   "learnings_recur_heading": "Wiederkehrend über Repos hinweg",
-  "learnings_recur_lead": "Diese Regeln treten in mehreren Repos auf — erwäge, eine davon in deine globale CLAUDE.md aufzunehmen.",
+  "learnings_recur_lead": "Diese Regeln treten in mehreren Repos auf — ein Hinweis, dass der zugrunde liegende Fakt in die CLAUDE.md des jeweiligen Repos gehört.",
   "learnings_recur_repos": "In {count} Repos: {repos}",
   "learnings_recur_dismiss_aria": "Diesen repoübergreifenden Vorschlag verwerfen",
   "learnings_help_rate": "half {helped}/{pulls}",
@@ -1937,12 +1937,6 @@
   "issues_filter_all_sub_issues": "Alle passenden Issues sind Epic-Unteraufgaben — zum Anzeigen ausschalten oder einen Epic-Drain starten",
   "feat_issues_filter_subissues_title": "Unteraufgaben standardmäßig ausblenden",
   "feat_issues_filter_subissues_body": "Die Issue-Listen in Repos und in „Neue Aufgabe“ blenden GitHub-native Unteraufgaben jetzt standardmäßig aus, damit du einen Epic-Drain vom übergeordneten Issue startest, statt ein einzelnes Kinder-Issue zu bearbeiten. Öffne das Filters-Menü und deaktiviere „Unteraufgaben ausblenden“, um sie einzublenden; übergeordnete Epic-Issues (einschließlich mehrstufiger Epics) bleiben sichtbar. Die Einstellung gilt für beide Listen.",
-  "learnings_recur_promote": "Zur globalen CLAUDE.md hinzufügen",
-  "learnings_recur_promote_aria": "Diese Regel zu deiner benutzerglobalen CLAUDE.md hinzufügen",
-  "learnings_recur_promote_confirm": "Dies schreibt die Regel in ~/.claude/CLAUDE.md – eine globale, nicht versionierte Datei, die für jedes Repo gilt. Shepherd verwaltet diesen Block und schreibt ihn bei jeder Übernahme neu.",
-  "learnings_recur_promote_action": "Schreiben",
-  "learnings_recur_promote_done": "Regel zu deiner globalen CLAUDE.md hinzugefügt.",
-  "learnings_recur_promote_failed": "Schreiben in deine globale CLAUDE.md fehlgeschlagen.",
   "feat_learnings_promote_global_title": "Eine Regel global per Klick übernehmen",
   "feat_learnings_promote_global_body": "Ein repoübergreifender Wiederholungsvorschlag lässt sich jetzt mit einem abgesicherten Klick (zweistufige Bestätigung) direkt in deine benutzerglobale ~/.claude/CLAUDE.md schreiben – ohne PR, gültig für jedes Repo.",
   "settings_reduced_push_title": "Reduzierte Benachrichtigungen",
@@ -3538,5 +3532,8 @@
   "gloss_spawn_prompt_term": "Spawn-Prompt",
   "gloss_spawn_prompt_def": "Die stehenden Anweisungen, die Shepherd zusammensetzt und einem Agenten beim Start übergibt — House Rules, Sicherheitshinweise und die Direktive für diese Art von Aufgabe. Sie fahren bei jedem Zug der Session mit, ihre Größe wird also immer wieder bezahlt.",
   "feat_prompt_budget_title": "Sehen, was der Prompt jedes Spawns kostet",
-  "feat_prompt_budget_body": "Die Nutzungsansicht hat eine neue Prompt-Linse: Für jeden Spawn — begleitet oder Drain — zeigt sie den zusammengesetzten System-Prompt Block für Block. So siehst du, welcher Hinweis, welche Direktive oder welche House Rules deinen Kontext verbrauchen und wie viel."
+  "feat_prompt_budget_body": "Die Nutzungsansicht hat eine neue Prompt-Linse: Für jeden Spawn — begleitet oder Drain — zeigt sie den zusammengesetzten System-Prompt Block für Block. So siehst du, welcher Hinweis, welche Direktive oder welche House Rules deinen Kontext verbrauchen und wie viel.",
+  "learnings_proposed_admission_hint": "Behalte Einträge, die einen nicht ableitbaren Repo-Fakt festhalten — was gilt, warum es weh tut, wie man es anwendet. Verwirf Vorgaben, die ein fähiges Modell ohnehin befolgt.",
+  "feat_learnings_gotchas_title": "Das Learnings-Schwungrad erfasst jetzt Fallstricke statt Regeln",
+  "feat_learnings_gotchas_body": "Destillierte Einträge zielen jetzt auf nicht ableitbare Repo-Fakten — was gilt, warum es weh tut, wie man es anwendet. Verhaltensvorgaben, die ein fähiges Modell ohnehin befolgt, werden abgelehnt und aus dem injizierten Block entfernt. Die Ein-Klick-Übernahme in deine benutzerglobale ~/.claude/CLAUDE.md entfällt; diese Datei verwaltet Claudes eigenes Gedächtnis."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1885,7 +1885,7 @@
   "learnings_merge_failed": "Couldn't merge rules",
   "learnings_actions_help": "The repo buttons start manual maintenance runs: “Suggest merges” looks for near-duplicate rules and groups them so you can fold each group into one rule while keeping its track record; “Distill now” scans recent sessions for signals and proposes new rules without waiting for the schedule.",
   "learnings_recur_heading": "Recurring across repos",
-  "learnings_recur_lead": "These rules appear in several repos — consider adding one to your global CLAUDE.md.",
+  "learnings_recur_lead": "These rules appear in several repos — a hint the underlying fact belongs in each repo's own CLAUDE.md.",
   "learnings_recur_repos": "In {count} repos: {repos}",
   "learnings_recur_dismiss_aria": "Dismiss this cross-repo suggestion",
   "learnings_help_rate": "helped {helped}/{pulls}",
@@ -1937,12 +1937,6 @@
   "issues_filter_all_sub_issues": "All matching issues are epic sub-issues — toggle off to see them, or start an epic drain",
   "feat_issues_filter_subissues_title": "Hide sub-issues by default",
   "feat_issues_filter_subissues_body": "The Repos and New Task issue lists now hide GitHub native sub-issues by default, so you start an epic drain from the parent instead of draining a child alone. Open the Filters menu and turn off \"hide sub-issues\" to show them; epic parents (including mid-level epics) stay visible. Remembered across both lists.",
-  "learnings_recur_promote": "Add to global CLAUDE.md",
-  "learnings_recur_promote_aria": "Add this rule to your user-global CLAUDE.md",
-  "learnings_recur_promote_confirm": "This writes the rule into ~/.claude/CLAUDE.md — a global, unversioned file applied to every repo. Shepherd owns this block and rewrites it on each promote.",
-  "learnings_recur_promote_action": "Write",
-  "learnings_recur_promote_done": "Rule added to your global CLAUDE.md.",
-  "learnings_recur_promote_failed": "Couldn't write to your global CLAUDE.md.",
   "feat_learnings_promote_global_title": "One-click promote a rule globally",
   "feat_learnings_promote_global_body": "A cross-repo recurrence suggestion can now be written straight into your user-global ~/.claude/CLAUDE.md with one guarded click (a two-step confirm) — no PR, applied to every repo.",
   "settings_reduced_push_title": "Reduced notifications",
@@ -3538,5 +3532,8 @@
   "gloss_spawn_prompt_term": "spawn prompt",
   "gloss_spawn_prompt_def": "The standing instructions Shepherd assembles and hands an agent the moment it starts — house rules, safety notices and the directive for this kind of task. It rides every turn of the session, so its size is paid for again and again.",
   "feat_prompt_budget_title": "See what every spawn's prompt costs",
-  "feat_prompt_budget_body": "Usage has a new Prompt lens: for any spawn, attended or drain, it shows the assembled system prompt block by block — which notice, directive or set of house rules is spending your context, and how much."
+  "feat_prompt_budget_body": "Usage has a new Prompt lens: for any spawn, attended or drain, it shows the assembled system prompt block by block — which notice, directive or set of house rules is spending your context, and how much.",
+  "learnings_proposed_admission_hint": "Keep entries that state a repo fact an agent can't derive — what is true, why it bites, how to apply it. Drop guidance a capable model already follows.",
+  "feat_learnings_gotchas_title": "The learnings flywheel now captures gotchas, not rules",
+  "feat_learnings_gotchas_body": "Distilled entries are re-targeted at non-derivable repo facts — what is true, why it bites, how to apply it — and behavioral guidance a capable model already follows is rejected and swept out of the injected block. One-click promote to your user-global ~/.claude/CLAUDE.md is gone; Claude's own memory owns that file now."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -2293,17 +2293,6 @@ export async function dismissMergeSuggestion(suggestionId: string): Promise<void
   if (!r.ok) throw await failed(r, "merge dismiss");
 }
 
-/** Promote a cross-repo recurrence rule into the user-global ~/.claude/CLAUDE.md (#872).
- *  Operator-confirmed; writes directly (no PR). Marks the suggestion applied server-side. */
-export async function promoteGlobalLearning(suggestionId: string): Promise<void> {
-  const r = await fetch(`/api/learnings/promote-global`, {
-    method: "POST",
-    headers: JSON_HEADERS,
-    body: JSON.stringify({ suggestionId }),
-  });
-  if (!r.ok) throw await failed(r, "promote global");
-}
-
 /** Manually trigger the background merge-suggestion pass for a repo ("Suggest merges now").
  *  Fire-and-forget; suggestions arrive via the learnings:update event. */
 export async function mergeSuggestNow(repoPath: string): Promise<void> {

--- a/ui/src/lib/components/LearningsDrawer.svelte
+++ b/ui/src/lib/components/LearningsDrawer.svelte
@@ -58,7 +58,6 @@
     onseenretired,
     onmerge,
     ondismissmerge,
-    onpromoteglobal,
     onmergenow,
     onclose,
   }: {
@@ -78,7 +77,6 @@
     onseenretired: (repoPath: string) => void;
     onmerge: (suggestionId: string) => void;
     ondismissmerge: (suggestionId: string) => void;
-    onpromoteglobal: (suggestionId: string) => void;
     onmergenow: (repoPath: string) => void;
     onclose: () => void;
   } = $props();
@@ -120,7 +118,6 @@
     onseenretired,
     onmerge,
     ondismissmerge,
-    onpromoteglobal,
     onmergenow,
     editingScope,
     scopeDraft,
@@ -277,7 +274,7 @@
 
   <!-- Phase 4: cross-repo recurrence band — rules that recur across repos, suggested for the
        user-global CLAUDE.md. Promote (guarded, two-step) writes the rule there; or dismiss. -->
-  <RecurrenceBand suggestions={crossSuggestions} {onpromoteglobal} {ondismissmerge} />
+  <RecurrenceBand suggestions={crossSuggestions} {ondismissmerge} />
 
   {#if empty}
     <p class="empty">{m.learnings_empty()}</p>

--- a/ui/src/lib/components/LearningsDrawer.svelte
+++ b/ui/src/lib/components/LearningsDrawer.svelte
@@ -272,8 +272,9 @@
   <!-- Change 3: Triage summary band — stable above group list, reflects ALL attention repos -->
   <TriageBand {attention} activeRepo={repoOnly} onselect={toggleRepoFilter} />
 
-  <!-- Phase 4: cross-repo recurrence band — rules that recur across repos, suggested for the
-       user-global CLAUDE.md. Promote (guarded, two-step) writes the rule there; or dismiss. -->
+  <!-- Phase 4: cross-repo recurrence band — entries that recur across repos, surfaced as a hint
+       that the underlying fact belongs in each repo's own CLAUDE.md. Dismiss is the only action:
+       the one-click write into the user-global ~/.claude/CLAUDE.md was dropped in #2004. -->
   <RecurrenceBand suggestions={crossSuggestions} {ondismissmerge} />
 
   {#if empty}

--- a/ui/src/lib/components/learnings-drawer/RecurrenceBand.svelte
+++ b/ui/src/lib/components/learnings-drawer/RecurrenceBand.svelte
@@ -5,18 +5,11 @@
 
   let {
     suggestions,
-    onpromoteglobal,
     ondismissmerge,
   }: {
     suggestions: MergeSuggestion[];
-    onpromoteglobal: (id: string) => void;
     ondismissmerge: (id: string) => void;
   } = $props();
-
-  // Cross-repo card pending the inline two-step confirm before a global CLAUDE.md write (#872).
-  // Owned here (not the parent) because this component renders ALL cross cards, so
-  // single-open is fully preserved within this component.
-  let confirmingGlobalId = $state<string | null>(null);
 </script>
 
 {#if suggestions.length > 0}
@@ -32,43 +25,16 @@
             repos: (s.repoPaths ?? []).map(basename).join(", "),
           })}
         </p>
-        {#if confirmingGlobalId === s.id}
-          <p class="recur-confirm">{m.learnings_recur_promote_confirm()}</p>
-          <div class="recur-foot">
-            <button class="ms-dismiss" type="button" onclick={() => (confirmingGlobalId = null)}>
-              {m.common_cancel()}
-            </button>
-            <button
-              class="ms-apply"
-              type="button"
-              onclick={() => {
-                onpromoteglobal(s.id);
-                confirmingGlobalId = null;
-              }}
-            >
-              {m.learnings_recur_promote_action()}
-            </button>
-          </div>
-        {:else}
-          <div class="recur-foot">
-            <button
-              class="ms-dismiss"
-              type="button"
-              onclick={() => ondismissmerge(s.id)}
-              aria-label={m.learnings_recur_dismiss_aria()}
-            >
-              {m.learnings_dismiss()}
-            </button>
-            <button
-              class="ms-apply"
-              type="button"
-              onclick={() => (confirmingGlobalId = s.id)}
-              aria-label={m.learnings_recur_promote_aria()}
-            >
-              {m.learnings_recur_promote()}
-            </button>
-          </div>
-        {/if}
+        <div class="recur-foot">
+          <button
+            class="ms-dismiss"
+            type="button"
+            onclick={() => ondismissmerge(s.id)}
+            aria-label={m.learnings_recur_dismiss_aria()}
+          >
+            {m.learnings_dismiss()}
+          </button>
+        </div>
       </article>
     {/each}
   </section>
@@ -113,25 +79,11 @@
     color: var(--color-muted);
     line-height: 1.45;
   }
-  .recur-confirm {
-    font-size: var(--fs-meta);
-    color: var(--color-amber);
-    line-height: 1.45;
-  }
   .recur-foot {
     display: flex;
     align-items: center;
     justify-content: flex-end;
     gap: 8px;
-  }
-  /* Merge = actionable consolidation → green (matches .promote) */
-  .ms-apply {
-    font-size: var(--fs-base);
-    padding: 4px 12px;
-    cursor: pointer;
-    border: 1px solid var(--color-green);
-    background: none;
-    color: var(--color-green);
   }
   .ms-dismiss {
     font-size: var(--fs-base);

--- a/ui/src/lib/components/learnings-drawer/RepoGroup.svelte
+++ b/ui/src/lib/components/learnings-drawer/RepoGroup.svelte
@@ -82,6 +82,11 @@
   {/if}
 
   <!-- Change 7: hide proposals under either active lens -->
+  {#if !(flaggedOnly || overBudgetOnly) && group.proposed.length > 0}
+    <!-- The admission test the distiller applies (#2004), restated where the operator's approve
+         click applies the same judgement. -->
+    <p class="admission-hint">{m.learnings_proposed_admission_hint()}</p>
+  {/if}
   {#each flaggedOnly || overBudgetOnly ? [] : group.proposed as l (l.id)}
     <ProposedRuleCard learning={l} {ctx} />
   {/each}
@@ -297,6 +302,11 @@
     letter-spacing: 0.1em;
     color: var(--color-amber);
     margin: 4px 0 2px;
+  }
+  .admission-hint {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    line-height: 1.45;
   }
   .retired-section {
     display: flex;

--- a/ui/src/lib/components/learnings-drawer/ctx.ts
+++ b/ui/src/lib/components/learnings-drawer/ctx.ts
@@ -16,7 +16,6 @@ export type LearningsCtx = {
   onseenretired: (repoPath: string) => void;
   onmerge: (suggestionId: string) => void;
   ondismissmerge: (suggestionId: string) => void;
-  onpromoteglobal: (suggestionId: string) => void;
   onmergenow: (repoPath: string) => void;
 
   // Shared scope-editor state — kept in parent to preserve single-open semantics.

--- a/ui/src/lib/components/page/AppOverlays.svelte
+++ b/ui/src/lib/components/page/AppOverlays.svelte
@@ -19,7 +19,6 @@
     markRetiredSeen,
     applyMergeSuggestion,
     dismissMergeSuggestion,
-    promoteGlobalLearning,
     mergeSuggestNow,
     getPlugins,
   } from "$lib/api";
@@ -443,13 +442,6 @@
       dismissMergeSuggestion(suggestionId)
         .then(() => learnings.load())
         .catch(() => {})}
-    onpromoteglobal={(suggestionId) =>
-      promoteGlobalLearning(suggestionId)
-        .then(() => {
-          toasts.info(m.learnings_recur_promote_done());
-          return learnings.load();
-        })
-        .catch(() => toasts.info(m.learnings_recur_promote_failed()))}
     onmergenow={(repoPath) =>
       mergeSuggestNow(repoPath)
         .then(() => toasts.info(m.learnings_merge_now_started({ repo: basename(repoPath) })))

--- a/ui/src/lib/feature-announcements/entries/v1.47.0-learnings-gotchas.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.47.0-learnings-gotchas.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "learnings-gotchas",
+  sinceVersion: "1.47.0",
+  titleKey: "feat_learnings_gotchas_title",
+  bodyKey: "feat_learnings_gotchas_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
Re-targets the learnings flywheel at **admission**: it now captures non-derivable repo facts instead of manufacturing behavioral rules. The decay/trial/reap/Wilson-retire machinery from the lifecycle epic is untouched.

Closes #2004.

## The admission test (`src/learning-shape.ts`)

One source of truth, embedded verbatim in the distiller prompt, the optimizer prompt and the sweep tooling so they cannot drift. A candidate qualifies only when all three hold — **non-derivable** (not learnable from the repo, README/CLAUDE.md or `--help` in the session that needs it), **consequential and quiet** ("the linter catches it" is a reject), **attached to an artifact** (names the file, flag, endpoint, table, field or invariant). It rejects outright: general judgement a capable model follows unprompted, restatements of the directives every spawn already carries, preferences with no failure mode, and anything broad enough to apply to any repo.

## What changed

- **Distiller** — fact-shaped ADD contract (*fact — why it bites — how to apply*, in the one line that actually reaches a future agent, since `renderHouseRulesBlock` injects `rule` only). DELETE gains a second criterion: an active rule that **fails the test**, judged on its own text with no signal required. That is what makes the sweep continuous — the daily run keeps draining judgement-shaped rules at 5/run/repo. Promoted rules stay delete-exempt.
- **Optimizer** — rewrites to the same shape, and **omits** a target that cannot be restated as a fact rather than making it a sterner instruction. Omitting leaves it flagged, so the existing auto-retire path takes it.
- **Sweep tooling** — `src/learning-sweep.ts` (pure: plan + price) and `scripts/sweep-house-rules.ts` (dry-run by default, `--apply` retires with `retiredReason = "not-a-gotcha"`, refuses promoted rules). Pricing runs the real spawn path — `planHouseRulesInjection` → `renderHouseRulesBlock` → `measurePromptBlocks` — so the numbers below are the #1999 meter's own math in its own units.
- **Word-boundary trim** at every rule-text entry point. The blunt `slice(0, 240)` had already left a live rule truncated mid-word ("…leaks into execution across consumers when one site "), and fact-shaped entries run longer.

## Sweep applied

Snapshot taken (`VACUUM INTO`) before applying. Every retirement is reversible via `POST /api/learnings/:id/restore`, and `retiredReason` records why.

| | rules | block chars | est-tokens |
|---|---|---|---|
| before | 234 | 22,089 | ~5,525 |
| after | **142** | **9,139** | **~2,288** |

−92 rules, −12,950 chars (−59%). Per repo, biggest movers: pulse 30→17 (−74% chars), oxidone 24→12 (−62%), shepherd-claude-swap 23→11 (−62%), shepherd 40→26 (−54%), topmedia-website 23→13 (−60%).

Two axes, scoped honestly:

- **Shepherd's own 40 rules: both axes** (judgement *and* derivability) — full repo context here. 14 dropped, e.g. "deliver findings first on analysis tasks", "never treat plan approval as opt-in for outward acts" (restates a standing directive), "call the build-queue API to mark each step" (restates the injected build-queue directive), "stamp feature-announcement `sinceVersion` from the helper" (restates the repo's own CLAUDE.md). Kept: the bwrap `--clearenv` fact, `listActiveLearnings` including promoted rows, the `store.ts` prune/cascade gap, the toast `key`/`duration:null`/`alert:true` triple.
- **The other ~194 rules: the judgement axis only.** Recognising "verify before claiming" as model-default needs no repo knowledge; deciding whether a fact is derivable from a repo I have not read does. What survives that pass but might still fail the derivability test is left to the distiller's new DELETE criterion.

One category call worth flagging for review: operator-policy rules with no artifact — "escalate after N plan-review rounds" and friends — fail criterion 3 and were dropped. If those should stand, their honest home is a spawn directive or the repo's CLAUDE.md, not a ranked, decaying house rule.

## Promote-to-global: dropped

`Promoter.promoteGlobal()`, `POST /api/learnings/promote-global`, the `onpromoteglobal` prop chain and its six message keys are gone. Rationale (also recorded in `src/promote.ts` where the method lived): Claude's auto-memory now owns `~/.claude/CLAUDE.md` and is written by the model that reads it; a rule promoted there is resident in every session of every repo — the widest blast radius, for exactly the class of instruction this epic is cutting; and it was the flywheel's one write with no review gate. The per-repo, PR-gated `promote()`/`resyncPromoted()` stay. The cross-repo recurrence band remains as an insight surface with dismiss only, and its lead copy now points at the repo's own CLAUDE.md. The v1.35.0 announcement entry stays as history.

## Verification

Root `bun run lint`, `bunx tsc --noEmit`, `bun test ./test` (8,142 pass); `cd ui && bun run check` (0 errors), `bun run test` (4,514 pass), `check:i18n`; branch-hygiene, announcement-versions, glossary and feature-catalog gates; `fallow audit --base <epic branch> --fail-on-issues` clean. Sweep re-run is a safe no-op (already-retired ids come back REFUSED, nothing re-priced).

Prompt text is untested by construction, so `distillPrompt()`/`optimizePrompt()` are now exported and asserted to embed the shared test — the regression guard against a future edit restoring rule-manufacturing.

## Note for the operator

The live server predates #1999, so `session_prompt_budget` has no rows yet; the numbers above are the meter's computation, and its own recorded rows will show the smaller `shepherd-house-rules` block from the next deploy onward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
