### PR TITLE
feat(backlog): show the repo emoji on Repos-overlay rows

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3556,5 +3556,7 @@
   "toast_terminal_unsupported": "Clean-Terminals brauchen ein neueres herdr — herdr aktualisieren und erneut versuchen",
   "toast_broadcast_skipped_terminals": "{skipped} Terminal-Session(s) übersprungen — Terminals erhalten keine Steers",
   "feat_clean_terminal_title": "Clean-Terminal im Main-Repo",
-  "feat_clean_terminal_body": "Rechtsklick auf eine Session-Zeile oder einen Repo-Chip und „Clean-Terminal im Main-Repo“ wählen: Eine nackte Shell öffnet sich direkt im Haupt-Checkout des Repos (kein Worktree, kein Agent) — für schnelle Git- und CLI-Handgriffe. Ein Terminal pro Repo; erneutes Wählen fokussiert das bestehende. Beim Beenden der Shell archiviert sich die Session selbst."
+  "feat_clean_terminal_body": "Rechtsklick auf eine Session-Zeile oder einen Repo-Chip und „Clean-Terminal im Main-Repo“ wählen: Eine nackte Shell öffnet sich direkt im Haupt-Checkout des Repos (kein Worktree, kein Agent) — für schnelle Git- und CLI-Handgriffe. Ein Terminal pro Repo; erneutes Wählen fokussiert das bestehende. Beim Beenden der Shell archiviert sich die Session selbst.",
+  "feat_backlog_repo_icon_title": "Repo-Emoji in der Repos-Übersicht",
+  "feat_backlog_repo_icon_body": "Die Repo-Liste in der Repos-Übersicht führt jede Zeile jetzt mit dem konfigurierten Emoji des Repos an — dasselbe Erkennungszeichen, das Session-Karten, Epic-Überschriften und die Repo-Auswahl in „Neue Aufgabe“ schon nutzen. So sieht ein Repo überall gleich aus. Repos ohne Emoji zeigen die schlichte ▣-Marke; setzen lässt sie sich in der Repo-Auswahl unter „Neue Aufgabe“."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3556,5 +3556,7 @@
   "toast_terminal_unsupported": "Clean terminals need a newer herdr — update herdr and retry",
   "toast_broadcast_skipped_terminals": "{skipped} terminal session(s) skipped — terminals receive no steers",
   "feat_clean_terminal_title": "Clean terminal in the main repo",
-  "feat_clean_terminal_body": "Right-click a session row or a repo chip and pick “Clean terminal in main repo”: a bare shell opens directly in the repo's main checkout (not a worktree, no agent) — for quick git and CLI work. One terminal per repo; picking it again focuses the existing one. Exit the shell and the session archives itself."
+  "feat_clean_terminal_body": "Right-click a session row or a repo chip and pick “Clean terminal in main repo”: a bare shell opens directly in the repo's main checkout (not a worktree, no agent) — for quick git and CLI work. One terminal per repo; picking it again focuses the existing one. Exit the shell and the session archives itself.",
+  "feat_backlog_repo_icon_title": "Repo emoji in the Repos overlay",
+  "feat_backlog_repo_icon_body": "The repo list in the Repos overlay now leads each row with the repo's configured emoji — the same identity glyph session cards, epic headers and the New Task repo picker already use, so a repo looks the same everywhere. Repos without an emoji show the plain ▣ marker; set one from the repo picker in New Task."
 }

--- a/ui/src/lib/components/ProjectRow.browser.test.ts
+++ b/ui/src/lib/components/ProjectRow.browser.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
 import ProjectRow from "./ProjectRow.svelte";
 import type { BacklogProject } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
+import { projectIcons } from "$lib/projectIcons.svelte";
 
 function project(partial: Partial<BacklogProject> = {}): BacklogProject {
   return {
@@ -81,6 +82,37 @@ describe("ProjectRow PR-kind counts", () => {
     const prs = document.body.querySelector(".count-prs");
     expect(prs?.textContent?.trim()).toBe("5");
     expect(document.body.querySelector(".bot-note")).toBeNull();
+  });
+});
+
+describe("ProjectRow repo glyph", () => {
+  afterEach(() => projectIcons.apply({}));
+
+  it("shows the configured project emoji", () => {
+    projectIcons.apply({ "/repo/a": "🐑" });
+    render(ProjectRow, {
+      project: project(),
+      pinned: false,
+      selected: false,
+      onselect: () => {},
+      onhide: () => {},
+    });
+    const glyph = document.body.querySelector(".row-glyph");
+    expect(glyph?.textContent?.trim()).toBe("🐑");
+    expect(glyph?.classList.contains("emoji")).toBe(true);
+  });
+
+  it("falls back to the ▣ marker when the repo has no icon", () => {
+    render(ProjectRow, {
+      project: project(),
+      pinned: false,
+      selected: false,
+      onselect: () => {},
+      onhide: () => {},
+    });
+    const glyph = document.body.querySelector(".row-glyph");
+    expect(glyph?.textContent?.trim()).toBe("▣");
+    expect(glyph?.classList.contains("emoji")).toBe(false);
   });
 });
 

