### PR TITLE
fix(critic): carry the verdict body as a markdown sidecar

### DIFF
--- a/src/codex-last-message.ts
+++ b/src/codex-last-message.ts
@@ -103,10 +103,18 @@ export function readRoleResultText(
  * race must not block the spawn). Harmless for base-checkout reviewers (the plan reviewer detaches at
  * the trusted base) — a defense-in-depth no-op there.
  */
-export function scrubStaleVerdictArtifacts(worktreePath: string, resultFile: string): void {
-  try {
-    rmSync(join(worktreePath, resultFile), { force: true });
-  } catch {
-    /* best-effort — a pre-seed we can't remove still fails closed via the read path's validators */
+export function scrubStaleVerdictArtifacts(worktreePath: string, ...resultFiles: string[]): void {
+  // Variadic so a role with more than one fixed-name artifact scrubs them in ONE call: the critic
+  // now also writes a sidecar body (`VERDICT_BODY_FILE`), and a second call site is exactly the kind
+  // of thing a later change forgets to add. A pre-seeded sidecar cannot fake a verdict on its own
+  // (the read still requires a parseable verdict JSON), but it WOULD be spliced in as the body of a
+  // genuine run and posted to the PR as the critic's review — attacker-authored prose under
+  // Shepherd's name. Same fixed name, same untrusted checkout, same scrub.
+  for (const f of resultFiles) {
+    try {
+      rmSync(join(worktreePath, f), { force: true });
+    } catch {
+      /* best-effort — a pre-seed we can't remove still fails closed via the read path's validators */
+    }
   }
 }

--- a/src/critic-core.ts
+++ b/src/critic-core.ts
@@ -6,6 +6,8 @@
  * streak/notes/publish control flow, which stays there.
  */
 import { readRoleResultText, codexLastMessageFile } from "./codex-last-message";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { execFileSync, timedAsync } from "./instrument";
@@ -713,10 +715,21 @@ function scopeAndOutputTail(
     '- At most 5 NEW findings per review, highest-severity first. This is a PRIORITISATION instruction, never a limit that may lose information: if more than 5 genuine blocking problems exist, emit ALL of them and say so in "summary" (the change needs reworking, not tweaking). NEVER move a blocking problem into `Nits (non-blocking):`, and never drop one, to fit the budget.',
     "- Re-raised prior findings do NOT count against those 5.",
     "",
-    "When done, write your verdict as JSON to the file `.shepherd-review.json` in the repository root, with EXACTLY this shape:",
-    '{"decision": "request-changes" | "comment", "summary": "<=100 char one-liner", "body": "<full markdown review>", "findings": ["<discrete actionable item>", ...]}',
+    "When done, write TWO files in the repository root:",
+    // Binds the term once: every rule above says `"body"` (sections, citations, stated limitations),
+    // and they all now resolve to this file. Cheaper and less drift-prone than restating ~10 rules.
+    '1. `.shepherd-review.md` — your full markdown review. Everywhere these instructions say "body" — the named sections, the `path:line` citations, the stated limitations — they mean THIS file. It is NOT JSON: write the prose directly, escape nothing, quote however you like.',
+    "2. `.shepherd-review.json` — the structured verdict, with EXACTLY this shape:",
+    '{"decision": "request-changes" | "comment", "summary": "<=100 char one-liner", "findings": ["<discrete actionable item>", ...]}',
+    // #2042: the body used to live inside this JSON. A single unescaped `"` before a `:` or `,` —
+    // which German `„…":` prose produces constantly — is indistinguishable from a real key/value
+    // boundary, so it silently destroyed complete verdicts. Keeping the prose out of JSON entirely
+    // is the only fix that cannot regress; the note below keeps the remaining escaping honest.
+    'Escaping matters ONLY in the JSON file, and it is short: inside "summary" and each "findings" entry every `"` must be written `\\"`. If that feels error-prone, phrase them without quotation marks — the markdown file is where quoting is free.',
     'The "findings" array lists every discrete change the author must make — one entry per point, routed per FINDINGS ROUTING above. Use [] when everything you found is non-blocking (report those in the body sections named above) or there is genuinely nothing to address; "request-changes" requires at least one finding.',
-    'Use "request-changes" ONLY for blocking problems (does not satisfy the task, logic bug, security hole). Otherwise use "comment". Never approve. Write the file as your final action, then stop.',
+    // Ordering is load-bearing: the server finalizes as soon as the JSON parses, so the JSON must be
+    // written LAST — otherwise a tick landing between the two writes finalizes with an empty body.
+    'Use "request-changes" ONLY for blocking problems (does not satisfy the task, logic bug, security hole). Otherwise use "comment". Never approve. Write `.shepherd-review.md` FIRST and `.shepherd-review.json` LAST — the JSON file is the completion signal — then stop.',
   ];
 }
 
@@ -724,6 +737,22 @@ function scopeAndOutputTail(
  *  sites can scrub a pre-seeded copy from the untrusted checkout before launch (see
  *  scrubStaleVerdictArtifacts). */
 export const VERDICT_FILE = ".shepherd-review.json";
+
+/** The critic's verdict BODY, written beside {@link VERDICT_FILE} as plain markdown.
+ *
+ *  #2042: the body is the one field that is long free prose, and the critic hand-authors its JSON —
+ *  so every `"` in it has to be escaped by the model. It only has to miss once. The unrecoverable
+ *  shape is a bare `"` immediately before `:` or `,` (`…nicht mehr": drei Dinge`), which is
+ *  byte-identical to a real key/value boundary — jsonrepair cannot resolve that ambiguity, and no
+ *  repairer could. German prose produces it constantly via `„…":` / `„…",`.
+ *
+ *  Carrying the body as its own file removes the escaping obligation entirely: markdown has no
+ *  reserved characters, so no prose can break the read. The JSON that remains (decision, summary,
+ *  findings) is short and structured, where the model's escaping is reliable in practice.
+ *
+ *  MUST be scrubbed before launch exactly like VERDICT_FILE — same fixed name, same untrusted
+ *  PR-head checkout, so the same pre-seed attack applies (see scrubStaleVerdictArtifacts). */
+export const VERDICT_BODY_FILE = ".shepherd-review.md";
 
 export interface RawVerdict {
   decision?: unknown;
@@ -873,9 +902,31 @@ export function defaultReadVerdict(
   );
   if (text === null) return { status: "absent" };
   const r = tolerantParseJson(text);
-  return r.status === "ok"
-    ? { status: "parsed", value: r.value as RawVerdict, repaired: r.repaired }
-    : { status: "unparseable" };
+  // Carry the raw bytes (as the recap read already does): they drive the stable-unparseable fail-fast
+  // in ReviewService.tick, and they fill the `snippet:` in the no-verdict diagnostic — which until
+  // now could never fire for a critic run, because this branch dropped `raw` on the floor.
+  if (r.status !== "ok") return { status: "unparseable", raw: text };
+  const value = r.value as RawVerdict;
+  // #2042: the body travels as a sidecar markdown file. Read it from the SAME worktree and splice it
+  // in. A missing sidecar is not an error — an inline `body` stays valid, which keeps every older
+  // critic, a Codex critic answering through the `-o` fallback, and any run already in flight across
+  // a server restart working unchanged. Sidecar wins when both exist: it is the format the current
+  // prompt asks for, and it is the one that cannot have been mangled by escaping.
+  const body = readVerdictBody(worktreePath);
+  if (body !== null) value.body = body;
+  return { status: "parsed", value, repaired: r.repaired };
+}
+
+/** Read the sidecar body written beside the verdict JSON. null when absent/unreadable (mid-write) —
+ *  never throws, so a sidecar problem can only cost the body, never the whole verdict. */
+function readVerdictBody(worktreePath: string): string | null {
+  const p = join(worktreePath, VERDICT_BODY_FILE);
+  if (!existsSync(p)) return null;
+  try {
+    return readFileSync(p, "utf8");
+  } catch {
+    return null;
+  }
 }
 
 export function normalizeDecision(d: unknown): ReviewDecision | null {

--- a/src/critic-core.ts
+++ b/src/critic-core.ts
@@ -719,13 +719,19 @@ function scopeAndOutputTail(
     // Binds the term once: every rule above says `"body"` (sections, citations, stated limitations),
     // and they all now resolve to this file. Cheaper and less drift-prone than restating ~10 rules.
     '1. `.shepherd-review.md` — your full markdown review. Everywhere these instructions say "body" — the named sections, the `path:line` citations, the stated limitations — they mean THIS file. It is NOT JSON: write the prose directly, escape nothing, quote however you like.',
-    "2. `.shepherd-review.json` — the structured verdict, with EXACTLY this shape:",
-    '{"decision": "request-changes" | "comment", "summary": "<=100 char one-liner", "findings": ["<discrete actionable item>", ...]}',
+    "2. `.shepherd-review.json` — the structured verdict, with this shape:",
+    '{"decision": "request-changes" | "comment", "summary": "<=100 char one-liner", "findings": ["<discrete actionable item>", ...], "body": "<optional — see below>"}',
     // #2042: the body used to live inside this JSON. A single unescaped `"` before a `:` or `,` —
     // which German `„…":` prose produces constantly — is indistinguishable from a real key/value
     // boundary, so it silently destroyed complete verdicts. Keeping the prose out of JSON entirely
     // is the only fix that cannot regress; the note below keeps the remaining escaping honest.
-    'Escaping matters ONLY in the JSON file, and it is short: inside "summary" and each "findings" entry every `"` must be written `\\"`. If that feels error-prone, phrase them without quotation marks — the markdown file is where quoting is free.',
+    //
+    // `body` stays a DOCUMENTED OPTIONAL field, not a removed one: a Codex critic answers in chat and
+    // writes no files at all (its verdict is recovered from the `-o` last-message capture — see
+    // captureLastMessage in review.ts and the fallback in defaultReadVerdict). For that provider the
+    // sidecar cannot exist, so dropping `body` from the shape would post a review with no text in it.
+    'OMIT "body" when you wrote `.shepherd-review.md` — the file always wins. Include it ONLY if you cannot write files at all (you are answering in chat rather than editing a worktree): then put the full markdown review in "body" and escape every `"` inside it as `\\"`.',
+    'Escaping matters ONLY in the JSON file, and — when you wrote the markdown file — it is short: inside "summary" and each "findings" entry every `"` must be written `\\"`. If that feels error-prone, phrase them without quotation marks; the markdown file is where quoting is free.',
     'The "findings" array lists every discrete change the author must make — one entry per point, routed per FINDINGS ROUTING above. Use [] when everything you found is non-blocking (report those in the body sections named above) or there is genuinely nothing to address; "request-changes" requires at least one finding.',
     // Ordering is load-bearing: the server finalizes as soon as the JSON parses, so the JSON must be
     // written LAST — otherwise a tick landing between the two writes finalizes with an empty body.
@@ -908,10 +914,16 @@ export function defaultReadVerdict(
   if (r.status !== "ok") return { status: "unparseable", raw: text };
   const value = r.value as RawVerdict;
   // #2042: the body travels as a sidecar markdown file. Read it from the SAME worktree and splice it
-  // in. A missing sidecar is not an error — an inline `body` stays valid, which keeps every older
-  // critic, a Codex critic answering through the `-o` fallback, and any run already in flight across
-  // a server restart working unchanged. Sidecar wins when both exist: it is the format the current
-  // prompt asks for, and it is the one that cannot have been mangled by escaping.
+  // in. A missing sidecar is not an error — an inline `body` stays valid, which keeps an older critic
+  // and any run already in flight across a server restart working unchanged.
+  //
+  // It is also the ONLY way a Codex critic can carry a body: that provider answers in chat and writes
+  // no files, so its verdict arrives through the `-o` last-message fallback above and NO sidecar can
+  // exist for it. That is why `body` remains a documented optional field in the prompt rather than a
+  // removed one — drop it there and this path posts a review with no text.
+  //
+  // Sidecar wins when both exist: it is the format the prompt asks for whenever files are writable,
+  // and it is the one that cannot have been mangled by escaping.
   const body = readVerdictBody(worktreePath);
   if (body !== null) value.body = body;
   return { status: "parsed", value, repaired: r.repaired };

--- a/src/review.ts
+++ b/src/review.ts
@@ -42,6 +42,7 @@ import {
   captureUsage,
   reapRun,
   VERDICT_FILE,
+  VERDICT_BODY_FILE,
   type RawVerdict,
   type EpicBaseDelta,
   type EpicContext,
@@ -187,6 +188,9 @@ interface InFlight {
   lastVisible?: string | null;
   /** Set once the pane is confirmed wedged on an interactive prompt; drives the `blocked` cause. */
   stuckShape?: BlockShape | null;
+  /** Raw bytes of the verdict file from the previous tick, recorded ONLY while it is unparseable.
+   *  Two consecutive identical reads mean the critic has stopped writing (see resolveWait). */
+  lastUnparseableRaw?: string;
   finalizing?: boolean;
 }
 
@@ -1079,6 +1083,18 @@ export class ReviewService {
       );
       return action;
     }
+    // #2042: a STABLE unparseable verdict means a finished-but-broken critic — finalize now.
+    //
+    // The prompt makes the verdict JSON the critic's LAST action ("then stop"), so once those bytes
+    // stop changing there is nothing left to wait for. Without this the run sits in `wait` until the
+    // hard deadline, because the pane stays alive-but-idle after the write and `isSpawnAlive` (rightly)
+    // reports alive. A real critic lost 23 of its 30 minutes to exactly that, then reported a bare
+    // timeout. Requiring two consecutive IDENTICAL reads keeps a genuine partial write waiting — that
+    // one is still growing between ticks.
+    if (read.status === "unparseable" && read.raw !== undefined) {
+      if (f.lastUnparseableRaw === read.raw) return "finalize-null"; // claim stays held; caller finalizes
+      f.lastUnparseableRaw = read.raw; // first sighting — re-check next tick
+    }
     f.finalizing = false; // release: not finalizing this tick
     // still running (or gated, awaiting completion) — surface what the critic is doing right now.
     // Emit every tick (not only on change) so a reloaded client repopulates within one tick; the
@@ -1488,7 +1504,7 @@ export class ReviewService {
     // strict-JSON verdict / `-o` fallback to short-circuit the real critic (see
     // scrubStaleVerdictArtifacts). Scrub HERE — after rebaseSkip, which can re-materialize a
     // committed artifact — right before spawn.
-    scrubStaleVerdictArtifacts(worktreePath, VERDICT_FILE);
+    scrubStaleVerdictArtifacts(worktreePath, VERDICT_FILE, VERDICT_BODY_FILE);
     const aux = prompt.assemble(fitted.prompt);
     try {
       const started = await this.deps.herdr.start(

--- a/src/standalone-critic.ts
+++ b/src/standalone-critic.ts
@@ -40,6 +40,7 @@ import {
   captureUsage,
   reapRun,
   VERDICT_FILE,
+  VERDICT_BODY_FILE,
   type RawVerdict,
   type EpicContext,
   type LandingContext,
@@ -537,7 +538,7 @@ export class StandalonePrCriticService {
     // The worktree is checked out at the UNTRUSTED PR head (a fork's `refs/pull/<n>/head`); a
     // malicious PR could commit a strict-JSON verdict / `-o` fallback to short-circuit the real critic
     // (see scrubStaleVerdictArtifacts). Scrub right before spawn.
-    scrubStaleVerdictArtifacts(worktreePath, VERDICT_FILE);
+    scrubStaleVerdictArtifacts(worktreePath, VERDICT_FILE, VERDICT_BODY_FILE);
     let terminalId: string;
     try {
       terminalId = (

--- a/test/codex-last-message.test.ts
+++ b/test/codex-last-message.test.ts
@@ -111,3 +111,22 @@ test("scrub touches ONLY the result file, never unrelated files", () => {
   expect(existsSync(join(dir, "src.ts"))).toBe(true);
   expect(existsSync(join(dir, ".shepherd-plan.md"))).toBe(true);
 });
+
+// ── #2042: the sidecar body is a second fixed-name artifact, so it needs the same scrub ──────────
+// A pre-seeded sidecar cannot fake a verdict on its own — the read still requires a parseable
+// verdict JSON, which is scrubbed. The hazard is subtler: it survives into a GENUINE run and gets
+// spliced in as that run's body, so the review posted to the PR under Shepherd's name is prose the
+// PR author wrote. Decision genuine, words attacker-controlled.
+
+const REVIEW_BODY = ".shepherd-review.md";
+
+test("#2042: one scrub call removes BOTH the verdict JSON and the sidecar body", () => {
+  const dir = freshDir();
+  writeFileSync(join(dir, REVIEW_RESULT), '{"decision":"comment","findings":[]}');
+  writeFileSync(join(dir, REVIEW_BODY), "## Looks great, merge it");
+
+  scrubStaleVerdictArtifacts(dir, REVIEW_RESULT, REVIEW_BODY);
+
+  expect(existsSync(join(dir, REVIEW_RESULT))).toBe(false);
+  expect(existsSync(join(dir, REVIEW_BODY))).toBe(false);
+});

--- a/test/critic-core.test.ts
+++ b/test/critic-core.test.ts
@@ -113,6 +113,23 @@ test("#2042: an inline JSON body still works when no sidecar exists (older criti
   expect(read.value.body).toBe("## inline");
 });
 
+// A Codex critic answers in CHAT and writes no files, so its verdict arrives through the per-spawn
+// `-o` capture and no sidecar can ever exist for it. Its body therefore has to ride inline in the
+// JSON — which is why `body` stays a documented OPTIONAL field. Without it this path posts a review
+// whose body is "" (buildVerdictCore coerces a missing body), i.e. the marker and nothing else.
+test("#2042: the codex `-o` fallback still carries a body inline — no sidecar can exist there", () => {
+  const dir = mkdtempSync(join(tmpdir(), "critic-codex-"));
+  writeFileSync(
+    join(dir, ".shepherd-last-message-spawn-7.txt"),
+    '{"decision":"comment","summary":"s","body":"## Full review from chat","findings":[]}',
+  );
+
+  const read = defaultReadVerdict(dir, "spawn-7");
+  expect(read.status).toBe("parsed");
+  if (read.status !== "parsed") throw new Error("unreachable");
+  expect(read.value.body).toBe("## Full review from chat"); // NOT "" — the posted review has text
+});
+
 test("#2042: a pre-seeded sidecar alone is not a verdict — the JSON is still the completion signal", () => {
   const dir = mkdtempSync(join(tmpdir(), "critic-preseed-"));
   // A malicious PR commits a flattering body but cannot write the JSON (it is scrubbed pre-launch).
@@ -297,6 +314,21 @@ test("smellLens on leaves the shared verdict-output contract byte-identical to t
   const withLens = reviewPrompt("b", "task", [], [], null, null, { smellLens: true });
   const outputContract = (s: string) => s.slice(s.indexOf("When done, write TWO files"));
   expect(outputContract(withLens)).toBe(outputContract(prReviewPrompt("b", "t", "body")));
+});
+
+// The prompt is the half that actually regressed: dropping `body` from the documented shape left a
+// Codex critic (chat-only, no files, no sidecar possible) with nowhere to put its review. The reader
+// has always accepted an inline body, so only asserting on the reader would not have caught it.
+test("#2042: the output contract still documents `body`, as optional and file-loses-to-sidecar", () => {
+  for (const p of [
+    reviewPrompt("BASE", "do the thing", [], []),
+    prReviewPrompt("b", "t", "body"),
+  ]) {
+    const contract = p.slice(p.indexOf("When done, write TWO files"));
+    expect(contract).toContain('"body"'); // still in the documented shape
+    expect(contract).toContain('OMIT "body" when you wrote `.shepherd-review.md`'); // sidecar wins
+    expect(contract).toContain("if you cannot write files at all"); // the codex-in-chat carve-out
+  }
 });
 
 test("reviewPrompt fences PR author notes as untrusted", () => {

--- a/test/critic-core.test.ts
+++ b/test/critic-core.test.ts
@@ -19,6 +19,7 @@ import {
   effectiveRound,
   captureUsage,
 } from "../src/critic-core";
+import { tolerantParseJson } from "../src/json-tolerant";
 import { allowedToolsFor } from "../src/transient-agent-argv";
 import { planReviewPrompt } from "../src/plan-gate";
 
@@ -50,6 +51,75 @@ test("#822 critic read path: malformed verdict recovers with decision + findings
   const findings = normalizeFindings(read.value.findings);
   expect(findings).toHaveLength(2);
   expect(findings[0]).toContain('"fast"');
+});
+
+// ── #2042 regression: the bare quote jsonrepair CANNOT recover ──────────────────────────────────
+//
+// #822 (above) covers a bare `"` followed by ordinary prose — jsonrepair recovers that. The case it
+// cannot recover is a bare `"` immediately followed by a JSON STRUCTURAL character (`:` or `,`):
+// `…mehr": drei Dinge` is byte-identical to a genuine key/value boundary, so jsonrepair "closes" the
+// string there and produces a different, wrong document (or gives up). No repair heuristic can
+// resolve that ambiguity — it is a real grammar collision, not a gap in the repairer.
+//
+// German prose hits it constantly: `„…":` and `„…",` are the normal way to quote a phrase before a
+// colon or comma. A live critic (TASK-2125) lost a complete 7.7 KB `request-changes` verdict to
+// exactly this, then burned the full 1800s deadline before reporting `no-verdict-unparseable`.
+//
+// This is the case the sidecar body file exists to make unreachable: prose that never has to be
+// escaped can never collide with the JSON grammar.
+
+test("#2042: a bare quote followed by `:` or `,` is NOT repairable — the body must not carry prose", () => {
+  const bodyWith = (b: string) =>
+    `{"decision":"comment","summary":"s","body":"${b}","findings":[]}`;
+
+  // Recoverable (the #822 shape): the bare quote is followed by prose, so the repair is unambiguous.
+  expect(tolerantParseJson(bodyWith('sagt „x" drei Dinge')).status).toBe("ok");
+
+  // NOT recoverable: `"` directly before a structural char is indistinguishable from real syntax.
+  expect(tolerantParseJson(bodyWith('sagt „x": drei Dinge')).status).toBe("unparseable");
+  expect(tolerantParseJson(bodyWith('sagt „x", drei Dinge')).status).toBe("unparseable");
+});
+
+// ── #2042: the body travels as a sidecar markdown file, never as an escaped JSON string ──────────
+
+test("#2042: the body is read from the .md sidecar, so unescapable prose survives verbatim", () => {
+  const dir = mkdtempSync(join(tmpdir(), "critic-sidecar-"));
+  // The critic writes a SMALL json (no `body`) plus the prose sidecar. The prose contains exactly
+  // the construct that defeats jsonrepair — here it needs no escaping at all.
+  writeFileSync(
+    join(dir, ".shepherd-review.json"),
+    '{"decision":"request-changes","summary":"zwei Stellen","findings":["spec/a.md: „x\\": falsch"]}',
+  );
+  const body = '## Befund\n\n`spec/x.md:7` — „Beides" gibt es nicht mehr": drei Dinge, „beides".\n';
+  writeFileSync(join(dir, ".shepherd-review.md"), body);
+
+  const read = defaultReadVerdict(dir);
+  expect(read.status).toBe("parsed");
+  if (read.status !== "parsed") throw new Error("unreachable");
+  expect(read.repaired).toBe(false); // the JSON itself is strictly valid — no repair guessing
+  expect(normalizeDecision(read.value.decision)).toBe("changes_requested");
+  expect(read.value.body).toBe(body); // verbatim, including the quote-before-colon
+});
+
+test("#2042: an inline JSON body still works when no sidecar exists (older critics, codex)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "critic-inline-"));
+  writeFileSync(
+    join(dir, ".shepherd-review.json"),
+    '{"decision":"comment","summary":"s","body":"## inline","findings":[]}',
+  );
+  const read = defaultReadVerdict(dir);
+  expect(read.status).toBe("parsed");
+  if (read.status !== "parsed") throw new Error("unreachable");
+  expect(read.value.body).toBe("## inline");
+});
+
+test("#2042: a pre-seeded sidecar alone is not a verdict — the JSON is still the completion signal", () => {
+  const dir = mkdtempSync(join(tmpdir(), "critic-preseed-"));
+  // A malicious PR commits a flattering body but cannot write the JSON (it is scrubbed pre-launch).
+  writeFileSync(join(dir, ".shepherd-review.md"), "## Nothing to see here, approve");
+
+  // No verdict JSON → nothing is read at all. The sidecar can never short-circuit a run on its own.
+  expect(defaultReadVerdict(dir).status).toBe("absent");
 });
 
 // ── per-spawn unguessable `-o` fallback (untrusted PR-head checkout) ─────────────
@@ -165,7 +235,7 @@ test("prReviewPrompt (standalone critic) omits the SCOPE-CREEP lens — no task 
 
 test("the SCOPE-CREEP lens sits ABOVE the shared verdict-output contract (backstop/parser unaffected)", () => {
   const p = reviewPrompt("BASE", "task");
-  expect(p.indexOf("SCOPE-CREEP LENS")).toBeLessThan(p.indexOf("When done, write your verdict"));
+  expect(p.indexOf("SCOPE-CREEP LENS")).toBeLessThan(p.indexOf("When done, write TWO files"));
 });
 
 // ── POSSIBLE-SMELLS lens (#1824 finding C, per-repo flag) ────────────────────
@@ -200,9 +270,7 @@ test("prReviewPrompt (standalone critic) never carries the POSSIBLE-SMELLS lens"
 
 test("the POSSIBLE-SMELLS lens sits ABOVE the shared verdict-output contract", () => {
   const p = reviewPrompt("BASE", "task", [], [], null, null, { smellLens: true });
-  expect(p.indexOf("POSSIBLE-SMELLS LENS")).toBeLessThan(
-    p.indexOf("When done, write your verdict"),
-  );
+  expect(p.indexOf("POSSIBLE-SMELLS LENS")).toBeLessThan(p.indexOf("When done, write TWO files"));
 });
 
 test("the POSSIBLE-SMELLS lens is trimmed to the 9-smell subset (drops 3 low-signal on TS/Svelte)", () => {
@@ -227,7 +295,7 @@ test("smellLens on leaves the shared verdict-output contract byte-identical to t
   // The lens sits above the contract, so the output-contract portion both critics key off must
   // stay identical even with the lens on (scope backstop + verdict parser unaffected).
   const withLens = reviewPrompt("b", "task", [], [], null, null, { smellLens: true });
-  const outputContract = (s: string) => s.slice(s.indexOf("When done, write your verdict"));
+  const outputContract = (s: string) => s.slice(s.indexOf("When done, write TWO files"));
   expect(outputContract(withLens)).toBe(outputContract(prReviewPrompt("b", "t", "body")));
 });
 
@@ -247,7 +315,7 @@ test("reviewPrompt and prReviewPrompt share the identical scope+output tail", ()
     prReviewPrompt("b", "t", "body").indexOf("SCOPE — "),
   );
   // tails differ only on the single judge clause line; the output contract below it is identical.
-  const outputContract = (s: string) => s.slice(s.indexOf("When done, write your verdict"));
+  const outputContract = (s: string) => s.slice(s.indexOf("When done, write TWO files"));
   expect(outputContract(a)).toBe(outputContract(b));
 });
 

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -1144,6 +1144,62 @@ test("wedged pane with an unparseable verdict still finalizes as an error", asyn
   }
 });
 
+// ── #2042: a STABLE unparseable verdict finalizes immediately, not at the deadline ───────────────
+// The prompt makes the verdict JSON the critic's last action, so once its bytes stop changing there
+// is nothing to wait for. The pane stays alive-but-idle after that write, so `wait` alone would hold
+// the run for the full 1800s and then report a bare timeout (TASK-2125 lost 23 of 30 minutes here).
+
+test("#2042: unparseable verdict that stops changing finalizes early, well inside the deadline", async () => {
+  let t = 1000;
+  const origWarn = console.warn;
+  console.warn = () => {};
+  try {
+    const { deps: d, reviews } = makeDeps(
+      { now: () => t, timeoutMs: 1_800_000 },
+      // Alive, NOT wedged (a plain idle pane) — so only the stable-bytes rule can finalize this.
+      { verdictRead: { status: "unparseable", raw: "{oops" }, criticProcs: ["node"] },
+    );
+    const svc = new ReviewService(d as any);
+    await svc.consider(session(), OPEN_GREEN);
+    t = 1000 + STARTUP_GRACE_MS + 1000;
+
+    await svc.tick(); // first sighting of the broken bytes — still waiting
+    expect(reviews["s1"]).toBeUndefined();
+
+    await svc.tick(); // identical bytes → the critic has stopped writing
+    expect(reviews["s1"]?.decision).toBe("error");
+    expect(reviews["s1"]?.summaryCode).toBe("no-verdict-unparseable");
+    expect(t - 1000).toBeLessThan(1_800_000); // finalized far short of the hard deadline
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
+test("#2042: a still-growing partial write keeps waiting — it is not 'stable'", async () => {
+  let t = 1000;
+  let n = 0;
+  const origWarn = console.warn;
+  console.warn = () => {};
+  try {
+    const { deps: d, reviews } = makeDeps(
+      { now: () => t, timeoutMs: 1_800_000 },
+      { criticProcs: ["node"] },
+    );
+    // Each read returns MORE bytes: a genuine mid-write file, which must never be failed fast.
+    (d as any).readVerdict = () => ({ status: "unparseable", raw: "{".repeat(++n) });
+    const svc = new ReviewService(d as any);
+    await svc.consider(session(), OPEN_GREEN);
+    t = 1000 + STARTUP_GRACE_MS + 1000;
+
+    await svc.tick();
+    await svc.tick();
+    await svc.tick();
+    expect(reviews["s1"]).toBeUndefined(); // still waiting, no premature error verdict
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
 // A live critic that is genuinely working must never be killed: its buffer advances between reads.
 test("advancing pane is left alone even when it looks like a menu", async () => {
   let t = 1000;


### PR DESCRIPTION
Two live sessions on a German-language repo produced no review verdicts. Diagnosed both; only one was actually broken, and this fixes it.

## Root cause

The critic hand-authors `.shepherd-review.json`, so every `"` inside the long prose `body` has to be escaped by the model. It only has to miss once.

The unrecoverable shape is a bare `"` **immediately before `:` or `,`**:

```
…gibt es nicht mehr": drei Dinge, „beides".
```

That is byte-identical to a genuine key/value boundary, so `jsonrepair` closes the string there and produces a different document. This is a real grammar collision, not a gap in the repairer — no repair heuristic can resolve it. (Plain unescaped quotes followed by prose, the #822 shape, *are* recoverable; those still work.)

German hits it constantly, because `„…":` and `„…",` are the ordinary way to quote a phrase before a colon or comma.

**What it cost.** A live critic wrote a complete, well-argued 7.7 KB `request-changes` verdict — 26 unescaped `"`, 0 escaped — and all of it was discarded. Verified by recovering the original `Write` call from the reviewer's transcript: repaired only the escaping and it parses cleanly, `changes_requested`, 2 findings, 6776-byte body.

**And it cost 30 minutes.** `decideVerdictAction` holds `unparseable` on `wait` unless the spawn finished or timed out. A critic that has written its file sits idle-but-alive, so `isSpawnAlive` correctly reports alive and the run waits out the full 1800s. That run wrote its file at ~18:39 and only failed at 19:02:16 — **23 minutes waiting on a file that was already final on disk.**

## The fix

**Body travels as a sidecar.** The critic writes `.shepherd-review.md` — ordinary markdown, nothing to escape — and the JSON keeps `decision`, `summary`, `findings`. Prose that never has to be escaped cannot collide with the JSON grammar, so this closes the class rather than patching an instance.

- Inline `body` is still honoured when no sidecar exists, so older critics, a Codex critic answering via the `-o` fallback, and any run in flight across a restart keep working.
- The prompt binds the term "body" to the new file once, so the ~10 existing rules that say `"body"` keep resolving without restating them.
- Write order is load-bearing and stated: `.md` first, `.json` last, because the JSON is the completion signal.

**The sidecar is scrubbed pre-spawn, like the JSON.** This is the part that would otherwise make the change a security regression. The critic worktree is a checkout of the untrusted PR head, so a PR can commit a fixed-name `.shepherd-review.md`. It cannot fake a verdict alone — the read still needs a parseable JSON, which is scrubbed — but it *would* survive into a genuine run, be spliced in as that run's body, and be posted to the PR as the critic's review: decision genuine, words attacker-authored. `scrubStaleVerdictArtifacts` is now variadic so both PR-critic call sites scrub JSON and sidecar in one call, rather than leaving a second call site for a later change to forget.

**Fail fast on a stable unparseable verdict.** The prompt makes the JSON the critic's last action, so once its bytes stop changing there is nothing to wait for. Two consecutive identical reads → finalize (~30s instead of 1800s). Requiring *identical* bytes keeps a genuine partial write waiting, since that one is still growing.

**`raw` is now populated on the critic's unparseable read.** It was dropped on the floor, which is why `logNoVerdict`'s `snippet:` could never fire for a critic run — confirmed absent in the real failure's log line. It also backs the stability check above.

I originally planned to steer the idle critic to rewrite its own file. Dropped it: `ReviewService`'s herdr dep has no `send`, and adding pane-steering there would bypass the `#serializeSteer` serialization that exists to prevent steer races. Too much surface for the benefit, especially once the sidecar makes the case rare.

## Verification

- `bun run lint` clean; `bunx tsc --noEmit` clean.
- `bun run test` — 8348 pass, 0 fail.
- New tests confirmed **red** before the fix (temporarily disabled the guard and watched the fail-fast test fail).
- End-to-end against the **real recovered 6776-byte payload** in the new format: parses with `repaired=false`, body byte-identical, and the exact construct that killed it survives verbatim.
- `bunx fallow audit --base origin/main --fail-on-issues` — no issues in the 7 changed files.

## Deliberately not in this PR

- `RecapService` shares `decideVerdictAction` and has the identical hazard — with a real occurrence already in the logs. Filed as #2045.
- Archiving deletes the session's `reviews` row, so a *passed* verdict becomes invisible in-app and the table reads empty DB-wide. Working as designed; noted in #2045 as an observation, no change proposed.

The second session in the original report turned out **not** to be broken: its critic finalized normally and posted its verdict to the PR three seconds before merge. It only looked identical to the failure because archiving had already dropped the row.