### PR TITLE
fix(preview): see dev servers agents start in the scratchpad

### DIFF
--- a/agent-skills/.claude/skills/shepherd-preview/SKILL.md
+++ b/agent-skills/.claude/skills/shepherd-preview/SKILL.md
@@ -8,23 +8,36 @@ description: How to expose a long-running local dev/test server from a Shepherd 
 Shepherd can proxy a dev server running in this worktree to the operator's browser (and, when
 enabled, onto the tailnet). It finds the server by port.
 
+## Where to start the server
+
+Start it **from this worktree**. That is the case the preview is built around, and it keeps the
+server next to the code you are changing.
+
+Prototyping from your scratchpad works too — Shepherd recognises a server you started there by the
+session marker every process you spawn inherits, so it is no longer invisible. It is still the
+second-best option: nothing in the scratchpad ends up in the PR.
+
 ## Pointing the preview at a specific port
 
-If you start a long-running dev server in this worktree and want Shepherd's live preview to target
-a specific port, write that port — a bare number, nothing else — to a file named
-`.shepherd-preview` in the repository root.
+If you start a long-running dev server and want Shepherd's live preview to target a specific port,
+write that port — a bare number, nothing else — to a file named `.shepherd-preview` in the
+repository root. If you started the server from the scratchpad instead, put that file in the
+directory you started it from; the repository root still wins if both exist.
 
 Shepherd uses that value only when the port is actually listening; otherwise it auto-detects the
 port. So this is optional: skip it if you have no dev server, or if the default detection already
 targets the right port.
+
+Debugger endpoints are never chosen as the preview, so a Node inspector or a CDP port on 9222 /
+9229 / 9230 cannot be picked up by mistake.
 
 ## What Shepherd does and does not do
 
 - Shepherd **never starts or stops your dev server**. Starting it is on you; keep it in a managed
   or background terminal, not as a blocking foreground command.
 - Shepherd owns tailnet exposure — do not run `tailscale serve` yourself.
-- The hint only applies to **isolated** sessions, which have their own worktree. A session sharing
-  the main repo directory has no dedicated worktree for the file to live in.
+- Preview only applies to **isolated** sessions, which have their own worktree. A session sharing
+  the main repo directory gets no preview at all.
 
 ## If no preview appears
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -249,7 +249,10 @@ const store = new SessionStore(config.dbPath);
 // refreshes the cell these consumers then read. A single instance here is for
 // clarity, not correctness; what WOULD carry an independent, always-cold cell is a
 // reaper constructed with its own `makeDarwinProbes()` (as the tests do).
-const reaper = new ProcessReaper();
+// `agentTmpDir()` arms the scratchpad provenance fallback: a dev server an agent started
+// from its scratchpad instead of the worktree is still this session's, and must be
+// stoppable and offerable as a leftover.
+const reaper = new ProcessReaper(undefined, agentTmpDir());
 // a repo root chosen in the UI (persisted) overrides the env var / default — but
 // only if it still sits within the immutable ceiling; a stale/escaping value is
 // ignored so the active root can never climb above the ceiling across restarts.

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -31,8 +31,14 @@ import { statSync } from "node:fs";
 import { classifyHalt, assistantSideText } from "./usage-halt";
 import type { UsageLimits } from "./usage-limits";
 import { maintenance } from "./maintenance";
-import { scanListeningPortsByWorktree, scanClaudeAliveByWorktree } from "./process-reaper";
+import {
+  scanListeningPortsByWorktree,
+  scanClaudeAliveByWorktree,
+  type ListenerScanTarget,
+  type WorktreeListeners,
+} from "./process-reaper";
 import { resolveDevPort } from "./preview";
+import { agentTmpDir } from "./tmp-sweep";
 import { config } from "./config";
 import { SessionLiveness, type LivenessOutcome, type TranscriptSignals } from "./session-liveness";
 
