### PR TITLE
feat(terminal): clean-terminal session in the main repo via right-click menus

### DIFF
--- a/src/herdr-capabilities.ts
+++ b/src/herdr-capabilities.ts
@@ -83,3 +83,18 @@ export function herdrUsesExternalRegistrationSpawn(): boolean {
   if (!detected) return false;
   return compareSemver(detected, HERDR_EXTERNAL_REGISTRATION_VERSION) >= 0;
 }
+
+/** First herdr version whose CLI exposes pane-level `terminal session control` — the ONLY
+ *  transport an agentless clean-terminal pane can attach through (`agent attach` refuses such
+ *  panes with `agent_not_found`; probe-verified live on 0.7.5). Matches the version the
+ *  SocketPtyBridge wire fixtures were captured on. */
+const HERDR_FIRST_PANE_CONTROL_VERSION = "0.7.3";
+
+/** Whether the detected herdr can host a clean terminal (pane-level socket attach available).
+ *  Unlike the spawn gates above this fails CLOSED on an unknown version: a clean terminal
+ *  whose pane cannot be attached would be a session with no usable terminal, so the create
+ *  preflight refuses until the boot probe has recorded a capable version. */
+export function herdrPaneControlSupported(): boolean {
+  if (!detected) return false;
+  return compareSemver(detected, HERDR_FIRST_PANE_CONTROL_VERSION) >= 0;
+}

--- a/src/herdr-socket-driver.ts
+++ b/src/herdr-socket-driver.ts
@@ -118,6 +118,19 @@ export class SocketHerdrDriver implements IHerdrDriver {
     return this.cli.panes();
   }
 
