### PR TITLE
feat(agent-cli): support mise-managed claude/codex install + update

### DIFF
--- a/docs-site/src/content/docs/operating.md
+++ b/docs-site/src/content/docs/operating.md
@@ -109,6 +109,28 @@ the package-manager store reclaim, which doesn't depend on process data. Idle-st
 behaves the same way; see `SHEPHERD_PREVIEW_IDLE_STOP_MS` in
 [Configuration](/reference/configuration/).
 
+## Agent CLIs managed by mise
+
+If `claude` or `codex` is managed by [mise](https://mise.jdx.dev), Shepherd works
+_with_ that install instead of planting a second one beside it.
+
+**Installing.** When a `claude`/`codex` check is red and `mise which <tool>` resolves,
+the **Fix** button symlinks the mise binary into `~/.local/bin` rather than running the
+vendor installer. mise exposes tools through a shims dir that isn't on the systemd
+unit's `PATH`, and `mise activate` only runs in interactive shells — so the binary
+existed, it was just unreachable. `~/.local/bin` **is** on the unit's `PATH`. Hosts
+without mise, and tools mise doesn't manage, get the vendor installer exactly as before.
+
+**Updating.** When mise owns the `codex` on `PATH` — a shim, an install path, or a
+symlink resolving to one — the codex update runs `mise upgrade codex` and **nothing
+else**. `mise upgrade` respects the version request in your mise config, so a pinned
+codex won't advance; Shepherd then reports the update as not converged and points you at
+`mise use -g codex@latest` rather than falling back to `codex update` or `npm install -g`,
+either of which would install a second codex shadowing the mise-managed one.
+
+Claude Code has no Shepherd-side updater (it self-updates), so a mise-managed `claude` is
+upgraded by you: `mise upgrade claude`.
+
 ## Host tuning — tmpfs inodes
 
 Shepherd keeps spawned agents' Node compile cache **off** the `/tmp` tmpfs and runs

--- a/src/codex-update.ts
+++ b/src/codex-update.ts
@@ -103,10 +103,21 @@ function sanitizeVersion(v: string | null | undefined): string {
   return clean || "unknown";
 }
 
-/** The two installers that can update the codex on PATH. Which one actually
- *  WORKS is a property of the host, not something either side can know up front
- *  — see {@link buildUpdateScript}. */
-export type CodexUpdateChannel = "npm" | "codex";
+/** The installers that can update the codex on PATH. Which one actually WORKS is
+ *  a property of the host, not something either side can know up front — see
+ *  {@link buildUpdateScript}. `mise` is not a peer of the other two: it applies
+ *  only when mise OWNS the on-PATH codex, and then it is the only channel. */
+const CODEX_UPDATE_CHANNELS = ["npm", "codex", "mise"] as const;
+export type CodexUpdateChannel = (typeof CODEX_UPDATE_CHANNELS)[number];
+
+/** Narrow an untrusted value (the persisted memo, a parsed log marker) to a
+ *  channel. ONE validator so the union cannot grow past a hard-coded membership
+ *  test left behind in the store read or the marker parse. */
+export function parseCodexUpdateChannel(value: unknown): CodexUpdateChannel | null {
+  return (CODEX_UPDATE_CHANNELS as readonly unknown[]).includes(value)
+    ? (value as CodexUpdateChannel)
+    : null;
+}
 
 /** Marker the script emits once the on-PATH version has ADVANCED, naming the
  *  channel that did it. This is the ONLY attribution of a winning channel:
@@ -127,7 +138,8 @@ export const CONVERGED_MARKER = `${CODEX_UPDATE_LOG_PREFIX} converged via channe
  *   put (issue #1560).
  * - **`npm install -g @openai/codex`** — updates the npm-global copy.
  *
- * Neither is universally right. `codex update` SELF-SELECTS its channel, and that
+ * …unless **mise owns the codex we run**, which changes the shape entirely (see the mise section
+ * below). Neither is universally right. `codex update` SELF-SELECTS its channel, and that
  * choice can miss the install actually on PATH: on a host whose on-PATH `codex` is
  * a wrapper resolving to the npm-global copy, `codex update` may run `bun install
  * -g`, succeed, exit 0 — and change nothing the operator runs. Success therefore
@@ -141,6 +153,19 @@ export const CONVERGED_MARKER = `${CODEX_UPDATE_LOG_PREFIX} converged via channe
  * that changed channels), which rewrites the memo. With no memo yet, the order is
  * `codex update` then npm — the historical order, so a fresh host is never worse
  * off than before.
+ *
+ * **mise-managed codex.** If the codex actually on PATH is one mise hands out, BOTH channels above
+ * are wrong: `codex update` cannot repoint a mise install, and npm would install a second codex that
+ * shadows — or is shadowed by — the mise-managed one. So a mise-owned codex gets `mise upgrade
+ * codex` as the ONLY channel, with no fallback. `mise upgrade` deliberately respects the version
+ * request in the operator's mise config, so a PINNED codex does not advance and the run reports
+ * non-converged (naming `mise use -g codex@latest` as the operator's escape hatch) rather than
+ * shadow-installing past the pin. Ownership is tested two ways because both host shapes exist: the
+ * on-PATH path lies under `$MISE_DATA_DIR` (a shim, or a direct install path), or it resolves to the
+ * same real file as `mise which codex` (the `~/.local/bin` symlink our own install remediation
+ * creates). Realpath alone is not enough — a mise shim is a symlink to the `mise` BINARY, not into
+ * the install tree. When mise does not own it, everything below is unchanged, and a stale `mise`
+ * memo simply falls through to the default order like any non-runnable channel.
  *
  * Safety rails baked into the script:
  * - **Probe first.** `codex update` is only ever invoked if `codex --help`
@@ -178,7 +203,7 @@ export function buildUpdateScript(
   const cx = `'${codexBin.replace(/'/g, "'\\''")}'`;
   const P = CODEX_UPDATE_LOG_PREFIX;
   // `preferred` is a closed union, never interpolated from an external string.
-  const pref = preferred === "npm" || preferred === "codex" ? preferred : "";
+  const pref = parseCodexUpdateChannel(preferred) ?? "";
   const readVersion = `"$CX" --version 2>/dev/null | grep -oE '[0-9]+[.][0-9]+[.][0-9]+' | head -1`;
   return [
     `LOG=${q}`,
@@ -196,17 +221,42 @@ export function buildUpdateScript(
     // reveals PATH duplicates — the documented cause of a non-converging update.
     `  dups="$(type -a codex 2>/dev/null || true)"`,
     `  echo "${P} codex on PATH:" $dups`,
+    // Does mise OWN the codex we run? Two tests, because both host shapes exist: the on-PATH path
+    // sits under the mise data dir (a shim, or a direct install path), or it resolves to the same
+    // real file as `mise which codex` (the ~/.local/bin symlink our install remediation creates).
+    // Realpath alone would miss a shim — a shim is a symlink to the `mise` binary itself, not into
+    // the install tree. `-x "$cxpath"` first, so the `<not found>` placebo above never matches.
+    // The data dir follows mise's own resolution order (MISE_DATA_DIR, then XDG_DATA_HOME, then
+    // the default). `readlink -f` is absent on older macOS; there it yields an empty string, which
+    // the `-n "$cxreal"` guard turns into "prefix test only" rather than a false match.
+    `  MISE_DATA="\${MISE_DATA_DIR:-\${XDG_DATA_HOME:-$HOME/.local/share}/mise}"`,
+    "  mise_owns=0",
+    '  if command -v mise >/dev/null 2>&1 && [ -x "$cxpath" ]; then',
+    `    mw="$(mise which codex 2>/dev/null || true)"`,
+    `    if [ -n "$mw" ]; then`,
+    `      case "$cxpath" in "$MISE_DATA"/*) mise_owns=1 ;; esac`,
+    `      cxreal="$(readlink -f "$cxpath" 2>/dev/null || true)"`,
+    `      mwreal="$(readlink -f "$mw" 2>/dev/null || true)"`,
+    `      if [ -n "$cxreal" ] && [ "$cxreal" = "$mwreal" ]; then mise_owns=1; fi`,
+    "    fi",
+    `    if [ "$mise_owns" -eq 1 ]; then echo "${P} codex is mise-managed: $mw"; fi`,
+    "  fi",
     // Probe once: a codex without the subcommand leaves npm as the ONLY channel,
     // so it must never appear in the order — not even as the fallback.
     `  if "$CX" --help 2>/dev/null | grep -qE '^[[:space:]]+update[[:space:]]'; then`,
     "    has_update=1",
     "  else",
-    `    echo '${P} codex update subcommand not present; using npm'`,
+    // …but not on a mise-owned host, where npm is never in the order and the line would misdescribe
+    // what happens next.
+    `    [ "$mise_owns" -eq 1 ] || echo '${P} codex update subcommand not present; using npm'`,
     "    has_update=0",
     "  fi",
     // Channel order: memo first when we have one and it is runnable, else the
     // historical order (codex update, then npm).
-    `  if [ "$has_update" -eq 0 ]; then order='npm'; src='default'`,
+    // A mise-owned codex is updated by mise ALONE: falling back would install a second codex that
+    // shadows the mise-managed one — the exact defect this branch exists to prevent.
+    `  if [ "$mise_owns" -eq 1 ]; then order='mise'; src='mise-owned'`,
+    `  elif [ "$has_update" -eq 0 ]; then order='npm'; src='default'`,
     `  elif [ "$PREF" = 'npm' ]; then order='npm codex'; src='memo'`,
     `  elif [ "$PREF" = 'codex' ]; then order='codex npm'; src='memo'`,
     `  else order='codex npm'; src='default'; fi`,
@@ -220,6 +270,11 @@ export function buildUpdateScript(
     `    if [ "$ch" = 'codex' ]; then`,
     `      "$CX" update; rc=$?`,
     `      echo "${P} codex update exited rc=$rc"`,
+    `    elif [ "$ch" = 'mise' ]; then`,
+    // Bare tool name, matching `mise which codex` — mise resolves by tool, not by our (possibly
+    // absolute, possibly CODEX_BIN-overridden) launcher path.
+    "      mise upgrade codex; rc=$?",
+    `      echo "${P} mise upgrade exited rc=$rc"`,
     "    else",
     "      npm install -g @openai/codex; rc=$?",
     `      echo "${P} npm install exited rc=$rc"`,
@@ -241,6 +296,15 @@ export function buildUpdateScript(
     `    echo "${CONVERGED_MARKER}$winner"`,
     "  else",
     `    echo '${P} did not converge'`,
+    // A mise-owned codex that did not move is the EXPECTED outcome of a pinned version, not a
+    // broken update — so say what happened and hand over the one command that moves the pin. The
+    // modal streams these lines verbatim, which is why the explanation lives here and needs no
+    // user-facing string of its own.
+    `    if [ "$mise_owns" -eq 1 ]; then`,
+    `      echo '${P} codex is managed by mise, and mise upgrade respects the version request in your mise config — a pinned codex will not advance.'`,
+    `      echo '${P} to move the pin: mise use -g codex@latest'`,
+    `      echo '${P} not falling back to codex update / npm: either would install a SECOND codex shadowing the mise-managed one.'`,
+    "    fi",
     "  fi",
     `  echo "${P} codex --version now: $("$CX" --version 2>/dev/null || echo '<unreadable>')"`,
     '} 2>&1 | tee -a "$LOG"',
@@ -834,8 +898,8 @@ export class CodexUpdateService {
         }
         const ch = line.indexOf(CONVERGED_MARKER);
         if (ch !== -1) {
-          const val = line.slice(ch + CONVERGED_MARKER.length).trim();
-          if (val === "npm" || val === "codex") channel = val;
+          const parsed = parseCodexUpdateChannel(line.slice(ch + CONVERGED_MARKER.length).trim());
+          if (parsed) channel = parsed;
         }
         this.onLog(line);
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ import { bootstrapAuth } from "./operator-auth";
 import { backupConfiguredMarker, lastSuccessMarker } from "./backup-paths";
 import { UpdateService } from "./update";
 import { HerdrUpdateService } from "./herdr-update";
-import { CodexUpdateService } from "./codex-update";
+import { CodexUpdateService, parseCodexUpdateChannel } from "./codex-update";
 import { PluginUpdateService } from "./plugin-update";
 import { RestartService } from "./restart";
 import { DiagnosticsService, defaultReadHerdrFleet, nextDiagnosticsDelay } from "./diagnostics";
@@ -2750,10 +2750,7 @@ const codexUpdates = new CodexUpdateService({
   // self-selects its channel and can miss the install actually on PATH, so the
   // only way to know which one works is to have watched one work. Persisting it
   // makes the next update a single installer run instead of a try-fail-retry.
-  readChannel: () => {
-    const saved = store.getSetting(CODEX_UPDATE_CHANNEL_KEY);
-    return saved === "npm" || saved === "codex" ? saved : null;
-  },
+  readChannel: () => parseCodexUpdateChannel(store.getSetting(CODEX_UPDATE_CHANNEL_KEY)),
   writeChannel: (channel) => store.setSetting(CODEX_UPDATE_CHANNEL_KEY, channel),
 });
 const checkCodexUpdate = async () =>

--- a/src/remediations.ts
+++ b/src/remediations.ts
@@ -87,6 +87,38 @@ export const HERDR_SERVE =
 
 const CODEX_INSTALL =
   "curl -fsSL https://chatgpt.com/codex/install.sh | CODEX_NON_INTERACTIVE=1 sh";
+const CLAUDE_INSTALL = "curl -fsSL https://claude.ai/install.sh | bash";
+
+/**
+ * The claude/codex install remediation, made mise-aware.
+ *
+ * When the tool is ALREADY managed by mise, the native installer is the wrong fix: it plants a
+ * SECOND copy beside the mise-managed one, and the two then diverge silently (the shepherd host
+ * this was written on carries a native claude 2.1.226 next to mise's 2.1.222). mise-managed is the
+ * ONLY condition that diverts — never a "mise exists, so prefer it" heuristic — and `mise which
+ * <tool>` is the test: exit 0 + a path when mise can hand us that binary right now, non-zero
+ * ("… is not a mise bin") otherwise. `mise ls <tool>` exits 0 either way and cannot be used.
+ *
+ * The diverted branch SYMLINKS rather than installs, because when `mise which` succeeds the binary
+ * already exists — it is merely unreachable. mise exposes tools through a shims dir that is absent
+ * from shepherd.service's pinned PATH, and `mise activate` only ever runs in an interactive shell.
+ * `$HOME/.local/bin` IS on that PATH, so one symlink turns the red check green with no change to
+ * how anything resolves binaries. This mirrors NODE_INSTALL's fnm handling directly above.
+ *
+ * Overwriting `$HOME/.local/bin/<tool>` is safe: a remediation only ever runs for a NON-ok check,
+ * i.e. `<tool> --version` already failed, so what it replaces is a broken or absent entry.
+ *
+ * POSIX sh only — the in-app Fix endpoint spawns `sh -c` (see DiagnosticsService.runRemediation).
+ * On a host with no mise, or a tool mise does not manage, the emitted command is the native
+ * installer verbatim, so the onboarding harness and deploy/provision.ts are unaffected.
+ */
+function agentCliInstall(tool: "claude" | "codex", nativeInstall: string): string {
+  return (
+    `if command -v mise >/dev/null 2>&1 && M="$(mise which ${tool} 2>/dev/null)" && [ -n "$M" ]; ` +
+    `then mkdir -p "$HOME/.local/bin" && ln -sf "$M" "$HOME/.local/bin/${tool}"; ` +
+    `else ${nativeInstall}; fi`
+  );
+}
 
 // git has no user-space installer — it's a distro system package. One cross-distro
 // chain (the same apt||apk||dnf||pacman shape the onboarding baseline's ensurePkg
@@ -136,10 +168,10 @@ export const REMEDIATIONS: Record<string, string> = {
   // detection-only), so buildUpdateScript's baked `config.herdrBin` is always the right one.
   diagnostics_hint_herdr_outdated: buildUpdateScript(config.herdrUpdateLogPath),
   diagnostics_hint_herdr_offline: HERDR_SERVE,
-  diagnostics_hint_claude_missing: "curl -fsSL https://claude.ai/install.sh | bash",
-  diagnostics_hint_claude_optional: "curl -fsSL https://claude.ai/install.sh | bash",
-  diagnostics_hint_codex_missing: CODEX_INSTALL,
-  diagnostics_hint_codex_optional: CODEX_INSTALL,
+  diagnostics_hint_claude_missing: agentCliInstall("claude", CLAUDE_INSTALL),
+  diagnostics_hint_claude_optional: agentCliInstall("claude", CLAUDE_INSTALL),
+  diagnostics_hint_codex_missing: agentCliInstall("codex", CODEX_INSTALL),
+  diagnostics_hint_codex_optional: agentCliInstall("codex", CODEX_INSTALL),
   diagnostics_hint_tailscale_missing: "curl -fsSL https://tailscale.com/install.sh | sh",
   diagnostics_hint_git_missing: GIT_INSTALL,
 };

--- a/test/codex-update.test.ts
+++ b/test/codex-update.test.ts
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -13,6 +14,7 @@ import { join } from "node:path";
 import {
   CodexUpdateService,
   buildUpdateScript,
+  parseCodexUpdateChannel,
   CODEX_UPDATE_LOG_PREFIX,
   CONVERGED_MARKER,
   type CodexUpdateChannel,
@@ -135,6 +137,14 @@ interface HarnessOpts {
   codexAdvances?: boolean;
   /** does `npm install -g` actually move the on-PATH version? */
   npmAdvances?: boolean;
+  /** How mise sees this host. Absent ⇒ no `mise` on PATH at all (every pre-mise test).
+   *  - `unmanaged`: mise is installed but `mise which codex` fails — NOT mise's codex.
+   *  - `shim`: the on-PATH codex lives under the mise data dir (mise's shims dir).
+   *  - `symlink`: the on-PATH codex is a symlink resolving to the same file as
+   *    `mise which codex` — the `~/.local/bin` link our install remediation creates. */
+  mise?: "unmanaged" | "shim" | "symlink";
+  /** does `mise upgrade codex` actually move the on-PATH version? (false ⇒ a pinned tool) */
+  miseAdvances?: boolean;
 }
 
 function runScript(opts: HarnessOpts) {
@@ -142,14 +152,36 @@ function runScript(opts: HarnessOpts) {
   const version = join(dir, "version"); // the "installed" version, mutated by a winning fake
   const codexRan = join(dir, "codex-update.ran");
   const npmRan = join(dir, "npm-install.ran");
+  const miseRan = join(dir, "mise-upgrade.ran");
   writeFileSync(version, BEFORE);
 
   // the `update` line must match the script's `^[[:space:]]+update[[:space:]]` probe
   const helpBody = opts.hasUpdate === false ? "  login    Log in" : "  update   Update codex";
   const bump = (advances: boolean | undefined) => (advances ? `echo ${AFTER} > '${version}'` : ":");
 
+  // HOME=dir, so this is the `$MISE_DATA_DIR` default the script computes. `mise which` reports
+  // the install path; where the ON-PATH codex sits is what decides ownership, and each `mise`
+  // shape puts it somewhere different.
+  const miseInstall = join(dir, ".local/share/mise/installs/codex/latest/bin/codex");
+  let codexPath = join(dir, "codex");
+  const pathDirs = [dir];
+  if (opts.mise === "shim") {
+    // a real mise shim is a symlink to the `mise` BINARY, so realpath can't identify it — only
+    // the mise-data-dir prefix can. Model that: the fake codex IS the shim, and `mise which`
+    // reports the (separate) install path.
+    const shims = join(dir, ".local/share/mise/shims");
+    mkdirSync(shims, { recursive: true });
+    codexPath = join(shims, "codex");
+    pathDirs.unshift(shims);
+  } else if (opts.mise === "symlink") {
+    // the ~/.local/bin shape: the on-PATH entry is OUTSIDE the mise tree and only resolves in.
+    mkdirSync(join(dir, ".local/share/mise/installs/codex/latest/bin"), { recursive: true });
+    codexPath = miseInstall;
+    symlinkSync(miseInstall, join(dir, "codex"));
+  }
+
   writeFileSync(
-    join(dir, "codex"),
+    codexPath,
     `#!/bin/bash
 case "$1" in
   --version) echo "codex-cli $(cat '${version}')" ;;
@@ -166,8 +198,21 @@ touch '${npmRan}'; ${bump(opts.npmAdvances)}; echo "npm $*"
 exit 0
 `,
   );
-  chmodSync(join(dir, "codex"), 0o755);
+  chmodSync(codexPath, 0o755);
   chmodSync(join(dir, "npm"), 0o755);
+  if (opts.mise) {
+    writeFileSync(
+      join(dir, "mise"),
+      `#!/bin/bash
+case "$1" in
+  which)   ${opts.mise === "unmanaged" ? "exit 1" : `echo '${miseInstall}'`} ;;
+  upgrade) touch '${miseRan}'; ${bump(opts.miseAdvances)}; echo "mise upgrade $2" ;;
+esac
+exit 0
+`,
+    );
+    chmodSync(join(dir, "mise"), 0o755);
+  }
 
   const script = buildUpdateScript(
     join(dir, "log"),
@@ -178,12 +223,13 @@ exit 0
   );
   const stdout = execFileSync("bash", ["-c", script], {
     encoding: "utf8",
-    env: { PATH: `${dir}:/usr/bin:/bin`, HOME: dir }, // fakes shadow the real installers
+    env: { PATH: `${pathDirs.join(":")}:/usr/bin:/bin`, HOME: dir }, // fakes shadow the real installers
   });
   return {
     stdout,
     codexUpdateRan: existsSync(codexRan),
     npmInstallRan: existsSync(npmRan),
+    miseUpgradeRan: existsSync(miseRan),
     installed: readFileSync(version, "utf8").trim(),
     converged: /converged via channel=(\w+)/.exec(stdout)?.[1] ?? null,
   };
@@ -300,6 +346,85 @@ test("harness: neither channel advances → no winner, nothing to memoize", () =
   expect(r.converged).toBeNull(); // …neither won
   expect(r.stdout).toContain("did not converge");
   expect(r.installed).toBe(BEFORE);
+});
+
+// ── mise-managed codex: one channel, no fallback ───────────────────────────────
+//
+// When mise owns the codex on PATH, BOTH other channels install a SECOND codex that
+// shadows (or is shadowed by) the mise-managed one — the divergence this branch exists
+// to prevent. So mise is the whole order, and a pinned tool that refuses to advance is
+// reported, never worked around.
+
+test("harness: mise owns the on-PATH codex (shim) → `mise upgrade` ONLY", () => {
+  const r = runScript({ mise: "shim", miseAdvances: true, codexAdvances: true, npmAdvances: true });
+  expect(r.miseUpgradeRan).toBe(true);
+  expect(r.codexUpdateRan).toBe(false); // neither may run: both would plant a second codex
+  expect(r.npmInstallRan).toBe(false);
+  expect(r.converged).toBe("mise");
+  expect(r.installed).toBe(AFTER);
+  expect(r.stdout).toContain("channel=mise (source=mise-owned)");
+  expect(r.stdout).toContain("codex is mise-managed:");
+});
+
+test("harness: mise owns it via a ~/.local/bin symlink → `mise upgrade` ONLY", () => {
+  // The shape our own install remediation creates: the on-PATH entry sits outside the
+  // mise tree, so ownership is provable only by resolving it.
+  const r = runScript({ mise: "symlink", miseAdvances: true, codexAdvances: true });
+  expect(r.miseUpgradeRan).toBe(true);
+  expect(r.codexUpdateRan).toBe(false);
+  expect(r.converged).toBe("mise");
+});
+
+test("harness: a pinned mise codex does NOT fall back to codex update / npm", () => {
+  const r = runScript({
+    mise: "shim",
+    miseAdvances: false,
+    codexAdvances: true,
+    npmAdvances: true,
+  });
+  expect(r.miseUpgradeRan).toBe(true);
+  expect(r.codexUpdateRan).toBe(false); // …even though either WOULD have advanced a shadow copy
+  expect(r.npmInstallRan).toBe(false);
+  expect(r.converged).toBeNull();
+  expect(r.installed).toBe(BEFORE);
+  expect(r.stdout).toContain("did not converge");
+  expect(r.stdout).toContain("mise use -g codex@latest"); // the operator's escape hatch
+});
+
+test("harness: mise installed but not managing codex → untouched historical order", () => {
+  const r = runScript({ mise: "unmanaged", codexAdvances: true, npmAdvances: true });
+  expect(r.miseUpgradeRan).toBe(false);
+  expect(r.codexUpdateRan).toBe(true);
+  expect(r.converged).toBe("codex");
+  expect(r.stdout).toContain("channel=codex (source=default)");
+  expect(r.stdout).not.toContain("mise-managed");
+});
+
+test("harness: a stale `mise` memo on a non-mise host falls back to the default order", () => {
+  // The operator moved off mise. The memo is not a precondition — it only picks who goes
+  // first — so an unrunnable channel must degrade to the historical order, not strand us.
+  const r = runScript({ preferred: "mise", codexAdvances: true, npmAdvances: true });
+  expect(r.miseUpgradeRan).toBe(false);
+  expect(r.codexUpdateRan).toBe(true);
+  expect(r.converged).toBe("codex");
+  expect(r.stdout).toContain("channel=codex (source=default)");
+});
+
+test("buildUpdateScript: mise-owned ordering and step are emitted", () => {
+  const s = buildUpdateScript(LOG, "0.142.2", "0.142.4", CB);
+  expect(s).toContain(`if [ "$mise_owns" -eq 1 ]; then order='mise'; src='mise-owned'`);
+  expect(s).toContain("mise upgrade codex"); // bare tool name, as `mise which codex` resolves it
+  expect(s).not.toContain("mise use -g codex@latest;"); // named as advice, never RUN for the operator
+});
+
+test("parseCodexUpdateChannel: accepts the three channels, rejects anything else", () => {
+  expect(parseCodexUpdateChannel("npm")).toBe("npm");
+  expect(parseCodexUpdateChannel("codex")).toBe("codex");
+  expect(parseCodexUpdateChannel("mise")).toBe("mise");
+  expect(parseCodexUpdateChannel("brew")).toBeNull();
+  expect(parseCodexUpdateChannel(null)).toBeNull();
+  expect(parseCodexUpdateChannel(undefined)).toBeNull();
+  expect(parseCodexUpdateChannel(7)).toBeNull();
 });
 
 // ── check(): version compare against the npm registry ─────────────────────────
@@ -917,6 +1042,17 @@ test("memo: `codex update` winning persists `codex` (standalone / #1560 attribut
   svc.apply();
   await settle();
   expect(memoWrites).toEqual(["codex"]);
+});
+
+test("memo: a mise-owned win persists `mise` (the widened union reaches the store)", async () => {
+  const { svc, memoWrites } = primed({
+    installedAfter: "0.142.4",
+    runUpdate: emitting(`${CONVERGED_MARKER}mise`),
+  });
+  await svc.check(1);
+  svc.apply();
+  await settle();
+  expect(memoWrites).toEqual(["mise"]);
 });
 
 test("memo: converged but NO channel marker → left untouched, never guessed", async () => {

--- a/test/remediations.test.ts
+++ b/test/remediations.test.ts
@@ -1,7 +1,16 @@
 import { HERDR_LAST_SUPPORTED_VERSION } from "../src/herdr-capabilities";
 import { describe, expect, it } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { REMEDIATIONS, autoFixCommandFor, HERDR_SERVE, HERDR_INSTALL } from "../src/remediations";
@@ -334,4 +343,124 @@ describe("herdr_outdated is behaviorally recover-on-fail, not just shaped right 
     }
     // buildUpdateScript's grace loop sleeps 3×2s before the fallback — allow for it.
   }, 15_000);
+});
+
+// ── claude/codex install: mise-managed hosts must not get a second copy ────────
+//
+// EXECUTED, not string-matched: which branch a host takes is the whole feature. The PATH
+// here is tighter than makeSandbox's usual one and deliberately EXCLUDES the system bin
+// dirs — a developer host really can have mise in /usr/bin, and inheriting it would make
+// the "no mise" cases flip branch depending on whose machine runs the suite. Only the few
+// externals the remediation and the stubs need are linked in, resolved from the real PATH
+// so this is not pinned to a distro's /usr/bin layout.
+
+/** Sandbox HOME with a stubbed `curl` (records the native-installer branch) and, optionally,
+ *  a stubbed `mise`. Returns the marker paths the assertions read. */
+function makeInstallSandbox(mise: "absent" | "unmanaged" | "manages") {
+  const dir = mkdtempSync(join(tmpdir(), "agent-cli-install-"));
+  const binDir = join(dir, ".local", "bin");
+  const sysBin = join(dir, "sysbin");
+  mkdirSync(binDir, { recursive: true });
+  mkdirSync(sysBin);
+  // mkdir/ln for the mise branch, touch for the stubs' markers, sh/bash for the `| sh` and
+  // `| bash` the native installers end in. Throw rather than degrade: a silently missing
+  // util would make the native branch look un-taken and pass the wrong assertion.
+  for (const util of ["mkdir", "ln", "touch", "sh", "bash"]) {
+    const real = Bun.which(util);
+    if (!real) throw new Error(`test host has no \`${util}\``);
+    symlinkSync(real, join(sysBin, util));
+  }
+  const curlRan = join(dir, "curl.ran");
+  // `| bash` still runs on the native branch, so the stub must emit a script bash can read.
+  writeFileSync(join(binDir, "curl"), `#!/bin/sh\ntouch '${curlRan}'\necho ':'\n`, { mode: 0o755 });
+  const installs = join(dir, ".local", "share", "mise", "installs");
+  if (mise !== "absent") {
+    writeFileSync(
+      join(binDir, "mise"),
+      mise === "manages"
+        ? `#!/bin/sh\n[ "$1" = which ] && echo "${installs}/$2/bin/$2"\nexit 0\n`
+        : `#!/bin/sh\nexit 1\n`, // `mise which <tool>` fails ⇒ mise does not manage it
+      { mode: 0o755 },
+    );
+  }
+  return {
+    dir,
+    curlRan,
+    binDir,
+    misePathFor: (tool: string) => join(installs, tool, "bin", tool),
+    run: (cmd: string) =>
+      spawnSync("sh", ["-c", cmd], {
+        env: { ...process.env, HOME: dir, PATH: `${binDir}:${sysBin}` },
+        encoding: "utf8",
+      }),
+  };
+}
+
+describe("claude/codex install remediation is mise-aware", () => {
+  for (const [tool, hint] of [
+    ["claude", "diagnostics_hint_claude_missing"],
+    ["codex", "diagnostics_hint_codex_missing"],
+  ] as const) {
+    it(`${tool}: a mise-managed tool is linked into ~/.local/bin, never re-installed`, () => {
+      const s = makeInstallSandbox("manages");
+      try {
+        s.run(REMEDIATIONS[hint]!);
+        // the binary already exists — it was only unreachable from shepherd.service's PATH
+        expect(readlinkSync(join(s.binDir, tool))).toBe(s.misePathFor(tool));
+        expect(existsSync(s.curlRan)).toBe(false); // a second, diverging copy is the bug
+      } finally {
+        rmSync(s.dir, { recursive: true, force: true });
+      }
+    });
+
+    it(`${tool}: no mise on the host → the native installer, unchanged`, () => {
+      const s = makeInstallSandbox("absent");
+      try {
+        s.run(REMEDIATIONS[hint]!);
+        expect(existsSync(s.curlRan)).toBe(true);
+        expect(existsSync(join(s.binDir, tool))).toBe(false);
+      } finally {
+        rmSync(s.dir, { recursive: true, force: true });
+      }
+    });
+
+    it(`${tool}: mise installed but not managing it → still the native installer`, () => {
+      // mise's mere presence must never divert: only "mise can hand us this binary" does.
+      const s = makeInstallSandbox("unmanaged");
+      try {
+        s.run(REMEDIATIONS[hint]!);
+        expect(existsSync(s.curlRan)).toBe(true);
+        expect(existsSync(join(s.binDir, tool))).toBe(false);
+      } finally {
+        rmSync(s.dir, { recursive: true, force: true });
+      }
+    });
+  }
+
+  it("keeps the verbatim native installers the harness and provision.ts rely on", () => {
+    expect(REMEDIATIONS.diagnostics_hint_claude_missing).toContain(
+      "curl -fsSL https://claude.ai/install.sh | bash",
+    );
+    expect(REMEDIATIONS.diagnostics_hint_codex_missing).toContain(
+      "curl -fsSL https://chatgpt.com/codex/install.sh | CODEX_NON_INTERACTIVE=1 sh",
+    );
+    // `optional` (the other CLI is present) fixes the same way as `missing`
+    expect(REMEDIATIONS.diagnostics_hint_claude_optional).toBe(
+      REMEDIATIONS.diagnostics_hint_claude_missing,
+    );
+    expect(REMEDIATIONS.diagnostics_hint_codex_optional).toBe(
+      REMEDIATIONS.diagnostics_hint_codex_missing,
+    );
+  });
+
+  it("stays one-click fixable in-app for every agent-CLI hint", () => {
+    for (const hint of [
+      "diagnostics_hint_claude_missing",
+      "diagnostics_hint_claude_optional",
+      "diagnostics_hint_codex_missing",
+      "diagnostics_hint_codex_optional",
+    ]) {
+      expect(autoFixCommandFor(hint)).toBe(REMEDIATIONS[hint]!);
+    }
+  });
 });

