### PR TITLE
fix(forge): don't send merge_method into a required merge queue

### DIFF
--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -86,6 +86,21 @@ interface StackProbe {
   size?: number;
   /** Head SHA, passed to merge-async as the optimistic-concurrency guard. */
   sha?: string;
+  /** The stack's TRUNK — `stack.base.ref`, the branch the whole stack lands on. NOT the PR's
+   *  own `base.ref`, which for any layer above the bottom is the layer below it. Merging any
+   *  layer lands the stack on the trunk, so the trunk is what carries the rules that apply. */
+  stackBase?: string;
+}
+
+/** `stackBase` is interpolated straight into a `gh api` path, so — like {@link MERGE_UUID_RE} — it
+ *  is shape-checked first: a garbled or hostile ref would otherwise retarget the request at a
+ *  different endpoint. Checked per SLASH-SEPARATED SEGMENT rather than against the whole string,
+ *  because it is a `..` segment specifically that traverses; each segment must start with a word
+ *  character, which rules out `..`, `.`, and an empty segment in one move. Deliberately narrower
+ *  than git's ref grammar — a ref this rejects is treated as "we don't know the trunk", which
+ *  fails open to today's behaviour. */
+function isPathSafeRef(ref: string): boolean {
+  return ref.length <= 255 && ref.split("/").every((seg) => /^\w[\w.-]*$/.test(seg));
 }
 
 /** A merge-request uuid is interpolated straight into the `gh api` path, so it is validated
@@ -1703,7 +1718,9 @@ export class GithubForge implements GitForge {
     await this.run(args);
   }
 
-  /** Stack membership + head SHA in one REST call, narrowed with `--jq` so the payload stays small.
+  /** Stack membership, head SHA and the stack's trunk in one REST call, narrowed with `--jq` so
+   *  the payload stays small. The trunk rides along for free: `.stack` is taken wholesale and
+   *  GitHub puts `base: { ref, sha }` on it.
    *
    *  FAILS OPEN. A probe error (rate limit, transient 5xx) reports "unstacked", which routes the
    *  merge down the legacy path — i.e. precisely today's behaviour, so a probe failure can never
@@ -1718,7 +1735,7 @@ export class GithubForge implements GitForge {
         "{stack: .stack, sha: .head.sha}",
       ]);
       const p = JSON.parse(out || "{}") as {
-        stack?: { position?: number; size?: number } | null;
+        stack?: { position?: number; size?: number; base?: { ref?: string } | null } | null;
         sha?: string | null;
       };
       return {
@@ -1726,6 +1743,7 @@ export class GithubForge implements GitForge {
         position: p.stack?.position,
         size: p.stack?.size,
         sha: p.sha ?? undefined,
+        stackBase: p.stack?.base?.ref ?? undefined,
       };
     } catch (err) {
       console.warn(`[github] stack probe failed for pr#${prNumber}; assuming unstacked:`, err);
@@ -1757,21 +1775,56 @@ export class GithubForge implements GitForge {
     await this.pollMergeAsync(prNumber, uuid);
   }
 
+  /** Does the stack's trunk require a merge queue? A `merge_queue` rule there makes
+   *  `merge_method` illegal on the merge request (#2062), so the answer decides the PUT's shape.
+   *
+   *  FAILS OPEN, for the same reason {@link probeStack} does: an unknown answer keeps today's
+   *  request shape, so a flaky rules call can never be worse than not asking at all. An unknown
+   *  trunk is NOT substituted with the PR's own base — for a layer above the bottom that is the
+   *  layer below, and asking about it would answer a different question than the one that
+   *  matters. */
+  private async requiresMergeQueue(stackBase: string | undefined): Promise<boolean> {
+    if (!stackBase) return false;
+    if (!isPathSafeRef(stackBase)) {
+      console.warn(`[github] stack base ${JSON.stringify(stackBase)} is not a probeable ref`);
+      return false;
+    }
+    try {
+      const out = await this.run([
+        "api",
+        `repos/${this.slug}/rules/branches/${stackBase}`,
+        "--jq",
+        '[.[] | select(.type == "merge_queue")] | length',
+      ]);
+      return Number(out.trim()) > 0;
+    } catch (err) {
+      console.warn(`[github] merge-queue probe failed for ${stackBase}; assuming none:`, err);
+      return false;
+    }
+  }
+
   /** PUT the merge request. On a 409 ("a merge request is already in flight for this PR") the
    *  body still carries that request's uuid — adopt it so a retry JOINS the in-flight merge
-   *  instead of racing or erroring. Any other failure with no uuid to adopt is re-thrown. */
+   *  instead of racing or erroring. Any other failure with no uuid to adopt is re-thrown.
+   *
+   *  Under a required merge queue the host rejects `merge_method` outright, so the queue case
+   *  sends an explicit `merge_action=merge_queue` and no merge params at all — the queue's own
+   *  configured method governs. Explicit rather than implicit: were the probe ever wrong about
+   *  the trunk, this fails as a 422 at request time instead of merging under a method nobody
+   *  chose. Both shapes keep the `sha` guard. */
   private async putMergeAsync(
     prNumber: number,
     o: MergeInput,
     probe: StackProbe,
   ): Promise<MergeAsyncBody | null> {
+    const queued = await this.requiresMergeQueue(probe.stackBase);
     const args = [
       "api",
       "--method",
       "PUT",
       `repos/${this.slug}/pulls/${prNumber}/merge-async`,
       "-f",
-      `merge_method=${o.method}`,
+      queued ? "merge_action=merge_queue" : `merge_method=${o.method}`,
     ];
     // Optimistic-concurrency guard: the host rejects the merge if the head moved under us.
     if (probe.sha) args.push("-f", `sha=${probe.sha}`);

--- a/test/forge/github-stacked-merge.test.ts
+++ b/test/forge/github-stacked-merge.test.ts
@@ -16,6 +16,11 @@ const UUID = "11111111-2222-3333-4444-555555555555";
 const PROBE = "repos/o/r/pulls/7 --jq";
 const PUT_PATH = "repos/o/r/pulls/7/merge-async";
 const POLL_PATH = `repos/o/r/pulls/7/merge-async/${UUID}`;
+/** The stack's trunk, and the layer directly below pr#7 — deliberately different names, so
+ *  "probed the trunk" and "probed the layer below" leave different evidence (#2062). */
+const TRUNK = "main";
+const PARENT = "b2-fail";
+const RULES = "rules/branches/";
 
 const noSleep = async (): Promise<void> => {};
 
@@ -44,8 +49,26 @@ function harness(routes: [match: string, reply: () => string][]) {
 }
 
 const unstackedProbe = (): string => JSON.stringify({ stack: null, sha: HEAD_SHA });
+/** pr#7 as a realistic MIDDLE layer: 2 of 3, sitting on `b2-fail`, stack rooted at `main`.
+ *
+ *  The top-level `base` is a deliberate TRAP, not a faithful copy of the projection — the probe's
+ *  `--jq` does not select it. It is here so that a regression which starts reading the PR's own
+ *  base instead of `stack.base.ref` probes `b2-fail`, which the assertions below catch. */
 const stackedProbe = (): string =>
+  JSON.stringify({
+    stack: { id: 9, number: 3, size: 3, position: 2, base: { ref: TRUNK, sha: "0ddba110000" } },
+    sha: HEAD_SHA,
+    base: PARENT,
+  });
+/** Same middle layer, but the host reported no trunk on the stack object. */
+const trunklessProbe = (): string =>
   JSON.stringify({ stack: { id: 9, number: 3, size: 3, position: 2 }, sha: HEAD_SHA });
+
+/** The `-f` values of the merge-async PUT, which is what #2062 is about. */
+const putFields = (calls: string[][]): string[] => {
+  const put = calls.find((c) => c.includes(PUT_PATH)) ?? [];
+  return put.filter((_, i) => put[i - 1] === "-f");
+};
 
 test("merge: unstacked PR takes the legacy `gh pr merge` path, untouched (#2059)", async () => {
   const { forge, calls, joined } = harness([[PROBE, unstackedProbe]]);
@@ -321,4 +344,100 @@ test("merge: a malformed uuid is never interpolated into the API path", async ()
   expect(joined().some((c) => c.includes("pulls/1/merge"))).toBe(false);
   // The PUT is the only merge-async traffic — nothing was polled at all.
   expect(joined().filter((c) => c.includes("merge-async")).length).toBe(1);
+});
+
+// #2062 — a required merge queue rejects `merge_method`. The rule lives on the stack's TRUNK,
+// because merging any layer lands the whole stack there; the layer this PR directly targets is
+// irrelevant. `harness` matches routes by substring, so a `rules/branches/` stub answers for ANY
+// branch — these tests must therefore assert the exact path probed, not merely that one was.
+
+test("merge: a merge-queue trunk drops merge_method and enqueues (#2062)", async () => {
+  const { forge, calls, joined } = harness([
+    [PROBE, stackedProbe],
+    [RULES, () => "1"], // one `merge_queue` rule applies to the trunk
+    [PUT_PATH, () => JSON.stringify({ status: "enqueued", details: { uuid: UUID } })],
+  ]);
+
+  const err = await forge
+    .merge(7, { method: "squash", deleteBranch: true, allowStacked: true })
+    .catch((e: unknown) => e);
+
+  // The trunk was probed — NOT `b2-fail`, the layer pr#7 actually bases on.
+  expect(calls.find((c) => c.some((a) => a.includes(RULES)))?.[1]).toBe(
+    `repos/o/r/${RULES}${TRUNK}`,
+  );
+  expect(joined().some((c) => c.includes(PARENT))).toBe(false);
+  // The whole point: an explicit queue action, and no merge params for the queue to reject.
+  expect(putFields(calls)).toEqual(["merge_action=merge_queue", `sha=${HEAD_SHA}`]);
+  expect(err).toBeInstanceOf(MergeEnqueuedError);
+  expect((err as MergeEnqueuedError).code).toBe("merge_enqueued");
+});
+
+test("merge: a trunk with other rules but no merge queue keeps merge_method (#2062)", async () => {
+  const { forge, calls } = harness([
+    [PROBE, stackedProbe],
+    [RULES, () => "0"], // required_status_checks, pull_request, … — but no merge_queue
+    [POLL_PATH, () => JSON.stringify({ status: "merged" })],
+    [PUT_PATH, () => JSON.stringify({ status: "pending", details: { uuid: UUID } })],
+  ]);
+
+  await forge.merge(7, { method: "squash", deleteBranch: true, allowStacked: true });
+
+  expect(putFields(calls)).toEqual(["merge_method=squash", `sha=${HEAD_SHA}`]);
+});
+
+test("merge: a failed merge-queue probe falls open to today's request shape (#2062)", async () => {
+  const { forge, calls } = harness([
+    [PROBE, stackedProbe],
+    [
+      RULES,
+      () => {
+        throw new Error("HTTP 503: upstream unavailable");
+      },
+    ],
+    [POLL_PATH, () => JSON.stringify({ status: "merged" })],
+    [PUT_PATH, () => JSON.stringify({ status: "pending", details: { uuid: UUID } })],
+  ]);
+
+  // Fails open: the merge still happens, exactly as it does today.
+  await forge.merge(7, { method: "squash", deleteBranch: true, allowStacked: true });
+
+  expect(putFields(calls)).toEqual(["merge_method=squash", `sha=${HEAD_SHA}`]);
+});
+
+test("merge: no trunk on the stack object probes nothing — never the layer below (#2062)", async () => {
+  const { forge, calls, joined } = harness([
+    [PROBE, trunklessProbe],
+    [RULES, () => "1"], // would report a queue if anything asked
+    [POLL_PATH, () => JSON.stringify({ status: "merged" })],
+    [PUT_PATH, () => JSON.stringify({ status: "pending", details: { uuid: UUID } })],
+  ]);
+
+  await forge.merge(7, { method: "squash", deleteBranch: true, allowStacked: true });
+
+  expect(joined().some((c) => c.includes(RULES))).toBe(false);
+  expect(putFields(calls)).toEqual(["merge_method=squash", `sha=${HEAD_SHA}`]);
+});
+
+test("merge: a malformed trunk ref is never interpolated into the API path (#2062)", async () => {
+  const { forge, calls, joined } = harness([
+    [
+      PROBE,
+      () =>
+        JSON.stringify({
+          stack: { size: 3, position: 2, base: { ref: "../../pulls/1/merge" } },
+          sha: HEAD_SHA,
+        }),
+    ],
+    [RULES, () => "1"],
+    [POLL_PATH, () => JSON.stringify({ status: "merged" })],
+    [PUT_PATH, () => JSON.stringify({ status: "pending", details: { uuid: UUID } })],
+  ]);
+
+  await forge.merge(7, { method: "squash", deleteBranch: true, allowStacked: true });
+
+  // Traversal would show up as a GET on the retargeted path; the guard makes it "no trunk".
+  expect(joined().some((c) => c.includes(RULES))).toBe(false);
+  expect(joined().some((c) => c.includes("pulls/1/merge"))).toBe(false);
+  expect(putFields(calls)).toEqual(["merge_method=squash", `sha=${HEAD_SHA}`]);
 });


### PR DESCRIPTION
Closes #2062.

## The bug

`putMergeAsync` always sent `merge_method` and never `merge_action`. Under a branch that requires a merge queue, GitHub **accepts** that PUT and then fails it asynchronously:

```
poll1: {"status":"failed","details":{"message":"Custom merge params are not supported
        when merging via a merge queue"}}
```

`mergeAsyncSettled` turned that into a generic `Error`, so the operator saw a complaint about request parameters they never chose, for a merge that never had a chance to land.

## The fix

Probe the stack's **trunk** for a `merge_queue` rule; when one applies, send `merge_action=merge_queue` and no merge params at all (the queue's configured method governs). The request then settles as `enqueued`, which `MergeEnqueuedError` already expresses and drain/the merge train already handle.

The load-bearing detail — and what an earlier draft of this fix got wrong — is *which* branch to probe. Merging any layer lands the whole stack on the trunk, so the trunk carries the rule. Top-level `.base.ref` is the layer **below** this PR, so probing it would have missed the queue for every PR at stack position ≥ 2 — precisely the case in the issue's own repro. `.stack.base.ref` is the trunk, and `probeStack()` already parses the `stack` object wholesale, so it costs no extra request and no `--jq` change.

`merge_action` is sent explicitly rather than left to GitHub's `default`: if the probe were ever wrong about a branch, that fails loudly as a 422 at request time instead of merging under a method nobody chose.

## Failure posture

The probe **fails open** — a probe error, an absent `stack.base.ref`, or a ref failing the path guard all keep today's request shape, mirroring `probeStack()`'s existing contract that a flaky REST call can never be worse than not asking. It deliberately does *not* fall back to the PR's own base: probing the wrong branch answers the wrong question.

The trunk is interpolated into a `gh api` path, so it is shape-checked per slash-separated segment first (each segment must start with a word character, which rules out `..` traversal), the same posture `MERGE_UUID_RE` already applies to the merge-request uuid.

## Verification

Five new cases in `test/forge/github-stacked-merge.test.ts`. Note the harness matches routes by substring, so a `rules/branches/` stub answers for *any* branch — the queue test therefore asserts the **exact** path probed (`repos/o/r/rules/branches/main`) and that no call anywhere mentions the intermediate layer, with the fixture reshaped into a realistic mid-stack PR so the two cases leave different evidence.

- merge-queue trunk → exact trunk probed, PUT fields are exactly `merge_action=merge_queue` + `sha`, surfaces as `MergeEnqueuedError`
- trunk with other rules only → `merge_method` unchanged from today
- rules probe throws → falls open, merge still proceeds
- no trunk on the stack object → no rules call at all, never the layer below
- malformed trunk ref → never interpolated into an API path

Root suite (8426 pass), `lint`, `tsc --noEmit` and the Fallow delta audit green. No UI or i18n surface: the outcome is the existing `merge_enqueued` state shipped in #2061.

Found by the #2060 spike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)