### PR TITLE
feat(readiness): stop generating posture prose into target repos

### DIFF
--- a/src/readiness.ts
+++ b/src/readiness.ts
@@ -653,9 +653,20 @@ export function analyzeReadiness(dir: string): ReadinessReport {
 }
 
 /**
- * A repo-tailored house-rules snippet encoding the surgical/mechanical posture
- * (generalized from Shepherd's own `<shepherd-house-rules>` + Karpathy posture),
- * plus a prescription of the missing tooling. Fully profile-driven: the stack label,
+ * A repo-tailored house-rules snippet: the few failure modes tooling can't catch, plus a
+ * prescription of the missing tooling.
+ *
+ * The posture section is deliberately short (issue #2015). It used to carry seven bullets —
+ * simplicity first, surgical changes, verify before claiming done and no dead code among them —
+ * which either restate the engineering posture every Shepherd spawn already receives in its system
+ * prompt, or state general judgement a capable model follows unprompted. This file is written into
+ * a *target* repo, where it is re-read on every turn of every session, so prose that says nothing
+ * new is pure cost. What survives is what fails QUIETLY: a swallowed error reading as success, a
+ * hardcoded count drifting, a doc comment left stale by a behavior change — none of which a gate
+ * fires on. Anything a gate CAN catch belongs in the prescription below as tooling, not here as
+ * prose. Keep it that way when editing.
+ *
+ * Fully profile-driven: the stack label,
  * all four adopt-line maps (tooling label, churn prose, install steps, prescription
  * note) and the trailing section come from the selected profile, so nothing JS-specific
  * (e.g. a "prettier + lint-staged" churn line) can leak into another stack's artifact.
@@ -689,22 +700,14 @@ with minimal human back-and-forth by having deterministic guardrails do the
 coaching — the gate fails, the agent self-corrects, a human is never pulled in to
 re-explain a mechanical defect.
 
-## Engineering posture (surgical & mechanical)
+## What the guardrails can't catch
 
-- **Simplicity first.** Write the minimum code that solves the stated problem —
-  no speculative features, abstractions for single use, or config nobody asked for.
-- **Surgical changes.** Every changed line traces to the request. Don't refactor,
-  reformat, or polish adjacent code; match existing style. Delete only what your
-  change orphaned; surface pre-existing dead code rather than silently expanding the diff.
 - **Fail closed.** Render error/unreachable paths as explicit failures; never let a
   swallowed error, empty result, or zero count masquerade as success.
 - **Single source of truth.** Derive counts, totals, and dimensions from the data
   (array length, column count) — never hardcode a magic number that silently drifts.
 - **Keep names and comments honest.** When you change a function's behavior, update
   its name, doc comment, and inline comments to match — no stale comment left behind.
-- **No dead code.** Delete unreachable branches and unused fields/params, or wire
-  them to a real path, before opening a PR.
-- **Verify before claiming done.** Run the gate; show the output. Evidence before assertions.
 
 ## Adopt these guardrails (highest leverage first)
 

--- a/test/readiness-rust.test.ts
+++ b/test/readiness-rust.test.ts
@@ -157,6 +157,10 @@ test("generated Rust CLAUDE.md is Rust-correct and free of JS tooling text", () 
   expect(r.claudeMd).not.toContain("lint-staged");
   expect(r.claudeMd).not.toContain("eslint");
   expect(r.claudeMd).not.toContain("tsc");
+  // The posture section is profile-independent (issue #2015), so the cut must hold here too —
+  // a regression would otherwise reach Rust repos unnoticed.
+  expect(r.claudeMd).toContain("Fail closed");
+  expect(r.claudeMd).not.toContain("Surgical changes");
 });
 
 test("a mixed repo with both Cargo.toml and package.json resolves to js-ts (no regression)", () => {

--- a/test/readiness.test.ts
+++ b/test/readiness.test.ts
@@ -195,13 +195,32 @@ test("score is the weighted fraction of present guardrails, derived from the che
   expect(present("git_hooks", r)).toBe(true); // .husky/ implies a hook manager
 });
 
-test("generated CLAUDE.md is non-empty, encodes the surgical posture, and names missing tooling", () => {
+test("generated CLAUDE.md is non-empty, keeps the quiet-failure posture, and names missing tooling", () => {
   pkg({ name: "needs-coaching", devDependencies: { typescript: "^6" } });
   write("tsconfig.json", "{}");
   const r = analyzeReadiness(dir);
-  expect(r.claudeMd).toContain("Surgical");
+  expect(r.claudeMd).toContain("Fail closed");
   // a missing high-leverage guardrail should be called out in the prescription
   expect(r.claudeMd.toLowerCase()).toContain("prettier");
+});
+
+// Issue #2015: the artifact is written into a TARGET repo and re-read every turn, so it must not
+// restate the engineering posture every Shepherd spawn already carries in its system prompt, nor
+// general judgement a capable model follows unprompted. Without this guard nothing stops the
+// section re-growing — which is the whole failure the cut exists to prevent.
+test("generated CLAUDE.md carries no posture bullet the system prompt or the guardrails already cover", () => {
+  pkg({ name: "needs-coaching", devDependencies: { typescript: "^6" } });
+  const md = analyzeReadiness(dir).claudeMd;
+  for (const dropped of [
+    "Simplicity first",
+    "Surgical changes",
+    "Verify before claiming done",
+    "No dead code",
+  ])
+    expect(md).not.toContain(dropped);
+  // …while the bullets that describe a QUIET failure no gate fires on all survive.
+  for (const kept of ["Fail closed", "Single source of truth", "Keep names and comments honest"])
+    expect(md).toContain(kept);
 });
 
 test("CLAUDE.md always tells the repo to add .shepherd-* to .prettierignore, even when prettier is already present", () => {


### PR DESCRIPTION
Closes #2015.

`generateClaudeMd()` was writing a 1,177-char `## Engineering posture (surgical & mechanical)` section into the `CLAUDE.md` it generates **for other people's repos** — the one file re-read on every turn of every session. Three of its seven bullets restated `ENGINEERING_POSTURE` (`src/service.ts`), which every Shepherd spawn already carries. Cut to the non-derivable bullets: **not deleted wholesale** (the artifact must stand alone for an agent that is not a Shepherd spawn), and not kept as-is. Section is now 527 chars.

## Which rejection test applies (recorded divergence)

#2004 landed its test as `LEARNING_ADMISSION_TEST` in `src/learning-shape.ts`, but it is written for **learnings-flywheel entries** — repo-specific gotchas. Applied verbatim it rejects all seven bullets, including the three the issue proposes keeping, because this artifact is generic by construction: it is generated for a repo Shepherd has only just scanned, with no session history to draw a repo-specific fact from.

So the transferable half is applied and the rest is not:

- **Applied** — REJECT clause 1: *"general engineering judgement or process a capable model already follows unprompted: scope discipline, verify-before-claiming, … don't-build-what-wasn't-asked"*.
- **Applied** — REJECT clause 2: restating a directive the agent is handed every session.
- **Applied** — ADMIT criterion 2, **CONSEQUENTIAL AND QUIET**: the failure is silent, delayed or expensive to undo, and *"the linter catches it"* is a reject.
- **Not applied** — criterion 1 (non-derivable **for this repo**), criterion 3 (attached to a named file/flag/table), and the final REJECT clause (*"broad enough to apply to any repository"*). All three test for repo-specificity, which is a property of a learnings entry, not of a generated house-rules file. Inventing a parallel definition of "derivable" is the failure this epic exists to fix, so the divergence is scoped to exactly these three and recorded here rather than encoded anywhere.

## Verdicts — all seven bullets

| Bullet | Verdict | Justification against the applied test |
|---|---|---|
| Simplicity first | **DROP** | REJECT clause 1 verbatim ("don't-build-what-wasn't-asked"); also restates `ENGINEERING_POSTURE`'s *Simplicity first*. |
| Surgical changes | **DROP** | REJECT clause 1 ("scope discipline"); restates `ENGINEERING_POSTURE`'s *Surgical changes* near-verbatim. |
| Verify before claiming done | **DROP** | REJECT clause 1 ("verify-before-claiming"); restates *Goal-driven execution*. |
| Fail closed | **KEEP** | Consequential and quiet: a swallowed error / empty result / zero count reading as success is silent and survives review. No system-prompt counterpart. |
| Single source of truth | **KEEP** | Consequential and quiet: a hardcoded count or dimension drifts with no gate firing — the wrong number just ships. |
| Keep names and comments honest | **KEEP** | Consequential and quiet: a doc comment left stale by a behavior change misleads the *next* agent, delayed and unlinted. |
| No dead code | **DROP** (adjudicated) | The issue left this open. It restates the `dead_code_audit` guardrail the scorecard already prescribes as **tooling** (fallow / cargo-machete). Guardrail present → the gate catches it mechanically; absent → the adopt list prescribes it. Redundant in both states, and "let deterministic guardrails do the coaching" is the artifact's own stated thesis. |

**No divergence from the issue's proposed table** on the six bullets it decided; `No dead code` adjudicated to DROP.

The heading `## Engineering posture (surgical & mechanical)` named a dropped bullet, so it became **`## What the guardrails can't catch`** — the one property the three survivors share, and it reads straight into the `## Adopt these guardrails` section below it.

## The prescription is byte-identical

Verified mechanically rather than by eye: a throwaway script generated the artifact for a JS/TS and a Rust fixture at the base commit and after the change and diffed them. The diff is confined to the posture section in **both** profiles — stack label, leverage-ranked adopt list, install commands, prescription notes and the trailing `.prettierignore`/profile note come out unchanged. Script deleted; nothing scaffolding-shaped is committed.

Detection and scoring are untouched (no detector, weight or `GUARDRAILS` edit), and `agent_instructions` stays presence-only — no byte threshold or leanness heuristic.

## Tests

- `test/readiness.test.ts` — the artifact's only guard against regenerating empty was `toContain("Surgical")`, bound to a dropped bullet. **Retargeted, not deleted**: now `toContain("Fail closed")`, with the prescription assertion untouched.
- New test asserting the four dropped bullets are absent and the three retained ones present. Without it nothing stops the section re-growing, which is the exact failure this slice exists to prevent.
- `test/readiness-rust.test.ts` — the posture section is profile-independent, so a regression would hit both profiles; the Rust artifact test now asserts the cut too.

## No UI, i18n or skill change needed

- `buildAdoptPrompt()` concatenates the intro with the artifact verbatim, so the one-click adopt task inherits the trim with no code change.
- `readiness_adopt_intro_create` / `_merge` say "install the guardrails below and add a CLAUDE.md with these house rules" — still accurate, so the catalogs are untouched and `check:i18n` parity is unaffected.
- `.claude/skills/shepherd-onboarding/SKILL.md` — both relevant clauses stay true: the artifact keeps the `# House rules for AI agents` heading and its adopt list. (If #2002 deletes the spawn-side posture, that clause's "already receives an engineering posture" is #2002's to correct.)

## Gates

`bun run lint`, `bun run test` (8176 pass / 0 fail), and `cd ui && bun run check` (0 errors) all pass locally, plus the pre-push hook.

[no-feature-entry] — this removes generated prose rather than shipping new UX, and touches no `ui/src/lib/components/**` or `ui/src/routes/**` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
