### PR TITLE
fix(reaper): guard every killPid site with a pid-recycle fingerprint (#1925)

### DIFF
--- a/src/proc-probes-darwin.ts
+++ b/src/proc-probes-darwin.ts
@@ -42,6 +42,12 @@ import type { ReaperProbes } from "./process-reaper";
 // structurally unreachable here (the orphan reaps need the omitted `ppidForPid`,
 // the runaway reaper the omitted `environForPid`/`cpuStatForPid`/`uptimeSeconds`,
 // and `reap()` is gated on `canAuthorizeSignal`).
+//
+// Since #1925 `cpuStatForPid` carries a SECOND meaning: it is the starttime the
+// generic kill sites bracket their signals with. Omitting it therefore fails each
+// of them closed here a second time over, independently of the omissions above —
+// which is consistent, not redundant, because the one path that IS armed proves
+// its candidates the other way (below).
 
 /** The one `lsof` invocation the backend runs. `-d cwd` and `-iTCP` are different
  *  selection types, so lsof ORs them: one call yields, per process, its command,

--- a/src/process-reaper.ts
+++ b/src/process-reaper.ts
@@ -30,6 +30,19 @@ export interface Leftover {
   key: string;
   /** present for kind "process": the pid to kill */
   pid?: number;
+  /**
+   * present for kind "process": that pid's `starttime` (USER_HZ ticks since boot, /proc/<pid>/stat)
+   * as captured by `openSignalBracket` at detection — the kernel's own pid-recycle fingerprint.
+   * `reap()` re-reads it immediately before signalling and refuses on any mismatch, closing the
+   * bracket that the cwd/comm re-read and the `portsForPid` read sit inside. A pid recycled
+   * anywhere in the detect→kill window is therefore never signalled (bar same-tick reuse — see the
+   * pid-recycle note further down).
+   *
+   * ALWAYS SERVER-PRODUCED, never client-supplied: `SessionService.archive` re-runs `detect` and
+   * intersects by KEY, so the objects that reach `reap()` come from a fresh scan. The client only
+   * ever echoes back key strings. Absent ⇒ `reap()` refuses to signal (fail closed).
+   */
+  startTicks?: number;
   /** present for kind "system": the counter-command to run */
   command?: { bin: string; args: string[] };
 }
