### PR TITLE
feat(forge): stacked-PR API surface on GithubForge (#2068)

### DIFF
--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -46,6 +46,7 @@ import type {
   RedeployInput,
   RepoCounts,
   RollupEntry,
+  StackInfo,
   SubIssueRef,
   WorkflowJob,
   WorkflowRun,
@@ -101,6 +102,21 @@ interface StackProbe {
  *  fails open to today's behaviour. */
 function isPathSafeRef(ref: string): boolean {
   return ref.length <= 255 && ref.split("/").every((seg) => /^\w[\w.-]*$/.test(seg));
+}
+
+/** `--jq` projection of one stack resource onto {@link StackInfo}'s wire shape (#2068). Narrowing
+ *  host-side keeps the payload small; `// []` keeps jq from erroring on a stack the host returned
+ *  without a membership list, which {@link stackInfoFrom} then rejects as unusable. */
+const STACK_JQ = "{number, baseRef: .base.ref, prNumbers: [(.pull_requests // [])[].number]}";
+
+/** Validate one {@link STACK_JQ} projection. Null for anything unusable — a missing stack number,
+ *  a missing trunk, or no members — so both the fail-open read and the throwing writes have one
+ *  definition of "the host did not describe a stack we can address". */
+function stackInfoFrom(raw: Partial<StackInfo> | null | undefined): StackInfo | null {
+  if (!raw || typeof raw.number !== "number" || !raw.baseRef) return null;
+  const prNumbers = (raw.prNumbers ?? []).filter((n) => typeof n === "number");
+  if (!prNumbers.length) return null;
+  return { number: raw.number, baseRef: raw.baseRef, prNumbers };
 }
 
 /** A merge-request uuid is interpolated straight into the `gh api` path, so it is validated
@@ -1716,6 +1732,81 @@ export class GithubForge implements GitForge {
     const args = ["pr", "merge", String(prNumber), "--repo", this.slug, method];
     if (o.deleteBranch) args.push("--delete-branch");
     await this.run(args);
+  }
+
+  /** The stack `prNumber` belongs to, or null when it belongs to none (#2068).
+   *
+   *  Reads the STACK resource (`GET /stacks?pull_request=`) rather than the `.stack` object
+   *  embedded in the pull request, because only the stack resource carries `pull_requests` — the
+   *  membership list is the whole point of this read. The sibling {@link probeStack} takes the
+   *  other route for the opposite reason: the merge path needs the head SHA, which lives on the
+   *  pull request and not on the stack.
+   *
+   *  FAILS OPEN to null, exactly as {@link probeStack} does — see its note. A stack whose trunk
+   *  the host did not report is also null: `baseRef` is the load-bearing field, and handing a
+   *  caller an empty ref to interpolate or compare against is worse than reporting nothing.
+   *
+   *  NEVER shells out to `gh stack`: under a PTY it opens a full-screen TUI and would wedge an
+   *  unattended agent. Every stack call in this file is a `gh api` call. */
+  async stackForPr(prNumber: number): Promise<StackInfo | null> {
+    try {
+      // Projected as an ARRAY so the unstacked case (`[]`) stays valid jq input and parses to [].
+      const out = await this.run([
+        "api",
+        `repos/${this.slug}/stacks?pull_request=${prNumber}`,
+        "--jq",
+        `[.[] | ${STACK_JQ}]`,
+      ]);
+      const stacks = JSON.parse(out || "[]") as Partial<StackInfo>[];
+      const info = stackInfoFrom(stacks[0]);
+      // Membership is re-checked locally rather than taken on trust: were the `pull_request=`
+      // filter ever dropped or ignored host-side, the endpoint would answer with SOME OTHER
+      // stack in the repo, and reporting that one as this PR's stack is the one failure mode
+      // worse than reporting nothing.
+      const at = info ? info.prNumbers.indexOf(prNumber) : -1;
+      if (!info || at < 0) return null;
+      return { ...info, position: at + 1, size: info.prNumbers.length };
+    } catch (err) {
+      console.warn(`[github] stack read failed for pr#${prNumber}; assuming unstacked:`, err);
+      return null;
+    }
+  }
+
+  /** Link `prNumbers` (BOTTOM → TOP) into a new stack. A mutation: host errors propagate, and an
+   *  unreadable response body throws rather than reporting a stack nobody can address later. */
+  async createStack(prNumbers: number[]): Promise<StackInfo> {
+    const out = await this.run([
+      "api",
+      "--method",
+      "POST",
+      `repos/${this.slug}/stacks`,
+      "--jq",
+      STACK_JQ,
+      ...prNumbers.flatMap((n) => ["-F", `pull_requests[]=${n}`]),
+    ]);
+    const info = stackInfoFrom(JSON.parse(out || "null") as Partial<StackInfo> | null);
+    if (!info) throw new Error(`create stack for #${prNumbers.join(", #")} returned no stack`);
+    return { ...info, size: info.prNumbers.length };
+  }
+
+  /** Append one pull request to the TOP of an existing stack. Mutation — errors propagate. */
+  async addToStack(stackNumber: number, prNumber: number): Promise<void> {
+    await this.run([
+      "api",
+      "--method",
+      "POST",
+      `repos/${this.slug}/stacks/${stackNumber}/add`,
+      "-F",
+      `pull_requests[]=${prNumber}`,
+    ]);
+  }
+
+  /** Dissolve a stack. Its unmerged pull requests are unlinked; merged or merge-queued ones stay
+   *  linked host-side. The only repair primitive there is — no reorder/insert/drop-one API
+   *  exists, so a stack that needs reshaping is unstacked and recreated. Mutation — errors
+   *  propagate. */
+  async unstack(stackNumber: number): Promise<void> {
+    await this.run(["api", "--method", "POST", `repos/${this.slug}/stacks/${stackNumber}/unstack`]);
   }
 
   /** Stack membership, head SHA and the stack's trunk in one REST call, narrowed with `--jq` so

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -383,6 +383,27 @@ export class MergePendingError extends MergeNotCompletedError {
   }
 }
 
+/** One GitHub pull-request stack, as the stacked-PR API surface reports it (#2068).
+ *
+ *  Public preview on the host side: every stacked-PR docs page says "subject to change", so treat
+ *  a shape change as expected maintenance rather than a defect. */
+export interface StackInfo {
+  /** The stack's own number — the handle every write endpoint takes (`/stacks/{number}/…`).
+   *  NOT a pull-request number. */
+  number: number;
+  /** The stack's TRUNK: the branch the whole stack lands on. NOT the branch a given layer
+   *  directly targets, which for any layer above the bottom is the layer below it. Every layer
+   *  is evaluated against the trunk's rules, so this is the field consumers actually need. */
+  baseRef: string;
+  /** Stack membership, BOTTOM → TOP, as the host ordered it. Includes layers that have already
+   *  merged — the list describes the stack as composed, not what is left to land. */
+  prNumbers: number[];
+  /** 1-based position of the pull request the read was keyed on, and the membership count.
+   *  Advisory (message text); absent when the read was not keyed on a pull request. */
+  position?: number;
+  size?: number;
+}
+
 export interface RedeployInput {
   workflow: string;
   ref: string;
@@ -646,6 +667,29 @@ export interface GitForge {
    *  rows + headRefName-keyed poll statuses). Optional: only GitHub implements it;
    *  Gitea/Local omit it and callers fall back to listPullRequests / per-session prStatus. */
   listOpenPrSnapshot?(): Promise<OpenPrSnapshot>;
+  // Stacked pull requests (#2068). GitHub only, and a public PREVIEW there — Gitea and Local omit
+  // these entirely, so callers must branch on the method's presence, never on `kind`.
+  //
+  // Two constraints shape everything built on top of this surface:
+  //  - There is NO reorder / insert / drop-one endpoint, and `gh stack modify` is TUI-only. The
+  //    single repair primitive is {@link unstack} followed by {@link createStack}.
+  //  - The async merge API takes no delete-branch parameter, so layer branches survive a stack
+  //    merge and nothing reaps them (BranchPruner only sweeps LOCAL `shepherd/*` branches).
+  /** The stack a pull request belongs to, or null when it belongs to none.
+   *
+   *  FAILS OPEN: any error (rate limit, transient 5xx, an unreadable body) reports null, i.e.
+   *  "not stacked" — which is how every caller behaves today, so a flaky read can never be a
+   *  regression. Callers that must distinguish "no stack" from "could not tell" cannot use this. */
+  stackForPr?(prNumber: number): Promise<StackInfo | null>;
+  /** Link existing pull requests into a new stack, ordered BOTTOM → TOP. Unlike
+   *  {@link stackForPr} this is a mutation and does NOT fail open: host errors propagate, because
+   *  a swallowed failure would leave the caller believing a stack exists when it does not. */
+  createStack?(prNumbers: number[]): Promise<StackInfo>;
+  /** Append one pull request to the TOP of an existing stack. Mutation — errors propagate. */
+  addToStack?(stackNumber: number, prNumber: number): Promise<void>;
+  /** Dissolve a stack, unlinking its UNMERGED pull requests (merged or merge-queued ones stay
+   *  linked, host-side). Mutation — errors propagate. */
+  unstack?(stackNumber: number): Promise<void>;
 }
 
 /** Per-host configuration loaded from ~/.shepherd/forges.json. */

--- a/test/forge/github-stacks.test.ts
+++ b/test/forge/github-stacks.test.ts
@@ -1,0 +1,179 @@
+// Stacked-PR API surface (#2068): read a PR's stack, create one, append to one, dissolve one.
+// Everything drives the injected GhRunner seam, so no network and no real stacks. The read fails
+// open (an error is "unstacked", today's behaviour everywhere); the three writes do NOT — a
+// swallowed write failure would leave a caller believing a stack exists when it does not.
+import { test, expect } from "bun:test";
+import { GithubForge } from "../../src/forge/github";
+import { GiteaForge } from "../../src/forge/gitea";
+import { LocalForge } from "../../src/forge/local";
+import { SessionStore } from "../../src/store";
+import type { ForgeConfig, GitForge } from "../../src/forge/types";
+
+const READ = "repos/o/r/stacks?pull_request=7";
+const CREATE = "repos/o/r/stacks";
+const TRUNK = "epic/2063-stack-epic-children-onto-the-integration";
+
+/** Build a forge whose runner replies from `routes` (first matching substring wins) and records
+ *  every call. Mirrors test/forge/github-stacked-merge.test.ts. */
+function harness(routes: [match: string, reply: () => string][]) {
+  const calls: string[][] = [];
+  const run = async (args: string[]): Promise<string> => {
+    calls.push(args);
+    const joined = args.join(" ");
+    for (const [match, reply] of routes) if (joined.includes(match)) return reply();
+    return "";
+  };
+  return { forge: new GithubForge("o/r", {}, run), calls };
+}
+
+/** What the runner sees after `--jq` narrowing: gh applies the filter, so the fake replies with
+ *  the PROJECTION, not the raw stack resource. */
+const projection = (prNumbers: number[], baseRef: string = TRUNK) => ({
+  number: 42,
+  baseRef,
+  prNumbers,
+});
+
+const boom = () => {
+  throw new Error("HTTP 503: upstream unavailable");
+};
+
+test("stackForPr: maps the stack, deriving the PR's position from the membership order", async () => {
+  const { forge, calls } = harness([[READ, () => JSON.stringify([projection([5, 7, 9])])]]);
+
+  expect(await forge.stackForPr(7)).toEqual({
+    number: 42,
+    baseRef: TRUNK,
+    prNumbers: [5, 7, 9], // bottom → top, verbatim from the host
+    position: 2,
+    size: 3,
+  });
+  // The stack RESOURCE is read, keyed on the PR — the PR's own `.stack` object carries no
+  // membership list, which is the whole point of this call.
+  expect(calls[0]?.[1]).toBe(READ);
+});
+
+test("stackForPr: an unstacked PR reports null", async () => {
+  const { forge } = harness([[READ, () => "[]"]]);
+
+  expect(await forge.stackForPr(7)).toBeNull();
+});
+
+test("stackForPr: a failed read FAILS OPEN to null rather than rejecting", async () => {
+  const { forge } = harness([[READ, boom]]);
+
+  expect(await forge.stackForPr(7)).toBeNull();
+});
+
+test("stackForPr: an unparseable body reports null", async () => {
+  const { forge } = harness([[READ, () => "<html>502 Bad Gateway</html>"]]);
+
+  expect(await forge.stackForPr(7)).toBeNull();
+});
+
+test("stackForPr: a stack with no readable trunk reports null, never an empty baseRef", async () => {
+  const { forge } = harness([[READ, () => JSON.stringify([projection([5, 7], "")])]]);
+
+  // baseRef is the load-bearing field; a caller must not receive "" to compare or interpolate.
+  expect(await forge.stackForPr(7)).toBeNull();
+});
+
+test("stackForPr: a stack the PR is not a member of is not reported as its stack", async () => {
+  // Would only happen if the host dropped or ignored the `pull_request=` filter — in which case
+  // answering with somebody else's stack is worse than answering with nothing.
+  const { forge } = harness([[READ, () => JSON.stringify([projection([5, 9])])]]);
+
+  expect(await forge.stackForPr(7)).toBeNull();
+});
+
+test("createStack: POSTs the pull requests bottom→top and returns the created stack", async () => {
+  const { forge, calls } = harness([[CREATE, () => JSON.stringify(projection([5, 7, 9]))]]);
+
+  expect(await forge.createStack([5, 7, 9])).toEqual({
+    number: 42,
+    baseRef: TRUNK,
+    prNumbers: [5, 7, 9],
+    size: 3,
+  });
+  const post = calls[0] ?? [];
+  expect(post.slice(0, 4)).toEqual(["api", "--method", "POST", CREATE]);
+  expect(post.filter((_, i) => post[i - 1] === "-F")).toEqual([
+    "pull_requests[]=5",
+    "pull_requests[]=7",
+    "pull_requests[]=9",
+  ]);
+});
+
+test("createStack: a host rejection PROPAGATES — writes never fail open", async () => {
+  const { forge } = harness([[CREATE, boom]]);
+
+  await expect(forge.createStack([5, 7])).rejects.toThrow("503");
+});
+
+test("createStack: an unreadable response is an error, not a stack nobody can address", async () => {
+  const { forge } = harness([[CREATE, () => ""]]);
+
+  await expect(forge.createStack([5, 7])).rejects.toThrow("no stack");
+});
+
+test("addToStack: appends one PR to an existing stack", async () => {
+  const { forge, calls } = harness([]);
+
+  await forge.addToStack(42, 9);
+
+  expect(calls[0]).toEqual([
+    "api",
+    "--method",
+    "POST",
+    "repos/o/r/stacks/42/add",
+    "-F",
+    "pull_requests[]=9",
+  ]);
+});
+
+test("addToStack: a host rejection propagates", async () => {
+  const { forge } = harness([["stacks/42/add", boom]]);
+
+  await expect(forge.addToStack(42, 9)).rejects.toThrow("503");
+});
+
+test("unstack: dissolves the stack, with no fields to send", async () => {
+  const { forge, calls } = harness([]);
+
+  await forge.unstack(42);
+
+  expect(calls[0]).toEqual(["api", "--method", "POST", "repos/o/r/stacks/42/unstack"]);
+});
+
+test("unstack: a host rejection propagates", async () => {
+  const { forge } = harness([["stacks/42/unstack", boom]]);
+
+  await expect(forge.unstack(42)).rejects.toThrow("503");
+});
+
+test("no stack method ever shells out to `gh stack` (it opens a TUI under a PTY)", async () => {
+  const { forge, calls } = harness([[READ, () => JSON.stringify([projection([5, 7])])]]);
+
+  await forge.stackForPr(7);
+  await forge.addToStack(42, 9);
+  await forge.unstack(42);
+  await forge.createStack([5, 7]).catch(() => {});
+
+  expect(calls.length).toBe(4);
+  expect(calls.every((c) => c[0] === "api")).toBe(true);
+});
+
+test("Gitea and Local omit the stack surface, so callers branch on capability not on kind", async () => {
+  const cfg: ForgeConfig = { type: "gitea", baseUrl: "https://git.example.com", token: "s" };
+  const forges: GitForge[] = [
+    new GiteaForge("team/proj", cfg),
+    new LocalForge("/nonexistent", new SessionStore(":memory:")),
+  ];
+
+  for (const forge of forges) {
+    expect(forge.stackForPr).toBeUndefined();
+    expect(forge.createStack).toBeUndefined();
+    expect(forge.addToStack).toBeUndefined();
+    expect(forge.unstack).toBeUndefined();
+  }
+});


### PR DESCRIPTION
Gives `GitForge` a stacked-PR surface — read a PR's stack, create one, append to one, dissolve one
— on GitHub only, entirely over `gh api` REST. No production caller lands here; the consumer is a
later child of #2063.

Closes #2068

## What's here

| Method | Call | On failure |
| --- | --- | --- |
| `stackForPr(prNumber)` | `GET repos/{slug}/stacks?pull_request=n` | **fails open** → `null` |
| `createStack(prNumbers)` | `POST repos/{slug}/stacks`, `-F pull_requests[]=…` bottom→top | propagates |
| `addToStack(stackNumber, prNumber)` | `POST repos/{slug}/stacks/{n}/add` | propagates |
| `unstack(stackNumber)` | `POST repos/{slug}/stacks/{n}/unstack` | propagates |

Plus `StackInfo { number, baseRef, prNumbers /* bottom→top */, position?, size? }`. `baseRef` is
the stack **trunk** — every layer is evaluated against the base of the stack, not the branch it
directly targets, and getting that wrong is exactly what #2062 fixed on the merge path.

The read keeps the fail-open contract of the existing private `probeStack()`: any error (rate
limit, transient 5xx, unreadable body) reports "unstacked", which is today's behaviour everywhere,
so a flaky call can never be a regression. The three writes deliberately do **not** fail open — a
swallowed write failure would leave a caller believing a stack exists when it does not.

**Never `gh stack`.** Under a PTY it opens a full-screen TUI and would wedge an unattended agent
(research note §2.5). A test asserts every call is a `gh api` call.

## Two decisions worth a reviewer's attention

**`stackForPr` reads the stack resource, not the PR's embedded `.stack`.** `prNumbers` needs the
whole membership list, and GitHub documents `pull_requests` on the stack resource but not on the
`.stack` object hanging off a pull request. The documented `pull_request=` filter was verified
live against this repo (`200 []`; stacks are enabled here — a 404 is how "not enabled" presents).
Membership is nonetheless re-checked locally: were that filter ever dropped or ignored host-side,
the endpoint would answer with some *other* stack in the repo, and reporting that as this PR's
stack is the one failure mode worse than reporting nothing.

**`probeStack()` stays private and `merge()` is untouched**, despite the issue phrasing this as
"promote `probeStack()` to a full read". The two answer different questions: the merge probe must
return the head SHA (merge-async's concurrency guard, deliberately absent from `StackInfo`), the
public read must return membership (which the PR endpoint does not promise). Routing `merge()`
through the new read would cost a second REST call on the merge hot path and disturb #2059/#2062
behaviour that 15 tests currently pin. Both carry the same fail-open contract and cross-reference
each other in their doc comments.

## Constraints recorded in the doc comments

No reorder / insert / drop-one endpoint exists (`gh stack modify` is TUI-only), so the only repair
primitive is unstack-and-recreate · `merge-async` takes no delete-branch parameter, so layer
branches survive a stack merge and nothing reaps them (`BranchPruner` only sweeps local
`shepherd/*`) · the whole API is a public preview, "subject to change" on every docs page.

## Verification

`bun run lint`, `bunx tsc --noEmit`, `bun run test` (8441 pass / 0 fail) and
`fallow audit --base origin/main --fail-on-issues` (no issues in the 3 changed files) all clean.
15 new tests against the fake `gh` runner cover each method, the null/unstacked and fail-open-on-
throw paths the issue calls out, error propagation on all three writes, and the absence of all
four methods on `GiteaForge` and `LocalForge`.