### PR TITLE
fix(epic): strip leading `Epic:`, lowercase landing-PR subject

### DIFF
--- a/src/epic-landing.ts
+++ b/src/epic-landing.ts
@@ -29,6 +29,15 @@ const RELEASE_TYPES = new Set([
  *  entry rather than letting the merge fall through unrecognized (#1206). */
 const FALLBACK_TYPE = "feat";
 
+/** Lowercase the first character of a subject. `.github/workflows/pr-title.yml` lints this very
+ *  title with the repo's commitlint config, whose `subject-case` rule (never sentence-case /
+ *  start-case / pascal-case / upper-case) rejects a subject starting with an uppercase letter —
+ *  that single character is the whole invariant (#2021). A non-letter lead (digit, backtick,
+ *  paren) already passes, and `toLowerCase` is a no-op there. */
+function lowerFirst(subject: string): string {
+  return subject.charAt(0).toLowerCase() + subject.slice(1);
+}
+
 /** Landing-PR title that doubles as the squash-merge **subject** release-please parses, so it
  *  MUST lead with a recognized conventional `type(scope)!?:` at column 0 (#1206 — a subject
  *  led by `Land epic #<n>:` pushes the real type mid-line and release-please skips the merge).
@@ -37,19 +46,27 @@ const FALLBACK_TYPE = "feat";
  *  - Parent title already conventional with a recognized type → keep it (type lowercased,
  *    scope/`!` verbatim), append ` (epic #<n>)`.
  *  - Bare title, OR a non-type `Word:` prefix (e.g. `Comments: …`) → prepend `feat:`.
- *  A trailing `[EPIC]`/`[epic]` tag is stripped either way. */
+ *  A trailing `[EPIC]`/`[epic]` tag and a leading `Epic:` — the prefix Shepherd's own epic
+ *  authoring produces — are stripped either way. The description is then lowercase-initial in
+ *  BOTH branches so the `pr title` gate stays green (#2021; see `lowerFirst`). A title that is
+ *  nothing but the tag leaves no description, hence the guard in both returns. */
 export function buildLandingPrTitle(parentNumber: number, parentTitle: string): string {
-  const cleaned = parentTitle.trim().replace(/\s*\[epic\]\s*$/i, "");
+  // `epic` is not in RELEASE_TYPES, so stripping the leading tag can never clobber a real type.
+  const cleaned = parentTitle
+    .trim()
+    .replace(/\s*\[epic\]\s*$/i, "")
+    .replace(/^epic\s*:\s*/i, "");
   const epicTag = `(epic #${parentNumber})`;
 
   const m = /^(\w+)(\([^)]*\))?(!)?:\s*(.*)$/.exec(cleaned);
   if (m && RELEASE_TYPES.has(m[1]!.toLowerCase())) {
     const prefix = `${m[1]!.toLowerCase()}${m[2] ?? ""}${m[3] ?? ""}`;
-    const desc = m[4]!.trim();
+    const desc = lowerFirst(m[4]!.trim());
     return desc ? `${prefix}: ${desc} ${epicTag}` : `${prefix}: epic #${parentNumber}`;
   }
 
-  return `${FALLBACK_TYPE}: ${cleaned} ${epicTag}`;
+  const desc = lowerFirst(cleaned);
+  return desc ? `${FALLBACK_TYPE}: ${desc} ${epicTag}` : `${FALLBACK_TYPE}: epic #${parentNumber}`;
 }
 
 /** Sanitize a child title for a single Markdown table cell: collapse newlines to spaces (a

--- a/test/epic-landing.test.ts
+++ b/test/epic-landing.test.ts
@@ -1,47 +1,89 @@
 import { describe, expect, it } from "bun:test";
 import { buildLandingPrBody, buildLandingPrTitle } from "../src/epic-landing";
 
+/** Build a landing title AND assert it clears the `pr title` gate. `.github/workflows/pr-title.yml`
+ *  lints the PR title with the repo's commitlint config, whose `subject-case` rule rejects a
+ *  subject whose first character is uppercase (#2021 — verified against `bunx commitlint`). Every
+ *  case below goes through this wrapper so the builder can never drift away from the gate again. */
+function build(parentNumber: number, parentTitle: string): string {
+  const title = buildLandingPrTitle(parentNumber, parentTitle);
+
+  const subject = /^\w+(?:\([^)]*\))?!?:\s*(.*)$/.exec(title)?.[1];
+  // A missing prefix is itself the #1206 bug — assert on `title` so the failure names it.
+  if (subject === undefined) expect(title).toBe("<a conventional type(scope)!?: prefix>");
+  expect(subject).not.toMatch(/^[A-Z]/);
+
+  return title;
+}
+
 describe("buildLandingPrTitle", () => {
   it("keeps a recognized conventional prefix at column 0 and appends the epic tag", () => {
-    expect(buildLandingPrTitle(535, "feat(comments): communication feed on Objectives")).toBe(
+    expect(build(535, "feat(comments): communication feed on Objectives")).toBe(
       "feat(comments): communication feed on Objectives (epic #535)",
     );
   });
 
   it("preserves a breaking-change `!` (with and without scope)", () => {
-    expect(buildLandingPrTitle(88, "fix(api)!: drop legacy route")).toBe(
+    expect(build(88, "fix(api)!: drop legacy route")).toBe(
       "fix(api)!: drop legacy route (epic #88)",
     );
-    expect(buildLandingPrTitle(89, "feat!: rework pipeline")).toBe(
-      "feat!: rework pipeline (epic #89)",
-    );
+    expect(build(89, "feat!: rework pipeline")).toBe("feat!: rework pipeline (epic #89)");
   });
 
   it("prepends the `feat:` fallback for a bare (non-conventional) title", () => {
-    expect(buildLandingPrTitle(327, "EFI value map")).toBe("feat: EFI value map (epic #327)");
+    expect(build(327, "EFI value map")).toBe("feat: eFI value map (epic #327)");
   });
 
   it("falls back to `feat:` for a non-type `Word:` prefix (not a real conventional type)", () => {
-    expect(buildLandingPrTitle(90, "Comments: communication feed")).toBe(
-      "feat: Comments: communication feed (epic #90)",
+    expect(build(90, "Comments: communication feed")).toBe(
+      "feat: comments: communication feed (epic #90)",
     );
   });
 
   it("lowercases a recognized but mixed-case type", () => {
-    expect(buildLandingPrTitle(91, "Feat(x): add y")).toBe("feat(x): add y (epic #91)");
+    expect(build(91, "Feat(x): add y")).toBe("feat(x): add y (epic #91)");
   });
 
   it("strips a trailing `[EPIC]` tag (case-insensitive)", () => {
-    expect(buildLandingPrTitle(535, "feat(comments): comms feed [EPIC]")).toBe(
+    expect(build(535, "feat(comments): comms feed [EPIC]")).toBe(
       "feat(comments): comms feed (epic #535)",
     );
-    expect(buildLandingPrTitle(328, "EFI value map [epic]")).toBe(
-      "feat: EFI value map (epic #328)",
-    );
+    expect(build(328, "EFI value map [epic]")).toBe("feat: eFI value map (epic #328)");
   });
 
   it("guards an empty description after a recognized prefix", () => {
-    expect(buildLandingPrTitle(42, "chore:")).toBe("chore: epic #42");
+    expect(build(42, "chore:")).toBe("chore: epic #42");
+  });
+
+  it("strips the leading `Epic:` Shepherd's own epic authoring produces", () => {
+    expect(build(7, "Epic: adopt X")).toBe("feat: adopt X (epic #7)");
+    expect(build(8, "epic: adopt X")).toBe("feat: adopt X (epic #8)");
+    expect(build(9, "Epic:adopt X")).toBe("feat: adopt X (epic #9)");
+  });
+
+  it("strips a leading `Epic:` and a trailing `[epic]` together", () => {
+    expect(build(10, "Epic: adopt X [epic]")).toBe("feat: adopt X (epic #10)");
+  });
+
+  it("keeps a real conventional type carried behind the `Epic:` tag", () => {
+    expect(build(11, "Epic: fix(api)!: drop legacy route")).toBe(
+      "fix(api)!: drop legacy route (epic #11)",
+    );
+  });
+
+  it("guards a title that is nothing but the `Epic:` tag", () => {
+    expect(build(12, "Epic:")).toBe("feat: epic #12");
+    expect(build(13, "Epic: [epic]")).toBe("feat: epic #13");
+  });
+
+  it("lowercases a capitalized description behind a recognized type", () => {
+    expect(build(14, "fix(api)!: Drop legacy route")).toBe(
+      "fix(api)!: drop legacy route (epic #14)",
+    );
+  });
+
+  it("leaves a non-letter-initial description alone (already gate-safe)", () => {
+    expect(build(15, "5 things to fix")).toBe("feat: 5 things to fix (epic #15)");
   });
 });
 


### PR DESCRIPTION
Closes #2021

`buildLandingPrTitle` emitted landing-PR titles that Shepherd's own `pr title` workflow rejects. PR #2018 (landing epic #2005) went red on `pr title` alone and had to be hand-retitled.

## What the gate actually enforces

`.github/workflows/pr-title.yml` pipes the title through `bunx commitlint` with the repo's config. I ran the real binary rather than reasoning about the rule; `subject-case` reduces to one invariant:

> the subject — everything after `type(scope)!?: ` — must not begin with an uppercase letter.

That makes the bug wider than #2021 frames it. Measured, before this change:

| Emitted title | Gate |
| --- | --- |
| `feat: Epic: adopt the Claude 5 … (epic #2005)` | RED — the reported case |
| `feat: EFI value map (epic #327)` | RED — asserted as *expected* in the suite |
| `feat: Comments: communication feed (epic #90)` | RED — asserted as *expected* in the suite |
| `feat(x): Rework pipeline (epic #91)` | RED — the recognized-type branch, not in the issue |

So the suite was green while the gate would have failed for those epics, and the typed branch was affected too — the issue only discusses the fallback branch.

## Fix

Both inside `buildLandingPrTitle`:

1. Strip a leading `Epic:` (case-insensitive) in the same cleanup as the existing trailing `[epic]` tag, before the conventional-prefix match. Safe by construction — `epic` is not in `RELEASE_TYPES`, so no legitimately-typed parent can match it.
2. Lowercase the description's first character in **both** branches.

Stripping `Epic:` also lets the fallback branch produce an empty description (a title that is nothing but the tag), so the `desc ? … : "<type>: epic #<n>"` guard now covers both returns, not just the typed one.

| Parent epic title | Emitted |
| --- | --- |
| `Epic: adopt X` | `feat: adopt X (epic #7)` |
| `Epic:` | `feat: epic #7` |
| `EFI value map` | `feat: eFI value map (epic #327)` |
| `fix(api)!: Drop legacy route` | `fix(api)!: drop legacy route (epic #88)` |
| `feat(x): add y` | `feat(x): add y (epic #91)` (untouched) |

`eFI` is deliberate: ugly but green. Acronym-aware special-casing would still leave the gate red, and gate correctness beats prettiness on a rare title shape. Confirmed with the operator before implementing.

Type, scope and `!` at column 0 are untouched in every path, so release-please attribution (#1206 — the reason this builder exists) is unaffected.

## Testing

Every title case now goes through a wrapper that asserts the gate's invariant (subject's first char is not `[A-Z]`) in addition to the exact expected string, so the builder and the gate can't drift apart again. Deliberately *not* shelling out to commitlint from the unit suite — that would make it slow and add a `bunx` dependency; the invariant is measured once and encoded.

Two existing expectations changed (`EFI value map`, `Comments: communication feed`): they asserted output the real gate rejects.

New cases: `Epic:`/`epic:`/`Epic:no-space` prefixes, leading + trailing tag together, a real type carried behind the tag, the tag-only degenerate case, a capitalized description behind a recognized type, and a non-letter-initial description.

## Verification

- `bun run lint` — clean
- `bun run test` — 8240 pass, 0 fail
- Every one of the 19 titles the updated tests expect piped through the real `bunx commitlint`: all green, including the exact #2018 title that failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)