@@ -90,15 +96,16 @@ export interface PreviewWiring {
    *  union filter, so the liveness sweep — which has no wiring of its own — is
    *  covered too. Defaults to `deps.reaper`-backed refresh in index.ts. */
   refresh?: (opts?: { force?: boolean }) => Promise<void>;
-  /** Batched /proc scan: builds the inode→port map ONCE and resolves all worktrees.
+  /** Batched /proc scan: builds the inode→port map ONCE and resolves all sessions.
    *  Defaults to the real `scanListeningPortsByWorktree`. Returns `null` when the
    *  snapshot backend cannot support a negative verdict (darwin, stale/none cell) —
    *  the sweep must then leave bound listeners untouched, not tear them down. */
-  scan: (worktrees: string[]) => Map<string, number[]> | null;
+  scan: (targets: ListenerScanTarget[]) => Map<string, WorktreeListeners> | null;
   /** Pick the primary dev port from a set of listening ports for a given worktree.
    *  Defaults to `resolveDevPort`, which honors the agent-declared `.shepherd-preview`
-   *  hint (if listening + HTTP-live) and otherwise falls back to the primary-port heuristic. */
-  pick: (ports: number[], worktreePath: string) => Promise<number | null>;
+   *  hint (if listening + HTTP-live) and otherwise falls back to the primary-port heuristic.
+   *  `hintDirs` is worktree-root-first; see `resolveDevPort`. */
+  pick: (ports: number[], hintDirs: string[]) => Promise<number | null>;
   /** Opt-in idle-stop. idleMs > 0 enables it; `stop` signals a session's dev-server
    *  process (wired to SessionService.stopPreview in index.ts). Returns the stop
    *  outcome. The two that signalled NOTHING must NOT advance the escalation ladder:
@@ -519,8 +526,10 @@ export class StatusPoller {
       },
       sweepMs: preview?.sweepMs ?? config.previewSweepMs,
       refresh: preview?.refresh,
-      scan: preview?.scan ?? ((worktrees) => scanListeningPortsByWorktree(worktrees)),
-      pick: preview?.pick ?? ((ports, worktreePath) => resolveDevPort(ports, worktreePath)),
+      scan:
+        preview?.scan ??
+        ((targets) => scanListeningPortsByWorktree(targets, undefined, agentTmpDir())),
+      pick: preview?.pick ?? ((ports, hintDirs) => resolveDevPort(ports, hintDirs)),
       idleStop: preview?.idleStop,
     };
     this.livenessWiring = {
@@ -1881,6 +1890,18 @@ export class StatusPoller {
       });
   }
 
+  /** This session's dev port from its scan result. The worktree root leads `hintDirs`:
+   *  an agent-declared hint there outranks one found next to a scratchpad-rooted server. */
+  private pickDevPort(
+    s: Session,
+    listeners: WorktreeListeners | undefined,
+  ): Promise<number | null> {
+    return this.previewWiring.pick(listeners?.ports ?? [], [
+      s.worktreePath,
+      ...(listeners?.hintDirs ?? []),
+    ]);
+  }
+
   /**
    * Async core of the preview sweep. Builds the /proc map ONCE, picks a primary
    * port per session, then calls converge() on the full active set. The PreviewService
@@ -1889,9 +1910,11 @@ export class StatusPoller {
    */
   private async runPreviewSweep(isolated: Session[]): Promise<void> {
     const now = this.now();
-    const worktrees = isolated.map((s) => s.worktreePath);
-    // Single /proc scan for ALL sessions — never once per session.
-    const portsMap = this.previewWiring.scan(worktrees);
+    // Single /proc scan for ALL sessions — never once per session. Session ids ride along
+    // so a scratchpad-rooted server can be attributed by its inherited marker.
+    const portsMap = this.previewWiring.scan(
+      isolated.map((s) => ({ worktreePath: s.worktreePath, sessionId: s.id })),
+    );
 
     // `null` = the snapshot backend can't support a negative verdict (darwin,
     // stale/none cell). An empty/partial map here would drive `converge` to tear
@@ -1901,8 +1924,7 @@ export class StatusPoller {
 
     const active: Array<{ sessionId: string; devPort: number }> = [];
     for (const s of isolated) {
-      const ports = portsMap.get(s.worktreePath) ?? [];
-      const devPort = await this.previewWiring.pick(ports, s.worktreePath);
+      const devPort = await this.pickDevPort(s, portsMap.get(s.worktreePath));
       if (devPort === null) {
         // Server is gone — clear any escalation state and skip (converge will release it).
         this.previewStopState.delete(s.id);

--- a/src/preview-launch.ts
+++ b/src/preview-launch.ts
@@ -3,8 +3,14 @@ import { chmod, mkdir, stat, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { promisify } from "node:util";
 import { spawn } from "node:child_process";
-import { ProcessReaper, scanListeningPortsByWorktree } from "./process-reaper";
+import {
+  ProcessReaper,
+  scanListeningPortsByWorktree,
+  type ListenerScanTarget,
+  type WorktreeListeners,
+} from "./process-reaper";
 import { resolveDevPort } from "./preview";
+import { agentTmpDir } from "./tmp-sweep";
 
 const execFileAsync = promisify(execFile);
 
@@ -166,7 +172,7 @@ export interface FindDevPortDeps {
   refresh: (opts?: { force?: boolean }) => Promise<void>;
   /** Batched listening-port scan; returns `null` when the snapshot backend can't
    *  support a negative verdict. Defaults to the real `scanListeningPortsByWorktree`. */
-  scan: (worktrees: string[]) => Map<string, number[]> | null;
+  scan: (targets: ListenerScanTarget[]) => Map<string, WorktreeListeners> | null;
 }
 
 // Constructed without explicit probes, so it shares the module-private default
@@ -175,19 +181,20 @@ export interface FindDevPortDeps {
 const defaultReaper = new ProcessReaper();
 const defaultFindDevPortDeps: FindDevPortDeps = {
   refresh: (opts) => defaultReaper.refresh(opts),
-  scan: (worktrees) => scanListeningPortsByWorktree(worktrees),
+  scan: (targets) => scanListeningPortsByWorktree(targets, undefined, agentTmpDir()),
 };
 
 export async function findPreviewDevPort(
   worktreePath: string,
+  sessionId: string,
   deps: FindDevPortDeps = defaultFindDevPortDeps,
 ): Promise<number | null> {
   // Force so a dev server started within the coalescing window is seen (else a
   // start click could spawn a second server where an existing one would bind).
   await deps.refresh({ force: true });
-  const map = deps.scan([worktreePath]);
+  const map = deps.scan([{ worktreePath, sessionId }]);
   // `null` = unknown (darwin, stale/none cell) — no dev port can be asserted.
   if (map === null) return null;
-  const ports = map.get(worktreePath) ?? [];
-  return resolveDevPort(ports, worktreePath);
+  const listeners = map.get(worktreePath);
+  return resolveDevPort(listeners?.ports ?? [], [worktreePath, ...(listeners?.hintDirs ?? [])]);
 }

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -209,6 +209,15 @@ const CURATED_PORTS: readonly number[] = [5173, 5174, 4321, 4173, 3000, 8000, 80
 const CURATED_SET = new Set<number>(CURATED_PORTS);
 
 /**
+ * Never a preview, always an HTTP responder: the Node inspector (9229, and 9230 for a
+ * second concurrent inspector) and a Chrome DevTools Protocol endpoint (9222) both answer
+ * a plain GET, so the liveness probe alone would let one win the non-curated fallback.
+ * Excluded outright rather than probed — proxying a debugger to the operator's browser is
+ * never the intent, and the agent scratchpad is full of both.
+ */
+const EXCLUDED_PORTS = new Set<number>([9222, 9229, 9230]);
+
+/**
  * HTTP liveness probe: returns true when a plain HTTP GET/HEAD to 127.0.0.1:<port>
  * yields any well-formed HTTP response within ~500 ms.
  *
@@ -259,7 +268,7 @@ async function readHintFileBounded(path: string, enc: "utf8"): Promise<string> {
 }
 
 /**
- * Read a `.shepherd-preview` hint file from the worktree root.
+ * Read a `.shepherd-preview` hint file from a directory.
  *
  * Returns the declared port (integer in [1, 65535]) or null on any failure:
  * missing/unreadable file, empty/whitespace content, content that is not a
@@ -272,10 +281,10 @@ async function readHintFileBounded(path: string, enc: "utf8"): Promise<string> {
  * between digits.
  */
 async function readPreviewHint(
-  worktreePath: string,
+  dir: string,
   readFile: (path: string, enc: "utf8") => Promise<string> = readHintFileBounded,
 ): Promise<number | null> {
-  const hintPath = join(worktreePath, PREVIEW_HINT_FILE);
+  const hintPath = join(dir, PREVIEW_HINT_FILE);
   let text: string;
   try {
     text = await readFile(hintPath, "utf8");
@@ -287,6 +296,22 @@ async function readPreviewHint(
   const port = Number.parseInt(trimmed, 10);
   if (port < 1 || port > 65535) return null;
   return port;
+}
+
+/**
+ * First readable, well-formed hint across `hintDirs`, in order. The caller puts the
+ * worktree root first, so an agent-declared port there always outranks one found next
+ * to a scratchpad-rooted server.
+ */
+async function firstPreviewHint(
+  hintDirs: readonly string[],
+  readFile?: (path: string, enc: "utf8") => Promise<string>,
+): Promise<number | null> {
+  for (const dir of hintDirs) {
+    const hint = await readPreviewHint(dir, readFile);
+    if (hint !== null) return hint;
+  }
+  return null;
 }
 
 /**
@@ -303,20 +328,24 @@ async function readPreviewHint(
  *     the heuristic for multi-listener apps or apps on uncommon ports
  *
  * Falls through to `pickPrimaryPort` when the hint is absent, unreadable,
- * not in `ports`, or not an HTTP server.
+ * not in `ports`, or not an HTTP server. `EXCLUDED_PORTS` are dropped up front, so not
+ * even an explicit hint can point the preview at a debugger.
  *
- * @param ports        Listening ports for this worktree (from /proc scan).
- * @param worktreePath Absolute path to the worktree root (hint file location).
- * @param readFile     Injectable file reader (forwarded to readPreviewHint).
- * @param httpProbe    Injectable HTTP liveness probe (default: real network call).
+ * @param candidates Listening ports for this worktree (from /proc scan).
+ * @param hintDirs   Directories to look for `.shepherd-preview` in, most authoritative
+ *                   FIRST — the worktree root, then any directory contributed by a
+ *                   scratchpad-rooted listener.
+ * @param readFile   Injectable file reader (forwarded to readPreviewHint).
+ * @param httpProbe  Injectable HTTP liveness probe (default: real network call).
  */
 export async function resolveDevPort(
-  ports: number[],
-  worktreePath: string,
+  candidates: number[],
+  hintDirs: readonly string[],
   readFile?: (path: string, enc: "utf8") => Promise<string>,
   httpProbe: (port: number) => Promise<boolean> = defaultHttpProbe,
 ): Promise<number | null> {
-  const hint = await readPreviewHint(worktreePath, readFile);
+  const ports = candidates.filter((p) => !EXCLUDED_PORTS.has(p));
+  const hint = await firstPreviewHint(hintDirs, readFile);
   if (hint !== null && ports.includes(hint)) {
     // Curated ports are trusted HTTP servers — no probe needed.
     // Non-curated declared ports must still pass the HTTP probe to be surfaced.
@@ -342,13 +371,16 @@ export async function resolveDevPort(
  *    the HTTP liveness probe.
  * 3. If nothing answers → null.
  *
- * @param ports      Listening ports detected in the worktree (any order).
+ * `EXCLUDED_PORTS` are dropped before either step.
+ *
+ * @param candidates Listening ports detected in the worktree (any order).
  * @param httpProbe  Injectable probe; defaults to real network call.
  */
 export async function pickPrimaryPort(
-  ports: number[],
+  candidates: number[],
   httpProbe: (port: number) => Promise<boolean> = defaultHttpProbe,
 ): Promise<number | null> {
+  const ports = candidates.filter((p) => !EXCLUDED_PORTS.has(p));
   if (ports.length === 0) return null;
 
   // Step 1: curated-first by list order.

--- a/src/process-reaper.ts
+++ b/src/process-reaper.ts
@@ -1,4 +1,5 @@
 import { readdirSync, readlinkSync, readFileSync } from "node:fs";
+import { dirname } from "node:path";
 import { execFileSync } from "./instrument";
 import { jsonlPathFor } from "./usage";
 import { eachJsonlObject } from "./jsonl";
@@ -9,10 +10,11 @@ import { makeDarwinProbes } from "./proc-probes-darwin";
 // but anything the agent spun up out-of-band keeps running. Three classes:
 //   1. children of the agent (run_in_background bash, stdio MCP) — die WITH the
 //      agent, so we never touch them.
-//   2. detached processes living in the worktree (Vite / `bun run dev`) — survive,
-//      found by scanning /proc for a cwd under the worktree that also LISTENS on a
-//      port (the listening-port test is what tells a persistent server apart from a
-//      transient agent child; servers listen, one-shot children don't).
+//   2. detached processes the session left behind (Vite / `bun run dev`) — survive,
+//      found by scanning /proc for a cwd under the worktree (or, since the scratchpad
+//      fallback below, one under the agent scratch tree carrying this session's marker)
+//      that also LISTENS on a port (the listening-port test is what tells a persistent
+//      server apart from a transient agent child; servers listen, one-shot children don't).
 //   3. system side-effects (`tailscale serve --bg` — its own daemon, often root) —
 //      survive, found by scanning the transcript for the launching command and
 //      derived back to a counter-command. Only offered when the port still LISTENS,
@@ -261,6 +263,88 @@ export function leftoverKey(l: Pick<Leftover, "kind" | "name" | "port" | "pid">)
  *  guard would treat `/a/bc` as under `/a/b`). */
 export function isUnder(path: string, root: string): boolean {
   return path === root || path.startsWith(root + "/");
+}
+
+// ── scratchpad provenance fallback ──────────────────────────────────────────
+//
+// Containment used to be cwd-only: a process counted as a session's if its cwd sat
+// under that session's worktree. Agents prototyping in the Claude scratchpad
+// (`$TMPDIR/claude-$uid/…`, i.e. under `agentTmpDir()`) start their dev servers THERE,
+// so a cwd test alone renders them invisible — no preview, no stop, no leftover offer.
+//
+// The fallback attributes such a process by PROVENANCE instead: `SESSION_MARKER_ENV` is
+// stamped on every agent spawn and inherited by everything it spawns, so it survives the
+// `cd` that moved the process out of the worktree. Two properties keep it narrow:
+//
+//   - the cwd must first be under the scratch root, a plain string test on data
+//     `scanProcs` already read. Only then is the environ consulted, so the mmap-lock
+//     read never touches an unrelated host process.
+//   - `scratchRoot === null` (redirect disabled via SHEPHERD_AGENT_TMPDIR="") and a
+//     backend without `environForPid` (darwin, deliberately, to keep the #1144 runaway
+//     reaper fail-closed) both disable it entirely.
+//
+// The scratch root is passed IN rather than imported: `tmp-sweep.ts` already imports
+// this module, so reading `agentTmpDir()` here would close a cycle. It doubles as the
+// test seam.
+
+/** This process's owning session per `SESSION_MARKER_ENV`, or null when the backend
+ *  exposes no environ or the process carries no marker. */
+function sessionMarkerFor(pid: number, probes: ReaperProbes): string | null {
+  const id = probes.environForPid?.(pid)?.[SESSION_MARKER_ENV];
+  return typeof id === "string" && id.length > 0 ? id : null;
+}
+
+/** Cheap gate: is this cwd inside the agent scratch tree at all? False whenever the
+ *  redirect is disabled, which is what keeps the whole fallback opt-out-able. */
+function isScratchRooted(cwd: string, scratchRoot: string | null): boolean {
+  return scratchRoot !== null && isUnder(cwd, scratchRoot);
+}
+
+/**
+ * Does this process belong to the session rooted at `root`?
+ *
+ * cwd containment first (unchanged fast path), then the scratchpad provenance fallback.
+ * THE single predicate for every single-session site — the class-2 leftover sweep and
+ * BOTH halves of the stop path (`candidatesOn` proposes, `verifiesLive` re-proves).
+ * Teaching only one half of that pair would either propose candidates the live check
+ * then rejects — turning every stop of a scratchpad-rooted server into `"refused"` — or
+ * signal on a weaker rule than the one that proposed it. `scanListeningPortsByWorktree`
+ * resolves many sessions at once so it cannot use this shape, but it is built from the
+ * same two primitives above.
+ */
+function containedBySession(
+  proc: { pid: number; cwd: string },
+  root: string,
+  sessionId: string | null | undefined,
+  scratchRoot: string | null,
+  probes: ReaperProbes,
+): boolean {
+  if (isUnder(proc.cwd, root)) return true;
+  if (!sessionId || !isScratchRooted(proc.cwd, scratchRoot)) return false;
+  return sessionMarkerFor(proc.pid, probes) === sessionId;
+}
+
+/** Max hint directories reported per scratchpad-rooted listener (see `hintDirsFor`). */
+const MAX_HINT_DIRS = 4;
+
+/**
+ * Directories to look for a `.shepherd-preview` hint next to a scratchpad-rooted
+ * server: its own cwd, then ancestors, stopping at (and excluding) the scratch root.
+ *
+ * An agent that writes the hint one level up from where it started the server is the
+ * case this covers. Capped, and every entry is already proven to be under the scratch
+ * root, so the preview sweep reads a bounded number of tiny files.
+ */
+function hintDirsFor(cwd: string, scratchRoot: string): string[] {
+  const out: string[] = [];
+  let dir = cwd;
+  while (out.length < MAX_HINT_DIRS && isUnder(dir, scratchRoot) && dir !== scratchRoot) {
+    out.push(dir);
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return out;
 }
 
 // ── pid-recycle fingerprint (#1925) ─────────────────────────────────────────
@@ -704,10 +788,17 @@ export function liveProcCwds(probes: ReaperProbes = defaultProbes): string[] | n
 }
 
 export class ProcessReaper {
-  constructor(private probes: ReaperProbes = defaultProbes) {}
+  /** `scratchRoot` enables the scratchpad provenance fallback for the single-session
+   *  paths (leftover sweep + stop). Null (the default) leaves them cwd-only; production
+   *  wires `agentTmpDir()` in src/index.ts. */
+  constructor(
+    private probes: ReaperProbes = defaultProbes,
+    private scratchRoot: string | null = null,
+  ) {}
 
   /** Detect surviving leftovers for a session (classes 2 + 3). */
   detect(s: {
+    id: string;
     worktreePath: string;
     claudeSessionId: string;
     isolated: boolean;
@@ -717,12 +808,13 @@ export class ProcessReaper {
     // the shared repo root, where the shepherd server itself (and other unrelated
     // long-running servers) are rooted. A cwd scan there flags processes that merely
     // share the dir, not ones the session launched, so skip class 2 entirely.
-    const procs = s.isolated ? this.scanWorktreeProcs(s.worktreePath) : [];
+    const procs = s.isolated ? this.scanWorktreeProcs(s.worktreePath, s.id) : [];
     return [...procs, ...this.scanSystemSideEffects(s)];
   }
 
-  /** Class 2 — processes living in the worktree that listen on a port. */
-  private scanWorktreeProcs(worktreePath: string): Leftover[] {
+  /** Class 2 — processes belonging to the session that listen on a port: living in its
+   *  worktree, or scratchpad-rooted and carrying its marker. */
+  private scanWorktreeProcs(worktreePath: string, sessionId: string): Leftover[] {
     // A backend that may not authorize a signal on its own (darwin) must not OFFER
     // class-2 leftovers: `reap()` gates its pid branch on that same
     // `canAuthorizeSignal` flag, so every one of them would be listed under
@@ -745,7 +837,8 @@ export class ProcessReaper {
       // Never offer to reap ourselves: the shepherd server runs in the worktree's
       // own repo and listens on a port, so without this it could surface itself.
       if (p.pid === process.pid) continue;
-      if (!isUnder(p.cwd, root) || AGENT_COMMS.has(p.comm)) continue;
+      if (AGENT_COMMS.has(p.comm)) continue;
+      if (!containedBySession(p, root, sessionId, this.scratchRoot, this.probes)) continue;
       // Open the signal bracket BEFORE the portsForPid read, so both that read and `reap`'s later
       // verify sit inside it. A process the bracket refuses is not OFFERED at all: `reap` would
       // refuse to signal it, so offering it would put an un-killable entry under "Terminate &
@@ -828,6 +921,7 @@ export class ProcessReaper {
     worktreePath: string,
     port: number,
     signal: NodeJS.Signals = "SIGTERM",
+    sessionId?: string | null,
   ): { signalled: number; outcome: "ok" | "unsupported" | "refused" } {
     const verify = this.probes.liveProcForPid?.bind(this.probes);
     // No authority of its own AND no way to earn it per-signal ⇒ nothing to do here.
@@ -842,7 +936,7 @@ export class ProcessReaper {
     const root = normRoot(worktreePath, this.probes);
     let count = 0;
     let rejected = 0;
-    for (const { pid, startTicks } of this.candidatesOn(root, port)) {
+    for (const { pid, startTicks } of this.candidatesOn(root, port, sessionId)) {
       // TWO WAYS to prove the pid still belongs to the process the snapshot proposed, and a
       // backend supplies exactly one of them:
       //  - `liveProcForPid` (darwin, #1922) — re-prove the SAME predicates against live data.
@@ -854,7 +948,7 @@ export class ProcessReaper {
       // the hole #1925 closed. `isSameProcess` fails closed on a null capture, so a backend with
       // neither seam signals nothing.
       const proven = verify
-        ? this.verifiesLive(verify, pid, root, port)
+        ? this.verifiesLive(verify, pid, root, port, sessionId)
         : isSameProcess(pid, startTicks, this.probes);
       if (!proven) {
         rejected++;
@@ -874,9 +968,10 @@ export class ProcessReaper {
     return { signalled: count, outcome: "ok" };
   }
 
-  /** Candidates the backing snapshot PROPOSES for a stop: under `root`, listening on `port`,
-   *  and neither ourselves nor the agent. Only a proposal — `stopListenersOnPort` proves each
-   *  one before it may be signalled, either live (`verifiesLive`) or by fingerprint.
+  /** Candidates the backing snapshot PROPOSES for a stop: contained by the session (under
+   *  `root`, or scratchpad-rooted with its marker), listening on `port`, and neither ourselves
+   *  nor the agent. Only a proposal — `stopListenersOnPort` proves each one before it may be
+   *  signalled, either live (`verifiesLive`) or by fingerprint.
    *
    *  `startTicks` is captured BEFORE the `portsForPid` read so that read falls inside the
    *  bracket (#1925); it is null on a snapshot backend with no `cpuStatForPid`, which proves
@@ -884,10 +979,12 @@ export class ProcessReaper {
   private *candidatesOn(
     root: string,
     port: number,
+    sessionId?: string | null,
   ): Iterable<{ pid: number; startTicks: number | null }> {
     for (const proc of this.probes.scanProcs()) {
       if (proc.pid === process.pid) continue;
-      if (!isUnder(proc.cwd, root) || AGENT_COMMS.has(proc.comm)) continue;
+      if (AGENT_COMMS.has(proc.comm)) continue;
+      if (!containedBySession(proc, root, sessionId, this.scratchRoot, this.probes)) continue;
       const startTicks = openSignalBracket(proc, this.probes);
       if (!this.probes.portsForPid(proc.pid).includes(port)) continue;
       yield { pid: proc.pid, startTicks };
@@ -903,10 +1000,12 @@ export class ProcessReaper {
     pid: number,
     root: string,
     port: number,
+    sessionId?: string | null,
   ): boolean {
     const live = verify(pid);
     if (!live) return false;
-    if (!isUnder(live.cwd, root)) return false;
+    if (!containedBySession({ pid, cwd: live.cwd }, root, sessionId, this.scratchRoot, this.probes))
+      return false;
     if (AGENT_COMMS.has(live.comm)) return false;
     return live.ports.includes(port);
   }
@@ -1356,29 +1455,93 @@ export function scanClaudeAliveByWorktree(
   return result;
 }
 
+/** Everything one sweep needs to attribute a single process; built once per scan. */
+interface AttributionCtx {
+  roots: string[];
+  worktreePaths: string[];
+  /** sessionId → worktreePath, for the provenance fallback. */
+  pathBySession: Map<string, string>;
+  inodeMap: Map<number, number> | null;
+  scratchRoot: string | null;
+  probes: ReaperProbes;
+}
+
 /**
- * Scan listening ports for a set of worktree paths in a single pass.
+ * Resolve ONE process to the worktree whose listeners it belongs to.
+ *
+ * Returns null whenever the process is not a session's server: it is us or the agent, its
+ * cwd is neither under a worktree nor under the scratch root, it listens on nothing, or
+ * its marker names no session in this sweep.
+ */
+function attributeListener(
+  proc: { pid: number; cwd: string; comm: string },
+  ctx: AttributionCtx,
+): { path: string; ports: number[]; hintDirs: string[] } | null {
+  if (proc.pid === process.pid || AGENT_COMMS.has(proc.comm)) return null;
+  const owned = matchWorktreePath(proc.cwd, ctx.roots, ctx.worktreePaths);
+  if (owned === null && !isScratchRooted(proc.cwd, ctx.scratchRoot)) return null;
+
+  const ports = portsForProcBatched(proc.pid, ctx.inodeMap, ctx.probes);
+  if (ports.length === 0) return null; // not a server — and no reason to read its environ
+  if (owned !== null) return { path: owned, ports, hintDirs: [] };
+
+  // Environ LAST: only a scratchpad-rooted process that actually LISTENS is worth the
+  // mmap-lock read, which keeps the fallback's cost at zero on a normal sweep.
+  const sessionId = sessionMarkerFor(proc.pid, ctx.probes);
+  const path = sessionId === null ? undefined : ctx.pathBySession.get(sessionId);
+  if (path === undefined) return null;
+  return { path, ports, hintDirs: hintDirsFor(proc.cwd, ctx.scratchRoot!) };
+}
+
+/** One session to resolve listeners for. The id is the provenance key the scratchpad
+ *  fallback matches against `SESSION_MARKER_ENV`. */
+export interface ListenerScanTarget {
+  worktreePath: string;
+  sessionId: string;
+}
+
+/** What a worktree's listeners amount to for one sweep. */
+export interface WorktreeListeners {
+  /** Sorted unique listening ports. */
+  ports: number[];
+  /** Extra directories to look for a `.shepherd-preview` hint in, contributed by
+   *  scratchpad-rooted listeners. Always empty on a backend without `environForPid`. */
+  hintDirs: string[];
+}
+
+/**
+ * Scan listening ports for a set of sessions in a single pass.
  *
  * Builds the listening inode→port map EXACTLY ONCE, then resolves each
  * candidate PID's socket inodes against it — never rebuilds per-PID.
  * Excludes `claude` agent processes and the current process (process.pid).
  *
- * Returns a Map from worktreePath → sorted unique listening port numbers (every
- * supplied worktreePath appears as a key, empty array when no ports found), or
- * `null` when the snapshot backend cannot support a negative verdict
- * (`snapshotState()` is `"none"`/`"stale"`). An empty map here would drive
- * `converge` to tear down every bound preview, so `null` must be treated as
+ * A process whose cwd is under a worktree is that worktree's, as before. One whose cwd
+ * is under `scratchRoot` instead is resolved by its `SESSION_MARKER_ENV` marker (see the
+ * fallback header above) and contributes its own directory tree as hint locations.
+ *
+ * Returns a Map from worktreePath → listeners (every supplied worktreePath appears as a
+ * key, empty when nothing found), or `null` when the snapshot backend cannot support a
+ * negative verdict (`snapshotState()` is `"none"`/`"stale"`). An empty map here would
+ * drive `converge` to tear down every bound preview, so `null` must be treated as
  * "unknown, leave listeners bound", not as "no ports".
  */
 export function scanListeningPortsByWorktree(
-  worktreePaths: string[],
+  targets: ListenerScanTarget[],
   probes: ReaperProbes = defaultProbes,
-): Map<string, number[]> | null {
+  scratchRoot: string | null = null,
+): Map<string, WorktreeListeners> | null {
   if (probes.snapshotState && probes.snapshotState() !== "fresh") return null;
-  const result = new Map<string, number[]>(worktreePaths.map((p) => [p, []]));
+  const worktreePaths = [...new Set(targets.map((t) => t.worktreePath))];
+  const result = new Map<string, WorktreeListeners>(
+    worktreePaths.map((p) => [p, { ports: [], hintDirs: [] }]),
+  );
   if (worktreePaths.length === 0) return result;
 
   const roots = worktreePaths.map((p) => normRoot(p, probes));
+  // Keyed by session id, not worktree path: ids are unique, so two sessions sharing a
+  // worktree path resolve to that same path rather than shadowing each other.
+  const pathBySession = new Map(targets.map((t) => [t.sessionId, t.worktreePath]));
 
   // Build the inode→port map exactly once for all PIDs.
   // Both inodeToPortMap + socketInodesForPid must be supplied together;
@@ -1389,21 +1552,30 @@ export function scanListeningPortsByWorktree(
       : null;
 
   const portSets = new Map<string, Set<number>>(worktreePaths.map((p) => [p, new Set()]));
+  const hintSets = new Map<string, Set<string>>(worktreePaths.map((p) => [p, new Set()]));
 
+  const ctx: AttributionCtx = {
+    roots,
+    worktreePaths,
+    pathBySession,
+    inodeMap,
+    scratchRoot,
+    probes,
+  };
   for (const proc of probes.scanProcs()) {
-    if (proc.pid === process.pid || AGENT_COMMS.has(proc.comm)) continue;
-    const matchedPath = matchWorktreePath(proc.cwd, roots, worktreePaths);
-    if (matchedPath === null) continue;
-    const ports = portsForProcBatched(proc.pid, inodeMap, probes);
-    const set = portSets.get(matchedPath)!;
-    for (const port of ports) set.add(port);
+    const hit = attributeListener(proc, ctx);
+    if (hit === null) continue;
+    const set = portSets.get(hit.path)!;
+    for (const port of hit.ports) set.add(port);
+    const hintSet = hintSets.get(hit.path)!;
+    for (const dir of hit.hintDirs) hintSet.add(dir);
   }
 
-  for (const [path, set] of portSets) {
-    result.set(
-      path,
-      [...set].sort((a, b) => a - b),
-    );
+  for (const path of worktreePaths) {
+    result.set(path, {
+      ports: [...portSets.get(path)!].sort((a, b) => a - b),
+      hintDirs: [...hintSets.get(path)!],
+    });
   }
   return result;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -372,7 +372,7 @@ export interface AppDeps {
   /** Local preview launcher. Defaults to `.git/shepherd/preview-start.sh` scripts;
    *  injectable so route tests never spawn real dev servers. */
   previewLauncher?: {
-    findDevPort(worktreePath: string): Promise<number | null>;
+    findDevPort(worktreePath: string, sessionId: string): Promise<number | null>;
     scriptExists(path: string | null | undefined): Promise<boolean>;
     scriptPath(worktreePath: string): Promise<string | null>;
     ensureScript(worktreePath: string, command: string): Promise<string | null>;
@@ -2736,7 +2736,7 @@ async function bindExistingPreviewServer(
   deps: AppDeps,
   launcher: PreviewLauncher,
 ): Promise<Response | null> {
-  const devPort = await launcher.findDevPort(s.worktreePath);
+  const devPort = await launcher.findDevPort(s.worktreePath, s.id);
   if (devPort === null) return null;
   const previewPort = deps.preview?.ensure?.(id, devPort) ?? null;
   if (previewPort === null) return json({ error: "preview_slot_unavailable" }, 503);

--- a/src/service.ts
+++ b/src/service.ts
@@ -822,12 +822,14 @@ const RESEARCH_FIRST_NOTICE =
  * BRANCH_RENAME_NOTICE and the other spawn-constant notices. No i18n.
  */
 const PREVIEW_HINT_NOTICE =
-  "If you start a long-running dev server in this worktree and want Shepherd's live preview to " +
-  "target a specific port, write that port — a bare number, nothing else — to a file named " +
-  "`.shepherd-preview` in the repository root. Shepherd uses it only when that port is actually " +
-  "listening; otherwise it auto-detects the port. This is optional: skip it if you have no dev " +
-  "server or the default detection already targets the right port. Shepherd never starts or stops " +
-  "your dev server.";
+  "If you start a long-running dev server and want Shepherd's live preview to target a specific " +
+  "port, write that port — a bare number, nothing else — to a file named `.shepherd-preview` in " +
+  "the repository root. Start the server from this worktree whenever you can; if you are " +
+  "prototyping from your scratchpad instead, Shepherd still finds it, and the hint file then " +
+  "belongs in the directory you started the server from. Shepherd uses the declared port only " +
+  "when it is actually listening; otherwise it auto-detects the port. This is optional: skip it " +
+  "if you have no dev server or the default detection already targets the right port. Shepherd " +
+  "never starts or stops your dev server.";
 
 /**
  * Seeded into the system prompt at spawn when the repo has autopilot on, so the agent knows
@@ -4882,6 +4884,7 @@ export class SessionService {
       s.worktreePath,
       devPort,
       signal,
+      s.id,
     );
     // Both non-`ok` outcomes signalled NOTHING, and both are distinct from a genuine
     // zero-kill "stopped": the idle-stop escalation ladder must not advance on either,

--- a/test/poller-preview.test.ts
+++ b/test/poller-preview.test.ts
@@ -15,6 +15,7 @@ import { SessionStore } from "../src/store";
 import { StatusPoller } from "../src/poller";
 import { makeApp } from "../src/server";
 import type { HerdrAgent } from "../src/herdr";
+import type { ListenerScanTarget, WorktreeListeners } from "../src/process-reaper";
 
 /**
  * tick() (issue #1529) now reads agents over the socket via `listAsync()`, not the
@@ -109,11 +110,14 @@ function makePollerWithPreview(opts: {
     now = () => Date.now(),
   } = opts;
 
-  const scan = (worktrees: string[]): Map<string, number[]> => {
+  const scan = (worktrees: ListenerScanTarget[]): Map<string, WorktreeListeners> => {
     scanCalls.count++;
-    const result = new Map<string, number[]>();
-    for (const wt of worktrees) {
-      result.set(wt, scanResult.get(wt) ?? []);
+    const result = new Map<string, WorktreeListeners>();
+    for (const t of worktrees) {
+      result.set(t.worktreePath, {
+        ports: scanResult.get(t.worktreePath) ?? [],
+        hintDirs: [],
+      });
     }
     return result;
   };
@@ -241,8 +245,8 @@ test("preview sweep: re-entrancy — pending sweep blocks a concurrent second sw
       sweepMs: 4000,
       scan: (worktrees) => {
         scanCalls.count++;
-        const result = new Map<string, number[]>();
-        for (const wt of worktrees) result.set(wt, [5173]);
+        const result = new Map<string, WorktreeListeners>();
+        for (const t of worktrees) result.set(t.worktreePath, { ports: [5173], hintDirs: [] });
         return result;
       },
       pick: pickFn,
@@ -383,8 +387,8 @@ test("preview sweep: when idle agent's port disappears → converge excludes it 
       sweepMs: 4000,
       scan: (worktrees) => {
         scanCalls.count++;
-        const m = new Map<string, number[]>();
-        for (const wt of worktrees) m.set(wt, currentPorts);
+        const m = new Map<string, WorktreeListeners>();
+        for (const t of worktrees) m.set(t.worktreePath, { ports: currentPorts, hintDirs: [] });
         return m;
       },
       pick: async () => pickResult,
@@ -449,13 +453,13 @@ test("preview sweep: single scan per sweep regardless of session count", async (
   expect(scanCalls.count).toBe(1);
 });
 
-// ── pick receives worktreePath ────────────────────────────────────────────────
+// ── pick receives the hint dirs ───────────────────────────────────────────────
 
-test("preview sweep: pick is called with the session's worktreePath", async () => {
+test("preview sweep: pick is called with the session's worktreePath first in hintDirs", async () => {
   const store = new SessionStore(":memory:");
   const s = store.create(baseSessionInput); // worktreePath = "/wt-a"
 
-  const pickCalls: Array<{ ports: number[]; worktreePath: string }> = [];
+  const pickCalls: Array<{ ports: number[]; hintDirs: string[] }> = [];
   const service = makePreviewService();
   const clock = 100_000;
 
@@ -477,12 +481,12 @@ test("preview sweep: pick is called with the session's worktreePath", async () =
       service,
       sweepMs: 4000,
       scan: (worktrees) => {
-        const m = new Map<string, number[]>();
-        for (const wt of worktrees) m.set(wt, [5173]);
+        const m = new Map<string, WorktreeListeners>();
+        for (const t of worktrees) m.set(t.worktreePath, { ports: [5173], hintDirs: [] });
         return m;
       },
-      pick: async (ports, worktreePath) => {
-        pickCalls.push({ ports, worktreePath });
+      pick: async (ports, hintDirs) => {
+        pickCalls.push({ ports, hintDirs });
         return 5173;
       },
     },
@@ -492,7 +496,7 @@ test("preview sweep: pick is called with the session's worktreePath", async () =
   await new Promise((r) => setTimeout(r, 10));
 
   expect(pickCalls.length).toBeGreaterThanOrEqual(1);
-  expect(pickCalls[0]!.worktreePath).toBe(s.worktreePath);
+  expect(pickCalls[0]!.hintDirs[0]).toBe(s.worktreePath);
 });
 
 // ── GET /api/preview server endpoint ─────────────────────────────────────────
@@ -548,7 +552,7 @@ test("preview sweep: throwing scan → no crash + previewSweeping resets → lat
       sweepMs: 4000,
       scan: () => {
         if (shouldThrow) throw new Error("scan boom");
-        return new Map([["/wt-a", [5173]]]);
+        return new Map([["/wt-a", { ports: [5173], hintDirs: [] }]]);
       },
       pick: async () => 5173,
     },
@@ -594,7 +598,7 @@ test("preview sweep: rejecting pick → no crash + previewSweeping resets → la
     {
       service,
       sweepMs: 4000,
-      scan: () => new Map([["/wt-a", [5173]]]),
+      scan: () => new Map([["/wt-a", { ports: [5173], hintDirs: [] }]]),
       pick: async () => {
         if (shouldReject) throw new Error("pick boom");
         return 5173;
@@ -690,8 +694,8 @@ function makeIdleStopPoller(opts: {
         service,
         sweepMs: 4000,
         scan: (worktrees) => {
-          const m = new Map<string, number[]>();
-          for (const wt of worktrees) m.set(wt, [5173]);
+          const m = new Map<string, WorktreeListeners>();
+          for (const t of worktrees) m.set(t.worktreePath, { ports: [5173], hintDirs: [] });
           return m;
         },
         pick: pickFn ?? (async () => pickResult),
@@ -745,8 +749,8 @@ test("idle-stop: disabled by default — no stop called even when idle+stale", a
       service,
       sweepMs: 4000,
       scan: (worktrees) => {
-        const m = new Map<string, number[]>();
-        for (const wt of worktrees) m.set(wt, [5173]);
+        const m = new Map<string, WorktreeListeners>();
+        for (const t of worktrees) m.set(t.worktreePath, { ports: [5173], hintDirs: [] });
         return m;
       },
       pick: async () => 5173,
@@ -859,8 +863,8 @@ test("idle-stop: stale-status guard — s.status is idle (stale snapshot) but st
       service,
       sweepMs: 4000,
       scan: (worktrees) => {
-        const m = new Map<string, number[]>();
-        for (const wt of worktrees) m.set(wt, [5173]);
+        const m = new Map<string, WorktreeListeners>();
+        for (const t of worktrees) m.set(t.worktreePath, { ports: [5173], hintDirs: [] });
         return m;
       },
       pick: async () => 5173,
@@ -1054,8 +1058,8 @@ test("idle-stop: reset on recovery — after SIGTERM, next sweep with low idleSi
       service,
       sweepMs: 4000,
       scan: (worktrees) => {
-        const m = new Map<string, number[]>();
-        for (const wt of worktrees) m.set(wt, [5173]);
+        const m = new Map<string, WorktreeListeners>();
+        for (const t of worktrees) m.set(t.worktreePath, { ports: [5173], hintDirs: [] });
         return m;
       },
       pick: async () => 5173,
@@ -1122,8 +1126,9 @@ test("idle-stop: reset on port death — after SIGTERM, port disappears then rea
       service,
       sweepMs: 4000,
       scan: (worktrees) => {
-        const m = new Map<string, number[]>();
-        for (const wt of worktrees) m.set(wt, currentPick !== null ? [5173] : []);
+        const m = new Map<string, WorktreeListeners>();
+        for (const t of worktrees)
+          m.set(t.worktreePath, { ports: currentPick !== null ? [5173] : [], hintDirs: [] });
         return m;
       },
       pick: async () => currentPick,
@@ -1190,8 +1195,8 @@ test("idle-stop: devPort change mid-escalation → resets to fresh SIGTERM (not 
       service,
       sweepMs: 4000,
       scan: (worktrees) => {
-        const m = new Map<string, number[]>();
-        for (const wt of worktrees) m.set(wt, [currentDevPort]);
+        const m = new Map<string, WorktreeListeners>();
+        for (const t of worktrees) m.set(t.worktreePath, { ports: [currentDevPort], hintDirs: [] });
         return m;
       },
       pick: async () => currentDevPort,

--- a/test/preview-launch.test.ts
+++ b/test/preview-launch.test.ts
@@ -80,21 +80,24 @@ test("ensurePreviewStartScript: package wrapper runs dev command with selected p
 // ── #1912: findPreviewDevPort forces a refresh + handles the null (unknown) scan ──
 
 import { findPreviewDevPort } from "../src/preview-launch";
+import type { WorktreeListeners } from "../src/process-reaper";
 
 test("findPreviewDevPort: forces a refresh before scanning (finds a just-started server)", async () => {
   const events: string[] = [];
   // The scan reflects a dev server that only became visible AFTER a forced refresh:
   // it returns nothing until `refresh({force})` runs, then 5173.
   let refreshed = false;
-  const port = await findPreviewDevPort("/wt/app", {
+  const port = await findPreviewDevPort("/wt/app", "s-1", {
     refresh: async (opts) => {
       events.push(`refresh:${opts?.force ? "force" : "coalesce"}`);
       if (opts?.force) refreshed = true;
     },
-    scan: (worktrees) => {
+    scan: (targets) => {
       events.push("scan");
-      const m = new Map<string, number[]>();
-      for (const w of worktrees) m.set(w, refreshed ? [5173] : []);
+      const m = new Map<string, WorktreeListeners>();
+      for (const t of targets) {
+        m.set(t.worktreePath, { ports: refreshed ? [5173] : [], hintDirs: [] });
+      }
       return m;
     },
   });
@@ -104,7 +107,7 @@ test("findPreviewDevPort: forces a refresh before scanning (finds a just-started
 });
 
 test("findPreviewDevPort: a null scan (unknown) yields no dev port", async () => {
-  const port = await findPreviewDevPort("/wt/app", {
+  const port = await findPreviewDevPort("/wt/app", "s-1", {
     refresh: async () => {},
     scan: () => null,
   });

--- a/test/preview.test.ts
+++ b/test/preview.test.ts
@@ -8,7 +8,11 @@ import {
   makeRelayHandlers,
   type FsAccessors,
 } from "../src/preview";
-import { scanListeningPortsByWorktree, type ReaperProbes } from "../src/process-reaper";
+import {
+  scanListeningPortsByWorktree,
+  type ListenerScanTarget,
+  type ReaperProbes,
+} from "../src/process-reaper";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -97,6 +101,18 @@ test("pickPrimaryPort: only non-curated, none answer HTTP → null", async () =>
   expect(result).toBeNull();
 });
 
+// EXCLUDED_PORTS: a debugger/CDP endpoint answers a plain HTTP GET, so the liveness
+// probe alone would happily hand one to the operator's browser as "the preview".
+
+test("pickPrimaryPort: debugger/CDP ports are never picked, even answering HTTP", async () => {
+  const alwaysLive = async (): Promise<boolean> => true;
+  for (const port of [9222, 9229, 9230]) {
+    expect(await pickPrimaryPort([port], alwaysLive)).toBeNull();
+  }
+  // …and they never outrank a real, higher-numbered dev port.
+  expect(await pickPrimaryPort([9222, 9500], alwaysLive)).toBe(9500);
+});
+
 // ── readPreviewHint + resolveDevPort ──────────────────────────────────────────
 
 // Fake readFile helpers
@@ -106,23 +122,29 @@ const rejectReadFile = async (): Promise<string> => {
 const makeReadFile = (content: string) => async (): Promise<string> => content;
 
 // These tests exercise readPreviewHint behaviour indirectly via resolveDevPort.
+test("resolveDevPort: an explicit hint cannot point the preview at a debugger", async () => {
+  const alwaysLive = async (): Promise<boolean> => true;
+  const result = await resolveDevPort([9229, 5173], ["/any"], makeReadFile("9229"), alwaysLive);
+  expect(result).toBe(5173);
+});
+
 test("resolveDevPort: valid port string '3000\\n' → hint honored (3000 curated, no probe)", async () => {
-  const result = await resolveDevPort([3000], "/any", makeReadFile("3000\n"), async () => true);
+  const result = await resolveDevPort([3000], ["/any"], makeReadFile("3000\n"), async () => true);
   expect(result).toBe(3000);
 });
 
 test("resolveDevPort: non-numeric 'abc' hint → null (falls back to pickPrimaryPort)", async () => {
-  const result = await resolveDevPort([5173], "/any", makeReadFile("abc"), neverProbe);
+  const result = await resolveDevPort([5173], ["/any"], makeReadFile("abc"), neverProbe);
   expect(result).toBe(5173); // bad hint → falls back
 });
 
 test("resolveDevPort: out-of-range '0' hint → null (falls back)", async () => {
-  const result = await resolveDevPort([5173], "/any", makeReadFile("0"), neverProbe);
+  const result = await resolveDevPort([5173], ["/any"], makeReadFile("0"), neverProbe);
   expect(result).toBe(5173);
 });
 
 test("resolveDevPort: out-of-range '70000' hint → null (falls back)", async () => {
-  const result = await resolveDevPort([5173], "/any", makeReadFile("70000"), neverProbe);
+  const result = await resolveDevPort([5173], ["/any"], makeReadFile("70000"), neverProbe);
   expect(result).toBe(5173);
 });
 
@@ -132,7 +154,7 @@ test("resolveDevPort: surrounding whitespace '  5173  ' → hint honored (curate
     probeCount++;
     return true;
   };
-  const result = await resolveDevPort([5173], "/any", makeReadFile("  5173  "), countingProbe);
+  const result = await resolveDevPort([5173], ["/any"], makeReadFile("  5173  "), countingProbe);
   expect(result).toBe(5173);
   expect(probeCount).toBe(0); // curated → no probe
 });
@@ -145,14 +167,14 @@ test("resolveDevPort: junk-suffixed hint '3000abc' → rejected (falls back to p
     probeCount++;
     return false;
   };
-  const result = await resolveDevPort([5173], "/any", makeReadFile("3000abc"), countingProbe);
+  const result = await resolveDevPort([5173], ["/any"], makeReadFile("3000abc"), countingProbe);
   expect(result).toBe(5173); // curated 5173 returned via fallback (no probe)
   expect(probeCount).toBe(0); // 3000 was NEVER probed (hint was rejected outright)
 });
 
 test("resolveDevPort: curated hint not in ports → falls back to pickPrimaryPort (ports.includes gate)", async () => {
   // hint=3000 (curated), ports=[5173] — 3000 not listening → ignored
-  const result = await resolveDevPort([5173], "/any", makeReadFile("3000"), neverProbe);
+  const result = await resolveDevPort([5173], ["/any"], makeReadFile("3000"), neverProbe);
   expect(result).toBe(5173); // fallback picks curated 5173
 });
 
@@ -163,7 +185,7 @@ test("resolveDevPort: hint curated, in ports → returns hint WITHOUT probing", 
     return true;
   };
   // hint=5173 (curated), ports=[3000, 5173]
-  const result = await resolveDevPort([3000, 5173], "/any", makeReadFile("5173"), countingProbe);
+  const result = await resolveDevPort([3000, 5173], ["/any"], makeReadFile("5173"), countingProbe);
   expect(result).toBe(5173);
   expect(probeCount).toBe(0);
 });
@@ -172,14 +194,14 @@ test("resolveDevPort: hint non-curated, in ports, probe passes → returns hint 
   // hint=9000 (non-curated), ports=[9000, 5173]; probe passes for 9000
   // Without the hint, pickPrimaryPort would return 5173. The hint overrides it.
   const probe = async (port: number): Promise<boolean> => port === 9000;
-  const result = await resolveDevPort([9000, 5173], "/any", makeReadFile("9000"), probe);
+  const result = await resolveDevPort([9000, 5173], ["/any"], makeReadFile("9000"), probe);
   expect(result).toBe(9000);
 });
 
 test("resolveDevPort: hint non-curated, in ports, probe fails → falls back to pickPrimaryPort (returns curated 5173)", async () => {
   // hint=9000 (non-curated), probe fails for 9000; 5173 is curated → returned unprobed
   const probe = async (port: number): Promise<boolean> => port !== 9000;
-  const result = await resolveDevPort([9000, 5173], "/any", makeReadFile("9000"), probe);
+  const result = await resolveDevPort([9000, 5173], ["/any"], makeReadFile("9000"), probe);
   expect(result).toBe(5173);
 });
 
@@ -192,7 +214,7 @@ test("resolveDevPort: failed non-curated hint is NOT re-probed in the fallback",
     probed.push(port);
     return port === 9500;
   };
-  const result = await resolveDevPort([9000, 9500], "/any", makeReadFile("9000"), probe);
+  const result = await resolveDevPort([9000, 9500], ["/any"], makeReadFile("9000"), probe);
   expect(result).toBe(9500);
   expect(probed.filter((p) => p === 9000).length).toBe(1); // probed once (hint branch), not re-probed
 });
@@ -204,13 +226,13 @@ test("resolveDevPort: hint not in ports → falls back, hint port never probed",
     probedPorts.push(port);
     return false;
   };
-  const result = await resolveDevPort([5173], "/any", makeReadFile("9000"), trackingProbe);
+  const result = await resolveDevPort([5173], ["/any"], makeReadFile("9000"), trackingProbe);
   expect(result).toBe(5173); // curated 5173 returned (no probe for curated)
   expect(probedPorts).not.toContain(9000);
 });
 
 test("resolveDevPort: no hint (readFile rejects) → falls back to pickPrimaryPort", async () => {
-  const result = await resolveDevPort([5173], "/any", rejectReadFile, neverProbe);
+  const result = await resolveDevPort([5173], ["/any"], rejectReadFile, neverProbe);
   expect(result).toBe(5173);
 });
 
@@ -227,11 +249,59 @@ test("resolveDevPort: default reader caps the read at MAX_HINT_BYTES", async () 
     writeFileSync(join(dir, ".shepherd-preview"), `9000${" ".repeat(200)}x`);
     const alwaysLive = async (): Promise<boolean> => true;
     // Default readFile (undefined) → bounded reader.
-    const result = await resolveDevPort([9000, 5173], dir, undefined, alwaysLive);
+    const result = await resolveDevPort([9000, 5173], [dir], undefined, alwaysLive);
     expect(result).toBe(9000);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+// ── resolveDevPort across several hint directories ────────────────────────────
+//
+// A scratchpad-rooted server contributes its own directory as a hint location, so the
+// worktree root has to keep winning: it is the canonical, agent-declared one.
+
+/** Reader that resolves `.shepherd-preview` per directory; missing dirs throw (ENOENT). */
+const makeDirReadFile = (byDir: Record<string, string>) => async (path: string) => {
+  for (const [dir, content] of Object.entries(byDir)) {
+    if (path === `${dir}/.shepherd-preview`) return content;
+  }
+  throw new Error("ENOENT: no such file");
+};
+
+test("resolveDevPort: the worktree-root hint outranks a scratchpad one", async () => {
+  const result = await resolveDevPort(
+    [3000, 4321],
+    ["/wt/app", "/scratch/proto"],
+    makeDirReadFile({ "/wt/app": "3000", "/scratch/proto": "4321" }),
+    neverProbe,
+  );
+  expect(result).toBe(3000);
+});
+
+test("resolveDevPort: a scratchpad hint is honored when the worktree root has none", async () => {
+  const result = await resolveDevPort(
+    [3000, 9000],
+    ["/wt/app", "/scratch/proto"],
+    makeDirReadFile({ "/scratch/proto": "9000" }),
+    async () => true,
+  );
+  expect(result).toBe(9000);
+});
+
+test("resolveDevPort: hint dirs are tried in order, first VALID one wins", async () => {
+  // An unreadable/garbage hint must not stop the walk — it is not a declaration.
+  const result = await resolveDevPort(
+    [4321],
+    ["/wt/app", "/scratch/proto", "/scratch"],
+    makeDirReadFile({ "/wt/app": "not-a-port", "/scratch": "4321" }),
+    neverProbe,
+  );
+  expect(result).toBe(4321);
+});
+
+test("resolveDevPort: no hint dirs at all still falls back to the heuristic", async () => {
+  expect(await resolveDevPort([5173], [], undefined, neverProbe)).toBe(5173);
 });
 
 // ── sanitizeCloseCode ─────────────────────────────────────────────────────────
@@ -315,6 +385,12 @@ function makeProbes(over: Partial<ReaperProbes> = {}): ReaperProbes {
   };
 }
 
+/** Scan targets from bare worktree paths, with a session id derived from each path.
+ *  Tests that exercise the scratchpad fallback build their targets explicitly instead. */
+function targets(paths: string[]): ListenerScanTarget[] {
+  return paths.map((worktreePath) => ({ worktreePath, sessionId: `sess:${worktreePath}` }));
+}
+
 test("scanListeningPortsByWorktree: builds the inode→port map EXACTLY ONCE for N worktrees/PIDs", () => {
   let mapBuildCount = 0;
 
@@ -346,14 +422,14 @@ test("scanListeningPortsByWorktree: builds the inode→port map EXACTLY ONCE for
     socketInodesForPid: (pid) => pidInodes[pid] ?? [],
   });
 
-  const result = scanListeningPortsByWorktree(["/wt/alpha", "/wt/beta"], probes);
+  const result = scanListeningPortsByWorktree(targets(["/wt/alpha", "/wt/beta"]), probes);
 
   // Map built exactly once
   expect(mapBuildCount).toBe(1);
   // alpha gets pid 101 (port 5173) + pid 103 (no ports)
-  expect(result!.get("/wt/alpha")).toEqual([5173]);
+  expect(result!.get("/wt/alpha")!.ports).toEqual([5173]);
   // beta gets pid 102 (port 3000)
-  expect(result!.get("/wt/beta")).toEqual([3000]);
+  expect(result!.get("/wt/beta")!.ports).toEqual([3000]);
 });
 
 test("scanListeningPortsByWorktree: ports are sorted and deduplicated per worktree", () => {
@@ -370,9 +446,9 @@ test("scanListeningPortsByWorktree: ports are sorted and deduplicated per worktr
     inodeToPortMap: () => inodeMap,
     socketInodesForPid: (pid) => (pid === 10 ? [1, 2] : [3]),
   });
-  const result = scanListeningPortsByWorktree(["/wt/app"], probes);
+  const result = scanListeningPortsByWorktree(targets(["/wt/app"]), probes);
   // sorted, deduped: [3000, 5173]
-  expect(result!.get("/wt/app")).toEqual([3000, 5173]);
+  expect(result!.get("/wt/app")!.ports).toEqual([3000, 5173]);
 });
 
 test("scanListeningPortsByWorktree: excludes the agent comm (claude)", () => {
@@ -382,8 +458,8 @@ test("scanListeningPortsByWorktree: excludes the agent comm (claude)", () => {
     inodeToPortMap: () => inodeMap,
     socketInodesForPid: () => [1],
   });
-  const result = scanListeningPortsByWorktree(["/wt/app"], probes);
-  expect(result!.get("/wt/app")).toEqual([]);
+  const result = scanListeningPortsByWorktree(targets(["/wt/app"]), probes);
+  expect(result!.get("/wt/app")!.ports).toEqual([]);
 });
 
 test("scanListeningPortsByWorktree: excludes own process.pid", () => {
@@ -393,8 +469,8 @@ test("scanListeningPortsByWorktree: excludes own process.pid", () => {
     inodeToPortMap: () => inodeMap,
     socketInodesForPid: () => [1],
   });
-  const result = scanListeningPortsByWorktree(["/wt/app"], probes);
-  expect(result!.get("/wt/app")).toEqual([]);
+  const result = scanListeningPortsByWorktree(targets(["/wt/app"]), probes);
+  expect(result!.get("/wt/app")!.ports).toEqual([]);
 });
 
 test("scanListeningPortsByWorktree: processes outside all worktrees are ignored", () => {
@@ -404,8 +480,8 @@ test("scanListeningPortsByWorktree: processes outside all worktrees are ignored"
     inodeToPortMap: () => inodeMap,
     socketInodesForPid: () => [1],
   });
-  const result = scanListeningPortsByWorktree(["/wt/app"], probes);
-  expect(result!.get("/wt/app")).toEqual([]);
+  const result = scanListeningPortsByWorktree(targets(["/wt/app"]), probes);
+  expect(result!.get("/wt/app")!.ports).toEqual([]);
 });
 
 test("scanListeningPortsByWorktree: returns empty arrays for worktrees with no matching procs", () => {
@@ -414,9 +490,9 @@ test("scanListeningPortsByWorktree: returns empty arrays for worktrees with no m
     inodeToPortMap: () => new Map([[1, 5173]]),
     socketInodesForPid: () => [1],
   });
-  const result = scanListeningPortsByWorktree(["/wt/alpha", "/wt/beta"], probes);
-  expect(result!.get("/wt/alpha")).toEqual([]);
-  expect(result!.get("/wt/beta")).toEqual([]);
+  const result = scanListeningPortsByWorktree(targets(["/wt/alpha", "/wt/beta"]), probes);
+  expect(result!.get("/wt/alpha")!.ports).toEqual([]);
+  expect(result!.get("/wt/beta")!.ports).toEqual([]);
 });
 
 test("scanListeningPortsByWorktree: empty worktreePaths → empty map", () => {
@@ -425,7 +501,7 @@ test("scanListeningPortsByWorktree: empty worktreePaths → empty map", () => {
     inodeToPortMap: () => new Map([[1, 5173]]),
     socketInodesForPid: () => [1],
   });
-  const result = scanListeningPortsByWorktree([], probes);
+  const result = scanListeningPortsByWorktree(targets([]), probes);
   expect(result!.size).toBe(0);
 });
 
@@ -436,8 +512,8 @@ test("scanListeningPortsByWorktree: a PID under a nested subdir is attributed to
     inodeToPortMap: () => inodeMap,
     socketInodesForPid: () => [1],
   });
-  const result = scanListeningPortsByWorktree(["/wt/myapp"], probes);
-  expect(result!.get("/wt/myapp")).toEqual([3000]);
+  const result = scanListeningPortsByWorktree(targets(["/wt/myapp"]), probes);
+  expect(result!.get("/wt/myapp")!.ports).toEqual([3000]);
 });
 
 test("scanListeningPortsByWorktree: multiple worktrees get independent port sets", () => {
@@ -453,9 +529,9 @@ test("scanListeningPortsByWorktree: multiple worktrees get independent port sets
     inodeToPortMap: () => inodeMap,
     socketInodesForPid: (pid) => (pid === 10 ? [1] : [2]),
   });
-  const result = scanListeningPortsByWorktree(["/wt/alpha", "/wt/beta"], probes);
-  expect(result!.get("/wt/alpha")).toEqual([5173]);
-  expect(result!.get("/wt/beta")).toEqual([4321]);
+  const result = scanListeningPortsByWorktree(targets(["/wt/alpha", "/wt/beta"]), probes);
+  expect(result!.get("/wt/alpha")!.ports).toEqual([5173]);
+  expect(result!.get("/wt/beta")!.ports).toEqual([4321]);
 });
 
 test("scanListeningPortsByWorktree: mismatched probe config (socketInodesForPid only) falls back to portsForPid", () => {
@@ -471,9 +547,9 @@ test("scanListeningPortsByWorktree: mismatched probe config (socketInodesForPid 
       return pid === 88 ? [5173] : [];
     },
   });
-  const result = scanListeningPortsByWorktree(["/wt/app"], probes);
+  const result = scanListeningPortsByWorktree(targets(["/wt/app"]), probes);
   expect(portsForPidCalled).toBe(true);
-  expect(result!.get("/wt/app")).toEqual([5173]);
+  expect(result!.get("/wt/app")!.ports).toEqual([5173]);
 });
 
 test("scanListeningPortsByWorktree: proc under /wt/appold is NOT attributed to /wt/app", () => {
@@ -484,8 +560,111 @@ test("scanListeningPortsByWorktree: proc under /wt/appold is NOT attributed to /
     inodeToPortMap: () => inodeMap,
     socketInodesForPid: () => [1],
   });
-  const result = scanListeningPortsByWorktree(["/wt/app"], probes);
-  expect(result!.get("/wt/app")).toEqual([]);
+  const result = scanListeningPortsByWorktree(targets(["/wt/app"]), probes);
+  expect(result!.get("/wt/app")!.ports).toEqual([]);
+});
+
+// ── scanListeningPortsByWorktree: the scratchpad provenance fallback ──────────
+//
+// Agents prototyping in the Claude scratchpad start their dev server there, so a cwd
+// test alone never sees it. The inherited SHEPHERD_SESSION_ID marker re-attaches it —
+// but only for a process that is BOTH inside the scratch root and actually listening.
+
+const SCRATCH = "/scratch";
+const PROTO = "/scratch/claude-1000/wt-slug/cc-session/scratchpad/proto";
+
+/** One listening scratchpad process, with whatever marker (or none) a test wants. */
+function scratchScanProbes(marker: string | null, over: Partial<ReaperProbes> = {}) {
+  return makeProbes({
+    scanProcs: () => [{ pid: 91, cwd: PROTO, comm: "python3" }],
+    inodeToPortMap: () => new Map([[1, 8123]]),
+    socketInodesForPid: () => [1],
+    environForPid: (): Record<string, string> =>
+      marker === null ? {} : { SHEPHERD_SESSION_ID: marker },
+    ...over,
+  });
+}
+
+const oneTarget = [{ worktreePath: "/wt/app", sessionId: "s-1" }];
+
+test("scanListeningPortsByWorktree: a marked scratchpad listener lands on its session's worktree", () => {
+  const result = scanListeningPortsByWorktree(oneTarget, scratchScanProbes("s-1"), SCRATCH);
+  expect(result!.get("/wt/app")!.ports).toEqual([8123]);
+});
+
+test("scanListeningPortsByWorktree: the scratchpad listener contributes its dirs as hint locations", () => {
+  const result = scanListeningPortsByWorktree(oneTarget, scratchScanProbes("s-1"), SCRATCH);
+  const hints = result!.get("/wt/app")!.hintDirs;
+  // Own dir first, then ancestors — capped, and never reaching the scratch root itself.
+  expect(hints[0]).toBe(PROTO);
+  expect(hints.length).toBeLessThanOrEqual(4);
+  expect(hints).not.toContain(SCRATCH);
+  for (const dir of hints) expect(dir.startsWith(`${SCRATCH}/`)).toBe(true);
+});
+
+test("scanListeningPortsByWorktree: a marker naming another session is not attributed", () => {
+  const result = scanListeningPortsByWorktree(oneTarget, scratchScanProbes("s-other"), SCRATCH);
+  expect(result!.get("/wt/app")).toEqual({ ports: [], hintDirs: [] });
+});
+
+test("scanListeningPortsByWorktree: an unmarked scratchpad listener is not attributed", () => {
+  const result = scanListeningPortsByWorktree(oneTarget, scratchScanProbes(null), SCRATCH);
+  expect(result!.get("/wt/app")).toEqual({ ports: [], hintDirs: [] });
+});
+
+test("scanListeningPortsByWorktree: no scratchRoot (redirect disabled) keeps the scan cwd-only", () => {
+  const result = scanListeningPortsByWorktree(oneTarget, scratchScanProbes("s-1"));
+  expect(result!.get("/wt/app")).toEqual({ ports: [], hintDirs: [] });
+});
+
+test("scanListeningPortsByWorktree: a backend without environForPid never attributes by marker", () => {
+  const probes = makeProbes({
+    scanProcs: () => [{ pid: 91, cwd: PROTO, comm: "python3" }],
+    inodeToPortMap: () => new Map([[1, 8123]]),
+    socketInodesForPid: () => [1],
+    // environForPid deliberately absent (darwin)
+  });
+  const result = scanListeningPortsByWorktree(oneTarget, probes, SCRATCH);
+  expect(result!.get("/wt/app")).toEqual({ ports: [], hintDirs: [] });
+});
+
+test("scanListeningPortsByWorktree: a non-listening scratchpad proc is never environ-read", () => {
+  // The environ read takes the target's mmap lock, so it must stay behind the
+  // listening test — a transient agent child must not cost one.
+  let environReads = 0;
+  const probes = makeProbes({
+    scanProcs: () => [{ pid: 91, cwd: PROTO, comm: "bash" }],
+    inodeToPortMap: () => new Map(),
+    socketInodesForPid: () => [],
+    environForPid: () => {
+      environReads++;
+      return { SHEPHERD_SESSION_ID: "s-1" };
+    },
+  });
+  const result = scanListeningPortsByWorktree(oneTarget, probes, SCRATCH);
+  expect(result!.get("/wt/app")!.ports).toEqual([]);
+  expect(environReads).toBe(0);
+});
+
+test("scanListeningPortsByWorktree: a marked listener outside the scratch root stays ignored", () => {
+  const probes = scratchScanProbes("s-1", {
+    scanProcs: () => [{ pid: 91, cwd: "/tmp/elsewhere", comm: "python3" }],
+  });
+  const result = scanListeningPortsByWorktree(oneTarget, probes, SCRATCH);
+  expect(result!.get("/wt/app")).toEqual({ ports: [], hintDirs: [] });
+});
+
+test("scanListeningPortsByWorktree: two sessions sharing a worktree path do not shadow each other", () => {
+  const result = scanListeningPortsByWorktree(
+    [
+      { worktreePath: "/wt/app", sessionId: "s-1" },
+      { worktreePath: "/wt/app", sessionId: "s-2" },
+    ],
+    scratchScanProbes("s-2"),
+    SCRATCH,
+  );
+  expect(result!.size).toBe(1);
+  expect(result!.get("/wt/app")!.ports).toEqual([8123]);
 });
 
 // ── PreviewService: reverse-proxy listeners + slot allocation ──────────────────

--- a/test/proc-probes-darwin.integration.test.ts
+++ b/test/proc-probes-darwin.integration.test.ts
@@ -64,9 +64,15 @@ maybe("darwin backend over real lsof: joins a child's cwd and its listening port
 
     // And the batched worktree mapping resolves the same port for the root — the
     // path the preview sweep actually takes.
-    const byWorktree = scanListeningPortsByWorktree([root], probes);
+    const byWorktree = scanListeningPortsByWorktree(
+      [{ worktreePath: root, sessionId: "s-1" }],
+      probes,
+    );
     expect(byWorktree).not.toBeNull();
-    expect(byWorktree!.get(root)).toContain(port);
+    expect(byWorktree!.get(root)!.ports).toContain(port);
+    // Darwin supplies no `environForPid`, so the scratchpad provenance fallback can
+    // never fire there — no hint dirs are ever contributed.
+    expect(byWorktree!.get(root)!.hintDirs).toEqual([]);
   } finally {
     child.kill("SIGKILL");
     rmSync(root, { recursive: true, force: true });

--- a/test/proc-probes-darwin.macos.test.ts
+++ b/test/proc-probes-darwin.macos.test.ts
@@ -104,9 +104,14 @@ onDarwin(
       await probes.refresh();
       // The stored root is the raw (pre-realpath) path; normalizeRoot must resolve it
       // so it matches lsof's kernel-resolved cwd.
-      const byWorktree = scanListeningPortsByWorktree([rawRoot], probes);
+      const byWorktree = scanListeningPortsByWorktree(
+        [{ worktreePath: rawRoot, sessionId: "s-1" }],
+        probes,
+      );
       expect(byWorktree).not.toBeNull();
-      expect(byWorktree!.get(rawRoot)).toContain(port);
+      expect(byWorktree!.get(rawRoot)!.ports).toContain(port);
+      // No `environForPid` on darwin ⇒ the scratchpad fallback never fires here.
+      expect(byWorktree!.get(rawRoot)!.hintDirs).toEqual([]);
     } finally {
       child.kill("SIGKILL");
       rmSync(rawRoot, { recursive: true, force: true });

--- a/test/proc-probes-reaper.test.ts
+++ b/test/proc-probes-reaper.test.ts
@@ -154,9 +154,9 @@ test("stopListenersOnPort: arming did NOT widen the blast radius (#1922 scope)",
   // The three other things `canAuthorizeSignal: false` gates must be untouched.
   const probes = armedFake();
   const reaper = new ProcessReaper(probes);
-  expect(reaper.detect({ worktreePath: "/wt/x", claudeSessionId: "c1", isolated: true })).toEqual(
-    [],
-  ); // class 2 still fails closed despite a listening proc in the cell
+  expect(
+    reaper.detect({ id: "s-1", worktreePath: "/wt/x", claudeSessionId: "c1", isolated: true }),
+  ).toEqual([]); // class 2 still fails closed despite a listening proc in the cell
   expect(reaper.canDetectLeftovers()).toBe(false); // still no lsof before an archive detect
   const killed: number[] = [];
   new ProcessReaper(armedFake({}, killed)).reap([
@@ -184,6 +184,7 @@ test("scanSystemSideEffects: no listeningPorts probe ⇒ offers zero class-3 lef
   const probes = darwinFake({ readTranscript: () => transcript });
   expect(probes.listeningPorts).toBeUndefined();
   const leftovers = new ProcessReaper(probes).detect({
+    id: "s-1",
     worktreePath: "/wt/x",
     claudeSessionId: "sess-1",
     isolated: true,
@@ -205,6 +206,7 @@ test("scanWorktreeProcs: no signal authority ⇒ offers zero class-2 leftovers",
   });
   const reaper = new ProcessReaper(probes);
   const leftovers = reaper.detect({
+    id: "s-1",
     worktreePath: "/wt/x",
     claudeSessionId: "sess-1",
     isolated: true,
@@ -238,6 +240,7 @@ test("scanWorktreeProcs: WITH signal authority the same process is still offered
     commForPid: () => "vite",
   });
   const leftovers = new ProcessReaper(probes).detect({
+    id: "s-1",
     worktreePath: "/wt/x",
     claudeSessionId: "sess-1",
     isolated: true,
@@ -276,7 +279,9 @@ test("scan helpers return null on a stale/none cell, not an all-false / empty ma
   for (const state of ["none", "stale"] as const) {
     const probes = darwinFake({ state });
     expect(scanClaudeAliveByWorktree(["/wt/x"], probes)).toBeNull();
-    expect(scanListeningPortsByWorktree(["/wt/x"], probes)).toBeNull();
+    expect(
+      scanListeningPortsByWorktree([{ worktreePath: "/wt/x", sessionId: "s-1" }], probes),
+    ).toBeNull();
     expect(liveProcCwds(probes)).toBeNull();
   }
 });

--- a/test/process-reaper.test.ts
+++ b/test/process-reaper.test.ts
@@ -61,7 +61,12 @@ function recycleAfterFirstRead(pid: number): (p: number) => CpuStat {
   return (p) => (p === pid && reads++ > 0 ? stat(TICKS + 7) : stat(TICKS));
 }
 
-const session = { worktreePath: "/wt/repo-x", claudeSessionId: "sess-1", isolated: true };
+const session = {
+  id: "s-1",
+  worktreePath: "/wt/repo-x",
+  claudeSessionId: "sess-1",
+  isolated: true,
+};
 
 test("class 2: a listening process under the worktree is detected", () => {
   const reaper = new ProcessReaper(
@@ -124,7 +129,7 @@ test("class 2: a non-isolated session (worktreePath == repo root) never cwd-scan
     }),
   );
   expect(
-    reaper.detect({ worktreePath: "/repo", claudeSessionId: "sess-1", isolated: false }),
+    reaper.detect({ id: "s-1", worktreePath: "/repo", claudeSessionId: "sess-1", isolated: false }),
   ).toEqual([]);
 });
 
@@ -136,6 +141,147 @@ test("class 2: the reaper never offers its own process (self-pid)", () => {
     }),
   );
   expect(reaper.detect(session)).toEqual([]);
+});
+
+// ── class 2 / stop: the scratchpad provenance fallback ───────────────────────
+//
+// An agent prototyping in its Claude scratchpad starts the dev server THERE, so the
+// cwd test alone never sees it. `SESSION_MARKER_ENV` is what re-attaches it to the
+// session — and it must reach the leftover sweep AND both halves of the stop path,
+// or Shepherd binds a preview it can neither stop nor clean up.
+
+const SCRATCH = "/scratch/claude-1000/wt-slug/cc-session/scratchpad";
+
+/** Probes for a listener at `cwd`, optionally carrying a session marker. */
+function scratchProbes(cwd: string, marker: string | null, over: Partial<ReaperProbes> = {}) {
+  return makeProbes({
+    scanProcs: () => [{ pid: 4242, cwd, comm: "vite" }],
+    portsForPid: (pid) => (pid === 4242 ? [5174] : []),
+    environForPid: (): Record<string, string> =>
+      marker === null ? {} : { SHEPHERD_SESSION_ID: marker },
+    ...over,
+  });
+}
+
+test("class 2: a scratchpad-rooted listener carrying this session's marker is offered", () => {
+  const reaper = new ProcessReaper(scratchProbes(`${SCRATCH}/proto`, "s-1"), "/scratch");
+  expect(reaper.detect(session)).toEqual([
+    {
+      kind: "process",
+      name: "vite",
+      port: 5174,
+      pid: 4242,
+      startTicks: TICKS,
+      key: "process:4242",
+    },
+  ]);
+});
+
+test("class 2: a scratchpad-rooted listener belonging to ANOTHER session is not offered", () => {
+  const reaper = new ProcessReaper(scratchProbes(`${SCRATCH}/proto`, "s-other"), "/scratch");
+  expect(reaper.detect(session)).toEqual([]);
+});
+
+test("class 2: an unmarked scratchpad-rooted listener is not offered", () => {
+  const reaper = new ProcessReaper(scratchProbes(`${SCRATCH}/proto`, null), "/scratch");
+  expect(reaper.detect(session)).toEqual([]);
+});
+
+test("class 2: no scratchRoot (redirect disabled) leaves the sweep cwd-only", () => {
+  const reaper = new ProcessReaper(scratchProbes(`${SCRATCH}/proto`, "s-1"));
+  expect(reaper.detect(session)).toEqual([]);
+});
+
+test("class 2: a backend without environForPid cannot attribute by marker (darwin)", () => {
+  const probes = makeProbes({
+    scanProcs: () => [{ pid: 4242, cwd: `${SCRATCH}/proto`, comm: "vite" }],
+    portsForPid: () => [5174],
+    // environForPid deliberately absent
+  });
+  expect(new ProcessReaper(probes, "/scratch").detect(session)).toEqual([]);
+});
+
+test("class 2: a marked listener OUTSIDE the scratch root is still ignored", () => {
+  // Provenance alone is not containment: the cwd gate is what keeps the environ read
+  // (and the blast radius) off unrelated host processes.
+  const reaper = new ProcessReaper(scratchProbes("/tmp/elsewhere", "s-1"), "/scratch");
+  expect(reaper.detect(session)).toEqual([]);
+});
+
+test("stopListenersOnPort: signals a scratchpad-rooted listener of this session", () => {
+  const killed: number[] = [];
+  const reaper = new ProcessReaper(
+    scratchProbes(`${SCRATCH}/proto`, "s-1", {
+      killPid: (pid) => {
+        killed.push(pid);
+      },
+    }),
+    "/scratch",
+  );
+  expect(reaper.stopListenersOnPort("/wt/repo-x", 5174, "SIGTERM", "s-1")).toEqual({
+    signalled: 1,
+    outcome: "ok",
+  });
+  expect(killed).toEqual([4242]);
+});
+
+test("stopListenersOnPort: without the session id the scratchpad listener stays invisible", () => {
+  // The pre-fallback behaviour, and what a caller that forgets to thread the id gets:
+  // no candidate, `ok`/0 — never a signal against a process we cannot attribute.
+  const killed: number[] = [];
+  const reaper = new ProcessReaper(
+    scratchProbes(`${SCRATCH}/proto`, "s-1", {
+      killPid: (pid) => {
+        killed.push(pid);
+      },
+    }),
+    "/scratch",
+  );
+  expect(reaper.stopListenersOnPort("/wt/repo-x", 5174)).toEqual({
+    signalled: 0,
+    outcome: "ok",
+  });
+  expect(killed).toEqual([]);
+});
+
+test("stopListenersOnPort: another session's scratchpad listener is never signalled", () => {
+  const killed: number[] = [];
+  const reaper = new ProcessReaper(
+    scratchProbes(`${SCRATCH}/proto`, "s-other", {
+      killPid: (pid) => {
+        killed.push(pid);
+      },
+    }),
+    "/scratch",
+  );
+  expect(reaper.stopListenersOnPort("/wt/repo-x", 5174, "SIGTERM", "s-1")).toEqual({
+    signalled: 0,
+    outcome: "ok",
+  });
+  expect(killed).toEqual([]);
+});
+
+test("stopListenersOnPort: verifiesLive judges a scratchpad candidate by the SAME rule that proposed it", () => {
+  // The divergence hazard: a snapshot backend proposes via `candidatesOn`, then re-proves
+  // via `verifiesLive`. If only the proposal knew about the fallback, every stop of a
+  // scratchpad-rooted server would come back "refused" having signalled nothing.
+  const killed: number[] = [];
+  const cwd = `${SCRATCH}/proto`;
+  const reaper = new ProcessReaper(
+    scratchProbes(cwd, "s-1", {
+      canAuthorizeSignal: false,
+      liveProcForPid: (pid) => (pid === 4242 ? { cwd, comm: "vite", ports: [5174] } : null),
+      killPid: (pid) => {
+        killed.push(pid);
+      },
+    }),
+    "/scratch",
+  );
+  expect(reaper.stopListenersOnPort("/wt/repo-x", 5174, "SIGTERM", "s-1")).toEqual({
+    signalled: 1,
+    outcome: "ok",
+  });
+  expect(killed).toEqual([4242]);
 });
 
 test("class 3: tailscale serve --bg is scraped from the transcript when its port still listens", () => {


### PR DESCRIPTION
Agents prototyping in their Claude scratchpad start dev servers there rather than in the worktree. Shepherd could not see them: no Preview badge, no Stop, and the server survived session archive unnoticed.

## Why the hint file was not the problem

Preview attribution was **cwd-only** — `scanListeningPortsByWorktree` keeps a process only if its `/proc/<pid>/cwd` is under a session worktree. A server started with `cd <scratchpad>` matches nothing, so its ports never enter the set. Relocating (or additionally reading) `.shepherd-preview` in the scratchpad would have changed nothing on its own: `resolveDevPort` honors a declared port **only when that port is already listed as listening**.

## The lever

Every process an agent spawns inherits `SHEPHERD_SESSION_ID` in its environ — cwd-independent, fixed at exec, and already the runaway reaper's provenance key. Attributing by that marker works no matter how Claude Code lays out its scratchpad, so a CLI change cannot break it.

It is kept narrow:

- the cwd must first be under `agentTmpDir()` — a plain string test on data `scanProcs` already read;
- only then is the environ consulted, and only for a process that **actually listens**, so the mmap-lock read costs nothing on a normal sweep;
- `scratchRoot === null` (`SHEPHERD_AGENT_TMPDIR=""`) disables it entirely — the existing one-env-var rollback still works.

## Three blind spots, one predicate

The same cwd filter gated four call sites. `containedBySession()` now covers all of them:

| Site | Before | After |
| --- | --- | --- |
| `scanListeningPortsByWorktree` | port never enters the set | attributed by marker |
| `resolveDevPort` | hint ignored (port not in set) | worktree hint first, then the server's own dir |
| `candidatesOn` + `verifiesLive` | Stop reports `killed: 0` as **success**; the idle ladder walks SIGTERM→SIGKILL→gaveUp having signalled nothing | proposed and re-proved by the same rule, actually signalled |
| `scanWorktreeProcs` | never offered at "Terminate & close" — leaks past archive | offered as a leftover |

Both halves of the stop path had to learn it together: teaching only `candidatesOn` would turn every stop of such a server into `"refused"`, teaching only `verifiesLive` would signal on a weaker rule than proposed it.

## Also

- **`EXCLUDED_PORTS` = 9222 / 9229 / 9230.** A CDP endpoint and the Node inspector answer a plain HTTP GET, so the liveness probe alone would let one win the non-curated fallback. Widening eligibility to the scratchpad — which is full of both — made that worth closing. Not even an explicit hint can now point the preview at a debugger.
- **`scratchRoot` is passed in, not imported.** `tmp-sweep.ts` already imports `process-reaper.ts`, so reading `agentTmpDir()` there would close a cycle. It doubles as the test seam.
- **macOS is untouched.** `makeDarwinProbes` supplies `portsForPid`, so the preview scan already works there and still does; darwin omits `environForPid` (deliberately, to keep the #1144 runaway reaper fail-closed), so the fallback never fires and `hintDirs` stays empty. The darwin tests assert exactly that.
- The `shepherd-preview` skill and the resident preview notice now state the same rule: start the server from the worktree; if you prototype from the scratchpad it is still found, and the hint file then belongs next to the server.

## Verification

`bun run lint`, `bunx tsc --noEmit`, `bun run test` (8375 pass / 0 fail), `bunx fallow audit --base origin/main --fail-on-issues` — all clean.

Beyond the unit tests, the chain was exercised against **real `/proc`**: a real HTTP server spawned with cwd in the scratchpad and the session marker set was attributed to the worktree, contributed its directory as a hint location, had a hint next to it honored, was offered as a leftover, was signalled by `stopListenersOnPort` (`{signalled: 1, outcome: "ok"}`) with the process confirmed dead and the port closed — and a second session scanning the same host did **not** see it.