--- a/ui/src/lib/components/ProjectRow.svelte
+++ b/ui/src/lib/components/ProjectRow.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { BacklogProject } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
+  import { projectIcons } from "$lib/projectIcons.svelte";
 
   let {
     project,
@@ -45,6 +46,11 @@
     project.path.replace(/\/+$/, "").split("/").pop() || project.slug || project.display,
   );
 
+  // Repo identity glyph, same recipe as the New Task repo picker (RepoSelect) and
+  // the learnings drawer's repo groups: the configured project emoji when set,
+  // else the ▣ marker so every row's name starts on the same column.
+  const repoIcon = $derived(projectIcons.iconFor(project.path));
+
   const issuesLabel = $derived(
     project.openIssues != null
       ? m.backlog_tab_issues_count({ count: project.openIssues })
@@ -68,6 +74,7 @@
   title={project.display}
 >
   <div class="row-main">
+    <span class="row-glyph" class:emoji={!!repoIcon} aria-hidden="true">{repoIcon ?? "▣"}</span>
     <span class="row-name">{displayName}</span>
     {#if pinned}
       <span class="pin-icon" role="img" aria-label={m.backlog_pinned_label()}>
@@ -237,6 +244,23 @@
     gap: 6px;
     min-width: 0;
     flex: 1;
+  }
+
+  /* Fixed box (sized off the type scale, not the glyph's own font-size) so the
+     names stay on one column whether a row shows an emoji or the ▣ fallback. */
+  .row-glyph {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: calc(var(--fs-base) * 1.4);
+    color: var(--color-faint);
+    font-size: var(--fs-micro);
+    line-height: 1;
+  }
+
+  .row-glyph.emoji {
+    font-size: var(--fs-base);
   }
 
   .row-name {

--- a/ui/src/lib/feature-announcements/entries/v1.47.0-backlog-repo-icon.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.47.0-backlog-repo-icon.ts
@@ -1,0 +1,12 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  // No targetId: the glyph sits on rows inside the Repos overlay, which is
+  // closed when the What's-New drawer opens — no anchor to point a coachmark at.
+  id: "backlog-repo-icon",
+  sinceVersion: "1.47.0",
+  titleKey: "feat_backlog_repo_icon_title",
+  bodyKey: "feat_backlog_repo_icon_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
## Was

Die Repo-Liste im **REPOS/Backlog-Overlay** war die einzige Repo-Fläche ohne das Projekt-Emoji. Session-Karten (`UnitRow`), Epic-Überschriften (`EpicGroupHeader`), die Repo-Gruppen im Learnings-Drawer (`RepoGroup`) und die Repo-Auswahl in „Neue Aufgabe" (`RepoSelect`) zeigen es längst — hier fehlte es.

Jede `ProjectRow` führt jetzt mit demselben Glyph-Rezept: das konfigurierte Emoji, sonst die ▣-Marke.

## Wie

- `ui/src/lib/components/ProjectRow.svelte`: `projectIcons.iconFor(project.path)` als `$derived`, `<span class="row-glyph">` vor dem Namen. `aria-hidden` — der Zeilenname trägt die Identität bereits, das Glyph ist rein visuell.
- Die Glyph-Box ist über `calc(var(--fs-base) * 1.4)` bemessen, **nicht** über die eigene `font-size` — sonst würde die Box mit dem Zustand (Emoji auf `--fs-base`, ▣ auf `--fs-micro`) mitwandern und die Namen in der Liste ausfransen. So starten alle Namen auf derselben Spalte.

## Bewusst nicht enthalten

Das Emoji ist hier **nur Anzeige**, kein Picker. Gesetzt wird es weiterhin in der Repo-Auswahl unter „Neue Aufgabe" — die anderen drei Anzeige-Flächen halten es genauso. Ein zweiter Setz-Ort (Popover-Positionierung in einer scrollenden Liste innerhalb eines Modals) wäre ein eigener Feature-Bau, den die Aufgabe nicht verlangt hat. Falls das gewünscht ist: gerne als Folge-Issue.

## Verifikation

- `ui/`: `bun run check` — 0 Fehler; `bun run test` — 289 Dateien / 4543 Tests grün.
- Zwei neue Browser-Tests in `ProjectRow.browser.test.ts`: Emoji-Zustand (inkl. `.emoji`-Klasse) und ▣-Fallback.
- `bun run check:i18n`, `check-glossary.mjs`, `check-feature-catalog.sh`, `check-announcement-versions.mjs`, Root-`bun run lint` — alle grün.

Hinweis: Ein erster Voll-Lauf der UI-Suite warf einen `Unhandled Error` in `GlossaryTerm.svelte:71` aus `NewTaskKeymap.browser.test.ts`. Das ist ein vorbestehendes, dateiübergreifendes Listener-Leck (der Test feuert `window.dispatchEvent(new PointerEvent(...))`, dessen `target` `window` und damit kein `Node` ist) — unabhängig von diesem Diff und bei identischem Code im Wiederholungslauf nicht reproduzierbar. Nicht in diesem PR angefasst.

## Feature-Katalog

Eintrag `v1.47.0-backlog-repo-icon.ts` + `feat_backlog_repo_icon_{title,body}` in `en.json`/`de.json`.