+  /** Delegates to the CLI driver's async runner — already non-blocking, and pane liveness is a
+   *  low-rate poller read, so a socket-native pane list buys nothing here. */
+  panesAsync() {
+    return this.cli.panesAsync();
+  }
+
+  /** Clean-terminal spawn (pane-direct `tab create`, no agent) — delegates to the CLI driver:
+   *  that exact path is live-probe-verified, and a bare tab create involves none of the
+   *  agent-registration machinery the socket transport exists to accelerate. */
+  startShellTab(cwd: string, label: string, env?: Record<string, string>) {
+    return this.cli.startShellTab(cwd, label, env);
+  }
+
   read(target: string, source: "visible" | "recent" = "visible", lines = 200): string {
     return this.cli.read(target, source, lines);
   }

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -804,6 +804,23 @@ export interface IHerdrDriver {
   stop(terminalId: string): Promise<void>;
   relabel(terminalId: string, newName: string): Promise<void>;
   closeTab(tabId: string): Promise<void>;
+  /** Non-blocking sibling of `panes()` — for poller-loop consumers (clean-terminal pane
+   *  liveness) that must never run `execFileSync` on Bun's loop. */
+  panesAsync(): Promise<HerdrPane[]>;
+  /** Spawn a bare shell tab (clean terminal, pane-direct): `tab create` ONLY — deliberately no
+   *  `agent start` (herdr hosts only known agent CLIs, and a shell needs none). The fresh tab's
+   *  root pane IS an interactive shell at `cwd`; callers attach via the pane-level socket
+   *  transport (`terminal session control <paneId>`), never `agent attach`. */
+  startShellTab(cwd: string, label: string, env?: Record<string, string>): Promise<HerdrShellTab>;
+}
+
+/** The result of a clean-terminal `tab create` — the root pane IS the shell. `cwd` echoes what
+ *  herdr reports back for that pane so the caller can assert it matches the requested repo. */
+export interface HerdrShellTab {
+  tabId: string;
+  paneId: string;
+  terminalId: string;
+  cwd: string;
 }
 
 export class HerdrDriver implements IHerdrDriver {
@@ -848,7 +865,15 @@ export class HerdrDriver implements IHerdrDriver {
 
   /** Every pane across all tabs (`pane list`). Includes idle shell panes left behind by exited agents. */
   panes(): HerdrPane[] {
-    const parsed = JSON.parse(this.runner(["pane", "list"]));
+    return this.parsePanes(JSON.parse(this.runner(["pane", "list"])));
+  }
+
+  /** Non-blocking sibling of `panes()` — see IHerdrDriver.panesAsync. */
+  async panesAsync(): Promise<HerdrPane[]> {
+    return this.parsePanes(JSON.parse(await this.asyncRunner(["pane", "list"])));
+  }
+
+  private parsePanes(parsed: { result?: { panes?: HerdrRecord[] } } | null): HerdrPane[] {
     const panes = parsed?.result?.panes ?? [];
     return panes.map((p: HerdrRecord) => ({
       paneId: p.pane_id ?? "",
@@ -980,6 +1005,37 @@ export class HerdrDriver implements IHerdrDriver {
    * concurrent spawns can't race the workspace/tab orchestration (the async yield points
    * removed the implicit mutual exclusion the blocking sync path had).
    */
+  /** See IHerdrDriver.startShellTab. Rides the same start serializer as agent spawns — tab
+   *  orchestration on the shared workspace must not interleave (issue #1553). */
+  async startShellTab(
+    cwd: string,
+    label: string,
+    env?: Record<string, string>,
+  ): Promise<HerdrShellTab> {
+    return this.serializeStart(() => this.startShellTabImpl(cwd, label, env));
+  }
+
+  private async startShellTabImpl(
+    cwd: string,
+    label: string,
+    env?: Record<string, string>,
+  ): Promise<HerdrShellTab> {
+    await this.ensureWorkspace(cwd);
+    const args = ["tab", "create", "--cwd", cwd, "--label", label, "--no-focus"];
+    for (const [k, v] of Object.entries(env ?? {})) args.push("--env", `${k}=${v}`);
+    const created = JSON.parse(await this.asyncRunner(args));
+    const tabId: string | undefined = created?.result?.tab?.tab_id;
+    const pane = created?.result?.root_pane ?? {};
+    const paneId: string | undefined = pane.pane_id;
+    const terminalId: string | undefined = pane.terminal_id;
+    if (!tabId || !paneId || !terminalId) {
+      // A half-created tab must not linger — roll it back so a failed create leaves nothing.
+      if (tabId) await this.closeTab(tabId).catch(() => {});
+      throw new Error(`herdr: tab create returned an incomplete shell pane for ${label}`);
+    }
+    return { tabId, paneId, terminalId, cwd: pane.cwd ?? "" };
+  }
+
   async start(
     name: string,
     cwd: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1126,6 +1126,11 @@ const poller = new StatusPoller(
     events.emit("session:halt", { id, haltReason, haltedAt }),
   // usageLimits: corroborates the transcript-tail match against measured pct windows.
   usageLimits,
+  undefined, // detectAuth — use default
+  // Clean-terminal auto-archive: the pane sweep confirmed the shell exited (2 consecutive
+  // gone sweeps) — archive so focus-existing never lands on a dead terminal. Fire-and-forget;
+  // archive() already tolerates a concurrently-archived row.
+  (id) => void service.archive(id).catch((err) => console.warn("[poller] terminal archive:", err)),
 );
 
 // Proactively re-drive a herdr-restored plugin/account pane (herdr's bare `claude --resume` lost the

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -60,6 +60,10 @@ const BLOCK_NOTIFICATION_TYPES = new Set(["permission_prompt"]);
  *  done-flip more than this apart are treated as unrelated turns and never paired. */
 const STOP_WINDOW_MAX_MS = 30_000;
 
+/** Clean-terminal pane sweep cadence: `pane list` costs a herdr round-trip, and shell-exit
+ *  detection tolerates seconds of latency (archive needs 2 confirmed-gone sweeps anyway). */
+export const TERMINAL_PANE_SWEEP_MS = 5_000;
+
 /** Codex session-id capture back-off: after a missed rescan, wait `BASE << misses` (capped) before the
  *  next scan. A rollout normally appears within seconds of spawn, so early retries stay quick; a
  *  never-matching session widens to one scan per ~2 min instead of every 1 s tick. */
@@ -357,6 +361,12 @@ export class StatusPoller {
 
   /** Timestamp of the last claude-liveness sweep (0 = never). */
   private lastLivenessSweepAt = 0;
+  /** Throttle stamp for the clean-terminal pane sweep (`pane list` at most every
+   *  TERMINAL_PANE_SWEEP_MS). */
+  private lastTerminalSweepAt = 0;
+  /** Consecutive confirmed-gone pane sweeps per clean-terminal session. Archive fires at 2
+   *  (same debounce idea as strandedSweeps); a FAILED pane listing never touches this. */
+  private terminalGoneSweeps = new Map<string, number>();
   /** Last-swept per-session claude liveness; onChange fires on flips only. */
   private lastClaudeAlive = new Map<string, boolean>();
   /** Session ids whose claude-liveness is UNKNOWN because the last sweep's scan
@@ -404,7 +414,7 @@ export class StatusPoller {
   constructor(
     private store: SessionStore,
     private herdr: Pick<HerdrDriver, "listAsync" | "read" | "readAsync" | "reportAgentState"> &
-      Partial<Pick<HerdrDriver, "tabsAsync">>,
+      Partial<Pick<HerdrDriver, "tabsAsync" | "panesAsync">>,
     private onChange: (id: string, status: string) => void,
     private onBlock: (id: string, block: BlockReason | null) => void,
     private intervalMs = 1000,
@@ -490,6 +500,12 @@ export class StatusPoller {
      * Injectable for tests; defaults to a bounded tail read + `detectAuthUrl`.
      */
     private detectAuth: (s: Session) => string | null = readAuthUrl,
+    /**
+     * Archive a clean-terminal session whose pane is confirmed gone (the shell exited) — a
+     * dead terminal has no branch/PR and focus-existing must never land on it. Wired in
+     * src/index.ts to `service.archive`; undefined (tests that don't care) ⇒ no auto-archive.
+     */
+    private archiveTerminal?: (id: string) => void,
   ) {
     // Merge supplied overrides with real defaults. When preview is omitted entirely
     // we create a no-op wiring so tick() never throws on undefined access.
@@ -621,6 +637,9 @@ export class StatusPoller {
       const activeIds = new Set<string>();
       for (const s of sessions) {
         activeIds.add(s.id);
+        // Clean-terminal sessions (pane-direct) have NO herdr agent: reconciling would read
+        // "gone" every tick. Their liveness is pane existence — sweepTerminalPanes below.
+        if (s.terminal) continue;
         const agent = matched.get(s.id) ?? null;
         if (!agent) this.reapGone(s);
         else this.reconcileAgent(s, agent);
@@ -652,6 +671,11 @@ export class StatusPoller {
       this.maybeRunPreviewSweep(sessions);
       // claude-liveness sweep: throttled; synchronous (one cheap /proc pass)
       this.maybeRunLivenessSweep(sessions);
+      // Clean-terminal pane liveness: throttled, async, fail-closed. Deliberately fire-and-
+      // forget — awaiting it would extend tick()'s awaited critical section by a socket
+      // round-trip and shift the microtask timing the classify paths' floating promises ride
+      // on. Overlap is impossible: the throttle stamp is taken synchronously before the await.
+      void this.maybeSweepTerminalPanes(sessions).catch(() => {});
     } finally {
       this.ticking = false;
     }
@@ -692,11 +716,60 @@ export class StatusPoller {
    * bare shell keeps the agent listed as idle). Emits onChange on flips only;
    * tracking for sessions no longer active is pruned in place.
    */
+  /**
+   * Clean-terminal pane liveness (pane-direct sessions have no herdr agent to reconcile).
+   * Fail-closed state machine over `panesAsync`:
+   *  - pane present in a SUCCESSFUL listing → live; gone-counter resets.
+   *  - pane absent in a SUCCESSFUL listing → count; archive on the 2nd consecutive miss
+   *    (debounce blunts a transient herdr hiccup, mirroring strandedSweeps).
+   *  - listing THROWS → no state change at all: counter frozen, no archive, retry next sweep.
+   *    Destructive action only ever follows positive evidence.
+   */
+  private async maybeSweepTerminalPanes(sessions: Session[]): Promise<void> {
+    const terms = sessions.filter((s) => s.terminal);
+    if (terms.length === 0) {
+      this.terminalGoneSweeps.clear();
+      return;
+    }
+    if (!this.herdr.panesAsync || !this.archiveTerminal) return;
+    const t = this.now();
+    if (t - this.lastTerminalSweepAt < TERMINAL_PANE_SWEEP_MS) return;
+    this.lastTerminalSweepAt = t;
+    let panes;
+    try {
+      panes = await this.herdr.panesAsync();
+    } catch (err) {
+      console.warn("[poller] terminal pane list failed; keeping state:", err);
+      return; // fail closed — see contract above
+    }
+    const livePaneIds = new Set(panes.map((p) => p.paneId));
+    for (const s of terms) {
+      if (s.terminalPaneId && livePaneIds.has(s.terminalPaneId)) {
+        this.terminalGoneSweeps.delete(s.id);
+        continue;
+      }
+      const n = (this.terminalGoneSweeps.get(s.id) ?? 0) + 1;
+      if (n < 2) {
+        this.terminalGoneSweeps.set(s.id, n);
+        continue;
+      }
+      this.terminalGoneSweeps.delete(s.id);
+      try {
+        this.archiveTerminal(s.id);
+      } catch (err) {
+        console.warn(`[poller] terminal auto-archive failed for ${s.id}:`, err);
+      }
+    }
+  }
+
   private maybeRunLivenessSweep(sessions: Session[]): void {
     const t = this.now();
     if (t - this.lastLivenessSweepAt < this.livenessWiring.sweepMs) return;
     this.lastLivenessSweepAt = t;
-    const candidates = sessions.filter((s) => s.worktreePath);
+    // Terminal sessions are exempt: scanClaudeAliveByWorktree matches agent comms only, so a
+    // shell would read husk/stranded and auto-revive could re-spawn it. Pane existence is
+    // their real signal (sweepTerminalPanes).
+    const candidates = sessions.filter((s) => s.worktreePath && !s.terminal);
     let byWorktree: Map<string, boolean> | null;
     try {
       byWorktree = this.livenessWiring.scan(candidates.map((s) => s.worktreePath));
@@ -753,6 +826,7 @@ export class StatusPoller {
    * sessions reset the debounce counter.
    */
   private maybeAutoRevive(s: Session, armed: boolean): void {
+    if (s.terminal) return; // a clean terminal is never husk/stranded and must never be revived
     if (this.lastLiveness.get(s.id) !== "stranded" || !isAutoRevivable(s)) {
       this.strandedSweeps.delete(s.id);
       this.reviveGaveUp.delete(s.id); // left the stranded set → a later strand starts fresh

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -62,7 +62,7 @@ const STOP_WINDOW_MAX_MS = 30_000;
 
 /** Clean-terminal pane sweep cadence: `pane list` costs a herdr round-trip, and shell-exit
  *  detection tolerates seconds of latency (archive needs 2 confirmed-gone sweeps anyway). */
-export const TERMINAL_PANE_SWEEP_MS = 5_000;
+const TERMINAL_PANE_SWEEP_MS = 5_000;
 
 /** Codex session-id capture back-off: after a missed rescan, wait `BASE << misses` (capped) before the
  *  next scan. A rollout normally appears within seconds of spawn, so early retries stay quick; a

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -634,9 +634,10 @@ export class RecapService {
     const idleMs = now - entry.stamp;
     if (!isSettledIdle(s.status, idleMs, this.idleThresholdMs)) return;
 
-    // Skip drain sessions and sessions without a branch — stable for the episode, so
-    // burn the marker (no point re-checking until the session re-activates).
-    if (s.auto || !s.branch) {
+    // Skip drain sessions, clean terminals (no agent transcript to summarize — also implied
+    // by branch:null, made explicit here), and sessions without a branch — stable for the
+    // episode, so burn the marker (no point re-checking until the session re-activates).
+    if (s.auto || s.terminal || !s.branch) {
       entry.fired = true;
       return;
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,11 +2,17 @@ import type { RepoConfig, SessionStore } from "./store";
 import type { PluginRegistry } from "./plugins/loader";
 import type { PluginInfo } from "./plugins/types";
 import type { SessionService } from "./service";
-import { PREVIEW_SETUP_STEER, RestoreError } from "./service";
+import {
+  PREVIEW_SETUP_STEER,
+  RestoreError,
+  TerminalExistsError,
+  TerminalSessionError,
+  TerminalUnsupportedError,
+} from "./service";
 import { WorktreeMissingBaseError, WorktreeRestoreError } from "./worktree";
 import { LearningsService } from "./learnings-service";
 import { RepoConfigService } from "./repo-config-service";
-import type { CreateSessionInput } from "./types";
+import type { StandardCreateInput } from "./types";
 import type { EventHub } from "./events";
 import { PtyBridge } from "./pty-bridge";
 import { SocketPtyBridge } from "./socket-pty-bridge";
@@ -1171,7 +1177,7 @@ function parseUpNextStartPayload(body: unknown): UpNextStartPayload | Response {
   };
 }
 
-function usageHoldApplies(value: CreateSessionInput, deps: AppDeps): boolean {
+function usageHoldApplies(value: StandardCreateInput, deps: AppDeps): boolean {
   const provider = normalizeAgentProvider(value.agentProvider ?? config.defaultAgentProvider);
   if (provider !== "claude") return false;
   const lim = deps.usageLimits.limits(Date.now());
@@ -1192,7 +1198,7 @@ function findHeldIssue(deps: AppDeps, repoPath: string, issueNumber: number) {
 
 function holdUpNextIssue(
   deps: AppDeps,
-  input: CreateSessionInput,
+  input: StandardCreateInput,
 ): { id: string; repoPath: string; number: number; reused?: boolean } {
   const number = input.issueRef?.number;
   if (number == null) throw new Error("held Up Next item missing issueRef");
@@ -1237,7 +1243,7 @@ async function handleUpNextStart(req: Request, deps: AppDeps): Promise<Response>
       const base = await forge.defaultBranch();
       const rc = deps.store.getRepoConfig(it.dir);
       const provider = choice?.agentProvider ?? config.defaultAgentProvider;
-      const input: CreateSessionInput = {
+      const input: StandardCreateInput = {
         repoPath: it.dir,
         baseBranch: base,
         prompt: issueSpawnPrompt(it.issueRef.number, it.issueRef.title),
@@ -2117,7 +2123,19 @@ export async function claimLinkedIssue(forge: GitForge | null, issueNumber: numb
 /** Map a service.create() error to the appropriate Response.
  *  SandboxAutoRefused → 403; missing base ref → 422; agent_name_taken → 409;
  *  anything else → 502. */
+/** 409 mappings for the clean-terminal fences (TerminalExistsError & friends, service.ts).
+ *  `existingId` rides the singleton conflict so the UI can focus the already-open terminal. */
+function terminalErrorResponse(e: unknown): Response | null {
+  if (e instanceof TerminalExistsError)
+    return json({ error: "terminal_exists", existingId: e.existingId }, 409);
+  if (e instanceof TerminalUnsupportedError) return json({ error: "terminal_unsupported" }, 409);
+  if (e instanceof TerminalSessionError) return json({ error: "terminal_session" }, 409);
+  return null;
+}
+
 function createErrorResponse(e: unknown): Response {
+  const t = terminalErrorResponse(e);
+  if (t) return t;
   if (e instanceof SandboxAutoRefused) return json({ error: e.holdReason }, 403);
   if (e instanceof WorktreeMissingBaseError) return json({ error: e.message }, 422);
   const msg = e instanceof Error ? e.message : "create failed";
@@ -2128,7 +2146,7 @@ function createErrorResponse(e: unknown): Response {
 /** Check hold gate; if triggered, persist the held task and return the 200 response.
  *  Returns null when the task should proceed to normal creation. */
 function persistHeldTask(
-  value: CreateSessionInput,
+  value: StandardCreateInput,
   deps: AppDeps,
   reason: "usage" | "capacity",
 ): Response {
@@ -2139,7 +2157,7 @@ function persistHeldTask(
   return json({ held: true, id, count: deps.store.countHeldTasks() }, 200);
 }
 
-function tryHoldNewTask(body: unknown, value: CreateSessionInput, deps: AppDeps): Response | null {
+function tryHoldNewTask(body: unknown, value: StandardCreateInput, deps: AppDeps): Response | null {
   const provider = normalizeAgentProvider(value.agentProvider ?? config.defaultAgentProvider);
   if (provider !== "claude") return null;
 
@@ -2174,6 +2192,19 @@ async function handleSessionCreate({ req, parts, deps }: Ctx): Promise<Response 
   const body = await req.json().catch(() => null);
   const result = validateCreate(body, config.repoRoot);
   if (!result.ok) return json({ error: result.error }, 400);
+
+  // Clean-terminal union arm: no usage-hold gate (a bare shell spends no agent budget) and no
+  // issue claim — straight to create. Singleton/preflight conflicts map to 409 in
+  // createErrorResponse (terminal_exists carries existingId so the UI can focus it).
+  if (result.value.terminal === true) {
+    try {
+      const t = await deps.service.create(result.value);
+      deps.events.emit("session:new", t);
+      return json(t, 201);
+    } catch (e) {
+      return createErrorResponse(e);
+    }
+  }
 
   // ── usage-aware hold gate ──────────────────────────────────────────────────
   const held = tryHoldNewTask(body, result.value, deps);
@@ -5515,6 +5546,9 @@ async function heldUpdate(id: string, deps: AppDeps, body: unknown): Promise<Res
   if (!existing) return json({ error: "not found" }, 404);
   const result = validateCreate(body, config.repoRoot);
   if (!result.ok) return json({ error: result.error }, 400);
+  // Held tasks are parked agent creates; a clean terminal is never held and can't become one.
+  if (result.value.terminal === true)
+    return json({ error: "held tasks cannot be terminal creates" }, 400);
   // The edit composer round-trips every field EXCEPT merge-train membership, which has no
   // UI — so carry mergeTrainPrs forward from the held row. Otherwise editing a held
   // merge-train task would strip its participant PRs and they'd never be marked "merging".
@@ -7653,9 +7687,18 @@ export function makeApp(deps: AppDeps, opts: { skipAuth?: boolean } = {}) {
       const parts = url.pathname.split("/").filter(Boolean); // ["api","sessions",":id"]
       const ctx: Ctx = { req, parts, url, deps };
 
-      for (const handle of ROUTE_HANDLERS) {
-        const res = await handle(ctx);
-        if (res) return res;
+      try {
+        for (const handle of ROUTE_HANDLERS) {
+          const res = await handle(ctx);
+          if (res) return res;
+        }
+      } catch (e) {
+        // Clean-terminal fence errors are business 409s, not 500s — mapped ONCE at the dispatch
+        // seam so every verb route (reply, resume, relaunch, replace, restore, preview,
+        // interrupt, …) surfaces them uniformly without per-route catches.
+        const t = terminalErrorResponse(e);
+        if (t) return t;
+        throw e;
       }
 
       if (url.pathname.startsWith("/api")) return json({ error: "not found" }, 404);
@@ -7787,6 +7830,11 @@ export function livePtyAttach(
   cur: Session,
   herdr: Pick<HerdrDriver, "list"> | undefined,
 ): LivePtyAttach | null {
+  // Clean-terminal session (pane-direct): the attach target is the PERSISTED pane — there is
+  // no herdr agent to match against. The stored ids are stable for the pane's lifetime; when
+  // the pane is gone the socket bridge reports terminal.closed("not found") → PTY_GONE.
+  if (cur.terminal)
+    return { terminalId: cur.herdrAgentId, paneTarget: cur.terminalPaneId ?? undefined };
   if (!herdr) return { terminalId: cur.herdrAgentId };
   try {
     const a = matchAgent(cur, herdr.list());
@@ -7837,7 +7885,15 @@ export function pickTerminalBridgeKind(opts: {
   herdrSocketActive?: boolean;
   paneTarget?: string;
   recentlyFailed: boolean;
+  /** True for a clean-terminal session (agentless pane). */
+  terminalSession?: boolean;
 }): "socket" | "node-pty" {
+  // A clean-terminal session has NO node-pty path — `herdr agent attach` refuses agentless
+  // panes with agent_not_found (probe-verified) — so it rides the socket bridge whenever its
+  // pane target exists, regardless of the interim sub-flag and the failure memo (falling back
+  // would land in a guaranteed-broken transport). A missing pane target (corrupt legacy row)
+  // keeps node-pty as the loud-failure path.
+  if (opts.terminalSession) return opts.paneTarget ? "socket" : "node-pty";
   return opts.herdrSocketTerminal &&
     opts.herdrSocketActive &&
     opts.paneTarget &&
@@ -7983,6 +8039,7 @@ export function serve(deps: AppDeps, port: number) {
             herdrSocketActive: deps.herdrSocketActive,
             paneTarget: attach.paneTarget,
             recentlyFailed: recentlyFailed(socketTerminalFailures, tid, Date.now()),
+            terminalSession: !!cur.terminal,
           });
           // Narrowed alias: the hook closures below run asynchronously, after which TS can no
           // longer see that `ws.data.kind === "pty"` still holds (it never changes, but control
@@ -8010,6 +8067,12 @@ export function serve(deps: AppDeps, port: number) {
                 flushPending(data.bridge!);
               },
               onFallback: () => {
+                // A clean-terminal pane has no node-pty fallback (agent attach refuses it) —
+                // surface "ended" instead of a guaranteed agent_not_found reconnect loop.
+                if (cur.terminal) {
+                  ws.close(PTY_GONE_CODE, "ended");
+                  return;
+                }
                 recordFallback();
                 console.info(`[herdr] socket terminal → node-pty fallback ${tid}`);
                 socketTerminalFailures.set(tid, Date.now());
@@ -8023,7 +8086,9 @@ export function serve(deps: AppDeps, port: number) {
                 ws.close(PTY_GONE_CODE, "ended");
               },
               onAbnormalExit: () => {
-                socketTerminalFailures.set(tid, Date.now());
+                // The failure memo only exists to steer AGENT terminals back to node-pty; a
+                // clean terminal has no such fallback, so don't stamp it.
+                if (!cur.terminal) socketTerminalFailures.set(tid, Date.now());
               },
             });
             data.bridge = sb;

--- a/src/service.ts
+++ b/src/service.ts
@@ -4980,12 +4980,14 @@ export class SessionService {
     const live = this.liveTerminalIds();
     let resumed = 0;
     let steered = 0;
-    for (const id of ids) {
-      const s = this.deps.store.get(id);
-      if (!s) continue;
-      // Defensive: a terminal can never carry haltReason, but a mixed id set must not steer or
-      // resume one — skip silently, keep processing the rest.
-      if (s.terminal) continue;
+    // Resolve + screen targets up front: unknown ids drop, and (defensively) so do clean
+    // terminals — a terminal can never carry haltReason, and a mixed id set must not steer or
+    // resume one. Screening here (not per-iteration branches) keeps the loop's complexity flat.
+    const targets = ids
+      .map((id) => this.deps.store.get(id))
+      .filter((s): s is Session => s !== null && !s.terminal);
+    for (const s of targets) {
+      const id = s.id;
       let succeeded = false;
       // A live herdr-restored account husk must be deferred to resume() (Locus B re-drive) rather
       // than steered — else the retry lands on the wrong-account pane.

--- a/src/service.ts
+++ b/src/service.ts
@@ -4,6 +4,8 @@ import { readdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
 import type { RepoConfig, SessionStore } from "./store";
+import { TERMINAL_CLAIM_TTL_MS } from "./store";
+import { detectedHerdrVersion, herdrPaneControlSupported } from "./herdr-capabilities";
 import type { EventHub } from "./events";
 import {
   agentMcpConfigArg,
@@ -34,6 +36,8 @@ import { CODEX_ID_SKEW_MS, findCodexSessionId } from "./codex-session-id";
 import type {
   AgentProvider,
   CreateSessionInput,
+  StandardCreateInput,
+  TerminalCreateInput,
   IssueRef,
   LaunchAttachmentMetadata,
   RelaunchOverrides,
@@ -151,6 +155,40 @@ export class UntrustedIssueAuthorError extends Error {
   }
 }
 
+/** Thrown by create() when a clean-terminal create loses the one-per-repo race: a live terminal
+ *  session already exists (`existingId` carried so the UI can focus it) or another create holds
+ *  the reservation lease (`existingId: null`). Route-mapped to 409. */
+export class TerminalExistsError extends Error {
+  constructor(readonly existingId: string | null) {
+    super(
+      existingId
+        ? `clean terminal already open for this repo (session ${existingId})`
+        : "a clean-terminal create for this repo is already in flight",
+    );
+    this.name = "TerminalExistsError";
+  }
+}
+
+/** Fail-closed create preflight: the detected herdr cannot host a clean terminal (its CLI lacks
+ *  pane-level `terminal session control`, the only transport an agentless pane can attach
+ *  through) — refuse rather than create a session with no usable terminal. */
+export class TerminalUnsupportedError extends Error {
+  constructor(version: string | null) {
+    super(`clean terminals need a newer herdr (detected ${version ?? "unknown"})`);
+    this.name = "TerminalUnsupportedError";
+  }
+}
+
+/** Thrown by every agent-input / agent-lifecycle verb when targeted at a clean-terminal
+ *  session — a bare shell has no agent to resume, relaunch, steer, or restore. Route-mapped
+ *  to 409. */
+export class TerminalSessionError extends Error {
+  constructor(verb: string) {
+    super(`${verb} is not available for a clean-terminal session`);
+    this.name = "TerminalSessionError";
+  }
+}
+
 export const MERGE_STALE_MS = 30 * 60_000;
 
 /** Absolute backstop for a STILL-RUNNING merge-train completion-tracker entry: a
@@ -177,7 +215,17 @@ export interface ServiceDeps {
     | "gitCommonDir"
     | "restoreExisting"
   >;
-  herdr: Pick<HerdrDriver, "start" | "list" | "stop" | "send" | "relabel" | "paneForegroundProcs">;
+  herdr: Pick<
+    HerdrDriver,
+    | "start"
+    | "list"
+    | "stop"
+    | "send"
+    | "relabel"
+    | "paneForegroundProcs"
+    | "startShellTab"
+    | "closeTab"
+  >;
   namer: (prompt: string) => string | Promise<string>;
   /** Background namer: comprehends the prompt into a slug (null = keep heuristic). Absent → no refine. */
   refineName?: (args: { taskText: string; label: string }) => Promise<string | null>;
@@ -2198,7 +2246,7 @@ export class SessionService {
    * proceeds without them; the caller emits an operator-visible signal for the drop.
    */
   private async composePromptArg(
-    input: CreateSessionInput,
+    input: StandardCreateInput,
     worktreePath: string,
   ): Promise<{
     promptArg: string;
@@ -2233,7 +2281,7 @@ export class SessionService {
   }
 
   private composeUploadPrompt(
-    input: CreateSessionInput,
+    input: StandardCreateInput,
     worktreePath: string,
   ): { promptBlock: string; dropped: number; attachments: LaunchAttachmentMetadata[] } {
     if (input.images.length === 0) return { promptBlock: "", dropped: 0, attachments: [] };
@@ -2744,7 +2792,7 @@ export class SessionService {
    *  set (#842). Records the injected rule ids against the session (join rows only — counters
    *  are advanced symmetrically with the reward at archive, never here). Injected into every
    *  new agent's system prompt via composeSystemPrompt. */
-  private recordInjectedHouseRules(sessionId: string, input: CreateSessionInput): string | null {
+  private recordInjectedHouseRules(sessionId: string, input: StandardCreateInput): string | null {
     const { repoPath } = input;
     if (!this.deps.store.getRepoConfig(repoPath).learningsEnabled) return null;
     const targetPaths = extractTargetPaths(
@@ -2862,7 +2910,7 @@ export class SessionService {
    * payload WAS assembled) and invisible to the reads (they inner-join `sessions`).
    */
   private composeDirectives(args: {
-    input: CreateSessionInput;
+    input: StandardCreateInput;
     sessionId: string;
     planGateOn: boolean | undefined;
     isolated: boolean;
@@ -2956,7 +3004,7 @@ export class SessionService {
   }
 
   private buildSpawnArgv(
-    input: CreateSessionInput,
+    input: StandardCreateInput,
     claudeSessionId: string,
     sessionId: string,
     promptArg: string,
@@ -3015,7 +3063,7 @@ export class SessionService {
   }
 
   private buildCodexSpawnArgv(args: {
-    input: CreateSessionInput;
+    input: StandardCreateInput;
     sessionId: string;
     promptArg: string;
     planGateOn: boolean | undefined;
@@ -3265,7 +3313,7 @@ export class SessionService {
    * config.sandboxDefaultProfile), using input.sandboxProfile as the override.
    */
   private researchSafeProfileOverride(
-    input: CreateSessionInput,
+    input: StandardCreateInput,
     repoConfig: RepoConfig,
     sessionId: string,
   ): string | null | undefined {
@@ -3296,7 +3344,7 @@ export class SessionService {
    * prompt, so the gate machinery must match — and it is drain-spawned/unattended, with no operator
    * to plan with).
    */
-  private resolvePlanGateOn(input: CreateSessionInput, repoConfig: RepoConfig): boolean {
+  private resolvePlanGateOn(input: StandardCreateInput, repoConfig: RepoConfig): boolean {
     if (input.research || input.epicAuthoring || input.landingRepair) return false;
     return input.planGateEnabled ?? repoConfig.planGateEnabled;
   }
@@ -3308,7 +3356,7 @@ export class SessionService {
    * resolved.baseRef may be a sha (fresh upstream tip when behind) or the branch name
    * (diverged / no upstream / up to date). Falls back to the named branch when the
    * impl returns nothing — fail-safe, never undefined. */
-  private async resolveBaseRef(input: CreateSessionInput): Promise<string> {
+  private async resolveBaseRef(input: StandardCreateInput): Promise<string> {
     const resolved = await this.deps.worktree.ensureBaseRef(input.repoPath, input.baseBranch);
     const baseRef = resolved?.baseRef ?? input.baseBranch;
     console.info(
@@ -3318,8 +3366,8 @@ export class SessionService {
   }
 
   private buildLaunchMetadata(args: {
-    input: CreateSessionInput;
-    spawnInput: CreateSessionInput;
+    input: StandardCreateInput;
+    spawnInput: StandardCreateInput;
     attachments: LaunchAttachmentMetadata[];
     branch: string | null;
     agentProvider: AgentProvider;
@@ -3380,7 +3428,7 @@ export class SessionService {
   }
 
   private async resolveCreateLaunch(
-    input: CreateSessionInput,
+    input: StandardCreateInput,
     wt: { isolated: boolean; worktreePath: string },
     promptArg: string,
     sessionId: string,
@@ -3388,8 +3436,8 @@ export class SessionService {
     opts: { planGateOn?: boolean } = {},
   ): Promise<{
     agentProvider: AgentProvider;
-    resolvedInput: CreateSessionInput;
-    spawnInput: CreateSessionInput;
+    resolvedInput: StandardCreateInput;
+    spawnInput: StandardCreateInput;
     repoConfig: RepoConfig;
     planGateOn: boolean;
     profileOverride: string | null | undefined;
@@ -3465,7 +3513,7 @@ export class SessionService {
    *  autonomous drain isn't silently disabled there; GitHub is never relaxed by the flag. Signals the
    *  untrusted_author store/event ONCE per (repoPath, issue) per process — the drain retries a
    *  refused issue on a cooldown, which would otherwise append a new signal on every retry. */
-  private async assertIssueAuthorTrusted(input: CreateSessionInput): Promise<void> {
+  private async assertIssueAuthorTrusted(input: StandardCreateInput): Promise<void> {
     if (!input.auto || !input.issueRef) return;
     const n = input.issueRef.number;
     let association: string | null;
@@ -3501,7 +3549,77 @@ export class SessionService {
     throw new UntrustedIssueAuthorError(n, association);
   }
 
+  /**
+   * Clean-terminal create (pane-direct, issue: clean-terminal-in-main-repo). Order matters:
+   * (1) fail-closed capability preflight; (2) reserve the one-per-repo singleton lease in the
+   * DB — BEFORE any herdr call, so a losing racer never spawns; (3) spawn a bare shell tab at
+   * the MAIN checkout and assert the reply's cwd; (4) persist. A heartbeat renews the lease
+   * while the spawn is in flight (a slow herdr can never get this create reclaimed out from
+   * under it); the sessions partial unique index remains the durable final invariant, and any
+   * failure after the tab exists closes that tab — no orphan shells, no orphan claims.
+   */
+  private async createTerminalSession(input: TerminalCreateInput): Promise<Session> {
+    if (!herdrPaneControlSupported()) throw new TerminalUnsupportedError(detectedHerdrVersion());
+    const sessionId = randomUUID();
+    const claim = this.deps.store.claimTerminalRepo(input.repoPath, sessionId);
+    if (!claim.ok) throw new TerminalExistsError(claim.existingId);
+    const heartbeat = setInterval(
+      () => this.deps.store.renewTerminalClaim(input.repoPath, sessionId),
+      TERMINAL_CLAIM_TTL_MS / 6,
+    );
+    try {
+      const repoBasename = input.repoPath.split("/").filter(Boolean).at(-1) ?? "";
+      const herdSlug = repoBasename ? slugifyManual(repoBasename) : undefined;
+      const name = this.uniqueName("terminal", herdSlug, input.repoPath);
+      const shell = await this.deps.herdr.startShellTab(input.repoPath, name, {
+        [SESSION_MARKER_ENV]: sessionId,
+      });
+      try {
+        // Contract assert (probe-verified reply shape): the pane must sit exactly at the main
+        // checkout — a mismatch would hand the operator a shell in the wrong directory.
+        if (safeRealpath(shell.cwd) !== safeRealpath(input.repoPath)) {
+          throw new Error(`herdr: shell pane opened at ${shell.cwd}, expected ${input.repoPath}`);
+        }
+        return this.deps.store.create({
+          id: sessionId,
+          name,
+          prompt: "",
+          repoPath: input.repoPath,
+          baseBranch: "",
+          branch: null,
+          worktreePath: input.repoPath,
+          isolated: false,
+          herdrSession: config.herdrSession,
+          herdrAgentId: shell.terminalId,
+          claudeSessionId: "",
+          terminal: true,
+          terminalTabId: shell.tabId,
+          terminalPaneId: shell.paneId,
+          // Inert placeholder — a terminal has no agent; every agent flow is fenced on
+          // `terminal`, and widening AgentProvider would ripple through dozens of switches.
+          agentProvider: "claude",
+          model: null,
+          planGateEnabled: false,
+          autopilotEnabled: false,
+          planPhase: null,
+        });
+      } catch (err) {
+        // The tab exists but the session row doesn't (cwd mismatch / unique-index loss on a
+        // bypass race) — close the tab so nothing orphans.
+        await this.deps.herdr.closeTab(shell.tabId).catch(() => {});
+        throw err;
+      }
+    } finally {
+      clearInterval(heartbeat);
+      this.deps.store.releaseTerminalClaim(input.repoPath, sessionId);
+    }
+  }
+
   async create(input: CreateSessionInput): Promise<Session> {
+    // Clean-terminal kind (union arm): a bare operator shell in the MAIN checkout, pane-direct.
+    // None of the agent-create machinery below (worktree, prompt, argv, plan gate) applies —
+    // and the narrowed TerminalCreateInput has no prompt/baseBranch members to misuse.
+    if (input.terminal === true) return this.createTerminalSession(input);
     await this.assertIssueAuthorTrusted(input);
     const repoBasename = input.repoPath.split("/").filter(Boolean).at(-1) ?? "";
     const herdSlug = repoBasename ? slugifyManual(repoBasename) : undefined;
@@ -3705,6 +3823,12 @@ export class SessionService {
    * spawn). On any error AFTER `create`, the just-created session is best-effort
    * torn down and the error rethrown, so no orphaned new session leaks.
    */
+  /** Agent-verb fence: a clean-terminal session has no agent to resume/relaunch/steer/restore —
+   *  refuse with the typed 409 error instead of undefined behavior. See TerminalSessionError. */
+  private assertNotTerminal(s: Session, verb: string): void {
+    if (s.terminal) throw new TerminalSessionError(verb);
+  }
+
   async relaunch(
     originalId: string,
     issueRef?: IssueRef,
@@ -3714,6 +3838,7 @@ export class SessionService {
     const s = this.deps.store.get(originalId);
     if (!s || s.status === "archived")
       throw new Error(`cannot relaunch ${originalId}: missing or archived`);
+    this.assertNotTerminal(s, "relaunch");
 
     // Attachment handling forks on whether overrides are present:
     //   - quick relaunch (no overrides) → auto-carry the original's uploads, copied (not
@@ -3764,7 +3889,7 @@ export class SessionService {
     images: string[],
     attachmentNames: string[] | undefined,
     authPolicy: "error" | "clamp",
-  ): CreateSessionInput {
+  ): StandardCreateInput {
     // Provider/model coupling: resolve the EFFECTIVE provider and reconcile the carried model
     // against it (see reconcileRelaunchModel) so a provider switch never drags an incompatible model.
     const agentProvider = overrides?.agentProvider ?? original.agentProvider ?? "claude";
@@ -3823,6 +3948,7 @@ export class SessionService {
     const s = this.deps.store.get(id);
     if (!s || s.status === "archived")
       throw new Error(`cannot replace agent for ${id}: missing or archived`);
+    this.assertNotTerminal(s, "replace");
 
     const agentProvider = opts.agentProvider ?? s.agentProvider ?? "claude";
     const sourceProvider = s.agentProvider ?? "claude";
@@ -3834,7 +3960,7 @@ export class SessionService {
       console.warn(
         `[replace] ${s.id}: ${carriedUploads.length} files exceed cap ${MAX_IMAGES}; dropped ${carriedUploads.length - promptUploads.length}`,
       );
-    const input: CreateSessionInput = {
+    const input: StandardCreateInput = {
       repoPath: s.repoPath,
       baseBranch: s.baseBranch,
       prompt: composeProviderHandoffPrompt(
@@ -4291,6 +4417,7 @@ export class SessionService {
     if (!target) return null;
 
     const { session, provider } = target;
+    this.assertNotTerminal(session, "resume");
     const agent = this.liveAgentFor(id);
     if (agent && !opts.force && !needsAccountRedrive(session, agent)) {
       // Already live (idle at the prompt, or restored by a herdr restart under a new terminalId)
@@ -4505,6 +4632,9 @@ export class SessionService {
     if (!s) return null;
 
     if (s.status !== "archived") throw new RestoreError("not_archived");
+    // An archived terminal's pane is gone, and un-archiving would collide with the live-terminal
+    // singleton (partial unique index) — restoring it is undefined by design.
+    this.assertNotTerminal(s, "restore");
 
     const provider = s.agentProvider ?? "claude";
     // Codex resumes by an explicit id; Claude by `--resume`. resolveCodexRestoreId enforces
@@ -4680,6 +4810,7 @@ export class SessionService {
   async operatorReply(id: string, text: string): Promise<boolean> {
     const s = this.deps.store.get(id);
     if (!s) return false;
+    this.assertNotTerminal(s, "reply");
     const resumableCodex = (s.agentProvider ?? "claude") === "codex" && s.isolated;
     const target = await this.operatorReplyTarget(id, resumableCodex);
     if (!target) return false;
@@ -4713,6 +4844,9 @@ export class SessionService {
   async startPreview(id: string, command: string): Promise<boolean> {
     const s = this.deps.store.get(id);
     if (!s) return false;
+    // Fenced directly (not just via the reply→sendSteerTo funnel) so the route surfaces the
+    // typed 409 instead of a silent `false`.
+    this.assertNotTerminal(s, "preview");
     return await this.reply(id, PREVIEW_START_STEER(command, s.agentProvider ?? "claude"));
   }
 
@@ -4849,6 +4983,9 @@ export class SessionService {
     for (const id of ids) {
       const s = this.deps.store.get(id);
       if (!s) continue;
+      // Defensive: a terminal can never carry haltReason, but a mixed id set must not steer or
+      // resume one — skip silently, keep processing the rest.
+      if (s.terminal) continue;
       let succeeded = false;
       // A live herdr-restored account husk must be deferred to resume() (Locus B re-drive) rather
       // than steered — else the retry lands on the wrong-account pane.
@@ -4889,7 +5026,13 @@ export class SessionService {
   async broadcast(
     ids: string[],
     text: string,
-  ): Promise<{ delivered: number; queued: number; offline: number; total: number }> {
+  ): Promise<{
+    delivered: number;
+    queued: number;
+    offline: number;
+    skipped: number;
+    total: number;
+  }> {
     let agents: HerdrAgent[];
     try {
       agents = this.deps.herdr.list();
@@ -4901,8 +5044,17 @@ export class SessionService {
     let delivered = 0;
     let queued = 0;
     let offline = 0;
+    let skipped = 0;
     for (const id of ids) {
       const s = this.deps.store.get(id);
+      // A clean-terminal session must never receive an agent steer (the herdr.send invariant) —
+      // and one terminal in a fleet-wide id set must not abort the broadcast for everyone else.
+      // Skipped BEFORE the liveness split and reported additively (delivered + queued + offline
+      // + skipped === total); old clients simply ignore the new count (#1630 precedent).
+      if (s?.terminal) {
+        skipped++;
+        continue;
+      }
       if (!s || !live.has(s.herdrAgentId)) {
         offline++; // unknown id or dead pane — the steer can't land
         continue;
@@ -4917,7 +5069,7 @@ export class SessionService {
       if (statusByTerminal.get(s.herdrAgentId) === "working") queued++;
       else delivered++;
     }
-    return { delivered, queued, offline, total: ids.length };
+    return { delivered, queued, offline, skipped, total: ids.length };
   }
 
   /**
@@ -4940,7 +5092,10 @@ export class SessionService {
    */
   async haltAll(): Promise<{ halted: number }> {
     const agents = this.deps.herdr.list(); // let a herdr-unreachable error propagate
-    const sessions = this.deps.store.list({ activeOnly: true });
+    // Clean terminals are filtered out BEFORE matching: they have no agent, and a shell running
+    // a long build could plausibly read `working` through some future match path — it must never
+    // receive a stray ESC (haltAll deliberately bypasses the sendSteerTo funnel guard).
+    const sessions = this.deps.store.list({ activeOnly: true }).filter((s) => !s.terminal);
     let halted = 0;
     for (const agent of matchAgents(sessions, agents).values()) {
       if (agent?.agentStatus !== "working") continue;
@@ -5007,6 +5162,9 @@ export class SessionService {
   async interrupt(id: string): Promise<boolean> {
     const s = this.deps.store.get(id);
     if (!s) return false;
+    // Same invariant as the sendSteerTo funnel guard: a lone ESC is still herdr.send, and a
+    // clean-terminal pane must never receive it (this route bypasses the steer funnel).
+    this.assertNotTerminal(s, "interrupt");
     let agent: HerdrAgent | null;
     try {
       // liveAgentFor lets a herdr-unreachable error propagate; an interrupt that can't reach herdr
@@ -5071,6 +5229,11 @@ export class SessionService {
    *  recorded `reply` signal stays the operator's words alone, so the learnings distiller never
    *  mines Shepherd's own notice (`reply` is a mined signal kind). */
   private async sendSteerTo(s: Session, text: string, signalPayload: string = text): Promise<void> {
+    // FUNNEL GUARD — the herdr.send invariant: every steer in the codebase (reply, broadcast,
+    // retry-halted, autopilot, plan-gate, build-queue, …) flows through here, so this single
+    // check makes "a clean-terminal session never receives herdr.send" hold for every present
+    // and FUTURE call site. (haltAll bypasses this funnel by design and carries its own filter.)
+    this.assertNotTerminal(s, "steer");
     this.deps.store.addSignal({
       repoPath: s.repoPath,
       sessionId: s.id,
@@ -5187,7 +5350,7 @@ export class SessionService {
    * `#liveTrains` and any already-open participant session is marked immediately
    * (reconcileTrainMarks runs inside registerTrain). Empty/absent → no train.
    */
-  #maybeRegisterTrain(session: Session, input: CreateSessionInput): void {
+  #maybeRegisterTrain(session: Session, input: StandardCreateInput): void {
     if (input.mergeTrainPrs && input.mergeTrainPrs.length > 0)
       this.registerTrain(session.id, session.repoPath, input.mergeTrainPrs);
   }
@@ -5515,7 +5678,13 @@ export class SessionService {
       const hit = this.deps.reaper.detect(s).filter((l) => want.has(l.key));
       reaped = this.deps.reaper.reap(hit);
     }
-    await this.deps.herdr.stop(s.herdrAgentId); // stop the live claude agent so it doesn't leak
+    if (s.terminal) {
+      // Pane-direct teardown: there is no agent to stop — close the persisted tab (best-effort:
+      // the shell may already have exited and taken the tab with it).
+      if (s.terminalTabId) await this.deps.herdr.closeTab(s.terminalTabId).catch(() => {});
+    } else {
+      await this.deps.herdr.stop(s.herdrAgentId); // stop the live claude agent so it doesn't leak
+    }
     // Best-effort pre-teardown hook (recap generation): the recap generator reads the
     // worktree to build its prompt, so it MUST run while the worktree still exists.
     // Race a 15s timeout so a stuck git can never permanently stall teardown / the merge

--- a/src/store.ts
+++ b/src/store.ts
@@ -359,6 +359,12 @@ function strOrEmpty(v: string | null | undefined): string {
   return v ?? "";
 }
 
+/** Normalize an absent TEXT value to null (nullable columns) — a helper (not inline `??`) so
+ *  the flat, field-count-driven builders below stay under their complexity caps. */
+function strOrNull(v: string | null | undefined): string | null {
+  return v ?? null;
+}
+
 /** Coerce a persisted RundownEpicItem.pausedReason to its union, or undefined for anything else. */
 function coercePauseReason(v: unknown): RundownEpicItem["pausedReason"] {
   return v === "cap" || v === "conflict" || v === "driver" ? v : undefined;
@@ -2280,8 +2286,8 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       epicAuthoring: Boolean(input.epicAuthoring),
       landingRepair: Boolean(input.landingRepair),
       terminal: Boolean(input.terminal),
-      terminalTabId: input.terminalTabId ?? null,
-      terminalPaneId: input.terminalPaneId ?? null,
+      terminalTabId: strOrNull(input.terminalTabId),
+      terminalPaneId: strOrNull(input.terminalPaneId),
       status: "running",
       lastState: "idle",
       createdAt: now,
@@ -2352,8 +2358,8 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
           Number(s.epicAuthoring), // Number() not `? 1 : 0` — no ternary → no cognitive bump on the INSERT arrow
           Number(s.landingRepair), // Number() not `? 1 : 0` — no ternary → no cognitive bump on the INSERT arrow
           Number(s.terminal), // Number() not `? 1 : 0` — same rationale as the two kinds above
-          s.terminalTabId ?? null,
-          s.terminalPaneId ?? null,
+          strOrNull(s.terminalTabId), // helper, not inline `??` — no branch on the flat INSERT arrow
+          strOrNull(s.terminalPaneId),
           s.createdAt,
           s.updatedAt,
           s.archivedAt,
@@ -5569,8 +5575,8 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       epicAuthoring: !!r.epicAuthoring,
       landingRepair: !!r.landingRepair,
       terminal: !!r.terminal,
-      terminalTabId: r.terminalTabId ?? null,
-      terminalPaneId: r.terminalPaneId ?? null,
+      terminalTabId: strOrNull(r.terminalTabId),
+      terminalPaneId: strOrNull(r.terminalPaneId),
       mergingSince: r.mergingSince ?? null,
       mergingTrainId: r.mergingTrainId ?? null,
       mergeTrainPrs: parseMergeTrainPrsJson(r.mergeTrainPrs),

--- a/src/store.ts
+++ b/src/store.ts
@@ -38,7 +38,7 @@ import type {
   RundownItem,
   RundownEpicItem,
   HeldTask,
-  CreateSessionInput,
+  StandardCreateInput,
   SessionUsageRow,
   SessionUsageSnapshot,
   SessionUsageBucket,
@@ -367,6 +367,11 @@ function coercePauseReason(v: unknown): RundownEpicItem["pausedReason"] {
 /** Designation prefix for task sessions, e.g. "TASK-07". Single source for the prefix + its SUBSTR offset. */
 const DESIG_PREFIX = "TASK-";
 
+/** Staleness bound for a clean-terminal create's reservation lease: reclaim only when the
+ *  owner's heartbeat (renewTerminalClaim, every TTL/6) has been silent this long — i.e. the
+ *  owning process crashed or wedged. A still-running create is never reclaimable. */
+export const TERMINAL_CLAIM_TTL_MS = 30_000;
+
 /** Allowed learning status transitions (spec §3). Terminal states have no exits. */
 const LEARNING_TRANSITIONS: Record<LearningStatus, LearningStatus[]> = {
   proposed: ["active", "dismissed"],
@@ -547,7 +552,7 @@ const COLS = `id, desig, name, prompt, repoPath, baseBranch, branch, worktreePat
   planGateEnabled, planPhase,
   autoMergeEnabled, autoMergeRebaseCount, autoMergeRebaseHead, autoMergeRebaseSteeredAt,
   auto, issueNumber, sandboxApplied, sandboxDegraded, egressApplied, egressDegraded,
-  research, epicAuthoring, landingRepair,
+  research, epicAuthoring, landingRepair, terminal, terminalTabId, terminalPaneId,
   createdAt, updatedAt, archivedAt, mergingSince, mergingTrainId, mergeTrainPrs, mergingPrNumber,
   haltReason, haltedAt, manualStepsJson, manualStepsAckedAt, experimentId, experimentRole,
   spawnTerminalId, spawnAccountDir, providerSessionId, launchMetadataJson, archiveReason`;
@@ -596,6 +601,9 @@ type SessionRow = {
   research: number;
   epicAuthoring: number;
   landingRepair: number;
+  terminal: number;
+  terminalTabId: string | null;
+  terminalPaneId: string | null;
   createdAt: number;
   updatedAt: number;
   archivedAt: number | null;
@@ -2271,6 +2279,9 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       // field-count-driven buildSessionRow (keeps it under its complexity cap).
       epicAuthoring: Boolean(input.epicAuthoring),
       landingRepair: Boolean(input.landingRepair),
+      terminal: Boolean(input.terminal),
+      terminalTabId: input.terminalTabId ?? null,
+      terminalPaneId: input.terminalPaneId ?? null,
       status: "running",
       lastState: "idle",
       createdAt: now,
@@ -2299,7 +2310,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       const seq = this.nextDesignationSeq();
       const s = this.buildSessionRow(input, seq, now);
       this.db.run(
-        `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+        `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
         [
           s.id,
           s.desig,
@@ -2340,6 +2351,9 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
           s.research ? 1 : 0,
           Number(s.epicAuthoring), // Number() not `? 1 : 0` — no ternary → no cognitive bump on the INSERT arrow
           Number(s.landingRepair), // Number() not `? 1 : 0` — no ternary → no cognitive bump on the INSERT arrow
+          Number(s.terminal), // Number() not `? 1 : 0` — same rationale as the two kinds above
+          s.terminalTabId ?? null,
+          s.terminalPaneId ?? null,
           s.createdAt,
           s.updatedAt,
           s.archivedAt,
@@ -2369,6 +2383,72 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       .query(`SELECT ${COLS} FROM sessions WHERE id = ?`)
       .get(id) as SessionRow | null;
     return r ? this.hydrate(r) : null;
+  }
+
+  // ── Clean-terminal singleton lease ──────────────────────────────────────────
+
+  /** The live (unarchived) clean-terminal session for a repo, or null. Backs focus-existing
+   *  and the create-time singleton check. */
+  getLiveTerminalSession(repoPath: string): Session | null {
+    const r = this.db
+      .query(
+        `SELECT ${COLS} FROM sessions
+          WHERE repoPath = ? AND terminal = 1 AND archivedAt IS NULL LIMIT 1`,
+      )
+      .get(repoPath) as SessionRow | null;
+    return r ? this.hydrate(r) : null;
+  }
+
+  /**
+   * Reserve the one-clean-terminal-per-repo slot BEFORE any herdr spawn. One transaction:
+   * (a) reclaim claims whose heartbeat went stale (owner crashed/wedged ≥ TTL — a live create
+   * renews every TTL/6 via renewTerminalClaim, so it is never reclaimable); (b) refuse when a
+   * live terminal session already exists (carrying its id so the caller can focus it); (c)
+   * refuse when another create holds the claim; else insert. Single SQLite transaction on the
+   * shared DB file ⇒ atomic across processes and bypass paths.
+   */
+  claimTerminalRepo(
+    repoPath: string,
+    sessionId: string,
+    now: number = Date.now(),
+  ): { ok: true } | { ok: false; existingId: string | null } {
+    return this.db.transaction((): { ok: true } | { ok: false; existingId: string | null } => {
+      this.db.run(`DELETE FROM terminal_claims WHERE renewedAt < ?`, [now - TERMINAL_CLAIM_TTL_MS]);
+      const live = this.db
+        .query(
+          `SELECT id FROM sessions WHERE repoPath = ? AND terminal = 1 AND archivedAt IS NULL LIMIT 1`,
+        )
+        .get(repoPath) as { id: string } | null;
+      if (live) return { ok: false, existingId: live.id };
+      const holder = this.db
+        .query(`SELECT sessionId FROM terminal_claims WHERE repoPath = ?`)
+        .get(repoPath);
+      if (holder) return { ok: false, existingId: null };
+      this.db.run(`INSERT INTO terminal_claims (repoPath, sessionId, renewedAt) VALUES (?, ?, ?)`, [
+        repoPath,
+        sessionId,
+        now,
+      ]);
+      return { ok: true };
+    })();
+  }
+
+  /** Heartbeat for an in-flight terminal create — sessionId-matched so a reclaimed-and-reissued
+   *  claim belonging to another create is never touched. */
+  renewTerminalClaim(repoPath: string, sessionId: string, now: number = Date.now()): void {
+    this.db.run(`UPDATE terminal_claims SET renewedAt = ? WHERE repoPath = ? AND sessionId = ?`, [
+      now,
+      repoPath,
+      sessionId,
+    ]);
+  }
+
+  /** Release a terminal-create claim (sessionId-matched; see renewTerminalClaim). */
+  releaseTerminalClaim(repoPath: string, sessionId: string): void {
+    this.db.run(`DELETE FROM terminal_claims WHERE repoPath = ? AND sessionId = ?`, [
+      repoPath,
+      sessionId,
+    ]);
   }
 
   /**
@@ -3958,6 +4038,12 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     add("epicAuthoring", `epicAuthoring INTEGER NOT NULL DEFAULT 0`);
     // epic-landing-PR repair task kind: default 0 (false) for pre-existing rows.
     add("landingRepair", `landingRepair INTEGER NOT NULL DEFAULT 0`);
+    // clean-terminal task kind (bare shell in the main checkout): default 0 for pre-existing rows.
+    add("terminal", `terminal INTEGER NOT NULL DEFAULT 0`);
+    // clean-terminal pane target (pane-direct, no agent): tab to close on decommission + the
+    // socket-transport attach pane. Nullable — null on every non-terminal row.
+    add("terminalTabId", `terminalTabId TEXT`);
+    add("terminalPaneId", `terminalPaneId TEXT`);
     add("mergeTrainPrs", `mergeTrainPrs TEXT`);
     add("mergingPrNumber", `mergingPrNumber INTEGER`);
     // halt detection: reason + timestamp; nullable, no default (null = not halted).
@@ -3979,6 +4065,19 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     add("spawnAccountDir", `spawnAccountDir TEXT`);
     add("launchMetadataJson", `launchMetadataJson TEXT`);
     add("archiveReason", `archiveReason TEXT`);
+    // Durable one-clean-terminal-per-repo invariant. Partial: only LIVE terminal rows count, so
+    // archiving frees the slot. Created here (after the column adds above) so the terminal
+    // column exists on legacy DBs before the index references it.
+    this.db.run(
+      `CREATE UNIQUE INDEX IF NOT EXISTS sessions_terminal_singleton
+         ON sessions (repoPath) WHERE terminal = 1 AND archivedAt IS NULL`,
+    );
+    // Pre-spawn reservation lease for clean-terminal creates (heartbeat-renewed; see
+    // claimTerminalRepo). Its own table so a reservation never surfaces as a session row.
+    this.db.run(`CREATE TABLE IF NOT EXISTS terminal_claims (
+      repoPath TEXT PRIMARY KEY,
+      sessionId TEXT NOT NULL,
+      renewedAt INTEGER NOT NULL)`);
   }
 
   // Migrate build_queue_steps from the legacy global `PRIMARY KEY (id)` to the composite
@@ -5469,6 +5568,9 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       research: !!r.research,
       epicAuthoring: !!r.epicAuthoring,
       landingRepair: !!r.landingRepair,
+      terminal: !!r.terminal,
+      terminalTabId: r.terminalTabId ?? null,
+      terminalPaneId: r.terminalPaneId ?? null,
       mergingSince: r.mergingSince ?? null,
       mergingTrainId: r.mergingTrainId ?? null,
       mergeTrainPrs: parseMergeTrainPrsJson(r.mergeTrainPrs),
@@ -5494,7 +5596,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
   addHeldTask(row: {
     id: string;
     repoPath: string;
-    input: CreateSessionInput;
+    input: StandardCreateInput;
     createdAt: number;
     reason: "usage" | "capacity";
   }): void {
@@ -5518,7 +5620,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     }[];
     return rows.map((r) => ({
       ...r,
-      input: JSON.parse(r.input) as CreateSessionInput,
+      input: JSON.parse(r.input) as StandardCreateInput,
       reason: r.reason as "usage" | "capacity",
     }));
   }
@@ -5536,7 +5638,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     if (!r) return null;
     return {
       ...r,
-      input: JSON.parse(r.input) as CreateSessionInput,
+      input: JSON.parse(r.input) as StandardCreateInput,
       reason: r.reason as "usage" | "capacity",
     };
   }
@@ -5547,7 +5649,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
 
   /** Replace a held task's stored input (e.g. an operator edited it while it stays
    *  held). repoPath mirrors input.repoPath so a repo change updates both columns. */
-  updateHeldTask(id: string, input: CreateSessionInput): void {
+  updateHeldTask(id: string, input: StandardCreateInput): void {
     this.db.run(`UPDATE held_tasks SET repoPath = ?, input = ? WHERE id = ?`, [
       input.repoPath,
       JSON.stringify(input),

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,18 @@ export interface Session {
   /** True for an epic-landing-PR repair session: pushes directly to the epic integration branch and
    *  never opens a PR. */
   landingRepair: boolean;
+  /** True for a clean-terminal session: a bare operator shell in the repo's MAIN checkout
+   *  (pane-direct — no herdr agent, no worktree, no prompt). Fenced out of every agent-input
+   *  and agent-lifecycle flow; its pane target lives in terminalTabId/terminalPaneId.
+   *  OPTIONAL (like autoMergeRebaseSteeredAt above) so existing Session fixtures stay valid —
+   *  absent and false are equivalent; the store always hydrates a real boolean. */
+  terminal?: boolean;
+  /** herdr tab hosting the clean-terminal shell; null/absent on non-terminal sessions.
+   *  Decommission closes this tab directly (there is no agent to resolve it from). */
+  terminalTabId?: string | null;
+  /** herdr pane running the clean-terminal shell — the socket-transport attach target
+   *  (`terminal session control <pane>`); null/absent on non-terminal sessions. */
+  terminalPaneId?: string | null;
   /** Full-auto merge opt-in: true/false override, or null to inherit the repo default. */
   autoMergeEnabled: boolean | null;
   /** Consecutive auto-rebase attempts the merge train has spent on this session
@@ -231,7 +243,24 @@ export interface SessionLaunchMetadata {
   agent: { provider: AgentProvider; model: string | null; effort: string | null };
 }
 
-export interface CreateSessionInput {
+/**
+ * Create input is a DISCRIMINATED UNION on `terminal` (issue: clean-terminal-in-main-repo).
+ * The terminal arm deliberately has NO `prompt`/`baseBranch` members — a clean terminal is a
+ * bare shell in the repo's main checkout, so those fields cannot even be referenced in its
+ * create path (compile-time fence). The standard arm is byte-for-byte the pre-union shape;
+ * existing constructors satisfy it unchanged.
+ */
+export type CreateSessionInput = StandardCreateInput | TerminalCreateInput;
+
+/** A clean-terminal create: bare operator shell, pane-direct, main checkout. Nothing else. */
+export interface TerminalCreateInput {
+  terminal: true;
+  repoPath: string;
+}
+
+export interface StandardCreateInput {
+  /** Discriminant: absent/false = a normal agent session. */
+  terminal?: false;
   repoPath: string;
   baseBranch: string;
   prompt: string;
@@ -1162,7 +1191,7 @@ export interface HeldTask {
   id: string;
   repoPath: string;
   /** The original CreateSessionInput, replayed through service.create() when released. */
-  input: CreateSessionInput;
+  input: StandardCreateInput;
   createdAt: number;
   /** Hold reason: `'usage'` = usage-gate hold; `'capacity'` = plugin-refused (no account). */
   reason: "usage" | "capacity";

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -527,6 +527,13 @@ export function validateCreate(body: unknown, repoRoot: string): Result {
   }
 
   const obj = body as Record<string, unknown>;
+  // Clean-terminal union arm (TerminalCreateInput): branch BEFORE the standard allowlist —
+  // the terminal payload has its own, stricter key set, and the standard arm keeps its
+  // required prompt/baseBranch untouched (no weakening of ordinary creates).
+  if (obj.terminal !== undefined) {
+    if (obj.terminal !== true) return err("terminal must be true when present");
+    return validateTerminalCreate(obj, repoRoot);
+  }
   for (const key of Object.keys(obj)) {
     if (!ALLOWED_KEYS.has(key)) return err(`unknown key: ${key}`);
   }
@@ -571,6 +578,20 @@ export function validateCreate(body: unknown, repoRoot: string): Result {
       ...options.value,
     },
   };
+}
+
+const TERMINAL_ALLOWED_KEYS = new Set(["repoPath", "terminal"]);
+
+/** The clean-terminal arm of the create union: exactly `{ repoPath, terminal: true }` — a stray
+ *  `prompt`/`baseBranch`/anything else is an unknown-key rejection, never a silently-ignored
+ *  field (the arm has no such members to carry it in). */
+function validateTerminalCreate(obj: Record<string, unknown>, repoRoot: string): Result {
+  for (const key of Object.keys(obj)) {
+    if (!TERMINAL_ALLOWED_KEYS.has(key)) return err(`unknown key: ${key}`);
+  }
+  const repoPath = validateRepoPath(obj.repoPath, resolve(expandHome(repoRoot)));
+  if (!repoPath.ok) return repoPath;
+  return { ok: true, value: { terminal: true, repoPath: repoPath.value } };
 }
 
 function validateCreateLaunchFields(

--- a/test/drain-epic-divergence.test.ts
+++ b/test/drain-epic-divergence.test.ts
@@ -3,7 +3,7 @@ import { DrainService } from "../src/drain";
 import { SessionStore } from "../src/store";
 import type { GitForge, GitState, Issue, PrStatus, SubIssueRef } from "../src/forge/types";
 import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
-import type { CreateSessionInput, Session } from "../src/types";
+import type { StandardCreateInput, Session } from "../src/types";
 import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
 
 // #645 (c): drain.buildEpic scans the host for stray epic/* branches, throttled per epic,
@@ -103,7 +103,7 @@ function makeHarness(branchesRef: BranchesRef, clock: { t: number }) {
   const drain = new DrainService({
     store,
     service: {
-      create: async (input: CreateSessionInput): Promise<Session> =>
+      create: async (input: StandardCreateInput): Promise<Session> =>
         store.create({
           name: "auto",
           prompt: input.prompt,

--- a/test/drain-epic-pin-branch.test.ts
+++ b/test/drain-epic-pin-branch.test.ts
@@ -3,7 +3,7 @@ import { DrainService, type DrainStatus } from "../src/drain";
 import { SessionStore } from "../src/store";
 import type { GitForge, GitState, Issue, PrStatus, SubIssueRef } from "../src/forge/types";
 import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
-import type { CreateSessionInput, ReviewDecision, Session } from "../src/types";
+import type { StandardCreateInput, ReviewDecision, Session } from "../src/types";
 import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
 import type { Epic } from "../src/epic-core";
 
@@ -115,12 +115,12 @@ function makeHarness(parentTitleRef: { title: string }, subIssues: SubIssueRef[]
 
   const prCache: Record<string, GitState> = {};
   const reviews: Record<string, { decision: ReviewDecision; headSha: string }> = {};
-  const creates: CreateSessionInput[] = [];
+  const creates: StandardCreateInput[] = [];
   const statuses: DrainStatus[] = [];
   const epics: Epic[] = [];
 
   const service = {
-    create: async (input: CreateSessionInput): Promise<Session> => {
+    create: async (input: StandardCreateInput): Promise<Session> => {
       creates.push(input);
       return store.create({
         name: "auto",

--- a/test/drain-epic-retire-base.test.ts
+++ b/test/drain-epic-retire-base.test.ts
@@ -10,7 +10,7 @@ import type {
   PrStatus,
 } from "../src/forge/types";
 import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
-import type { CreateSessionInput, ReviewDecision, Session } from "../src/types";
+import type { StandardCreateInput, ReviewDecision, Session } from "../src/types";
 import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
 
 // #645 Task 2: retire enforces the child PR's base against the pinned epic integration branch.
@@ -150,7 +150,7 @@ function makeHarness(
   const archived: string[] = [];
 
   const service = {
-    create: async (input: CreateSessionInput): Promise<Session> =>
+    create: async (input: StandardCreateInput): Promise<Session> =>
       store.create({
         name: "auto",
         prompt: input.prompt,

--- a/test/drain-epic-retire-merge.test.ts
+++ b/test/drain-epic-retire-merge.test.ts
@@ -3,7 +3,7 @@ import { DrainService } from "../src/drain";
 import { SessionStore } from "../src/store";
 import type { GitForge, GitState, Issue, MergeMethod, PrStatus } from "../src/forge/types";
 import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
-import type { CreateSessionInput, ReviewDecision, Session } from "../src/types";
+import type { StandardCreateInput, ReviewDecision, Session } from "../src/types";
 import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
 
 const REPO = "/repo";
@@ -130,7 +130,7 @@ function makeHarness(
   const archived: string[] = [];
 
   const service = {
-    create: async (input: CreateSessionInput): Promise<Session> => {
+    create: async (input: StandardCreateInput): Promise<Session> => {
       return store.create({
         name: "auto",
         prompt: input.prompt,

--- a/test/drain-epic-spawn-base.test.ts
+++ b/test/drain-epic-spawn-base.test.ts
@@ -4,7 +4,7 @@ import { ACTIVE_LABEL } from "../src/drain-core";
 import { SessionStore } from "../src/store";
 import type { GitForge, GitState, Issue, PrStatus, SubIssueRef } from "../src/forge/types";
 import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
-import type { CreateSessionInput, ReviewDecision, Session } from "../src/types";
+import type { StandardCreateInput, ReviewDecision, Session } from "../src/types";
 import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
 import type { Epic } from "../src/epic-core";
 
@@ -100,7 +100,7 @@ interface Harness {
   store: SessionStore;
   drain: DrainService;
   forgeRec: ForgeRec;
-  creates: CreateSessionInput[];
+  creates: StandardCreateInput[];
   statuses: DrainStatus[];
   epics: Epic[];
 }
@@ -161,12 +161,12 @@ function makeHarness(
 
   const prCache: Record<string, GitState> = {};
   const reviews: Record<string, { decision: ReviewDecision; headSha: string }> = {};
-  const creates: CreateSessionInput[] = [];
+  const creates: StandardCreateInput[] = [];
   const statuses: DrainStatus[] = [];
   const epics: Epic[] = [];
 
   const service = {
-    create: async (input: CreateSessionInput): Promise<Session> => {
+    create: async (input: StandardCreateInput): Promise<Session> => {
       creates.push(input);
       return store.create({
         name: "auto",

--- a/test/drain-landing-repair.test.ts
+++ b/test/drain-landing-repair.test.ts
@@ -12,7 +12,7 @@ import { SessionStore } from "../src/store";
 import type { GitForge, Issue, PrStatus, SubIssueRef } from "../src/forge/types";
 import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
-import type { CreateSessionInput } from "../src/types";
+import type { StandardCreateInput } from "../src/types";
 import { epicIntegrationBranch } from "../src/epic-branch";
 import { config } from "../src/config";
 
@@ -109,7 +109,7 @@ function fakeForge(opts: { prStatus?: (branch: string) => Promise<PrStatus> }): 
 }
 
 interface CreateCall {
-  input: CreateSessionInput;
+  input: StandardCreateInput;
 }
 
 interface RepairCountCall {
@@ -189,7 +189,7 @@ function makeHarness(opts: {
   const drain = new DrainService({
     store,
     service: {
-      create: async (input: CreateSessionInput) => {
+      create: async (input: StandardCreateInput) => {
         createCalls.push({ input });
         if (opts.createThrows) throw new Error("spawn refused (hold/egress/transient)");
         return { id: "repair-sess", baseBranch: input.baseBranch } as never;

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -13,7 +13,7 @@ import type {
 import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import type {
   AgentProvider,
-  CreateSessionInput,
+  StandardCreateInput,
   ReviewDecision,
   Session,
   SessionArchiveReason,
@@ -133,7 +133,7 @@ interface Harness {
   store: SessionStore;
   drain: DrainService;
   forgeRec: ForgeRec;
-  creates: CreateSessionInput[];
+  creates: StandardCreateInput[];
   statuses: DrainStatus[];
   epics: Epic[];
   sessionNews: Session[];
@@ -222,7 +222,7 @@ function makeHarness(
 
   const prCache: Record<string, GitState> = {};
   const reviews: Record<string, { decision: ReviewDecision; headSha: string }> = {};
-  const creates: CreateSessionInput[] = [];
+  const creates: StandardCreateInput[] = [];
   const statuses: Harness["statuses"] = [];
   const epics: Epic[] = [];
   const sessionNews: Session[] = [];
@@ -231,7 +231,7 @@ function makeHarness(
 
   // fake service: create inserts an auto session into the real store so it shows up
   const service = {
-    create: async (input: CreateSessionInput): Promise<Session> => {
+    create: async (input: StandardCreateInput): Promise<Session> => {
       creates.push(input);
       if (opts.createImpl) await opts.createImpl();
       return store.create({
@@ -1027,13 +1027,13 @@ test("tick + snapshot over repos: only drain-enabled repo is acted on and report
     getIssueCalls: [],
   };
   const forge = fakeForge([issue(1)], forgeRec);
-  const creates: CreateSessionInput[] = [];
+  const creates: StandardCreateInput[] = [];
   const statuses: DrainStatus[] = [];
 
   const drain = new DrainService({
     store,
     service: {
-      create: async (input: CreateSessionInput): Promise<Session> => {
+      create: async (input: StandardCreateInput): Promise<Session> => {
         creates.push(input);
         return store.create({
           name: "auto",

--- a/test/epic-steer.test.ts
+++ b/test/epic-steer.test.ts
@@ -307,7 +307,7 @@ describe("broadcast", () => {
   test("injects the notice on an epic-intent broadcast while preserving accounting + raw signal", async () => {
     const { svc, store, pasted, id } = makeSvc();
     const res = await svc.broadcast([id], EPIC_MSG);
-    expect(res).toEqual({ delivered: 1, queued: 0, offline: 0, total: 1 });
+    expect(res).toEqual({ delivered: 1, queued: 0, offline: 0, skipped: 0, total: 1 });
     expect(pasted()).toContain(NOTICE_MARK); // the notice rides the PTY
     expect(store.listSignals("/r")[0]!.payload).toBe(EPIC_MSG); // ...but the signal stays raw
   });

--- a/test/held-release.test.ts
+++ b/test/held-release.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "bun:test";
 import { releaseHeldTasks, type HeldReleaseDeps } from "../src/held-release";
-import type { CreateSessionInput, Session } from "../src/types";
+import type { StandardCreateInput, Session } from "../src/types";
 import type { UsageLimits } from "../src/usage-limits";
 import { SandboxAutoRefused } from "../src/sandbox";
 
@@ -8,7 +8,7 @@ import { SandboxAutoRefused } from "../src/sandbox";
 // (it's the session:new payload), so a full literal would be noise.
 const fakeSession = (id: string) => ({ id }) as unknown as Session;
 
-function makeInput(prompt: string, issueNumber?: number): CreateSessionInput {
+function makeInput(prompt: string, issueNumber?: number): StandardCreateInput {
   return {
     repoPath: "/tmp/repo",
     baseBranch: "main",
@@ -22,12 +22,12 @@ function makeInput(prompt: string, issueNumber?: number): CreateSessionInput {
 }
 
 function makeDeps(
-  tasks: { id: string; input: CreateSessionInput }[],
+  tasks: { id: string; input: StandardCreateInput }[],
   limits: Partial<UsageLimits> = {},
-  createFn?: (input: CreateSessionInput) => Promise<Session>,
+  createFn?: (input: StandardCreateInput) => Promise<Session>,
 ): HeldReleaseDeps & {
   emitted: { event: string; data: unknown }[];
-  creates: CreateSessionInput[];
+  creates: StandardCreateInput[];
   labeled: number[];
 } {
   const rows = tasks.map((t, i) => ({
@@ -37,7 +37,7 @@ function makeDeps(
     createdAt: i + 1,
   }));
   const emitted: { event: string; data: unknown }[] = [];
-  const creates: CreateSessionInput[] = [];
+  const creates: StandardCreateInput[] = [];
   const labeled: number[] = [];
 
   const defaultLimits: UsageLimits = {
@@ -61,7 +61,7 @@ function makeDeps(
       countHeldTasks: () => rows.length,
     },
     service: {
-      async create(input: CreateSessionInput): Promise<Session> {
+      async create(input: StandardCreateInput): Promise<Session> {
         if (createFn) return createFn(input);
         creates.push(input);
         return fakeSession("fake-session");
@@ -103,7 +103,7 @@ test("usage high (>=holdPct) + enabled → released:0, service not called", asyn
 });
 
 test("usage low + 3 held → releases all 3 FIFO", async () => {
-  const creates: CreateSessionInput[] = [];
+  const creates: StandardCreateInput[] = [];
   const tasks = [
     { id: "t1", input: makeInput("task 1") },
     { id: "t2", input: makeInput("task 2") },
@@ -267,7 +267,7 @@ test("released task with linked issue → re-stamps the drain claim", async () =
 // listHeldTasks() returns usage-held tasks first, capacity-held tasks last.
 
 function makeRowsWithReason(
-  tasks: { id: string; input: CreateSessionInput; reason: "usage" | "capacity" }[],
+  tasks: { id: string; input: StandardCreateInput; reason: "usage" | "capacity" }[],
 ) {
   return tasks.map((t, i) => ({ ...t, repoPath: "/tmp/repo", createdAt: i + 1 }));
 }
@@ -278,7 +278,7 @@ test("capacity-last: usage-held task released before capacity-held (store orderi
   const capTask = { id: "c1", input: makeInput("cap task"), reason: "capacity" as const };
   const rows = makeRowsWithReason([usageTask, capTask]);
 
-  const creates: CreateSessionInput[] = [];
+  const creates: StandardCreateInput[] = [];
   const deps = makeDeps([], {}, async (input) => {
     creates.push(input);
     return fakeSession("fake");
@@ -308,7 +308,7 @@ test("capacity-last: failing capacity task does not block releasable usage task 
   const capTask = { id: "c1", input: makeInput("cap task"), reason: "capacity" as const };
   const rows = makeRowsWithReason([usageTask, capTask]);
 
-  const creates: CreateSessionInput[] = [];
+  const creates: StandardCreateInput[] = [];
   const deps = makeDeps([], {}, async (input) => {
     if (input.prompt === "cap task") throw new SandboxAutoRefused("no accounts");
     creates.push(input);

--- a/test/sandbox-wiring.test.ts
+++ b/test/sandbox-wiring.test.ts
@@ -7,7 +7,7 @@ import type { EgressBackend } from "../src/egress";
 import { egressTmpDir } from "../src/egress";
 import { existsSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import type { CreateSessionInput, Session } from "../src/types";
+import type { StandardCreateInput, Session } from "../src/types";
 import type { GitForge, Issue, PrStatus } from "../src/forge/types";
 import type { UsageLimits } from "../src/usage-limits";
 import type { EgressWatcher } from "../src/egress-watch";
@@ -70,7 +70,7 @@ function makeService(opts: {
   });
 }
 
-const baseInput = (over: Partial<CreateSessionInput> = {}): CreateSessionInput => ({
+const baseInput = (over: Partial<StandardCreateInput> = {}): StandardCreateInput => ({
   repoPath: "/repo",
   baseBranch: "main",
   prompt: "do it",
@@ -322,7 +322,7 @@ test("drain pre-check: standard profile holds → service.create NOT called", as
   store.setRepoConfig("/repo", { ...defaultRepoConfig(), sandboxProfile: "standard" });
   let createCalls = 0;
   const service = {
-    create: async (input: CreateSessionInput): Promise<Session> => {
+    create: async (input: StandardCreateInput): Promise<Session> => {
       createCalls++;
       return store.create({
         name: "auto",
@@ -426,7 +426,7 @@ test("drain + autonomous repo + egress NULL → held, service.create NOT called"
   store.setRepoConfig("/repo", { ...defaultRepoConfig(), sandboxProfile: "autonomous" });
   let createCalls = 0;
   const service = {
-    create: async (input: CreateSessionInput): Promise<Session> => {
+    create: async (input: StandardCreateInput): Promise<Session> => {
       createCalls++;
       return store.create({
         name: "auto",

--- a/test/server-up-next.test.ts
+++ b/test/server-up-next.test.ts
@@ -6,7 +6,7 @@ import { SessionStore } from "../src/store";
 import { EventHub } from "../src/events";
 import { config } from "../src/config";
 import type { UpNextSnapshot, UpNextSection } from "../src/up-next-core";
-import type { CreateSessionInput, Session } from "../src/types";
+import type { StandardCreateInput, Session } from "../src/types";
 
 let tmpRoot: string;
 let repoDir: string;
@@ -50,7 +50,7 @@ function harness(
   opts: {
     snapshot?: UpNextSnapshot | null;
     hiddenRepoPathsRaw?: () => Set<string>;
-    create?: (input: CreateSessionInput) => Promise<Session>;
+    create?: (input: StandardCreateInput) => Promise<Session>;
     defaultBranch?: () => Promise<string>;
     limits?: () => { session5h?: { pct: number }; week?: { pct: number } };
   } = {},
@@ -61,9 +61,9 @@ function harness(
     repoPath: string;
     number: number | undefined;
     prompt: string;
-    agentProvider: CreateSessionInput["agentProvider"];
-    model: CreateSessionInput["model"];
-    effort: CreateSessionInput["effort"];
+    agentProvider: StandardCreateInput["agentProvider"];
+    model: StandardCreateInput["model"];
+    effort: StandardCreateInput["effort"];
   }> = [];
   const labelCalls: number[] = [];
   const recomputeCalls: Array<Array<{ repoPath: string; issueNumber: number }>> = [];
@@ -74,7 +74,7 @@ function harness(
     service: {
       create:
         opts.create ??
-        (async (input: CreateSessionInput) => {
+        (async (input: StandardCreateInput) => {
           createCalls.push({
             at: ++n,
             repoPath: input.repoPath,

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -3720,7 +3720,7 @@ test("broadcast fans the text out to known sessions, skips unknown ids", async (
 
   // term_a + term_b are live & idle → delivered; "ghost" has no live pane → offline.
   const res = await svc.broadcast([a.id, "ghost", b.id], "run tests");
-  expect(res).toEqual({ delivered: 2, queued: 0, offline: 1, total: 3 });
+  expect(res).toEqual({ delivered: 2, queued: 0, offline: 1, skipped: 0, total: 3 });
   expect(sent).toEqual([
     { target: "term_a", text: "\x1b[200~run tests\x1b[201~" },
     { target: "term_a", text: "\r" },
@@ -3770,6 +3770,7 @@ test("broadcast classifies working agents as queued, non-working as delivered", 
     delivered: 1,
     queued: 1,
     offline: 0,
+    skipped: 0,
     total: 2,
   });
 });
@@ -3809,6 +3810,7 @@ test("broadcast reports every target offline when no panes are live", async () =
     delivered: 0,
     queued: 0,
     offline: 2,
+    skipped: 0,
     total: 2,
   });
   expect(sent).toEqual([]); // nothing delivered

--- a/test/terminal-session.test.ts
+++ b/test/terminal-session.test.ts
@@ -1,0 +1,335 @@
+// Clean-terminal sessions (pane-direct bare shell in the main checkout): create contract,
+// singleton lease, agent-verb fences (the herdr.send invariant), teardown, hydration, and the
+// poller's fail-closed pane-liveness state machine.
+import { test, expect, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionStore, TERMINAL_CLAIM_TTL_MS } from "../src/store";
+import {
+  SessionService,
+  TerminalExistsError,
+  TerminalSessionError,
+  TerminalUnsupportedError,
+} from "../src/service";
+import { setDetectedHerdrVersion } from "../src/herdr-capabilities";
+import { StatusPoller } from "../src/poller";
+import type { Session } from "../src/types";
+
+// The create preflight fails CLOSED on an unknown herdr version — pin a capable one per test
+// and always restore the un-probed state so no other suite inherits it.
+afterEach(() => setDetectedHerdrVersion(null));
+
+type ShellReply = { tabId: string; paneId: string; terminalId: string; cwd: string };
+
+function makeSvc(over: { shell?: Partial<ShellReply>; parkSpawn?: Promise<void> } = {}) {
+  setDetectedHerdrVersion("0.7.5");
+  const store = new SessionStore(":memory:");
+  const calls = {
+    shellTabs: [] as { cwd: string; label: string; env?: Record<string, string> }[],
+    closedTabs: [] as string[],
+    sends: [] as { target: string; text: string }[],
+    stops: [] as string[],
+    wtCreates: 0,
+    wtRemoves: 0,
+  };
+  const service = new SessionService({
+    store,
+    namer: async () => "unused-by-terminal",
+    worktree: {
+      ensureBaseRef: async () => {},
+      branchExists: () => false,
+      create: () => {
+        calls.wtCreates++;
+        throw new Error("worktree must never be created for a terminal session");
+      },
+      remove: () => {
+        calls.wtRemoves++;
+      },
+    } as any,
+    herdr: {
+      list: () => [],
+      send: async (target: string, text: string) => {
+        calls.sends.push({ target, text });
+      },
+      stop: async (target: string) => {
+        calls.stops.push(target);
+      },
+      startShellTab: async (cwd: string, label: string, env?: Record<string, string>) => {
+        calls.shellTabs.push({ cwd, label, env });
+        if (over.parkSpawn) await over.parkSpawn;
+        return {
+          tabId: "w1:t9",
+          paneId: "w1:p9",
+          terminalId: "term_shell9",
+          cwd,
+          ...over.shell,
+        };
+      },
+      closeTab: async (id: string) => {
+        calls.closedTabs.push(id);
+      },
+    } as any,
+  });
+  return { store, service, calls };
+}
+
+const TERM_INPUT = { repoPath: "/repo", terminal: true as const };
+
+test("terminal create: shell tab at the MAIN checkout, no worktree, fenced-inert row shape", async () => {
+  const { store, service, calls } = makeSvc();
+  const s = await service.create(TERM_INPUT);
+
+  expect(calls.wtCreates).toBe(0);
+  expect(calls.shellTabs).toHaveLength(1);
+  expect(calls.shellTabs[0]!.cwd).toBe("/repo");
+  // SESSION_MARKER_ENV rides tab create --env for runaway-reaper attribution.
+  expect(Object.values(calls.shellTabs[0]!.env ?? {})).toContain(s.id);
+
+  const row = store.get(s.id)!;
+  expect(row.terminal).toBe(true);
+  expect(row.terminalTabId).toBe("w1:t9");
+  expect(row.terminalPaneId).toBe("w1:p9");
+  expect(row.herdrAgentId).toBe("term_shell9");
+  expect(row.worktreePath).toBe("/repo");
+  expect(row.isolated).toBe(false);
+  expect(row.branch).toBeNull();
+  expect(row.baseBranch).toBe("");
+  expect(row.prompt).toBe("");
+  expect(row.planGateEnabled).toBe(false);
+  expect(row.autopilotEnabled).toBe(false);
+  expect(row.planPhase).toBeNull();
+});
+
+test("terminal create: preflight fails closed on an old or unknown herdr — no tab is spawned", async () => {
+  const { service, calls } = makeSvc();
+  setDetectedHerdrVersion("0.7.2");
+  await expect(service.create(TERM_INPUT)).rejects.toBeInstanceOf(TerminalUnsupportedError);
+  setDetectedHerdrVersion(null); // un-probed process → also refused
+  await expect(service.create(TERM_INPUT)).rejects.toBeInstanceOf(TerminalUnsupportedError);
+  expect(calls.shellTabs).toHaveLength(0);
+});
+
+test("terminal singleton: second create refuses with the live session's id, without spawning", async () => {
+  const { service, calls } = makeSvc();
+  const first = await service.create(TERM_INPUT);
+  const err = await service.create(TERM_INPUT).catch((e) => e);
+  expect(err).toBeInstanceOf(TerminalExistsError);
+  expect((err as TerminalExistsError).existingId).toBe(first.id);
+  expect(calls.shellTabs).toHaveLength(1); // the loser never reached herdr
+});
+
+test("terminal singleton: concurrent creates — the claim is taken BEFORE the spawn", async () => {
+  let release!: () => void;
+  const parked = new Promise<void>((r) => (release = r));
+  const { service, calls } = makeSvc({ parkSpawn: parked });
+  const a = service.create(TERM_INPUT);
+  const b = service.create(TERM_INPUT).catch((e) => e);
+  // Loser is refused while the winner's spawn is still parked (lease, not row, arbitrates).
+  const loser = await b;
+  expect(loser).toBeInstanceOf(TerminalExistsError);
+  release();
+  const winner = await a;
+  expect(winner.terminal).toBe(true);
+  expect(calls.shellTabs).toHaveLength(1);
+});
+
+test("terminal create: cwd-mismatch contract violation closes the tab and frees the slot", async () => {
+  const { service, calls } = makeSvc({ shell: { cwd: "/somewhere/else" } });
+  await expect(service.create(TERM_INPUT)).rejects.toThrow(/expected \/repo/);
+  expect(calls.closedTabs).toEqual(["w1:t9"]); // rollback — no orphan shell tab
+  // Claim released in finally → a corrected retry succeeds immediately.
+  const retry = makeSvc();
+  await expect(retry.service.create(TERM_INPUT)).resolves.toBeTruthy();
+});
+
+test("agent-verb fences: every input/lifecycle verb refuses a terminal session with 409-typed errors", async () => {
+  const { service } = makeSvc();
+  const s = await service.create(TERM_INPUT);
+
+  await expect(service.operatorReply(s.id, "hi")).rejects.toBeInstanceOf(TerminalSessionError);
+  await expect(service.startPreview(s.id, "bun dev")).rejects.toBeInstanceOf(TerminalSessionError);
+  await expect(service.interrupt(s.id)).rejects.toBeInstanceOf(TerminalSessionError);
+  await expect(service.relaunch(s.id)).rejects.toBeInstanceOf(TerminalSessionError);
+  await expect(service.replaceAgent(s.id, { model: null })).rejects.toBeInstanceOf(
+    TerminalSessionError,
+  );
+});
+
+test("restore fence: an archived terminal cannot be restored — even when a newer live terminal exists", async () => {
+  const { service, store } = makeSvc();
+  const first = await service.create(TERM_INPUT);
+  await service.archive(first.id);
+  const second = await service.create(TERM_INPUT); // slot freed by the archive
+  await expect(service.restore(first.id)).rejects.toBeInstanceOf(TerminalSessionError);
+  // The live terminal is untouched and still the singleton holder.
+  expect(store.get(second.id)?.status).not.toBe("archived");
+  expect(store.getLiveTerminalSession("/repo")?.id).toBe(second.id);
+});
+
+test("herdr.send invariant: broadcast skips terminals (additive count), retryHalted skips, haltAll filters — zero sends", async () => {
+  const { service, calls } = makeSvc();
+  const s = await service.create(TERM_INPUT);
+
+  const res = await service.broadcast([s.id, "ghost"], "run tests");
+  expect(res).toEqual({ delivered: 0, queued: 0, offline: 1, skipped: 1, total: 2 });
+
+  const retry = await service.retryHalted([s.id], "continue");
+  expect(retry).toEqual({ resumed: 0, steered: 0, total: 1 });
+
+  await service.haltAll();
+
+  expect(calls.sends).toHaveLength(0); // the invariant itself
+});
+
+test("terminal teardown: archive closes the persisted tab — no agent stop, no worktree reap", async () => {
+  const { service, calls, store } = makeSvc();
+  const s = await service.create(TERM_INPUT);
+  await service.archive(s.id);
+  expect(calls.closedTabs).toEqual(["w1:t9"]);
+  expect(calls.stops).toHaveLength(0);
+  expect(calls.wtRemoves).toBe(0);
+  expect(store.get(s.id)?.status).toBe("archived");
+});
+
+test("store lease: TTL reclaim only after the heartbeat goes silent; renewal keeps a slow create alive", () => {
+  const store = new SessionStore(":memory:");
+  const t0 = 1_000_000;
+  expect(store.claimTerminalRepo("/r", "a", t0)).toEqual({ ok: true });
+  // Within the lease, a rival is refused (no live session yet → existingId null).
+  expect(store.claimTerminalRepo("/r", "b", t0 + TERMINAL_CLAIM_TTL_MS - 1)).toEqual({
+    ok: false,
+    existingId: null,
+  });
+  // Heartbeat renewal moves the staleness horizon — still refused past the original TTL.
+  store.renewTerminalClaim("/r", "a", t0 + TERMINAL_CLAIM_TTL_MS - 1);
+  expect(store.claimTerminalRepo("/r", "b", t0 + TERMINAL_CLAIM_TTL_MS + 1)).toEqual({
+    ok: false,
+    existingId: null,
+  });
+  // Silent past the TTL → reclaimable.
+  expect(store.claimTerminalRepo("/r", "b", t0 + 2 * TERMINAL_CLAIM_TTL_MS)).toEqual({ ok: true });
+  // Release is sessionId-matched: the evicted "a" cannot delete b's claim.
+  store.releaseTerminalClaim("/r", "a");
+  expect(store.claimTerminalRepo("/r", "c", t0 + 2 * TERMINAL_CLAIM_TTL_MS + 1)).toEqual({
+    ok: false,
+    existingId: null,
+  });
+  store.releaseTerminalClaim("/r", "b");
+  expect(store.claimTerminalRepo("/r", "c", t0 + 2 * TERMINAL_CLAIM_TTL_MS + 2)).toEqual({
+    ok: true,
+  });
+});
+
+test("store: the partial unique index blocks a bypass second live terminal per repo", async () => {
+  const { service, store } = makeSvc();
+  const s = await service.create(TERM_INPUT);
+  expect(() =>
+    store.create({
+      ...(store.get(s.id) as any),
+      id: crypto.randomUUID(),
+      name: "bypass",
+    }),
+  ).toThrow(); // sessions_terminal_singleton
+});
+
+test("store hydration: terminal pane target survives a restart-shaped re-read", () => {
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-terminal-hydrate-"));
+  const dbPath = join(dir, "s.db");
+  try {
+    const w = new SessionStore(dbPath);
+    const s = w.create({
+      id: crypto.randomUUID(),
+      name: "terminal-repo",
+      prompt: "",
+      repoPath: "/repo",
+      baseBranch: "",
+      branch: null,
+      worktreePath: "/repo",
+      isolated: false,
+      herdrSession: "h",
+      herdrAgentId: "term_x",
+      claudeSessionId: "",
+      terminal: true,
+      terminalTabId: "w1:t3",
+      terminalPaneId: "w1:p3",
+      model: null,
+    } as any);
+    const r = new SessionStore(dbPath); // fresh store over the same file = restart
+    const row = r.get(s.id)!;
+    expect(row.terminal).toBe(true);
+    expect(row.terminalTabId).toBe("w1:t3");
+    expect(row.terminalPaneId).toBe("w1:p3");
+    expect(r.getLiveTerminalSession("/repo")?.id).toBe(s.id);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── poller pane-liveness state machine (fail-closed, 2-sweep debounce) ────────
+
+function makeSweeper(panesImpl: () => Promise<{ paneId: string }[]>) {
+  const store = new SessionStore(":memory:");
+  const archived: string[] = [];
+  const poller = new StatusPoller(
+    store,
+    { listAsync: async () => [], panesAsync: panesImpl } as any,
+    () => {},
+    () => {},
+  );
+  (poller as any).archiveTerminal = (id: string) => archived.push(id);
+  const session = {
+    id: "t1",
+    terminal: true,
+    terminalPaneId: "w1:p7",
+  } as unknown as Session;
+  // Bypass the throttle per invocation: each call below models one due sweep.
+  const sweep = async () => {
+    (poller as any).lastTerminalSweepAt = 0;
+    await (poller as any).maybeSweepTerminalPanes([session]);
+  };
+  return { archived, sweep };
+}
+
+test("pane sweep: live pane → no archive, counter resets between misses", async () => {
+  let panes = [{ paneId: "w1:p7" }];
+  const { archived, sweep } = makeSweeper(async () => panes);
+  await sweep();
+  expect(archived).toHaveLength(0);
+  panes = []; // one miss…
+  await sweep();
+  expect(archived).toHaveLength(0); // debounced — not archived yet
+  panes = [{ paneId: "w1:p7" }]; // …pane is back → counter resets
+  await sweep();
+  panes = [];
+  await sweep();
+  expect(archived).toHaveLength(0); // a single miss after a reset never archives
+});
+
+test("pane sweep: two consecutive confirmed-gone sweeps archive exactly once", async () => {
+  const { archived, sweep } = makeSweeper(async () => []);
+  await sweep();
+  expect(archived).toHaveLength(0);
+  await sweep();
+  expect(archived).toEqual(["t1"]);
+  await sweep(); // counter was cleared on archive; a fresh double-miss would be a new episode
+  expect(archived).toEqual(["t1", "t1"].slice(0, archived.length)); // no throw either way
+});
+
+test("pane sweep: a FAILED pane listing freezes state — no archive, no counter movement", async () => {
+  let fail = true;
+  const panes: { paneId: string }[] = [];
+  const { archived, sweep } = makeSweeper(async () => {
+    if (fail) throw new Error("herdr unreachable");
+    return panes;
+  });
+  await sweep(); // gone? unknown — listing failed
+  await sweep();
+  await sweep();
+  expect(archived).toHaveLength(0); // fail-closed: three failures, zero destructive actions
+  fail = false;
+  await sweep(); // first CONFIRMED miss
+  expect(archived).toHaveLength(0);
+  await sweep(); // second confirmed miss → archive
+  expect(archived).toEqual(["t1"]);
+});

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -31,7 +31,7 @@ test("validateCreate accepts a ~ path inside repoRoot", () => {
   // repoRoot = home; repoPath '~' resolves to home (which exists & is a dir)
   const r = validateCreate({ repoPath: "~", baseBranch: "main", prompt: "go" }, homedir());
   expect(r.ok).toBe(true);
-  if (r.ok) expect(r.value.repoPath).toBe(homedir());
+  if (r.ok && r.value.terminal !== true) expect(r.value.repoPath).toBe(homedir());
 });
 
 // ── validateCreate ────────────────────────────────────────────────────────────
@@ -53,7 +53,7 @@ test("valid input returns ok with value", () => {
     root,
   );
   expect(r.ok).toBe(true);
-  if (r.ok) {
+  if (r.ok && r.value.terminal !== true) {
     expect(r.value.repoPath).toBe(validRepo);
     expect(r.value.baseBranch).toBe("main");
     expect(r.value.prompt).toBe("do the thing");
@@ -84,7 +84,7 @@ test("validateCreate accepts index-aligned attachment names and visible launch c
   );
 
   expect(r.ok).toBe(true);
-  if (r.ok) {
+  if (r.ok && r.value.terminal !== true) {
     expect(r.value.images).toEqual([upload]);
     expect(r.value.attachmentNames).toEqual(["mockup.png"]);
     expect(r.value.launchUiState).toEqual({
@@ -165,7 +165,7 @@ test("known model accepted and passed through", () => {
     root,
   );
   expect(r.ok).toBe(true);
-  if (r.ok) expect(r.value.model).toBe("opus");
+  if (r.ok && r.value.terminal !== true) expect(r.value.model).toBe("opus");
 });
 
 test("codex model accepted and passed through when provider is codex", () => {
@@ -180,7 +180,7 @@ test("codex model accepted and passed through when provider is codex", () => {
     root,
   );
   expect(r.ok).toBe(true);
-  if (r.ok) expect(r.value.model).toBe("gpt-5.5");
+  if (r.ok && r.value.terminal !== true) expect(r.value.model).toBe("gpt-5.5");
 });
 
 test("verified curated GPT-5.6 Codex model accepted when provider is codex", () => {
@@ -195,7 +195,7 @@ test("verified curated GPT-5.6 Codex model accepted when provider is codex", () 
     root,
   );
   expect(r.ok).toBe(true);
-  if (r.ok) expect(r.value.model).toBe("gpt-5.6-sol");
+  if (r.ok && r.value.terminal !== true) expect(r.value.model).toBe("gpt-5.6-sol");
 });
 
 test("future-looking safe codex model accepted when provider is codex", () => {
@@ -210,7 +210,7 @@ test("future-looking safe codex model accepted when provider is codex", () => {
     root,
   );
   expect(r.ok).toBe(true);
-  if (r.ok) expect(r.value.model).toBe("gpt-5.6-codex");
+  if (r.ok && r.value.terminal !== true) expect(r.value.model).toBe("gpt-5.6-codex");
 });
 
 test("unsafe codex model rejected", () => {
@@ -250,7 +250,7 @@ test("agentProvider accepts claude and codex", () => {
       root,
     );
     expect(r.ok).toBe(true);
-    if (r.ok) expect(r.value.agentProvider).toBe(agentProvider);
+    if (r.ok && r.value.terminal !== true) expect(r.value.agentProvider).toBe(agentProvider);
   }
 });
 
@@ -274,7 +274,7 @@ test("1M-context and pinned model aliases accepted and passed through verbatim",
       root,
     );
     expect(r.ok).toBe(true);
-    if (r.ok) expect(r.value.model).toBe(alias);
+    if (r.ok && r.value.terminal !== true) expect(r.value.model).toBe(alias);
   }
 });
 
@@ -284,7 +284,7 @@ test('model "default" normalizes to null', () => {
     root,
   );
   expect(r.ok).toBe(true);
-  if (r.ok) expect(r.value.model).toBeNull();
+  if (r.ok && r.value.terminal !== true) expect(r.value.model).toBeNull();
 });
 
 test("unknown model rejected", () => {
@@ -302,13 +302,13 @@ test("sandboxProfile: valid value accepted + passed through", () => {
     root,
   );
   expect(r.ok).toBe(true);
-  if (r.ok) expect(r.value.sandboxProfile).toBe("autonomous");
+  if (r.ok && r.value.terminal !== true) expect(r.value.sandboxProfile).toBe("autonomous");
 });
 
 test("sandboxProfile: absent → undefined (inherit repo default)", () => {
   const r = validateCreate({ repoPath: validRepo, baseBranch: "main", prompt: "go" }, root);
   expect(r.ok).toBe(true);
-  if (r.ok) expect(r.value.sandboxProfile).toBeUndefined();
+  if (r.ok && r.value.terminal !== true) expect(r.value.sandboxProfile).toBeUndefined();
 });
 
 test("sandboxProfile: invalid value rejected", () => {
@@ -326,7 +326,7 @@ test("autopilotEnabled: false accepted + passed through", () => {
     root,
   );
   expect(r.ok).toBe(true);
-  if (r.ok) expect(r.value.autopilotEnabled).toBe(false);
+  if (r.ok && r.value.terminal !== true) expect(r.value.autopilotEnabled).toBe(false);
 });
 
 test("autopilotEnabled: true accepted + passed through", () => {
@@ -335,7 +335,7 @@ test("autopilotEnabled: true accepted + passed through", () => {
     root,
   );
   expect(r.ok).toBe(true);
-  if (r.ok) expect(r.value.autopilotEnabled).toBe(true);
+  if (r.ok && r.value.terminal !== true) expect(r.value.autopilotEnabled).toBe(true);
 });
 
 test("autopilotEnabled: null accepted (inherit repo default)", () => {
@@ -344,13 +344,13 @@ test("autopilotEnabled: null accepted (inherit repo default)", () => {
     root,
   );
   expect(r.ok).toBe(true);
-  if (r.ok) expect(r.value.autopilotEnabled).toBeNull();
+  if (r.ok && r.value.terminal !== true) expect(r.value.autopilotEnabled).toBeNull();
 });
 
 test("autopilotEnabled: absent → undefined (inherit repo default)", () => {
   const r = validateCreate({ repoPath: validRepo, baseBranch: "main", prompt: "go" }, root);
   expect(r.ok).toBe(true);
-  if (r.ok) expect(r.value.autopilotEnabled).toBeUndefined();
+  if (r.ok && r.value.terminal !== true) expect(r.value.autopilotEnabled).toBeUndefined();
 });
 
 test("autopilotEnabled: non-boolean string rejected", () => {
@@ -368,7 +368,7 @@ test("research: true accepted + passed through", () => {
     root,
   );
   expect(r.ok).toBe(true);
-  if (r.ok) expect(r.value.research).toBe(true);
+  if (r.ok && r.value.terminal !== true) expect(r.value.research).toBe(true);
 });
 
 test("research: false accepted + passed through", () => {
@@ -377,13 +377,13 @@ test("research: false accepted + passed through", () => {
     root,
   );
   expect(r.ok).toBe(true);
-  if (r.ok) expect(r.value.research).toBe(false);
+  if (r.ok && r.value.terminal !== true) expect(r.value.research).toBe(false);
 });
 
 test("research: absent → false", () => {
   const r = validateCreate({ repoPath: validRepo, baseBranch: "main", prompt: "go" }, root);
   expect(r.ok).toBe(true);
-  if (r.ok) expect(r.value.research).toBe(false);
+  if (r.ok && r.value.terminal !== true) expect(r.value.research).toBe(false);
 });
 
 test("research: non-boolean string rejected", () => {
@@ -684,13 +684,13 @@ test("validateCreate accepts attachments inside the staging dir", () => {
     root,
   );
   expect(r.ok).toBe(true);
-  if (r.ok) expect(r.value.images).toEqual([img]);
+  if (r.ok && r.value.terminal !== true) expect(r.value.images).toEqual([img]);
 });
 
 test("validateCreate defaults images to [] when omitted", () => {
   const r = validateCreate({ repoPath: validRepo, baseBranch: "main", prompt: "go" }, root);
   expect(r.ok).toBe(true);
-  if (r.ok) expect(r.value.images).toEqual([]);
+  if (r.ok && r.value.terminal !== true) expect(r.value.images).toEqual([]);
 });
 
 // regression: an empty images array must NOT require the staging dir to exist.
@@ -702,7 +702,7 @@ test("validateCreate accepts an empty images array without a staging dir", () =>
     root,
   );
   expect(r.ok).toBe(true);
-  if (r.ok) expect(r.value.images).toEqual([]);
+  if (r.ok && r.value.terminal !== true) expect(r.value.images).toEqual([]);
 });
 
 test("validateCreate rejects an attachment outside the staging dir", () => {
@@ -784,13 +784,13 @@ test("validateCreate accepts a valid issueRef with an oversized body", () => {
     root,
   );
   expect(r.ok).toBe(true);
-  if (r.ok) expect(r.value.issueRef).toEqual(validIssueRef);
+  if (r.ok && r.value.terminal !== true) expect(r.value.issueRef).toEqual(validIssueRef);
 });
 
 test("validateCreate defaults issueRef to undefined when omitted", () => {
   const r = validateCreate({ repoPath: validRepo, baseBranch: "main", prompt: "go" }, root);
   expect(r.ok).toBe(true);
-  if (r.ok) expect(r.value.issueRef).toBeUndefined();
+  if (r.ok && r.value.terminal !== true) expect(r.value.issueRef).toBeUndefined();
 });
 
 test("validateCreate rejects an issueRef with a non-positive number", () => {
@@ -1359,7 +1359,35 @@ test("mergeTrainPrs: [1, 2, 3] accepted", () => {
     root,
   );
   expect(r.ok).toBe(true);
-  if (r.ok) expect(r.value.mergeTrainPrs).toEqual([1, 2, 3]);
+  if (r.ok && r.value.terminal !== true) expect(r.value.mergeTrainPrs).toEqual([1, 2, 3]);
+});
+
+// ── clean-terminal union arm ───────────────────────────────────────────────────
+
+test("terminal arm: the exact payload {repoPath, terminal: true} yields the TerminalCreateInput", () => {
+  const r = validateCreate({ repoPath: validRepo, terminal: true }, root);
+  expect(r.ok).toBe(true);
+  if (r.ok) expect(r.value).toEqual({ terminal: true, repoPath: validRepo });
+});
+
+test("terminal arm: stray standard fields are unknown-key rejections, never silently ignored", () => {
+  for (const extra of [{ prompt: "hi" }, { baseBranch: "main" }, { model: null }, { auto: true }]) {
+    const r = validateCreate({ repoPath: validRepo, terminal: true, ...extra }, root);
+    expect(r.ok).toBe(false);
+  }
+});
+
+test("terminal arm: terminal must be true when present (false is not a standard create)", () => {
+  const r = validateCreate(
+    { repoPath: validRepo, terminal: false, prompt: "x", baseBranch: "main" },
+    root,
+  );
+  expect(r.ok).toBe(false);
+});
+
+test("terminal arm: repoPath is still fully validated (outside root rejects)", () => {
+  const r = validateCreate({ repoPath: "/etc", terminal: true }, root);
+  expect(r.ok).toBe(false);
 });
 
 // ── validateModelChoice / validateReplaceAgentChoice: effort (#1418) ─────────

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3547,5 +3547,14 @@
   "viewport_preview_stop_unsupported": "Dieser Host kann Devserver-Prozessen kein Signal senden; es wurde nichts gestoppt. Stoppe ihn stattdessen im Terminal der Session.",
   "viewport_preview_stop_refused": "Der Prozess hinter dem Vorschau-Port ließ sich nicht bestätigen; es wurde kein Signal gesendet. Versuche es gleich noch einmal.",
   "feat_macos_preview_stop_title": "Devserver unter macOS stoppen",
-  "feat_macos_preview_stop_body": "„Devserver stoppen\" funktioniert jetzt unter macOS. Bisher passierte dort nichts: Shepherd liest macOS-Prozesse aus einem periodischen Snapshot, und ein Snapshot kann nicht ausschließen, dass der gesehene Prozess inzwischen beendet und seine ID neu vergeben wurde — also wurde lieber kein Signal gesendet, als den falschen Prozess zu treffen. Shepherd prüft den Prozess jetzt unmittelbar vor dem Signal erneut und verweigert nur, wenn diese Prüfung nicht möglich ist — und sagt dir das, statt zu melden, es liefe nichts. Auch der Idle-Stop gibt untätige Vorschauen unter macOS wieder frei."
+  "feat_macos_preview_stop_body": "„Devserver stoppen\" funktioniert jetzt unter macOS. Bisher passierte dort nichts: Shepherd liest macOS-Prozesse aus einem periodischen Snapshot, und ein Snapshot kann nicht ausschließen, dass der gesehene Prozess inzwischen beendet und seine ID neu vergeben wurde — also wurde lieber kein Signal gesendet, als den falschen Prozess zu treffen. Shepherd prüft den Prozess jetzt unmittelbar vor dem Signal erneut und verweigert nur, wenn diese Prüfung nicht möglich ist — und sagt dir das, statt zu melden, es liefe nichts. Auch der Idle-Stop gibt untätige Vorschauen unter macOS wieder frei.",
+  "cardmenu_clean_terminal": "Clean-Terminal im Main-Repo",
+  "repo_chip_clean_terminal": "Clean-Terminal im Main-Repo",
+  "terminal_badge_label": "Terminal",
+  "terminal_badge_title": "Clean-Terminal: eine nackte Shell im Haupt-Checkout des Repos (ohne Agent)",
+  "toast_terminal_failed": "Clean-Terminal konnte nicht geöffnet werden",
+  "toast_terminal_unsupported": "Clean-Terminals brauchen ein neueres herdr — herdr aktualisieren und erneut versuchen",
+  "toast_broadcast_skipped_terminals": "{skipped} Terminal-Session(s) übersprungen — Terminals erhalten keine Steers",
+  "feat_clean_terminal_title": "Clean-Terminal im Main-Repo",
+  "feat_clean_terminal_body": "Rechtsklick auf eine Session-Zeile oder einen Repo-Chip und „Clean-Terminal im Main-Repo“ wählen: Eine nackte Shell öffnet sich direkt im Haupt-Checkout des Repos (kein Worktree, kein Agent) — für schnelle Git- und CLI-Handgriffe. Ein Terminal pro Repo; erneutes Wählen fokussiert das bestehende. Beim Beenden der Shell archiviert sich die Session selbst."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3547,5 +3547,14 @@
   "viewport_preview_stop_unsupported": "This host can't signal dev-server processes, so nothing was stopped. Stop it from the session's terminal instead.",
   "viewport_preview_stop_refused": "Couldn't confirm which process holds the preview port, so nothing was signalled. Try again in a moment.",
   "feat_macos_preview_stop_title": "Stop a dev server on macOS",
-  "feat_macos_preview_stop_body": "Stop dev server now works on macOS. It was previously a no-op there: Shepherd reads macOS processes from a periodic snapshot, and a snapshot can't rule out that the process it saw has since exited and its id been reused, so it refused to send a signal rather than risk hitting the wrong one. Shepherd now re-checks the process right before signalling it, and refuses only when that check can't be made — telling you so instead of reporting that nothing was running. Idle-stop reclaims idle previews on macOS too."
+  "feat_macos_preview_stop_body": "Stop dev server now works on macOS. It was previously a no-op there: Shepherd reads macOS processes from a periodic snapshot, and a snapshot can't rule out that the process it saw has since exited and its id been reused, so it refused to send a signal rather than risk hitting the wrong one. Shepherd now re-checks the process right before signalling it, and refuses only when that check can't be made — telling you so instead of reporting that nothing was running. Idle-stop reclaims idle previews on macOS too.",
+  "cardmenu_clean_terminal": "Clean terminal in main repo",
+  "repo_chip_clean_terminal": "Clean terminal in main repo",
+  "terminal_badge_label": "Terminal",
+  "terminal_badge_title": "Clean terminal: a bare shell in the repo's main checkout (no agent)",
+  "toast_terminal_failed": "Couldn't open the clean terminal",
+  "toast_terminal_unsupported": "Clean terminals need a newer herdr — update herdr and retry",
+  "toast_broadcast_skipped_terminals": "{skipped} terminal session(s) skipped — terminals receive no steers",
+  "feat_clean_terminal_title": "Clean terminal in the main repo",
+  "feat_clean_terminal_body": "Right-click a session row or a repo chip and pick “Clean terminal in main repo”: a bare shell opens directly in the repo's main checkout (not a worktree, no agent) — for quick git and CLI work. One terminal per repo; picking it again focuses the existing one. Exit the shell and the session archives itself."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1794,7 +1794,14 @@ export async function putSteers(steers: Steer[]): Promise<Steer[]> {
 export async function broadcast(
   text: string,
   ids: string[],
-): Promise<{ delivered: number; queued: number; offline: number; total: number }> {
+): Promise<{
+  delivered: number;
+  queued: number;
+  offline: number;
+  /** Clean-terminal targets excluded from delivery (additive; absent on older servers). */
+  skipped?: number;
+  total: number;
+}> {
   const r = await fetch("/api/broadcast", {
     method: "POST",
     headers: JSON_HEADERS,

--- a/ui/src/lib/components/BroadcastDialog.svelte
+++ b/ui/src/lib/components/BroadcastDialog.svelte
@@ -94,6 +94,13 @@
     failed = false;
     try {
       const r = await apiBroadcast(text.trim(), [...selected]);
+      if (r.delivered + r.queued === 0 && (r.skipped ?? 0) > 0 && r.offline === 0) {
+        // Every selected target was a clean terminal — nothing can receive a steer, but that
+        // is a deliberate skip, not a delivery failure.
+        toasts.info(m.toast_broadcast_skipped_terminals({ skipped: r.skipped ?? 0 }));
+        onclose();
+        return;
+      }
       if (r.delivered + r.queued === 0) {
         // Nothing reached any agent (all targets offline/dead-pane) — a literal no-op.
         // Surface it like a failure so the dialog stays open with Retry, not a "sent 0" toast.
@@ -105,6 +112,9 @@
       // Confirmation outlives the dialog: a toast names the reach after close. Honest about
       // queued-on-busy (those agents act only after their current turn) so a busy-herd
       // broadcast no longer reads as a no-op.
+      if ((r.skipped ?? 0) > 0) {
+        toasts.info(m.toast_broadcast_skipped_terminals({ skipped: r.skipped ?? 0 }));
+      }
       if (r.queued === 0 && r.offline === 0) {
         toasts.info(m.toast_broadcast_delivered({ delivered: r.delivered }));
       } else {

--- a/ui/src/lib/components/CardMenu.svelte
+++ b/ui/src/lib/components/CardMenu.svelte
@@ -19,6 +19,7 @@
     onrelaunchElsewhere,
     onvariant,
     onreplace,
+    oncleanTerminal,
     ondecommission,
     onclose,
   }: {
@@ -50,6 +51,9 @@
     // provider/model picker (its explicit confirm is the confirmation, so no two-step arm here)
     onvariant?: () => void;
     onreplace?: () => void;
+    // when provided, a "Clean terminal in main repo" item appears — opens (or focuses) the
+    // repo's bare-shell session in the MAIN checkout; one-click, the action is cheap+reversible
+    oncleanTerminal?: () => void;
     ondecommission?: () => void;
     onclose: () => void;
   } = $props();
@@ -243,6 +247,11 @@
   {#if onreplace}
     <button class="cm-item" type="button" role="menuitem" tabindex="-1" onclick={onreplace}>
       <span class="cm-icon" aria-hidden="true">⇆</span>{m.cardmenu_replace_with()}
+    </button>
+  {/if}
+  {#if oncleanTerminal}
+    <button class="cm-item" type="button" role="menuitem" tabindex="-1" onclick={oncleanTerminal}>
+      <span class="cm-icon" aria-hidden="true">❯</span>{m.cardmenu_clean_terminal()}
     </button>
   {/if}
   {#if ondecommission}

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -60,6 +60,7 @@
     ondecommission,
     onrelaunch = undefined,
     onrelaunchElsewhere = undefined,
+    oncleanTerminal = undefined,
     onvariant = undefined,
     onreplace = undefined,
     oncompare = undefined,
@@ -141,6 +142,8 @@
     onrelaunch?: (id: string) => void;
     // when provided, each row's CardMenu gains a one-click "Relaunch elsewhere" item
     onrelaunchElsewhere?: (id: string) => void;
+    // when provided, each row's CardMenu gains a "Clean terminal in main repo" item
+    oncleanTerminal?: (repoPath: string) => void;
     // when provided, each row's CardMenu gains "Start as variant…" / "Continue with…" items
     onvariant?: (id: string, anchor: { x: number; y: number }) => void;
     onreplace?: (id: string, anchor: { x: number; y: number }) => void;
@@ -422,6 +425,7 @@
     onrelaunchElsewhere,
     onvariant,
     onreplace,
+    oncleanTerminal,
     repoFilter,
     onrepofilter,
     workingBlocked,

--- a/ui/src/lib/components/RepoSwitcher.browser.test.ts
+++ b/ui/src/lib/components/RepoSwitcher.browser.test.ts
@@ -487,7 +487,7 @@ describe("RepoSwitcher — filter rail", () => {
     );
 
     const items = [...document.querySelectorAll<HTMLElement>(".rs-menu-item")];
-    expect(items.length).toBe(4);
+    expect(items.length).toBe(5);
     // The open effect focuses the first item.
     expect(document.activeElement).toBe(items[0]);
 
@@ -496,11 +496,11 @@ describe("RepoSwitcher — filter rail", () => {
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
     expect(document.activeElement).toBe(items[2]);
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
-    expect(document.activeElement).toBe(items[3]);
+    expect(document.activeElement).toBe(items[4]);
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "Home", bubbles: true }));
     expect(document.activeElement).toBe(items[0]);
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }));
-    expect(document.activeElement).toBe(items[3]);
+    expect(document.activeElement).toBe(items[4]);
 
     // Escape still closes.
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));

--- a/ui/src/lib/components/RepoSwitcher.svelte
+++ b/ui/src/lib/components/RepoSwitcher.svelte
@@ -17,6 +17,7 @@
     pinnedRepo = null,
     onrepofilter,
     onpinrepo = () => {},
+    oncleanterminal = () => {},
     mobile = false,
   }: {
     chips: RepoChip[];
@@ -29,6 +30,8 @@
     onrepofilter: (repoPath: string, additive: boolean) => void;
     // pin or unpin a repo in the switcher; null clears the pin
     onpinrepo?: (repoPath: string | null) => void;
+    // open (or focus) the repo's clean-terminal session — a bare shell in the MAIN checkout
+    oncleanterminal?: (repoPath: string) => void;
     // true when rendered on a phone-sized viewport — suppresses the lone-repo
     // telemetry band (collapses into the selected-state subline instead)
     mobile?: boolean;
@@ -269,6 +272,13 @@
     closeMenu();
   }
 
+  function commitCleanTerminal() {
+    if (!menu) return;
+    const { repoPath } = menu.chip;
+    closeMenu();
+    oncleanterminal(repoPath);
+  }
+
   function openAutomation() {
     if (!menu) return;
     // AutomationPanel is right-aligned to its positioned parent. Put that parent
@@ -483,6 +493,15 @@
       onclick={openAutomation}
     >
       <span class="rs-menu-icon" aria-hidden="true">⚙</span>{m.repo_chip_automation_settings()}
+    </button>
+    <button
+      class="rs-menu-item"
+      type="button"
+      role="menuitem"
+      tabindex="-1"
+      onclick={commitCleanTerminal}
+    >
+      <span class="rs-menu-icon" aria-hidden="true">❯</span>{m.repo_chip_clean_terminal()}
     </button>
     {#if menuRepoWeb?.repoPath === menu.chip.repoPath && menuRepoWeb.kind === "github" && menuRepoWeb.webUrl}
       <!-- eslint-disable svelte/no-navigation-without-resolve -- external GitHub URL, not an app route -->

--- a/ui/src/lib/components/TerminalBadge.svelte
+++ b/ui/src/lib/components/TerminalBadge.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import type { Session } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  import { statusTip } from "$lib/actions/statusTip.svelte";
+
+  // `tip` (Herd card only): swap the native title for the styled statusTip tooltip.
+  let { session, tip = false }: { session: Session; tip?: boolean } = $props();
+</script>
+
+{#if session.terminal}
+  <span
+    class="terminal-badge"
+    role="img"
+    aria-label={m.terminal_badge_label()}
+    title={tip ? undefined : m.terminal_badge_title()}
+    use:statusTip={tip ? { text: m.terminal_badge_title() } : null}
+  >
+    {m.terminal_badge_label()}
+  </span>
+{/if}
+
+<style>
+  /* Quiet informational kind-marker — same "noted info" tier as the research badge
+     (slate, never green: green is reserved for READY). */
+  .terminal-badge {
+    font-size: var(--fs-micro);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 1px 6px;
+    border: 1px solid var(--color-slate);
+    border-radius: 2px;
+    color: var(--color-slate);
+    white-space: nowrap;
+    font-weight: 600;
+  }
+</style>

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -72,6 +72,7 @@
     onrelaunchElsewhere,
     onvariant,
     onreplace,
+    oncleanTerminal,
     repoFilter = undefined,
     onrepofilter,
     workingBlocked = {},
@@ -110,6 +111,9 @@
     // the provider/model picker anchored at the passed coords (comparison experiments)
     onvariant?: (id: string, anchor: { x: number; y: number }) => void;
     onreplace?: (id: string, anchor: { x: number; y: number }) => void;
+    // when provided, the CardMenu gains a "Clean terminal in main repo" item (repo-scoped:
+    // the handler receives repoPath, not the session id). Hidden on a terminal row itself.
+    oncleanTerminal?: (repoPath: string) => void;
     // active page-level repo filter (selected repo paths); drives the icon's pressed state
     repoFilter?: ReadonlySet<string>;
     // when provided, clicking the inline repo emoji scopes the herd to this repo. Always a
@@ -592,11 +596,17 @@
   // it is stoppable too. Everything else (idle / blocked-not-working / done / archived) has no turn
   // to cut short, and its pane may well be gone. Like Merge PR the endpoint is session-scoped, so
   // no parent callback is threaded — the row calls it and toasts the outcome itself.
-  const stoppable = $derived(dStatus === "running");
+  // A clean-terminal session's status never advances (no agent to reconcile), so it would
+  // read "running" forever — and its pane must never receive the stop ESC anyway.
+  const stoppable = $derived(dStatus === "running" && !session.terminal);
   // Resolved here rather than as a ternary in the <CardMenu> tag: UnitRow's template sits at its
   // grandfathered complexity cap (#855), and every inline conditional in the markup counts against
   // it. undefined is what hides the menu item.
   const onStop = $derived(stoppable ? stopFromMenu : undefined);
+  // Same cap rationale: resolve the clean-terminal item outside the template. Hidden on a
+  // terminal row (focusing itself is pointless).
+  const cleanTerminalAble = $derived(!!oncleanTerminal && !session.terminal);
+  const onCleanTerminal = $derived(cleanTerminalAble ? cleanTerminalFromMenu : undefined);
   let hitEl = $state<HTMLButtonElement>();
   let elapsedEl = $state<HTMLSpanElement>();
   let menu = $state<{ x: number; y: number; opener: HTMLElement } | null>(null);
@@ -611,7 +621,8 @@
       relaunchable ||
       relaunchElsewhereAble ||
       variantable ||
-      replaceable,
+      replaceable ||
+      cleanTerminalAble,
   );
   function openMenuAt(x: number, y: number): boolean {
     if (menu || !hasMenu) return false;
@@ -694,6 +705,11 @@
     menu = null;
     onrelaunch?.(session.id);
   }
+  function cleanTerminalFromMenu() {
+    menu = null;
+    oncleanTerminal?.(session.repoPath);
+  }
+
   function relaunchElsewhereFromMenu() {
     menu = null;
     onrelaunchElsewhere?.(session.id);
@@ -999,6 +1015,7 @@
     onrelaunchElsewhere={relaunchElsewhereAble ? relaunchElsewhereFromMenu : undefined}
     onvariant={variantable ? variantFromMenu : undefined}
     onreplace={replaceable ? replaceFromMenu : undefined}
+    oncleanTerminal={onCleanTerminal}
     ondecommission={ondecommission ? decommissionFromMenu : undefined}
     onclose={() => (menu = null)}
   />

--- a/ui/src/lib/components/herd/HerdGroup.svelte
+++ b/ui/src/lib/components/herd/HerdGroup.svelte
@@ -16,6 +16,7 @@
     onrename?: (id: string) => void;
     onrelaunch?: (id: string) => void;
     onrelaunchElsewhere?: (id: string) => void;
+    oncleanTerminal?: (repoPath: string) => void;
     onvariant?: (id: string, anchor: { x: number; y: number }) => void;
     onreplace?: (id: string, anchor: { x: number; y: number }) => void;
     repoFilter: ReadonlySet<string>;
@@ -120,6 +121,7 @@
       onrename={ctx.onrename}
       onrelaunch={ctx.onrelaunch}
       onrelaunchElsewhere={ctx.onrelaunchElsewhere}
+      oncleanTerminal={ctx.oncleanTerminal}
       onvariant={ctx.onvariant}
       onreplace={ctx.onreplace}
       repoFilter={ctx.repoFilter}

--- a/ui/src/lib/components/merge-train.ts
+++ b/ui/src/lib/components/merge-train.ts
@@ -1,5 +1,5 @@
 import { m } from "$lib/paraglide/messages";
-import type { Session, GitState, CreateInput } from "$lib/types";
+import type { Session, GitState, StandardCreateInput } from "$lib/types";
 
 /** Safety backstop, NOT the authoritative TTL. The server keeps a merge mark for
  *  the life of the train and clears it authoritatively on merge/close/archive, so
@@ -109,7 +109,7 @@ export function mergeTrainCreateInput(
   baseBranch: string,
   prs: Pick<ReadyPr, "number" | "title" | "url">[],
   handpicked = false,
-): CreateInput {
+): StandardCreateInput {
   const formatted = formatReadyPrs(prs);
   return {
     repoPath,

--- a/ui/src/lib/components/unit-row/UnitRowRight.svelte
+++ b/ui/src/lib/components/unit-row/UnitRowRight.svelte
@@ -4,6 +4,7 @@
   import { isMerging } from "../merge-train";
   import { m } from "$lib/paraglide/messages";
   import ResearchBadge from "../ResearchBadge.svelte";
+  import TerminalBadge from "../TerminalBadge.svelte";
   import PrBadge from "../PrBadge.svelte";
   import CriticBadge from "../CriticBadge.svelte";
   import BuildQueueBadge from "../BuildQueueBadge.svelte";
@@ -162,6 +163,7 @@
     </span>
   {/if}
   <ResearchBadge {session} tip />
+  <TerminalBadge {session} tip />
   {#if !stepperTerminal}<PrBadge {git} sessionId={session.id} />{/if}
   <CriticBadge sessionId={session.id} tip prUrl={git?.url} />
   <BuildQueueBadge

--- a/ui/src/lib/feature-announcements/entries/v1.47.0-clean-terminal.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.47.0-clean-terminal.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "clean-terminal",
+  sinceVersion: "1.47.0",
+  titleKey: "feat_clean_terminal_title",
+  bodyKey: "feat_clean_terminal_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/format.test.ts
+++ b/ui/src/lib/format.test.ts
@@ -11,6 +11,7 @@ import {
   canRelaunch,
   canReplaceAgent,
   waitTier,
+  cleanTerminalCreateInput,
 } from "./format";
 import type { Session, SessionStatus, GitState } from "./types";
 
@@ -323,4 +324,20 @@ describe("heartbeatTone", () => {
   for (const [ms, out] of cases) {
     it(`${ms}ms → ${out}`, () => expect(heartbeatTone(ms)).toBe(out));
   }
+});
+
+describe("cleanTerminalCreateInput", () => {
+  it("pins the EXACT wire payload — {repoPath, terminal: true} and no other keys", () => {
+    const input = cleanTerminalCreateInput("/repo/x");
+    expect(input).toEqual({ repoPath: "/repo/x", terminal: true });
+    expect(Object.keys(input).sort()).toEqual(["repoPath", "terminal"]);
+    // The POST body the handler sends is exactly this JSON — no prompt, no baseBranch.
+    expect(JSON.parse(JSON.stringify(input))).toEqual({ repoPath: "/repo/x", terminal: true });
+  });
+});
+
+describe("terminal sessions are fenced out of agent-verb affordances", () => {
+  const term = { terminal: true, status: "running", agentProvider: "claude" } as never;
+  it("canResume refuses a terminal session", () => expect(canResume(term)).toBe(false));
+  it("canRelaunch refuses a terminal session", () => expect(canRelaunch(term)).toBe(false));
 });

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -1,5 +1,5 @@
 import { m } from "$lib/paraglide/messages";
-import type { Session, SessionStatus, GitState, LivenessState } from "./types";
+import type { Session, SessionStatus, GitState, LivenessState, TerminalCreateInput } from "./types";
 import { isMerging } from "./components/merge-train";
 
 /**
@@ -18,6 +18,7 @@ import { isMerging } from "./components/merge-train";
  * regardless.
  */
 export function canResume(s: Session, liveness?: LivenessState): boolean {
+  if (s.terminal) return false; // a clean terminal has no agent to resume (server fences it too)
   const provider = s.agentProvider ?? "claude";
   return (
     (provider === "codex" || !!s.claudeSessionId) &&
@@ -45,7 +46,14 @@ export function isStrandedLiveness(liveness?: LivenessState): boolean {
  * operator may legitimately redo it. The server independently 409s an already-archived
  * original; this gate is the UI affordance.
  */
+/** The EXACT clean-terminal create payload — `{repoPath, terminal: true}` and nothing else.
+ *  Single source of the wire shape so the handler and its payload-pin test cannot drift. */
+export function cleanTerminalCreateInput(repoPath: string): TerminalCreateInput {
+  return { repoPath, terminal: true };
+}
+
 export function canRelaunch(s: Session, git?: GitState, now: number = Date.now()): boolean {
+  if (s.terminal) return false; // relaunch/variant/replace are agent verbs (server fences them)
   if (s.readyToMerge || s.autopilotComplete) return false;
   if (git?.state === "merged") return false;
   if (isMerging(s, now)) return false;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1090,6 +1090,13 @@ export interface Session {
   sandboxDegraded: boolean;
   /** Research task kind: web research → report PR or issue; never code-PR-steered. */
   research: boolean;
+  /** Clean-terminal kind: a bare operator shell in the repo's MAIN checkout (pane-direct, no
+   *  agent, no worktree). Optional like the server mirror — absent and false are equivalent. */
+  terminal?: boolean;
+  /** herdr tab hosting the clean-terminal shell; null/absent on non-terminal sessions. */
+  terminalTabId?: string | null;
+  /** herdr pane of the clean-terminal shell (socket attach target); null/absent otherwise. */
+  terminalPaneId?: string | null;
   /** Epic-authoring task kind: attended guided shaping → an EPIC draft; writes no GitHub issues. */
   epicAuthoring: boolean;
   /** True when the network-egress allowlist was applied (autonomous sessions only). */
@@ -2028,7 +2035,19 @@ export interface SessionLaunchMetadata {
   agent: { provider: AgentProvider; model: string | null; effort: string | null };
 }
 
-export interface CreateInput {
+/** Create input mirrors the server's discriminated union (src/types.ts): the terminal arm has
+ *  no prompt/baseBranch members at all, the standard arm is the pre-union shape unchanged. */
+export type CreateInput = StandardCreateInput | TerminalCreateInput;
+
+/** A clean-terminal create: bare operator shell in the repo's main checkout. Nothing else. */
+export interface TerminalCreateInput {
+  terminal: true;
+  repoPath: string;
+}
+
+export interface StandardCreateInput {
+  /** Discriminant: absent/false = a normal agent session. */
+  terminal?: false;
   repoPath: string;
   baseBranch: string;
   prompt: string;
@@ -2052,7 +2071,7 @@ export interface CreateInput {
 export interface HeldTask {
   id: string;
   repoPath: string;
-  input: CreateInput;
+  input: StandardCreateInput;
   createdAt: number;
 }
 

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script module lang="ts">
   import { relaunchOverrides } from "./relaunch-payload";
+  import { cleanTerminalCreateInput } from "$lib/format";
 </script>
 
 <script lang="ts">
@@ -2146,6 +2147,37 @@
   // Relaunch elsewhere: open the New Task composer pre-filled from this session so the
   // operator can pick a different repo / base branch / prompt before submitting. The
   // submit routes through onsubmit's relaunch branch (relaunchOriginalId set).
+  // Clean terminal (right-click item on session rows + repo chips): ONE bare-shell session
+  // per repo in its MAIN checkout — focus the live one when present, else create. On the 409
+  // race (another tab/operator won the singleton) the new row arrives via the session:new
+  // push, so a store re-lookup usually resolves it; otherwise surface the coded toast.
+  async function openCleanTerminal(repoPath: string) {
+    const live = store.sessions.find((s) => s.terminal && s.repoPath === repoPath);
+    if (live) {
+      selectNewSession(live.id, repoPath);
+      return;
+    }
+    try {
+      const r = await createSession(cleanTerminalCreateInput(repoPath));
+      if (!("held" in r)) selectNewSession(r.id, repoPath);
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 409) {
+        const s = store.sessions.find((x) => x.terminal && x.repoPath === repoPath);
+        if (s) {
+          selectNewSession(s.id, repoPath);
+          return;
+        }
+      }
+      const slug = e instanceof ApiError && e.serverAuthored ? e.message : null;
+      toasts.info(
+        slug === "terminal_unsupported"
+          ? m.toast_terminal_unsupported()
+          : m.toast_terminal_failed(),
+        { alert: true },
+      );
+    }
+  }
+
   async function onrelaunchElsewhere(id: string) {
     const s = store.sessions.find((x) => x.id === id);
     if (!s) return;
@@ -2716,6 +2748,7 @@
         mobile={mobile.current}
         onrepofilter={applyRepoFilter}
         onpinrepo={setPinnedRepo}
+        oncleanterminal={openCleanTerminal}
       />
       <QueueStrip autoMerge={store.autoMerge} onselect={jumpToSession} />
     </header>
@@ -2769,6 +2802,7 @@
             ondecommission={onarchive}
             {onrelaunch}
             {onrelaunchElsewhere}
+            oncleanTerminal={openCleanTerminal}
             {onvariant}
             {onreplace}
             {oncompare}
@@ -2931,6 +2965,7 @@
               ondecommission={onarchive}
               {onrelaunch}
               {onrelaunchElsewhere}
+              oncleanTerminal={openCleanTerminal}
               {onvariant}
               {onreplace}
               {oncompare}


### PR DESCRIPTION
## What

Right-click a **session row** or a **repo chip** → **"Clean terminal in main repo"**: a bare operator shell (\`$SHELL\`) opens directly in the repo's **main checkout** — not a worktree, no agent, no prompt — visible and usable in the web UI like any session terminal. One clean terminal per repo: picking it again focuses the existing one. Exit the shell and the session auto-archives.

## Design (probe-verified against live herdr 0.7.5)

- **Pane-direct, no \`agent start\`**: herdr 0.7.5's \`agent start\` only hosts known agent CLIs, and \`agent attach\` refuses agentless panes (\`agent_not_found\`) — both verified live. So the shell comes from \`tab create --cwd <repoPath>\` (the root pane IS an interactive shell; the reply's cwd is asserted, mismatch → tab rollback), and the browser attaches through the **pane-level socket transport** (\`terminal session control\`), with the node-pty fallback disabled for this kind. Shepherd spawns no process at all; \`SESSION_MARKER_ENV\` rides \`tab create --env\`.
- **Discriminated union create**: \`TerminalCreateInput = { repoPath, terminal: true }\` — no \`prompt\`/\`baseBranch\` members exist to misuse; ordinary creates are untouched. Exact wire payload pinned by tests on both sides.
- **Atomic singleton**: a \`terminal_claims\` heartbeat lease (renew 5s / reclaim >30s stale) is taken in one DB transaction **before** any herdr call — a losing racer never spawns; \`sessions_terminal_singleton\` (partial unique index on live terminal rows) is the durable backstop. The 409 carries \`existingId\` so the UI focuses instead.
- **herdr.send invariant**: a terminal session never receives agent input — funnel guard in \`sendSteerTo\`, per-verb 409s (resume/relaunch/replace/reply/preview/interrupt/restore), \`broadcast\` skips terminals with an additive \`skipped\` count, \`retryHalted\` skips, \`haltAll\` filters before matching.
- **Lifecycle**: poller exempts terminals from agent reconcile / claude-liveness / auto-revive (a shell would otherwise read husk-stranded and get "revived"); a **fail-closed** \`panesAsync\` sweep auto-archives after two consecutive confirmed-gone sweeps; recap exempt; decommission closes the persisted \`terminalTabId\` (main repo untouched — no worktree reap); create preflight fails closed on a herdr without pane control.

## Tests

- New \`test/terminal-session.test.ts\` (15): create contract + row shape, preflight fail-closed, singleton + parked-spawn concurrency race, cwd-mismatch rollback, all verb fences, restore-with-newer-live edge, zero-\`herdr.send\` invariant across broadcast/retryHalted/haltAll, teardown, lease TTL/renew/release semantics, unique-index bypass, restart-shaped store hydration, pane-sweep live/gone/failure state machine.
- \`test/validate.test.ts\`: terminal-arm exact payload, unknown-key rejections, standard-create regression pins.
- UI: exact-payload pin via \`cleanTerminalCreateInput\` + \`canResume\`/\`canRelaunch\` fences (\`format.test.ts\`), RepoSwitcher menu roving updated for the 5th item.
- Suites: root 8356 pass / UI 4539 pass; lint, svelte-check, check:i18n (EN+DE), glossary, feature-catalog + announcement-version gates all green.

Feature-catalog entry: \`v1.47.0-clean-terminal.ts\` (EN+DE announcement).

Plan-gate: implemented per the 5-round-reviewed \`.shepherd-plan.md\` (design pivoted to pane-direct after the live herdr probe).