### PR TITLE
fix(ui): wrap glossary tooltip prose instead of a one-line scrollbar

### DIFF
--- a/ui/src/lib/components/GlossaryTerm.browser.test.ts
+++ b/ui/src/lib/components/GlossaryTerm.browser.test.ts
@@ -142,6 +142,54 @@ describe("GlossaryTerm — activation-only inline disclosure", () => {
   });
 });
 
+// Regression: a definition is prose and must wrap regardless of where the marker sits.
+// The new-task dialog's Guards toggles put their label under `white-space: nowrap`, which
+// DOM-inherits into the top-layer popover — so the definition ran on a single line ~1470px
+// wide inside the 260px popover, and the UA's `[popover] { overflow: auto }` rendered that
+// as a horizontal scrollbar: one clipped line above a full-width bar.
+describe("GlossaryTerm — definition wraps inside a nowrap host", () => {
+  afterEach(() => {
+    document.body.style.whiteSpace = "";
+  });
+
+  async function openFloating(id: string, label: string): Promise<HTMLElement> {
+    document.body.style.whiteSpace = "nowrap";
+    render(GlossaryTerm, { id, label });
+
+    page
+      .getByRole("button", { name: label })
+      .element()
+      .dispatchEvent(new PointerEvent("pointerenter", { pointerType: "mouse", bubbles: true }));
+
+    const tip = document.querySelector<HTMLElement>(".gloss-tooltip");
+    expect(tip).not.toBeNull();
+    await expect.poll(() => tip!.matches(":popover-open")).toBe(true);
+    return tip!;
+  }
+
+  it("internal term: body resets white-space, so the popover never scrolls sideways", async () => {
+    const tip = await openFloating("plan-gate", "Plan gate");
+
+    const body = document.querySelector<HTMLElement>(".gt-body");
+    expect(body).not.toBeNull();
+    expect(getComputedStyle(body!).whiteSpace).toBe("normal");
+
+    // The bar itself: overflow beyond the fixed width is what draws it.
+    expect(tip.scrollWidth).toBeLessThanOrEqual(tip.clientWidth);
+    // ...and the definition reads as a multi-line block. Measured against the computed
+    // line-height rather than a pixel constant so editing the definition can't flip it.
+    const lineHeight = Number.parseFloat(getComputedStyle(body!).lineHeight);
+    expect(body!.getBoundingClientRect().height).toBeGreaterThan(lineHeight * 1.5);
+  });
+
+  it("external term: the Wikipedia link line does not overflow either", async () => {
+    const tip = await openFloating("pr", "PR");
+
+    await expect.element(page.getByRole("link")).toBeVisible();
+    expect(tip.scrollWidth).toBeLessThanOrEqual(tip.clientWidth);
+  });
+});
+
 describe("GlossaryTerm — hide-info-tips preference", () => {
   afterEach(() => infoTips.set(false));
 

--- a/ui/src/lib/components/GlossaryTerm.svelte
+++ b/ui/src/lib/components/GlossaryTerm.svelte
@@ -307,12 +307,22 @@
   .gt-body {
     display: block;
     margin: 0;
-    font-size: var(--fs-base);
+    /* Matches sibling InfoTip: an explanation is secondary text, not body copy —
+       and the smaller rung fits the whole definition in fewer lines. */
+    font-size: var(--fs-meta);
     font-weight: 400;
     line-height: 1.5;
     /* Read as prose even when the marker sits on a section heading, whose
        uppercase / letter-spacing would otherwise be inherited into the definition
-       (DOM inheritance reaches the popover's top-layer body too). */
+       (DOM inheritance reaches the popover's top-layer body too).
+       `white-space` belongs in that reset for the same reason, and skipping it bit:
+       markers inside a nowrap host (the new-task Guards toggles' `.label`) inherited
+       nowrap, so the definition ran on one line far past the fixed-width popover —
+       which the UA's `[popover] { overflow: auto }` turned into a horizontal
+       scrollbar, i.e. one clipped line above a full-width bar. `overflow-wrap`
+       keeps that bar away for a token too long to fit the column at all. */
+    white-space: normal;
+    overflow-wrap: break-word;
     text-transform: none;
     letter-spacing: normal;
   }


### PR DESCRIPTION
Hovering **Plan gate** or **Autopilot** in the new-task dialog drew the definition as one
clipped line above a full-width bar instead of an explanation.

### Why

The Guards toggles set `white-space: nowrap` on their label (`InstrumentToggle.svelte`) so the
row never reflows. That nowrap DOM-inherits into the glossary tooltip — the top layer changes
where a popover *paints*, not where it *inherits from* — so the definition laid out on a single
line **1469px** wide inside the **260px** popover. The UA stylesheet's `[popover] { overflow: auto }`
then rendered that overflow the only way it can: as a horizontal scrollbar. The "bar" was a
scrollbar track.

### Fix

`.gt-body` already reset `text-transform` and `letter-spacing` against exactly this inheritance,
with a comment explaining why. `white-space` belonged in that reset and was missing:

- `white-space: normal` — the definition wraps; `scrollWidth 1469 → 258`, equal to `clientWidth`,
  so there is no overflow left to draw a bar from.
- `overflow-wrap: break-word` — keeps the bar away for a token too long for the column at all
  (German compounds in `de.json`), which wrapping alone would not catch.
- `font-size: --fs-base → --fs-meta` — the rung sibling `InfoTip` already uses for the same kind
  of explanatory prose. The whole definition fits in fewer lines, and the two tooltips stop
  disagreeing.

Result: the full definition as a 6-line block, no scrollbar. The longest catalog entry
(`gloss_autopilot_def`, 261 chars in DE) lands at ~7 lines; `flip()`/`shift()` already re-home the
popover when there is no room below.

### Verification

Two regression tests in `GlossaryTerm.browser.test.ts` render a term inside a nowrap host and
assert the popover cannot scroll sideways — one internal term, one external (the Wikipedia link
line). Both were confirmed **red** against the unfixed CSS before being kept. The multi-line
assertion measures against the computed `line-height`, not a pixel constant, so editing a
definition cannot flip it.

| Check | Result |
| --- | --- |
| `ui` browser suite | 1781 passed |
| `ui` node suite | 2743 passed |
| `bun run check` | 0 errors |
| `bun run lint` + prettier | clean |

Locally `bun run test` needs `--maxWorkers` on a loaded host — the unbounded pool OOMs a worker
and surfaces as `EPIPE`. Not a test failure; CI already caps the browser project at 2.

### Note for review

`InfoTip.svelte` carries the same incomplete "prose, not chrome" reset and the same fixed width,
so it has the identical latent bug. I left it alone — no current InfoTip host sits under a nowrap
ancestor, so there is nothing to fix yet, only something to know about.

Closes the report from the attached screenshot.