### PR TITLE
fix(ui): prefer active filter in repos dialog

### DIFF
--- a/ui/src/lib/components/page/AppOverlays.browser.test.ts
+++ b/ui/src/lib/components/page/AppOverlays.browser.test.ts
@@ -25,6 +25,7 @@ beforeEach(async () => {
 afterEach(() => {
   steers.list = [];
   steers.loaded = false;
+  repos.entries = [];
   repos.loaded = false;
 });
 
@@ -181,13 +182,21 @@ const frames = (n = 2) =>
   });
 
 describe("AppOverlays — Repos selection", () => {
-  it("selects the active repo filter instead of the pinned repo", async () => {
+  it("selects the backlog raw path for a realpath-based active repo filter", async () => {
     const props = baseProps();
     props.showBacklog = true;
     props.repoFilter = "/repos/filtered";
+    repos.entries = [
+      {
+        name: "filtered",
+        path: "/repos/filtered-link",
+        display: "/repos/filtered-link",
+        realPath: "/repos/filtered",
+      },
+    ];
     props.backlog = {
       pinnedPath: "/repos/pinned",
-      projects: ["/repos/pinned", "/repos/filtered"].map((path) => ({
+      projects: ["/repos/pinned", "/repos/filtered-link"].map((path) => ({
         path,
         display: path,
         slug: null,
@@ -204,9 +213,9 @@ describe("AppOverlays — Repos selection", () => {
 
     render(AppOverlays, props);
 
-    await expect.element(page.getByText("filtered", { exact: true })).toBeVisible();
+    await expect.element(page.getByText("filtered-link", { exact: true })).toBeVisible();
     expect(document.querySelectorAll(".project-row")).toHaveLength(2);
-    expect(document.querySelector(".project-row.sel .row-name")?.textContent).toBe("filtered");
+    expect(document.querySelector(".project-row.sel .row-name")?.textContent).toBe("filtered-link");
   });
 });
 

--- a/ui/src/lib/components/page/AppOverlays.browser.test.ts
+++ b/ui/src/lib/components/page/AppOverlays.browser.test.ts
@@ -6,6 +6,7 @@ import AppOverlays from "./AppOverlays.svelte";
 import type { HerdStore } from "$lib/store.svelte";
 import type {
   AgentProvider,
+  BacklogPayload,
   DiagnosticsSnapshot,
   HerdrUpdateStatus,
   Session,
@@ -178,6 +179,36 @@ const frames = (n = 2) =>
     const step = () => (++i >= n ? resolve() : requestAnimationFrame(step));
     requestAnimationFrame(step);
   });
+
+describe("AppOverlays — Repos selection", () => {
+  it("selects the active repo filter instead of the pinned repo", async () => {
+    const props = baseProps();
+    props.showBacklog = true;
+    props.repoFilter = "/repos/filtered";
+    props.backlog = {
+      pinnedPath: "/repos/pinned",
+      projects: ["/repos/pinned", "/repos/filtered"].map((path) => ({
+        path,
+        display: path,
+        slug: null,
+        kind: "github",
+        openIssues: 1,
+        openPRs: 0,
+        prKinds: null,
+        workflows: null,
+        ciStatus: null,
+        hidden: false,
+      })),
+      totals: { openIssues: 2, openPRs: 0 },
+    } satisfies BacklogPayload;
+
+    render(AppOverlays, props);
+
+    await expect.element(page.getByText("filtered", { exact: true })).toBeVisible();
+    expect(document.querySelectorAll(".project-row")).toHaveLength(2);
+    expect(document.querySelector(".project-row.sel .row-name")?.textContent).toBe("filtered");
+  });
+});
 
 describe("Settings deep links", () => {
   it("forwards the Steers request into the mobile detail and focused editor row", async () => {

--- a/ui/src/lib/components/page/AppOverlays.svelte
+++ b/ui/src/lib/components/page/AppOverlays.svelte
@@ -3,6 +3,7 @@
   import { m } from "$lib/paraglide/messages";
   import { displayStatus } from "$lib/display-status";
   import { learnings } from "$lib/learnings.svelte";
+  import { repos } from "$lib/repos.svelte";
   import { toasts } from "$lib/toasts.svelte";
   import { capacitySuggestedProvider } from "$lib/provider-capacity";
   import { basename } from "$lib/components/learnings-drawer";
@@ -354,6 +355,11 @@
   // in <script> rather than the overlay template (keeps this template's synthetic
   // complexity under the Tier-1 bar).
   const newTaskInitialRepo = $derived(composeRepoPath ?? repoFilter ?? undefined);
+  const backlogInitialRepo = $derived(
+    backlogSelectPath ??
+      repos.entries.find((entry) => entry.realPath === repoFilter)?.path ??
+      repoFilter,
+  );
   const newTaskInitialBaseBranch = $derived(composeBaseBranch ?? undefined);
   const newTaskInitialIssue = $derived(composeIssue ?? undefined);
   const newTaskInitialPrompt = $derived(composePrompt ?? undefined);
@@ -663,7 +669,7 @@
     {onaddclone}
     {onaddfork}
     {onaddnewproject}
-    selectPath={backlogSelectPath ?? repoFilter}
+    selectPath={backlogInitialRepo}
     onclose={onbacklogclose}
     epics={store.epics}
     {inTrainPrs}

--- a/ui/src/lib/components/page/AppOverlays.svelte
+++ b/ui/src/lib/components/page/AppOverlays.svelte
@@ -663,7 +663,7 @@
     {onaddclone}
     {onaddfork}
     {onaddnewproject}
-    selectPath={backlogSelectPath}
+    selectPath={backlogSelectPath ?? repoFilter}
     onclose={onbacklogclose}
     epics={store.epics}
     {inTrainPrs}


### PR DESCRIPTION
## Summary

- prefer the active single-repo herd filter when opening Repos
- preserve explicit add/command targets and the existing pinned-repo fallback
- keep the full repo list visible while selecting the filtered repo

## Verification

- `cd ui && bun run check`
- `cd ui && bun run test` (289 files, 4,540 tests)
- targeted regression: `cd ui && bun run test:browser -- src/lib/components/page/AppOverlays.browser.test.ts -t "selects the active repo filter instead of the pinned repo"`