@@ -96,7 +109,12 @@ export interface ReaperProbes {
   cpuStatForPid?(pid: number): CpuStat | null;
   /** System uptime in seconds (/proc/uptime), or null when unreadable. */
   uptimeSeconds?(): number | null;
-  /** A process's cwd, for the log line only — never a gate. Null when unreadable. */
+  /**
+   * A process's cwd. Null when unreadable. Two uses: the runaway sweep's log line, and — since
+   * #1925 — the identity re-read inside `openSignalBracket`, where it IS a gate (absent ⇒ nothing
+   * is signalled). Must be a LIVE read on any backend that authorizes signals, or the re-read
+   * would just replay the same stale value `scanProcs` gave.
+   */
   cwdForPid?(pid: number): string | null;
   // ── snapshot-cell backends (darwin) ────────────────────────────────────────
   /**
@@ -243,6 +261,107 @@ export function leftoverKey(l: Pick<Leftover, "kind" | "name" | "port" | "pid">)
  *  guard would treat `/a/bc` as under `/a/b`). */
 export function isUnder(path: string, root: string): boolean {
   return path === root || path.startsWith(root + "/");
+}
+
+// ── pid-recycle fingerprint (#1925) ─────────────────────────────────────────
+//
+// Every path in this file that signals a pid does so on the strength of data read EARLIER: a cwd
+// and comm from `scanProcs`, a "(deleted)" suffix, a port from `portsForPid`, a ppid. Between those
+// reads and the `killPid` the process can exit and the kernel can hand its pid to something
+// unrelated, which the signal would then hit. `starttime` (ticks since boot) is the kernel's own
+// answer to "is this still the same process", and it is what `reapMarkedOrphans` has always used.
+//
+// The idiom is OPEN A BRACKET, VERIFY LATE. `openSignalBracket` captures `starttime` and then
+// RE-READS the cwd/comm that qualified the candidate; `isSameProcess` re-reads `starttime` at the
+// signal. Every read the decision rests on therefore happens strictly BETWEEN two matching
+// `starttime` reads, so a recycle anywhere in that span is caught.
+//
+// WHY THE RE-READ IS LOAD-BEARING and not belt-and-braces: `scanProcs` is a full-host /proc walk
+// that readlinks a cwd per pid, so the identity of a pid enumerated early is already many
+// milliseconds stale by the time the loop reaches it — a WIDER window than the per-candidate probes
+// that follow. Capturing `starttime` without re-reading cwd/comm would fingerprint whatever now
+// holds the pid and then happily match it at verify time, signalling the recycled process on the
+// dead one's cwd. The bracket has to start before the identity is established, not after.
+//
+// RESIDUAL, inherent to the fingerprint: `starttime` has USER_HZ (10ms) granularity, so a pid
+// recycled into a process that started within the same tick is indistinguishable. Closing that
+// needs pidfd, which is out of scope here — and `reapMarkedOrphans` has always carried it too.
+
+/** The identity `scanProcs` reported for a candidate — what every site's filter actually judged. */
+type ScannedProc = { pid: number; cwd: string; comm: string };
+
+/**
+ * A pid's `starttime`, or null when it cannot be read: the backend supplies no `cpuStatForPid`
+ * (darwin, `nullProbes`), or the process is already gone.
+ */
+function startTicksFor(pid: number, probes: ReaperProbes): number | null {
+  return probes.cpuStatForPid?.(pid)?.starttime ?? null;
+}
+
+/**
+ * Open the signal bracket for a candidate `scanProcs` qualified: capture its recycle fingerprint,
+ * then re-read the cwd and comm the caller's filter judged and require them UNCHANGED. Returns the
+ * captured `starttime` to hand to {@link isSameProcess} at the signal, or null when this process
+ * must not be signalled at all.
+ *
+ * Byte-equality against the scanned values rather than re-running each site's predicate: the
+ * predicate already passed on exactly these strings, so "still the same strings" is both sufficient
+ * and site-agnostic. A process that legitimately `chdir`s (or `prctl(PR_SET_NAME)`s) between the
+ * scan and here is therefore spared — the safe direction, and rare enough not to cost real coverage.
+ *
+ * FAILS CLOSED — an unreadable stat, an absent `cpuStatForPid`/`cwdForPid`/`commForPid`, and any
+ * divergence all answer null. That costs nothing on either real backend: `linuxProbes` supplies all
+ * three and reads world-readable /proc, so a null there means the process is already gone;
+ * `makeDarwinProbes` omits `cpuStatForPid` and sets `canAuthorizeSignal: false`, so every caller
+ * here is already a no-op on that backend.
+ */
+function openSignalBracket(p: ScannedProc, probes: ReaperProbes): number | null {
+  const startTicks = startTicksFor(p.pid, probes);
+  if (startTicks === null) return null;
+  // Strictly AFTER the capture, so a recycle before this point is caught by the verify.
+  if (!probes.cwdForPid || !probes.commForPid) return null;
+  if (probes.cwdForPid(p.pid) !== p.cwd || probes.commForPid(p.pid) !== p.comm) return null;
+  return startTicks;
+}
+
+/**
+ * Does `pid` still fingerprint the process `captured` was taken from?
+ *
+ * FAILS CLOSED — an absent capture, an absent probe, an unreadable stat and a genuine mismatch all
+ * answer false, i.e. "do not signal". That costs nothing on either real backend: `linuxProbes`
+ * always supplies `cpuStatForPid` and /proc/<pid>/stat is world-readable, so a null there means the
+ * process is already gone; `makeDarwinProbes` omits the probe but also omits `ppidForPid` and sets
+ * `canAuthorizeSignal: false`, so every caller here is already a no-op on that backend.
+ */
+function isSameProcess(
+  pid: number,
+  captured: number | null | undefined,
+  probes: ReaperProbes,
+): boolean {
+  return captured != null && startTicksFor(pid, probes) === captured;
+}
+
+/**
+ * The shared tail of both PPID-1 orphan sweeps ({@link ProcessReaper.reapOrphansUnder},
+ * {@link reapDeletedWorktreeOrphans}): confirm the kernel has reparented this process to PID 1 —
+ * the "abandoned, not a live child" signal — then SIGKILL it. The bracket spans both the cwd/comm
+ * re-read and the `ppidForPid` read, so every gate the kill rests on is verified against one
+ * unchanged `starttime`.
+ *
+ * Returns whether a signal was actually SENT (not a death confirmation). Best-effort: a `killPid`
+ * that throws because the process exited first is a false, not an error.
+ */
+function killReparentedOrphan(p: ScannedProc, probes: ReaperProbes): boolean {
+  const startTicks = openSignalBracket(p, probes);
+  if (startTicks === null) return false;
+  if ((probes.ppidForPid?.(p.pid) ?? null) !== 1) return false;
+  if (!isSameProcess(p.pid, startTicks, probes)) return false;
+  try {
+    probes.killPid(p.pid, "SIGKILL");
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /** Canonical worktree root for comparison against probe-reported cwds: trailing
@@ -607,10 +726,12 @@ export class ProcessReaper {
     // A backend that may not authorize a signal on its own (darwin) must not OFFER
     // class-2 leftovers: `reap()` gates its pid branch on that same
     // `canAuthorizeSignal` flag, so every one of them would be listed under
-    // "Terminate & close", signal nothing, and still be counted as
-    // `reaped = hit.length` (SessionService.archive) — strictly worse than the
-    // pre-#1912 behaviour, where an empty `scanProcs` meant nothing was ever offered.
-    // So fail closed, exactly as class-3 does when `listeningPorts` is absent.
+    // "Terminate & close" and signal nothing — strictly worse than the pre-#1912
+    // behaviour, where an empty `scanProcs` meant nothing was ever offered. So fail
+    // closed, exactly as class-3 does when `listeningPorts` is absent. (The COUNT is
+    // honest either way since #1925: `reap()` returns terminations actually performed
+    // and `SessionService.archive` reports THAT, not the size of the list it was
+    // handed. It is the dead menu entry that is worth avoiding.)
     //
     // The gate is the flag, NOT an inert `killPid`: #1922 made darwin's a real
     // `process.kill`. It armed `stopListenersOnPort` alone, and only because that path
@@ -625,6 +746,14 @@ export class ProcessReaper {
       // own repo and listens on a port, so without this it could surface itself.
       if (p.pid === process.pid) continue;
       if (!isUnder(p.cwd, root) || AGENT_COMMS.has(p.comm)) continue;
+      // Open the signal bracket BEFORE the portsForPid read, so both that read and `reap`'s later
+      // verify sit inside it. A process the bracket refuses is not OFFERED at all: `reap` would
+      // refuse to signal it, so offering it would put an un-killable entry under "Terminate &
+      // close" that silently does nothing — the same dead affordance the no-authority
+      // short-circuit above exists to prevent. The COUNT is honest either way (`reap` returns
+      // terminations performed); it is the phantom menu entry that is worth avoiding.
+      const startTicks = openSignalBracket(p, this.probes);
+      if (startTicks === null) continue;
       const ports = this.probes.portsForPid(p.pid);
       if (ports.length === 0) continue; // no listener ⇒ a transient child, not a server
       out.push({
@@ -632,6 +761,7 @@ export class ProcessReaper {
         name: p.comm || `pid ${p.pid}`,
         port: ports[0]!,
         pid: p.pid,
+        startTicks,
         key: leftoverKey({ kind: "process", name: p.comm, port: ports[0]!, pid: p.pid }),
       });
     }
@@ -712,10 +842,21 @@ export class ProcessReaper {
     const root = normRoot(worktreePath, this.probes);
     let count = 0;
     let rejected = 0;
-    for (const pid of this.candidatePidsOn(root, port)) {
-      // Re-prove the SAME predicates against live data, so a pid that died and was
-      // recycled since the snapshot fails here rather than taking the signal.
-      if (verify && !this.verifiesLive(verify, pid, root, port)) {
+    for (const { pid, startTicks } of this.candidatesOn(root, port)) {
+      // TWO WAYS to prove the pid still belongs to the process the snapshot proposed, and a
+      // backend supplies exactly one of them:
+      //  - `liveProcForPid` (darwin, #1922) — re-prove the SAME predicates against live data.
+      //    macOS has no cheap starttime equivalent, so identity is proven by consequence: a
+      //    recycled pid fails on its cwd, its ports, or both.
+      //  - the starttime bracket (Linux, #1925) — re-read the fingerprint captured in
+      //    `candidatesOn` before `portsForPid`, so that read and this check straddle it.
+      // Requiring BOTH would disarm darwin, which has no `cpuStatForPid`; requiring neither is
+      // the hole #1925 closed. `isSameProcess` fails closed on a null capture, so a backend with
+      // neither seam signals nothing.
+      const proven = verify
+        ? this.verifiesLive(verify, pid, root, port)
+        : isSameProcess(pid, startTicks, this.probes);
+      if (!proven) {
         rejected++;
         continue;
       }
@@ -733,15 +874,23 @@ export class ProcessReaper {
     return { signalled: count, outcome: "ok" };
   }
 
-  /** Pids the backing snapshot PROPOSES for a stop: under `root`, listening on `port`,
-   *  and neither ourselves nor the agent. Only a proposal — on a snapshot backend
-   *  `verifiesLive` re-proves each one against live data before it may be signalled. */
-  private *candidatePidsOn(root: string, port: number): Iterable<number> {
+  /** Candidates the backing snapshot PROPOSES for a stop: under `root`, listening on `port`,
+   *  and neither ourselves nor the agent. Only a proposal — `stopListenersOnPort` proves each
+   *  one before it may be signalled, either live (`verifiesLive`) or by fingerprint.
+   *
+   *  `startTicks` is captured BEFORE the `portsForPid` read so that read falls inside the
+   *  bracket (#1925); it is null on a snapshot backend with no `cpuStatForPid`, which proves
+   *  its candidates the other way and never consults it. */
+  private *candidatesOn(
+    root: string,
+    port: number,
+  ): Iterable<{ pid: number; startTicks: number | null }> {
     for (const proc of this.probes.scanProcs()) {
       if (proc.pid === process.pid) continue;
       if (!isUnder(proc.cwd, root) || AGENT_COMMS.has(proc.comm)) continue;
+      const startTicks = openSignalBracket(proc, this.probes);
       if (!this.probes.portsForPid(proc.pid).includes(port)) continue;
-      yield proc.pid;
+      yield { pid: proc.pid, startTicks };
     }
   }
 
@@ -830,13 +979,7 @@ export class ProcessReaper {
     for (const p of this.probes.scanProcs()) {
       if (p.pid === process.pid || AGENT_COMMS.has(p.comm)) continue;
       if (!isUnder(p.cwd, root)) continue;
-      if ((this.probes.ppidForPid?.(p.pid) ?? null) !== 1) continue;
-      try {
-        this.probes.killPid(p.pid, "SIGKILL");
-        count++;
-      } catch {
-        /* best-effort: process may have already exited */
-      }
+      if (killReparentedOrphan(p, this.probes)) count++;
     }
     return count;
   }
@@ -844,25 +987,44 @@ export class ProcessReaper {
   /**
    * Best-effort terminate each leftover (kill pid / run counter-command).
    *
-   * The pid branch is gated on signal authority independently of `detect`. Today
-   * `scanWorktreeProcs` already returns [] on a no-authority backend, so a caller
-   * that derives leftovers from `detect` (SessionService.archive) can't reach it —
-   * but this method is what actually signals, and its keys round-trip through the
-   * client, so it refuses on its own rather than trusting an upstream filter. The
-   * counter-command branch is NOT gated: it runs `tailscale serve … off`, which
-   * targets a port mapping rather than a pid and so has no recycle hazard.
+   * Returns the number of terminations actually PERFORMED — a signal sent, or a counter-command
+   * that returned without throwing. Not a death confirmation (a process may ignore SIGTERM), but
+   * strictly honest about what this method did, which is why `SessionService.archive` reports it
+   * rather than the size of the list it was handed: the recycle guard below and a throwing
+   * `run()` both make the two diverge. BOTH kinds count — a class-3 `tailscale serve … off` is a
+   * termination the operator asked for, and dropping it would silently deflate the Clear-merged
+   * total `archiveMany` sums.
+   *
+   * The pid branch is gated twice, independently of `detect`:
+   *  - SIGNAL AUTHORITY. Today `scanWorktreeProcs` already returns [] on a no-authority backend, so
+   *    a caller that derives leftovers from `detect` (SessionService.archive) can't reach it — but
+   *    this method is what actually signals, and its keys round-trip through the client, so it
+   *    refuses on its own rather than trusting an upstream filter.
+   *  - PID RECYCLE. `startTicks` was captured when the leftover was detected; it is re-read here and
+   *    must still match. Fails closed, so a leftover carrying no fingerprint is never signalled.
+   *
+   * The counter-command branch is NOT gated: it targets a port mapping rather than a pid, so it has
+   * no recycle hazard.
    */
-  reap(leftovers: Leftover[]): void {
+  reap(leftovers: Leftover[]): number {
     const canSignal = this.probes.canAuthorizeSignal !== false;
+    let terminated = 0;
     for (const l of leftovers) {
       try {
         if (l.kind === "process" && l.pid != null) {
-          if (canSignal) this.probes.killPid(l.pid);
-        } else if (l.command) this.probes.run(l.command.bin, l.command.args);
+          if (!canSignal) continue;
+          if (!isSameProcess(l.pid, l.startTicks, this.probes)) continue;
+          this.probes.killPid(l.pid);
+          terminated++;
+        } else if (l.command) {
+          this.probes.run(l.command.bin, l.command.args);
+          terminated++;
+        }
       } catch {
-        /* best-effort: a process may have already exited */
+        /* best-effort: a process may have already exited, a counter-command may have failed */
       }
     }
+    return terminated;
   }
 }
 
@@ -891,13 +1053,7 @@ export function reapDeletedWorktreeOrphans(probes: ReaperProbes = defaultProbes)
     if (!p.cwd.endsWith(DELETED_SUFFIX)) continue;
     const realCwd = p.cwd.slice(0, -DELETED_SUFFIX.length);
     if (!(realCwd + "/").includes(WORKTREE_MARKER)) continue;
-    if ((probes.ppidForPid?.(p.pid) ?? null) !== 1) continue;
-    try {
-      probes.killPid(p.pid, "SIGKILL");
-      reaped++;
-    } catch {
-      /* best-effort: process may have already exited */
-    }
+    if (killReparentedOrphan(p, probes)) reaped++;
   }
   return { reaped };
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -5492,9 +5492,12 @@ export class SessionService {
    * Close a session: optionally terminate selected leftovers first, then stop the
    * agent, remove the worktree, and archive the row. `reapKeys` are leftover keys
    * the operator chose to kill; we re-detect and intersect by key so a stale/forged
-   * client selection can never make us kill an arbitrary pid. Returns the number of
-   * leftovers actually reaped (the intersection), so bulk callers can report a count
-   * that reflects what was killed rather than what was requested.
+   * client selection can never make us kill an arbitrary pid.
+   *
+   * Returns what `reap` actually TERMINATED — signals sent plus counter-commands run — not the size
+   * of the intersection, so bulk callers report what was killed rather than what was requested. The
+   * two diverge whenever `reap`'s pid-recycle guard refuses a pid recycled since the re-detect, or a
+   * counter-command throws.
    */
   async archive(
     id: string,
@@ -5510,8 +5513,7 @@ export class SessionService {
       await this.refreshForDetect(true);
       const want = new Set(reapKeys);
       const hit = this.deps.reaper.detect(s).filter((l) => want.has(l.key));
-      this.deps.reaper.reap(hit);
-      reaped = hit.length;
+      reaped = this.deps.reaper.reap(hit);
     }
     await this.deps.herdr.stop(s.herdrAgentId); // stop the live claude agent so it doesn't leak
     // Best-effort pre-teardown hook (recap generation): the recap generator reads the

--- a/test/proc-probes-reaper.test.ts
+++ b/test/proc-probes-reaper.test.ts
@@ -209,13 +209,17 @@ test("scanWorktreeProcs: no signal authority ⇒ offers zero class-2 leftovers",
     claudeSessionId: "sess-1",
     isolated: true,
   });
-  // Offering it would put it in the "Terminate & close" list, kill nothing (killPid
-  // is inert without signal authority), and still count as reaped — strictly worse
-  // than pre-#1912, where an empty scan meant nothing was ever offered.
+  // Offering it would put a dead entry in the "Terminate & close" list that kills nothing
+  // (killPid is inert without signal authority) — strictly worse than pre-#1912, where an
+  // empty scan meant nothing was ever offered. (Since #1925 the COUNT no longer lies either
+  // way: `reap` returns terminations performed, asserted below.)
   expect(leftovers).toEqual([]);
-  // And the belt-and-braces: even if a stale key were replayed, nothing is signalled.
-  reaper.reap([{ kind: "process", name: "vite", port: 5173, pid: 4242, key: "process:4242" }]);
+  // And the belt-and-braces: even if a stale key were replayed, nothing is signalled or counted.
+  const terminated = reaper.reap([
+    { kind: "process", name: "vite", port: 5173, pid: 4242, key: "process:4242" },
+  ]);
   expect(killed).toEqual([]);
+  expect(terminated).toBe(0);
 });
 
 test("scanWorktreeProcs: WITH signal authority the same process is still offered", () => {
@@ -225,6 +229,13 @@ test("scanWorktreeProcs: WITH signal authority the same process is still offered
     canAuthorizeSignal: true,
     scanProcs: () => [{ pid: 4242, cwd: "/wt/x", comm: "vite" }],
     portsForPid: () => [5173],
+    // `darwinFake` omits `cpuStatForPid` and stubs `cwdForPid` to null, either of which would
+    // suppress this process for a SECOND, unrelated reason (#1925's fail-closed signal bracket) and
+    // let the test pass without exercising the axis it exists to isolate. The bracket is satisfied
+    // here — matching cwd/comm, readable stat — so signal authority stays the only variable.
+    cpuStatForPid: () => ({ utime: 0, stime: 0, cutime: 0, cstime: 0, starttime: 1000 }),
+    cwdForPid: () => "/wt/x",
+    commForPid: () => "vite",
   });
   const leftovers = new ProcessReaper(probes).detect({
     worktreePath: "/wt/x",

--- a/test/process-reaper.test.ts
+++ b/test/process-reaper.test.ts
@@ -20,16 +20,45 @@ function bashLine(command: string): string {
   });
 }
 
+/** The starttime every fingerprintable fake process reports unless a test says otherwise. */
+const TICKS = 1000;
+
+function stat(starttime: number): CpuStat {
+  return { utime: 0, stime: 0, cutime: 0, cstime: 0, starttime };
+}
+
 function makeProbes(over: Partial<ReaperProbes> = {}): ReaperProbes {
-  return {
+  const base: ReaperProbes = {
     scanProcs: () => [],
     portsForPid: () => [],
     listeningPorts: () => new Set(),
     readTranscript: () => "",
     killPid: () => {},
     run: () => {},
+    // Every kill site fails closed without a pid-recycle fingerprint (#1925), so the default
+    // backend must supply one or no fake would ever signal anything.
+    cpuStatForPid: () => stat(TICKS),
     ...over,
   };
+  const scanned = (pid: number) => base.scanProcs().find((p) => p.pid === pid);
+  return {
+    ...base,
+    // `openSignalBracket` re-reads cwd/comm and requires them unchanged since `scanProcs`. Default
+    // both to agree with this fake's own scanProcs, so the re-read passes unless a test explicitly
+    // makes them diverge (which is how the recycle cases are written).
+    cwdForPid: over.cwdForPid ?? ((pid) => scanned(pid)?.cwd ?? null),
+    commForPid: over.commForPid ?? ((pid) => scanned(pid)?.comm ?? ""),
+  };
+}
+
+/**
+ * A `cpuStatForPid` that fingerprints `pid` as TICKS on its FIRST read and as something else on
+ * every read after — i.e. the pid was recycled between the capture and the verify. Drives the real
+ * capture/verify pair the production code makes, rather than a proxy for it.
+ */
+function recycleAfterFirstRead(pid: number): (p: number) => CpuStat {
+  let reads = 0;
+  return (p) => (p === pid && reads++ > 0 ? stat(TICKS + 7) : stat(TICKS));
 }
 
 const session = { worktreePath: "/wt/repo-x", claudeSessionId: "sess-1", isolated: true };
@@ -43,7 +72,14 @@ test("class 2: a listening process under the worktree is detected", () => {
   );
   const out = reaper.detect(session);
   expect(out).toEqual([
-    { kind: "process", name: "vite", port: 5174, pid: 4242, key: "process:4242" },
+    {
+      kind: "process",
+      name: "vite",
+      port: 5174,
+      pid: 4242,
+      startTicks: TICKS,
+      key: "process:4242",
+    },
   ]);
 });
 
@@ -175,9 +211,16 @@ test("reap kills process pids and runs counter-commands; survives a throw", () =
       run: (bin, args) => ran.push({ bin, args }),
     }),
   );
-  reaper.reap([
-    { kind: "process", name: "gone", port: null, pid: 999, key: "process:999" },
-    { kind: "process", name: "vite", port: 5174, pid: 4242, key: "process:4242" },
+  const terminated = reaper.reap([
+    { kind: "process", name: "gone", port: null, pid: 999, startTicks: TICKS, key: "process:999" },
+    {
+      kind: "process",
+      name: "vite",
+      port: 5174,
+      pid: 4242,
+      startTicks: TICKS,
+      key: "process:4242",
+    },
     {
       kind: "system",
       name: "tailscale serve",
@@ -188,6 +231,8 @@ test("reap kills process pids and runs counter-commands; survives a throw", () =
   ]);
   expect(killed).toEqual([4242]);
   expect(ran).toEqual([{ bin: "tailscale", args: ["serve", "--https=5174", "off"] }]);
+  // One signal + one counter-command. The ESRCH throw is not a termination performed.
+  expect(terminated).toBe(2);
 });
 
 // ── stopListenersOnPort ───────────────────────────────────────────────────────
@@ -522,6 +567,279 @@ test("reapDeletedWorktreeOrphans: spares a deleted cwd that isn't a shepherd wor
         { pid: process.pid, cwd: `${WT} (deleted)`, comm: "bun" }, // self
       ],
       ppidForPid: (pid) => (pid === 22 ? 5000 : 1),
+      killPid: k.killPid,
+    }),
+  );
+  expect(reaped).toBe(0);
+  expect(k.killed).toEqual([]);
+});
+
+// ── #1925: pid-recycle fingerprint at every kill site ────────────────────────
+//
+// Each site reads its identity signal (cwd, port, ppid, "(deleted)") strictly BEFORE it signals.
+// A pid recycled in that window would be signalled on the strength of the dead process's data.
+// `starttime` is captured once the cheap filter qualifies the process and re-read immediately
+// before killPid; a mismatch, an unreadable stat, or a backend with no `cpuStatForPid` at all must
+// all refuse. `reapMarkedOrphans` has always done this — these pin the other four.
+
+test("#1925 reap: a pid recycled between detect and kill is NOT signalled", () => {
+  const k = killSpy();
+  // reap() does not capture — startTicks came from detect — so the recycle is modelled by the
+  // backend simply reporting a different starttime than the one on the leftover.
+  const reaper = new ProcessReaper(
+    makeProbes({ killPid: k.killPid, cpuStatForPid: () => stat(TICKS + 7) }),
+  );
+  const terminated = reaper.reap([
+    {
+      kind: "process",
+      name: "vite",
+      port: 5174,
+      pid: 4242,
+      startTicks: TICKS,
+      key: "process:4242",
+    },
+  ]);
+  expect(k.killed).toEqual([]);
+  expect(terminated).toBe(0);
+});
+
+test("#1925 reap: a leftover carrying no fingerprint is refused (fail closed)", () => {
+  const k = killSpy();
+  const reaper = new ProcessReaper(makeProbes({ killPid: k.killPid }));
+  // No startTicks — e.g. a hand-built leftover, or one from a backend that couldn't fingerprint it.
+  const terminated = reaper.reap([
+    { kind: "process", name: "vite", port: 5174, pid: 4242, key: "process:4242" },
+  ]);
+  expect(k.killed).toEqual([]);
+  expect(terminated).toBe(0);
+});
+
+test("#1925 reap: a backend with no cpuStatForPid probe signals nothing (fail closed)", () => {
+  const k = killSpy();
+  const probes = makeProbes({ killPid: k.killPid });
+  delete probes.cpuStatForPid;
+  const terminated = new ProcessReaper(probes).reap([
+    {
+      kind: "process",
+      name: "vite",
+      port: 5174,
+      pid: 4242,
+      startTicks: TICKS,
+      key: "process:4242",
+    },
+  ]);
+  expect(k.killed).toEqual([]);
+  expect(terminated).toBe(0);
+});
+
+test("#1925 reap: a refused pid does not suppress a sibling counter-command, which still counts", () => {
+  // The class-3 branch targets a port mapping, not a pid, so it has no recycle hazard and stays
+  // ungated. It must still count, or archive()/archiveMany would under-report every class-3 kill.
+  const k = killSpy();
+  const ran: { bin: string; args: string[] }[] = [];
+  const reaper = new ProcessReaper(
+    makeProbes({
+      killPid: k.killPid,
+      cpuStatForPid: () => stat(TICKS + 7), // the pid was recycled since detect
+      run: (bin, args) => ran.push({ bin, args }),
+    }),
+  );
+  const terminated = reaper.reap([
+    {
+      kind: "process",
+      name: "vite",
+      port: 5174,
+      pid: 4242,
+      startTicks: TICKS,
+      key: "process:4242",
+    },
+    {
+      kind: "system",
+      name: "tailscale serve",
+      port: 5174,
+      command: { bin: "tailscale", args: ["serve", "--https=5174", "off"] },
+      key: "system:tailscale serve:5174",
+    },
+  ]);
+  expect(k.killed).toEqual([]);
+  expect(ran).toHaveLength(1);
+  expect(terminated).toBe(1);
+});
+
+test("#1925 reap: a counter-command that throws is not counted as a termination", () => {
+  const reaper = new ProcessReaper(
+    makeProbes({
+      run: () => {
+        throw new Error("exit 1");
+      },
+    }),
+  );
+  const terminated = reaper.reap([
+    {
+      kind: "system",
+      name: "tailscale serve",
+      port: 5174,
+      command: { bin: "tailscale", args: ["serve", "--https=5174", "off"] },
+      key: "system:tailscale serve:5174",
+    },
+  ]);
+  expect(terminated).toBe(0);
+});
+
+test("#1925 detect: a process whose starttime is unreadable is not OFFERED", () => {
+  // Offering it would list an un-killable process under "Terminate & close": reap() would refuse
+  // it, so detect must refuse it first and keep the two in agreement.
+  const reaper = new ProcessReaper(
+    makeProbes({
+      scanProcs: () => [{ pid: 4242, cwd: "/wt/repo-x", comm: "vite" }],
+      portsForPid: () => [5174],
+      cpuStatForPid: () => null,
+    }),
+  );
+  expect(reaper.detect(session)).toEqual([]);
+});
+
+test("#1925 detect: a backend with no cpuStatForPid probe offers no class-2 leftovers", () => {
+  const probes = makeProbes({
+    scanProcs: () => [{ pid: 4242, cwd: "/wt/repo-x", comm: "vite" }],
+    portsForPid: () => [5174],
+  });
+  delete probes.cpuStatForPid;
+  expect(new ProcessReaper(probes).detect(session)).toEqual([]);
+});
+
+// The window `scanProcs` itself opens: it is a full-host /proc walk, so a pid enumerated early can
+// be recycled before the loop reaches it. The fingerprint alone cannot see that — it would capture
+// the RECYCLED process and match it at verify time. Only re-reading cwd/comm inside the bracket
+// catches it, which is why `openSignalBracket` does both. Modelled by a probe whose live cwd/comm
+// disagree with what scanProcs reported.
+
+test("#1925 detect: a pid recycled between scanProcs and the capture is not OFFERED", () => {
+  const reaper = new ProcessReaper(
+    makeProbes({
+      scanProcs: () => [{ pid: 4242, cwd: "/wt/repo-x", comm: "vite" }],
+      portsForPid: () => [5174],
+      cwdForPid: () => "/home/u", // the pid now belongs to something else entirely
+      commForPid: () => "firefox",
+    }),
+  );
+  expect(reaper.detect(session)).toEqual([]);
+});
+
+test("#1925 detect: a candidate whose comm changed since scanProcs is not OFFERED", () => {
+  // comm is what spares `claude`/`codex`, so a stale one could get the agent killed.
+  const reaper = new ProcessReaper(
+    makeProbes({
+      scanProcs: () => [{ pid: 4242, cwd: "/wt/repo-x", comm: "vite" }],
+      portsForPid: () => [5174],
+      commForPid: () => "claude",
+    }),
+  );
+  expect(reaper.detect(session)).toEqual([]);
+});
+
+test("#1925 stopListenersOnPort: a pid recycled between scanProcs and the capture is not signalled", () => {
+  const k = killSpy();
+  const reaper = new ProcessReaper(
+    makeProbes({
+      scanProcs: () => [{ pid: 4242, cwd: "/wt/repo-x", comm: "vite" }],
+      portsForPid: () => [5174],
+      cwdForPid: () => "/home/u",
+      killPid: k.killPid,
+    }),
+  );
+  expect(reaper.stopListenersOnPort("/wt/repo-x", 5174, "SIGKILL").signalled).toBe(0);
+  expect(k.killed).toEqual([]);
+});
+
+test("#1925 reapOrphansUnder: a pid recycled between scanProcs and the capture is not SIGKILLed", () => {
+  const k = killSpy();
+  const reaper = new ProcessReaper(
+    makeProbes({
+      scanProcs: () => [{ pid: ORPHAN_PID, cwd: WT, comm: "yes" }],
+      ppidForPid: () => 1,
+      cwdForPid: () => "/home/u", // recycled into an unrelated process outside the worktree
+      killPid: k.killPid,
+    }),
+  );
+  expect(reaper.reapOrphansUnder(WT)).toBe(0);
+  expect(k.killed).toEqual([]);
+});
+
+test("#1925 reapDeletedWorktreeOrphans: a pid whose cwd is no longer the deleted worktree is spared", () => {
+  const k = killSpy();
+  const { reaped } = reapDeletedWorktreeOrphans(
+    makeProbes({
+      scanProcs: () => [{ pid: ORPHAN_PID, cwd: `${WT} (deleted)`, comm: "yes" }],
+      ppidForPid: () => 1,
+      cwdForPid: () => "/home/u",
+      killPid: k.killPid,
+    }),
+  );
+  expect(reaped).toBe(0);
+  expect(k.killed).toEqual([]);
+});
+
+test("#1925 a backend that cannot re-read cwd/comm signals nothing (fail closed)", () => {
+  const k = killSpy();
+  const probes = makeProbes({
+    scanProcs: () => [{ pid: ORPHAN_PID, cwd: WT, comm: "yes" }],
+    ppidForPid: () => 1,
+    killPid: k.killPid,
+  });
+  delete probes.cwdForPid;
+  expect(new ProcessReaper(probes).reapOrphansUnder(WT)).toBe(0);
+  const noComm = makeProbes({
+    scanProcs: () => [{ pid: ORPHAN_PID, cwd: WT, comm: "yes" }],
+    ppidForPid: () => 1,
+    killPid: k.killPid,
+  });
+  delete noComm.commForPid;
+  expect(new ProcessReaper(noComm).reapOrphansUnder(WT)).toBe(0);
+  expect(k.killed).toEqual([]);
+});
+
+test("#1925 stopListenersOnPort: a pid recycled while its ports are read is not signalled", () => {
+  const k = killSpy();
+  const reaper = new ProcessReaper(
+    makeProbes({
+      scanProcs: () => [{ pid: 4242, cwd: "/wt/repo-x", comm: "vite" }],
+      portsForPid: () => [5174],
+      cpuStatForPid: recycleAfterFirstRead(4242),
+      killPid: k.killPid,
+    }),
+  );
+  expect(reaper.stopListenersOnPort("/wt/repo-x", 5174, "SIGKILL")).toEqual({
+    signalled: 0,
+    // "refused", NOT "ok" with 0: the listener may well still be running, we just could not
+    // prove this pid is still it. #1922's ladder must not advance on that — an "ok" here would
+    // read as "nothing was listening" and escalate past a live server.
+    outcome: "refused",
+  });
+  expect(k.killed).toEqual([]);
+});
+
+test("#1925 reapOrphansUnder: a pid recycled while its ppid is read is not SIGKILLed", () => {
+  const k = killSpy();
+  const reaper = new ProcessReaper(
+    makeProbes({
+      scanProcs: () => [{ pid: ORPHAN_PID, cwd: WT, comm: "yes" }],
+      ppidForPid: () => 1,
+      cpuStatForPid: recycleAfterFirstRead(ORPHAN_PID),
+      killPid: k.killPid,
+    }),
+  );
+  expect(reaper.reapOrphansUnder(WT)).toBe(0);
+  expect(k.killed).toEqual([]);
+});
+
+test("#1925 reapDeletedWorktreeOrphans: a pid recycled while its ppid is read is not SIGKILLed", () => {
+  const k = killSpy();
+  const { reaped } = reapDeletedWorktreeOrphans(
+    makeProbes({
+      scanProcs: () => [{ pid: ORPHAN_PID, cwd: `${WT} (deleted)`, comm: "yes" }],
+      ppidForPid: () => 1,
+      cpuStatForPid: recycleAfterFirstRead(ORPHAN_PID),
       killPid: k.killPid,
     }),
   );

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -914,7 +914,7 @@ test("GET /api/sessions/:id/leftovers returns the reaper's detected list", async
 test("GET /api/sessions/:id/leftovers flags a dead probe snapshot", async () => {
   const { app, store } = harnessWithReaper({
     detect: () => [],
-    reap: () => {},
+    reap: () => 0,
     health: () => ({ state: "none", driven: true }),
   });
   const s = mkLeftoverSession(store);
@@ -928,7 +928,7 @@ test("GET /api/sessions/:id/leftovers flags a dead probe snapshot", async () => 
 test("GET /api/sessions/:id/leftovers flags a fresh snapshot that still can't detect", async () => {
   const { app, store } = harnessWithReaper({
     detect: () => [],
-    reap: () => {},
+    reap: () => 0,
     canDetectLeftovers: () => false,
     health: () => ({ state: "fresh", driven: true }),
   });
@@ -2196,7 +2196,11 @@ function clearMergedHarness(reaperExtra?: { canDetectLeftovers?: any; health?: a
     } as any,
     reaper: {
       detect,
-      reap: (ls: any[]) => reaped.push(...ls.map((l) => l.key)),
+      reap: (ls: any[]) => {
+        reaped.push(...ls.map((l) => l.key));
+
+        return ls.length; // terminations performed; nothing is refused here
+      },
       stopListenersOnPort: () => ({ signalled: 0, outcome: "ok" as const }),
       ...reaperExtra,
     },
@@ -2834,7 +2838,7 @@ function harnessWithPreviewStop({
       stop: async () => {},
       send: () => {},
     } as any,
-    reaper: { detect: () => [], reap: () => {}, stopListenersOnPort, refresh },
+    reaper: { detect: () => [], reap: () => 0, stopListenersOnPort, refresh },
     preview: { devPortFor },
   });
   const usageLimits = {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -2612,7 +2612,7 @@ test("leftovers proxies to the reaper for the session; [] for unknown id", () =>
     herdr: { start: async () => ({}) as any, list: () => [], stop: async () => {} } as any,
     reaper: {
       detect: detect as any,
-      reap: () => {},
+      reap: () => 0,
       stopListenersOnPort: () => ({ signalled: 0, outcome: "ok" }),
     },
   });
@@ -2661,7 +2661,10 @@ test("archive reaps only the selected leftovers, re-detected (no trusting raw cl
     herdr: { start: async () => ({}) as any, list: () => [], stop: async () => {} } as any,
     reaper: {
       detect: () => detected as any,
-      reap: (ls: any[]) => reaped.push(ls.map((l) => l.key)),
+      reap: (ls: any[]) => {
+        reaped.push(ls.map((l) => l.key));
+        return ls.length; // terminations performed; nothing is refused here
+      },
       stopListenersOnPort: () => ({ signalled: 0, outcome: "ok" }),
     },
   });
@@ -2709,6 +2712,7 @@ test("archive with no reap keys never calls the reaper", async () => {
       },
       reap: () => {
         reapCalls++;
+        return 0;
       },
       stopListenersOnPort: () => ({ signalled: 0, outcome: "ok" }),
     },
@@ -4223,7 +4227,10 @@ test("archiveMany clears each session, reaping all its leftovers", async () => {
     } as any,
     reaper: {
       detect,
-      reap: (ls: any[]) => calls.reaped.push(...ls.map((l) => l.key)),
+      reap: (ls: any[]) => {
+        calls.reaped.push(...ls.map((l) => l.key));
+        return ls.length; // terminations performed; nothing is refused here
+      },
       stopListenersOnPort: () => ({ signalled: 0, outcome: "ok" }),
     },
   });
@@ -4272,7 +4279,7 @@ test("archiveMany forces a probe refresh per detect, not once per batch (#1912)"
     herdr: { start: async () => ({}) as any, list: () => [], stop: async () => {} } as any,
     reaper: {
       detect,
-      reap: () => {},
+      reap: () => 0,
       stopListenersOnPort: () => ({ signalled: 0, outcome: "ok" }),
       refresh: async (opts) => {
         refreshCalls.push(opts ?? {});
@@ -4320,7 +4327,7 @@ test("archiveMany skips the probe refresh when the backend can't produce leftove
     herdr: { start: async () => ({}) as any, list: () => [], stop: async () => {} } as any,
     reaper: {
       detect: () => [],
-      reap: () => {},
+      reap: () => 0,
       stopListenersOnPort: () => ({ signalled: 0, outcome: "unsupported" }),
       canDetectLeftovers: () => false,
       refresh: async (opts) => {
@@ -4848,7 +4855,7 @@ test("archiveMany isolates a failing session: others still clear, the failed id 
     herdr: { start: async () => ({}) as any, list: () => [], stop: async () => {} } as any,
     reaper: {
       detect,
-      reap: () => {},
+      reap: () => 0,
       stopListenersOnPort: () => ({ signalled: 0, outcome: "ok" }),
     },
   });
@@ -5981,7 +5988,7 @@ function makeStopPreviewSvc(opts: {
     ? undefined
     : {
         detect: () => [],
-        reap: () => {},
+        reap: () => 0,
         stopListenersOnPort: (worktreePath: string, port: number, signal: NodeJS.Signals) => {
           stopCalls.push({ worktreePath, port, signal });
           return { signalled: opts.stopReturn ?? 1, outcome: opts.stopOutcome ?? "ok" };
@@ -6120,7 +6127,7 @@ test("stopPreview: does NOT call any release method on the preview dep", () => {
     } as any,
     reaper: {
       detect: () => [],
-      reap: () => {},
+      reap: () => 0,
       stopListenersOnPort: () => ({ signalled: 1, outcome: "ok" }),
     } as any,
     preview,

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -2328,5 +2328,8 @@ export interface Leftover {
   port: number | null;
   key: string; // stable selection key echoed back to the server
   pid?: number;
+  // Server-side pid-recycle fingerprint (/proc/<pid>/stat starttime). Present for kind "process";
+  // serialized but not consumed here — only `key` is echoed back.
+  startTicks?: number;
   command?: { bin: string; args: string[] };
 }


### PR DESCRIPTION
-