--- a/ui/src/lib/docs-manifest.ts
+++ b/ui/src/lib/docs-manifest.ts
@@ -33,7 +33,7 @@ export const DOCS_PAGES: readonly DocsPage[] = [
     title: "Operating Shepherd",
     path: "/operating/",
     keywords:
-      "run shepherd as a systemd service, expose it over tailscale, and deploy code changes. run as a systemd user service expose it over the network deploy a code change backups & restore preview detection host tuning — tmpfs inodes host tuning — resource guardrails add a limit (one click) add a limit (copy-paste)",
+      "run shepherd as a systemd service, expose it over tailscale, and deploy code changes. run as a systemd user service expose it over the network deploy a code change backups & restore preview detection agent clis managed by mise host tuning — tmpfs inodes host tuning — resource guardrails add a limit (one click) add a limit (copy-paste)",
   },
   {
     title: "CLI reference",


### PR DESCRIPTION
Two host-mutating agent-CLI surfaces assumed a native install. On a mise-managed host both pushed a **second**, diverging copy instead of touching the one the operator actually runs.

Live evidence from the host this was written on: `~/.local/bin/claude` → native **2.1.226** while `mise ls` tracks **2.1.222**; `~/.local/bin/codex` is a hand-rolled `mise exec node@latest -- npx @openai/codex` wrapper reporting 0.147.0 against mise's 0.146.0.

## Installing (`src/remediations.ts`)

The claude/codex diagnostics Fix is now one self-selecting shell string: when `mise which <tool>` resolves, it symlinks the mise binary into `~/.local/bin` instead of running `curl … | bash`.

It **symlinks rather than installs** because when `mise which` succeeds the binary already exists — it is merely unreachable: mise exposes tools through a shims dir absent from `shepherd.service`'s pinned PATH, and `mise activate` only runs in interactive shells. `~/.local/bin` *is* on that PATH, so one symlink clears the check with no change to how anything resolves binaries. Same trick `NODE_INSTALL` already uses for fnm-managed node.

**mise-managed is the only diverting condition** — never a "mise exists, so prefer it" heuristic. On hosts without mise, and for tools mise does not manage, the emitted command is the vendor installer verbatim, so `deploy/provision.ts` and the onboarding harness are unaffected.

## Updating (`src/codex-update.ts`)

`CodexUpdateChannel` gains `mise`. When mise owns the codex on PATH, the order is `mise upgrade codex` and **nothing else**.

No fallback, deliberately: `mise upgrade` respects the version request in the operator's mise config, so a **pinned** codex will not advance — and falling through to `codex update` / npm would install a second codex shadowing the mise-managed one, which is the defect being fixed. A pinned run reports the existing non-converged result plus a log line naming `mise use -g codex@latest`. On non-mise hosts every existing behaviour (memo order, markers, fallback, log block) is byte-identical.

Ownership is tested two ways because both host shapes exist: the on-PATH path lies under `$MISE_DATA_DIR`, or it resolves to the same real file as `mise which codex` (the `~/.local/bin` symlink the install fix creates). Realpath alone is not enough — a mise shim is a symlink to the `mise` **binary**, not into the install tree.

One shared `parseCodexUpdateChannel()` now narrows the memo read and the converged-marker parse, so the widened union cannot outgrow a hard-coded membership test.

## Testing

Executed, not string-matched — which branch a host takes is the whole feature.

- `test/remediations.test.ts`: a hermetic sandbox (stub `curl`/`mise`, PATH excluding the system bin dirs so a dev host's real mise can't flip the verdict) proves the mise branch links and never curls, and that both the absent and installed-but-unmanaged cases still take the vendor installer.
- `test/codex-update.test.ts`: the existing fake-installer harness gains mise-shaped hosts (shim, `~/.local/bin` symlink, unmanaged). Asserts `mise upgrade` runs alone, that a pinned tool runs neither other channel, and that a stale `mise` memo on a non-mise host degrades to the historical order.

`bun run lint`, `bun run test` (8366 pass), `bunx tsc --noEmit` and the fallow delta audit are green.

## Not in scope

No claude updater — Shepherd has none (Claude Code self-updates), so a mise-managed claude still can't self-update and its auto-updater can keep planting a native copy. That is how this host diverged; tracked in #2052. No binary-resolution/PATH changes either; the install fix's symlink is the only reachability mechanism added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)