### PR TITLE
refactor(epic): persist epic-child identity as a session fact (#2067)

### DIFF
--- a/src/critic-core.ts
+++ b/src/critic-core.ts
@@ -43,9 +43,10 @@ export interface EpicBaseDelta {
   commitsTruncated: number;
 }
 
-/** Epic-child review context. Present iff the reviewed branch's base is an epic integration branch
- *  (`isEpicIntegrationBranch`), i.e. this PR is ONE CHILD of a draining epic whose base already
- *  carries merged sibling work. `baseSha` null = the base could not be resolved to a commit (the
+/** Epic-child review context. Present iff the reviewed session is an epic child (`isEpicChild` —
+ *  the persisted `epicParent` fact, falling back to the base-branch name for legacy rows), i.e. this
+ *  PR is ONE CHILD of a draining epic whose base already carries merged sibling work.
+ *  `baseSha` null = the base could not be resolved to a commit (the
  *  fetch/rev-parse failed and there is usually no local ref for an epic branch) → the block degrades
  *  to its no-base mode: no base commands, and existence conclusions become limitations, not
  *  findings. */

--- a/src/drain-core.ts
+++ b/src/drain-core.ts
@@ -54,6 +54,9 @@ export type DrainDecision =
       kind: "spawn";
       issue: Issue;
       integrationBranch?: string;
+      /** Epic parent issue number to stamp on the spawned session (#2067). Set from the same
+       *  epic run as `integrationBranch`, so the two cannot drift; undefined for label-drain. */
+      epicParent?: number;
       epicProviderSettings?: EpicProviderSettings;
     }
   | { kind: "retire"; sessionId: string; prNumber: number }
@@ -120,6 +123,9 @@ export interface DrainRepoState {
   /** Epic mode: the active epic's integration branch — epic-child spawns base on it.
    *  null/undefined for label-drain (spawns base on the default branch). */
   epicIntegrationBranch?: string | null;
+  /** Epic mode: the active epic's PARENT issue number, stamped on each child it spawns (#2067).
+   *  Set from the same epic run as `epicIntegrationBranch`; null/undefined for label-drain. */
+  epicParent?: number | null;
   /** Epic mode: explicit provider/model/effort for child spawns. Undefined for label-drain
    *  and for epics inheriting the repo/global defaults. */
   epicProviderSettings?: EpicProviderSettings | null;
@@ -291,8 +297,9 @@ export function computeNext(state: DrainRepoState): DrainDecision {
   // 2b. Epic base unavailable (#1757): the forge's `ensureBranch` THREW for a child spawn, so the
   // integration branch could not be ensured. Basing the child on the default branch instead would
   // silently mix bases mid-epic — the merge train would land that one child on main (it is not
-  // excluded from full-auto: `isEpicIntegrationBranch(baseBranch)` is false for it) while its
-  // siblings integrate on the epic branch. So fail closed and hold. Gated on an active epic run, so
+  // excluded from full-auto: a child that did NOT get the integration branch carries no `epicParent`
+  // stamp, so `isEpicChild` is false for it) while its siblings integrate on the epic branch.
+  // So fail closed and hold. Gated on an active epic run, so
   // it can never fire in label-mode drain; while an epic runs the candidate set IS that epic's
   // children, and every sibling would fail identically, so pausing new spawns is exactly right.
   // Placed AFTER the retire gate (a ready PR still retires) and BEFORE the cap. The marker is
@@ -334,6 +341,7 @@ export function computeNext(state: DrainRepoState): DrainDecision {
     kind: "spawn",
     issue: next,
     integrationBranch: state.epicIntegrationBranch ?? undefined,
+    epicParent: state.epicParent ?? undefined,
     epicProviderSettings: state.epicProviderSettings ?? undefined,
   };
 }

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -18,7 +18,7 @@ import {
 import { assembleEpic } from "./epic-model";
 import {
   epicIntegrationBranch as epicBranchName,
-  isEpicIntegrationBranch,
+  isEpicChild,
   branchReferencesEpic,
 } from "./epic-branch";
 import { selectEpicCandidates, type Epic, type EpicRun } from "./epic-core";
@@ -2419,11 +2419,11 @@ export class DrainService {
     const s = this.deps.store.get(decision.sessionId);
     // Epic child: squash-merge the PR INTO its integration branch (not the default branch) and
     // record it so dependents unblock without a GitHub issue auto-close (the child issue stays
-    // open until the final epic→default PR lands). Detected by the integration-branch base +
-    // an active epic for the repo.
+    // open until the final epic→default PR lands). Detected by the session's persisted epic-child
+    // identity (#2067) + an active epic for the repo.
     const epicRun = this.deps.store.getEpicRun(repoPath);
     const epicActive = !!epicRun && (epicRun.status === "running" || epicRun.status === "paused");
-    if (epicActive && s?.issueNumber != null && isEpicIntegrationBranch(s.baseBranch)) {
+    if (epicActive && s?.issueNumber != null && isEpicChild(s)) {
       // #645 (Task 2): enforce the child PR's actual base against the integration branch. On
       // mismatch (or while throttled-blocked from a prior mismatch) this returns true → fail
       // closed: skip merge/record/archive/claim-drop so the child stays un-integrated and the
@@ -2473,10 +2473,10 @@ export class DrainService {
    *
    *  - `ensureBranch` THREW (GitHub; a rate-limit, 5xx, race): FAIL CLOSED — throw
    *    {@link EpicBaseUnavailableError}. Degrading this ONE child onto the default branch would mix
-   *    bases mid-epic: it would lose `epicBaseDirective`, open its PR against main, and — since
-   *    `isFullAuto` excludes only sessions whose base IS an integration branch — the merge train
-   *    would then land it on main automatically, while its siblings integrate on the epic branch.
-   *    A retry may well succeed, so doSpawn's catch backs off (cooldown) and the drain holds
+   *    bases mid-epic: it would lose `epicBaseDirective`, open its PR against main, and — since a
+   *    degraded child gets NO `epicParent` stamp, so `isFullAuto` does not exclude it — the merge
+   *    train would then land it on main automatically, while its siblings integrate on the epic
+   *    branch. A retry may well succeed, so doSpawn's catch backs off (cooldown) and the drain holds
    *    visibly (`epic_base_unavailable`) meanwhile.
    *
    *  - The forge simply LACKS `ensureBranch` (gitea/local): DEGRADE, as before. On such a forge NO
@@ -2490,7 +2490,7 @@ export class DrainService {
   private async resolveSpawnBase(
     forge: GitForge,
     decision: Extract<DrainDecision, { kind: "spawn" }>,
-  ): Promise<{ base: string; prompt: string }> {
+  ): Promise<{ base: string; prompt: string; epicParent: number | null }> {
     const { number, title } = decision.issue;
     const def = await forge.defaultBranch();
     let base = def;
@@ -2515,7 +2515,12 @@ export class DrainService {
     const usingEpicBase = !!decision.integrationBranch && base === decision.integrationBranch;
     const task = issueSpawnPrompt(number, title);
     const prompt = usingEpicBase ? `${task}\n\n${epicBaseDirective(base)}` : task;
-    return { base, prompt };
+    // Stamp epic-child identity (#2067) ONLY for a child that actually got the integration branch.
+    // A DEGRADED child (forge without `ensureBranch`) bases on the default branch and behaves like
+    // any ordinary session — the merge train carries it and it retires normally — so stamping it
+    // would silently reroute every gitea/local epic through the squash-into-integration path.
+    const epicParent = usingEpicBase ? (decision.epicParent ?? null) : null;
+    return { base, prompt, epicParent };
   }
 
   private async doSpawn(
@@ -2595,7 +2600,7 @@ export class DrainService {
     // sub-issue) session never appears until a full page reload.
     let session: Session | undefined;
     try {
-      const { base, prompt } = await this.resolveSpawnBase(forge, decision);
+      const { base, prompt, epicParent } = await this.resolveSpawnBase(forge, decision);
       const epicSettings = decision.epicProviderSettings;
       // Auto-spawns honor an explicit operator default-model — the repo override
       // wins over the global default; when both are unset ("inherit"/"auto") they
@@ -2613,6 +2618,7 @@ export class DrainService {
         images: [],
         auto: true,
         issueRef: { number, url, title, body },
+        epicParent, // persisted epic-child identity; null for a label-drain or degraded spawn
       });
       this.spawnFailures.delete(failKey); // #790: clear any prior failure cooldown on success
       // The new auto session appears in the next buildState → counts toward the

--- a/src/epic-branch.ts
+++ b/src/epic-branch.ts
@@ -13,11 +13,37 @@ export function epicIntegrationBranch(parentNumber: number, parentTitle: string)
 }
 
 /** True when `branch` is an epic integration branch (`epic/<#>` or `epic/<#>-<slug>`) as
- *  produced by {@link epicIntegrationBranch}. The session-local marker that a drain auto
- *  session is an epic child — used to keep it off the merge train and route its retire to a
- *  squash-merge into the integration branch. */
+ *  produced by {@link epicIntegrationBranch}. A test on a branch NAME — use it for a PR's HEAD
+ *  ref (is this the epic's aggregate landing PR?). To ask whether a SESSION is an epic child, use
+ *  {@link isEpicChild}: the name of a base branch is a heuristic, not identity. */
 export function isEpicIntegrationBranch(branch: string): boolean {
   return /^epic\/\d+(-[a-z0-9-]+)?$/.test(branch);
+}
+
+/** The facts {@link isEpicChild} answers from. Structural, not `Session`, so the standalone PR
+ *  critic — which holds a PR and no session — can supply the same two fields. */
+export interface EpicChildFacts {
+  /** `Session.epicParent`: the epic parent issue number stamped at spawn. Null/absent = unknown
+   *  (a non-epic session, OR a legacy row written before the field existed). */
+  epicParent?: number | null;
+  /** The base branch to fall back on when `epicParent` is unknown. */
+  baseBranch: string;
+}
+
+/** Whether this session is ONE CHILD of a draining epic — the identity that keeps it off the merge
+ *  train and routes its retire to a squash-merge into the integration branch.
+ *
+ *  Answered from the persisted `epicParent` fact, NOT from the shape of the base branch name: a
+ *  child stacked onto a predecessor's branch is still a child, and every site that re-derived this
+ *  from `isEpicIntegrationBranch(baseBranch)` would silently answer "no" for it (merging it into
+ *  the wrong branch, or stalling its epic with no operator signal).
+ *
+ *  The branch-name test survives ONLY as the legacy fallback: rows written before the field existed
+ *  carry a null stamp, so an epic already in flight across the deploy keeps working. That fallback
+ *  lives here and nowhere else — a call site that re-derived it could forget it. Note the fallback
+ *  can only ADD childness, never remove it: a stamped child always reads true. */
+export function isEpicChild(facts: EpicChildFacts): boolean {
+  return facts.epicParent != null || isEpicIntegrationBranch(facts.baseBranch);
 }
 
 /** True iff `branch` references `parentNumber` as a digit-bounded token — the number

--- a/src/full-auto.ts
+++ b/src/full-auto.ts
@@ -1,7 +1,7 @@
 import type { Session } from "./types";
 import type { RepoConfig } from "./store";
 import { effectiveAutopilot } from "./effective-autopilot";
-import { isEpicIntegrationBranch } from "./epic-branch";
+import { isEpicChild } from "./epic-branch";
 
 /**
  * A session is "full-auto" — the merge train carries its PR all the way to a merge — when
@@ -15,14 +15,18 @@ import { isEpicIntegrationBranch } from "./epic-branch";
  * autoMergeEnabled override — draft PRs must go through sign-off before they can be landed.
  */
 export function isFullAuto(
-  s: Pick<Session, "autopilotEnabled" | "autoMergeEnabled" | "baseBranch" | "agentProvider"> & {
+  s: Pick<
+    Session,
+    "autopilotEnabled" | "autoMergeEnabled" | "baseBranch" | "agentProvider" | "epicParent"
+  > & {
     isolated?: boolean;
   },
   cfg: Pick<RepoConfig, "autopilotEnabled" | "autoMergeEnabled" | "draftMode">,
 ): boolean {
   // Epic children are squash-merged into their integration branch by the drain's retire path,
   // never carried by the merge train — exclude them regardless of repo auto-merge config.
-  if (isEpicIntegrationBranch(s.baseBranch)) return false;
+  // Identity, not base-branch shape: a child based on anything else is still a child (#2067).
+  if (isEpicChild(s)) return false;
   // Codex can only be carried by full-auto when Shepherd owns an isolated worktree. Rebase/CI
   // recovery may resume the pane, and Codex resume is currently `codex resume --last`; in a shared
   // cwd that can target a sibling Codex session. This mirrors autopilot.ts's isolated-session guard

--- a/src/review.ts
+++ b/src/review.ts
@@ -51,7 +51,7 @@ import { scrubStaleVerdictArtifacts } from "./codex-last-message";
 // Generic secret-redactor for a bounded diagnostic string, despite the recap-flavoured name — the
 // critic's pane tail gets the same treatment before it reaches the log.
 import { sanitizeRecapFailureDetail } from "./recap";
-import { isEpicIntegrationBranch } from "./epic-branch";
+import { isEpicChild } from "./epic-branch";
 import { resolveAuxPatch, assembleAuxSpawn, type MembraneSeams } from "./spawn-membrane";
 import { spawnBudget, type SpawnAssembler } from "./spawn-budget";
 import { OversizedArgvError } from "./argv-limit";
@@ -526,7 +526,7 @@ export class ReviewService {
     // — i.e. still BEFORE the `starting` re-check below, so that re-check remains the LAST
     // await-gated step before the spawn and covers this suspension too (same reasoning as the
     // issue-body fetch above).
-    const epicBase = isEpicIntegrationBranch(session.baseBranch) ? session.baseBranch : null;
+    const epicBase = isEpicChild(session) ? session.baseBranch : null;
     const epic = await this.resolveEpicContext(epicBase, wt.worktreePath, baseSha);
 
     // forget() (session archived) may have fired during any await above (author-notes, issue-body

--- a/src/service.ts
+++ b/src/service.ts
@@ -1949,6 +1949,20 @@ function pickOverride<T>(override: T | undefined, original: T): T {
   return override !== undefined ? override : original;
 }
 
+/** Epic-child identity (#2067) carried across a relaunch — but ONLY when the relaunch keeps both
+ *  the repo and the base branch. The fact is stamped at spawn from the drain's epic decision, which
+ *  a relaunch never re-runs, so a relaunch that re-points either one is no longer that child and
+ *  must fall back to the base-branch test (exactly what happened before the field existed). Its own
+ *  helper, not an inline conditional, so the flat field-mapping builder stays under its complexity
+ *  cap (mirrors store.ts's strOrNull/numOrNull). */
+function carriedEpicParent(
+  original: Session,
+  overrides: RelaunchOverrides | undefined,
+): number | null {
+  const repointed = overrides?.repoPath !== undefined || overrides?.baseBranch !== undefined;
+  return repointed ? null : (original.epicParent ?? null);
+}
+
 /** Resolve the relaunch model for the EFFECTIVE provider. `validateRelaunchOverrides` is
  *  session-blind, so the pairing is reconciled here: an absent override keeps the original's
  *  model, but if that carried model is incompatible with a provider switch it falls back to the
@@ -3711,6 +3725,9 @@ export class SessionService {
         effort: spawnInput.effort ?? null,
         auto: spawnInput.auto ?? false,
         issueNumber: spawnInput.issueRef?.number ?? null,
+        // Epic-child identity (#2067) — set only by the drain's epic spawn path. Passed through
+        // as-is (no `??`): the store's row builder normalizes absent to null.
+        epicParent: spawnInput.epicParent,
         // Provider-agnostic (TASK-413): Codex persists the flag too, no longer forced off.
         planGateEnabled: spawnInput.planGateEnabled ?? null,
         autopilotEnabled: spawnInput.autopilotEnabled ?? null,
@@ -3950,6 +3967,7 @@ export class SessionService {
       epicAuthoring: pickOverride(overrides?.epicAuthoring, original.epicAuthoring),
       // Carry the landing-repair flag so a relaunch keeps its push-not-PR repair directive.
       landingRepair: pickOverride(overrides?.landingRepair, original.landingRepair),
+      epicParent: carriedEpicParent(original, overrides),
       images,
       attachmentNames,
       launchUiState: overrides?.launchUiState,

--- a/src/standalone-critic.ts
+++ b/src/standalone-critic.ts
@@ -26,7 +26,7 @@ import { CRITIC_REVIEW_MARKER } from "./forge/types";
 import { randomUUID } from "node:crypto";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
 import type { RoleEnvironment } from "./default-model";
-import { isEpicIntegrationBranch } from "./epic-branch";
+import { isEpicChild, isEpicIntegrationBranch } from "./epic-branch";
 import { checksCleared, repoHasNoCiCached } from "./checks-gate";
 import { apiKeyFailClosed } from "./spawn-auth";
 import { readSessionUsage, type SessionUsage } from "./usage";
@@ -84,6 +84,7 @@ export interface StandalonePrCriticDeps extends MembraneSeams {
     | "recordReviewerSpawn"
     | "completeReviewerSpawn"
     | "listEpicCompleted"
+    | "getEpicParentByBranch"
   >;
   herdr: Pick<HerdrDriver, "start" | "stop" | "list" | "tabsAsync" | "closeTab">;
   worktree: Pick<WorktreeMgr, "createDetached" | "remove" | "gitCommonDir">;
@@ -410,7 +411,14 @@ export class StandalonePrCriticService {
       // eligibility carve-out above is then inert) and whenever the session critic is OFF (here it
       // is the SOLE reviewer). Same stale-tree problem: the child was never rebased onto its epic
       // integration base, so merged sibling work is absent from the checked-out tree.
-      const epic: EpicContext | null = isEpicIntegrationBranch(meta.baseRefName)
+      //
+      // Session-less by design, so the identity fact (#2067) is read by head branch: a PR with no
+      // Shepherd session (or a legacy one) resolves to null and falls back to the base-branch test
+      // inside the predicate — the answer this site gave before the fact existed.
+      const epic: EpicContext | null = isEpicChild({
+        epicParent: this.deps.store.getEpicParentByBranch(repoPath, pr.headRefName!),
+        baseBranch: meta.baseRefName,
+      })
         ? {
             base: meta.baseRefName,
             baseSha,

--- a/src/store.ts
+++ b/src/store.ts
@@ -365,6 +365,11 @@ function strOrNull(v: string | null | undefined): string | null {
   return v ?? null;
 }
 
+/** INTEGER counterpart of {@link strOrNull} — same reason: keep the flat builders branch-free. */
+function numOrNull(v: number | null | undefined): number | null {
+  return v ?? null;
+}
+
 /** Coerce a persisted RundownEpicItem.pausedReason to its union, or undefined for anything else. */
 function coercePauseReason(v: unknown): RundownEpicItem["pausedReason"] {
   return v === "cap" || v === "conflict" || v === "driver" ? v : undefined;
@@ -557,7 +562,7 @@ const COLS = `id, desig, name, prompt, repoPath, baseBranch, branch, worktreePat
   autopilotEnabled, autopilotStepCount, autopilotPaused, autopilotComplete, autopilotQuestion, completionRepromptCount,
   planGateEnabled, planPhase,
   autoMergeEnabled, autoMergeRebaseCount, autoMergeRebaseHead, autoMergeRebaseSteeredAt,
-  auto, issueNumber, sandboxApplied, sandboxDegraded, egressApplied, egressDegraded,
+  auto, issueNumber, epicParent, sandboxApplied, sandboxDegraded, egressApplied, egressDegraded,
   research, epicAuthoring, landingRepair, terminal, terminalTabId, terminalPaneId,
   createdAt, updatedAt, archivedAt, mergingSince, mergingTrainId, mergeTrainPrs, mergingPrNumber,
   haltReason, haltedAt, manualStepsJson, manualStepsAckedAt, experimentId, experimentRole,
@@ -600,6 +605,7 @@ type SessionRow = {
   autoMergeRebaseSteeredAt: number | null;
   auto: number;
   issueNumber: number | null;
+  epicParent: number | null;
   sandboxApplied: string | null;
   sandboxDegraded: number;
   egressApplied: number;
@@ -2276,6 +2282,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       autoMergeRebaseSteeredAt: null,
       auto: input.auto ?? false,
       issueNumber: input.issueNumber ?? null,
+      epicParent: numOrNull(input.epicParent),
       sandboxApplied: input.sandboxApplied ?? null,
       sandboxDegraded: input.sandboxDegraded ?? false,
       egressApplied: input.egressApplied ?? false,
@@ -2316,7 +2323,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       const seq = this.nextDesignationSeq();
       const s = this.buildSessionRow(input, seq, now);
       this.db.run(
-        `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+        `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
         [
           s.id,
           s.desig,
@@ -2350,6 +2357,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
           null, // autoMergeRebaseSteeredAt — never steered
           s.auto ? 1 : 0,
           s.issueNumber,
+          numOrNull(s.epicParent), // stamped at spawn for an epic child; null everywhere else
           s.sandboxApplied,
           s.sandboxDegraded ? 1 : 0,
           s.egressApplied ? 1 : 0,
@@ -2389,6 +2397,23 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       .query(`SELECT ${COLS} FROM sessions WHERE id = ?`)
       .get(id) as SessionRow | null;
     return r ? this.hydrate(r) : null;
+  }
+
+  /** The stamped epic parent of the session that owns `branch` as its WORK branch, or null when no
+   *  such session exists (or it carries no stamp). The single read seam for callers that hold a PR
+   *  but no session — the standalone PR critic — so they can answer epic-childness from the same
+   *  fact the session-holding sites use. Rows of ANY status (archived included) count: a child's
+   *  PR outlives its session. Newest-first so a relaunched child's row wins over a dead predecessor
+   *  that never got the stamp. */
+  getEpicParentByBranch(repoPath: string, branch: string): number | null {
+    const r = this.db
+      .query(
+        `SELECT epicParent FROM sessions
+           WHERE repoPath = ? AND branch = ? AND epicParent IS NOT NULL
+           ORDER BY createdAt DESC LIMIT 1`,
+      )
+      .get(repoPath, branch) as { epicParent: number } | null;
+    return r?.epicParent ?? null;
   }
 
   // ── Clean-terminal singleton lease ──────────────────────────────────────────
@@ -4030,6 +4055,10 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     add("autoMergeRebaseSteeredAt", `autoMergeRebaseSteeredAt INTEGER`);
     add("auto", `auto INTEGER NOT NULL DEFAULT 0`);
     add("issueNumber", `issueNumber INTEGER`);
+    // Epic-child identity (#2067): the epic parent issue number, stamped at spawn. Nullable with no
+    // default — legacy rows migrate to NULL, which the shared predicate reads as "unknown" and
+    // answers from the base-branch name instead, so in-flight epics survive the deploy.
+    add("epicParent", `epicParent INTEGER`);
     // sandbox badge/banner: applied profile (nullable for legacy rows) + degrade flag.
     add("sandboxApplied", `sandboxApplied TEXT`);
     add("sandboxDegraded", `sandboxDegraded INTEGER NOT NULL DEFAULT 0`);
@@ -5567,6 +5596,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       autoMergeRebaseSteeredAt: r.autoMergeRebaseSteeredAt,
       auto: !!r.auto,
       issueNumber: r.issueNumber ?? null,
+      epicParent: r.epicParent,
       sandboxApplied: isSandboxProfile(r.sandboxApplied) ? r.sandboxApplied : null,
       sandboxDegraded: !!r.sandboxDegraded,
       egressApplied: !!r.egressApplied,

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,14 @@ export interface Session {
   auto: boolean;
   /** Backlog issue number this session was spawned for; null for manual/non-issue sessions. */
   issueNumber: number | null;
+  /** The epic PARENT issue number this session was spawned as a child of — the persisted answer to
+   *  "is this an epic child?", stamped at spawn and never updated. Null/absent on every non-epic
+   *  session AND on legacy rows written before the field existed, so the shared predicate
+   *  ({@link isEpicChild}) falls back to the base-branch-name test for those. Read it through that
+   *  predicate, never directly: a raw `epicParent != null` check would answer "no" for a legacy
+   *  in-flight epic child. OPTIONAL (like `autoMergeRebaseSteeredAt`) so existing Session fixtures
+   *  stay valid — absent and null are equivalent; the store always hydrates a real number|null. */
+  epicParent?: number | null;
   /** Sandbox profile actually applied at spawn; null for legacy rows spawned before the feature. */
   sandboxApplied: SandboxProfile | null;
   /** True when a sandboxed profile was requested but no backend was available → ran unconfined. */
@@ -281,6 +289,11 @@ export interface StandardCreateInput {
   autopilotEnabled?: boolean | null;
   /** Per-spawn sandbox profile override; absent → inherit repo default. */
   sandboxProfile?: SandboxProfile | null;
+  /** Epic PARENT issue number for an epic-child spawn; absent/null otherwise. Set ONLY by the
+   *  drain's epic path (and only when the child actually got the integration branch as its base) —
+   *  no HTTP route passes it, they all build this input field-by-field. Persisted verbatim as
+   *  `Session.epicParent`. */
+  epicParent?: number | null;
   /** Research task kind; absent → false. */
   research?: boolean;
   /** Epic-authoring task kind; absent → false. Attended guided shaping → EPIC draft, no code PR. */

--- a/test/drain-epic-retire-merge.test.ts
+++ b/test/drain-epic-retire-merge.test.ts
@@ -292,3 +292,51 @@ describe("epic child retire → squash-merge into integration branch", () => {
     expect([...h.store.listEpicIntegrated(REPO, PARENT)]).not.toContain(7);
   });
 });
+
+// ── #2067: the retire path routes on the stamped fact, not the base-branch name ─────────────────
+
+describe("epic child retire routes on the persisted epicParent", () => {
+  test("stamped child whose base is NOT an epic branch still takes the epic retire path", async () => {
+    // The stacking shape: base is a sibling's task branch. Under the old base-name test this child
+    // fell through to the plain retire path — PR left open, never integrated, epic stalled silently.
+    const h = makeHarness({ epicStatus: "running" });
+    const s = h.store.create({
+      name: "auto",
+      prompt: "p",
+      repoPath: REPO,
+      baseBranch: "shepherd/auto-319",
+      branch: `shepherd/auto-${CHILD}`,
+      worktreePath: "/wt",
+      isolated: true,
+      herdrSession: "default",
+      herdrAgentId: "t",
+      auto: true,
+      issueNumber: CHILD,
+      epicParent: PARENT,
+    });
+    h.prCache[s.id] = openGreen(PR);
+    (h as Harness & { setReview: (id: string, d: ReviewDecision, sha: string) => void }).setReview(
+      s.id,
+      "commented",
+      `sha-${PR}`,
+    );
+
+    await h.drain.pump(REPO);
+
+    expect(h.forgeRec.merges).toEqual([{ prNumber: PR, method: "squash", deleteBranch: true }]);
+    expect([...h.store.listEpicIntegrated(REPO, PARENT)]).toContain(CHILD);
+    expect(h.forgeRec.links).toHaveLength(0); // epic path never issue-links
+    expect(h.store.get(s.id)?.status).toBe("archived");
+  });
+
+  test("legacy child (no stamp, epic/* base) is unchanged — still the epic retire path", async () => {
+    const h = makeHarness({ epicStatus: "running" });
+    const s = seedReadyChild(h, EPIC_BRANCH);
+    expect(s.epicParent).toBeNull(); // the pre-#2067 row shape
+
+    await h.drain.pump(REPO);
+
+    expect(h.forgeRec.merges).toHaveLength(1);
+    expect([...h.store.listEpicIntegrated(REPO, PARENT)]).toContain(CHILD);
+  });
+});

--- a/test/drain-epic-spawn-base.test.ts
+++ b/test/drain-epic-spawn-base.test.ts
@@ -389,8 +389,9 @@ describe("epic-child spawns base on the integration branch", () => {
 
 // ── #1757: the two epic-base failure modes are NOT the same ─────────────────────────────────────
 //
-// A child degraded onto the default branch is NOT stuck: the base-mismatch gate needs
-// isEpicIntegrationBranch(baseBranch) (drain.ts:2220), which a degraded child fails — so it retires
+// A child degraded onto the default branch is NOT stuck: the base-mismatch gate needs the session
+// to read as an epic child (`isEpicChild`), which a degraded child fails — it carries no epicParent
+// stamp and its base is the default branch — so it retires
 // normally, the merge train lands it on main (isFullAuto uses the same predicate), its issue closes,
 // and epic done-ness (`integrationMerged || issueClosed`) counts it. The epic PROGRESSES.
 // So the two causes get opposite treatment:
@@ -528,5 +529,73 @@ describe("#1757 epic base failures", () => {
     expect(h.statuses.at(-1)!.reason).not.toBe("epic_base_unavailable"); // and NO hold
     // ...but the operator can now SEE that this epic has no integration branch.
     expect(h.epics.at(-1)!.warnings.join("\n")).toContain("WITHOUT an integration branch");
+  });
+});
+
+// ── #2067: epic-child identity is a stamped session fact, not a base-branch name ────────────────
+//
+// The stamp is what keeps the merge train off a child (isFullAuto) and routes its retire into the
+// integration branch (doRetire) once children no longer base on `epic/*`. It is written ONLY when
+// the child really got the integration branch — a degraded child behaves like an ordinary session,
+// and stamping it would silently reroute every gitea/local epic through the epic retire path.
+
+describe("#2067 epic-child identity stamped at spawn", () => {
+  const PARENT = 327;
+  const CHILD = 320;
+  const subIssues: SubIssueRef[] = [
+    { number: CHILD, title: "EFI", url: "u320", body: "spec 320", closed: false, labels: [] },
+  ];
+  const parentIssue: Issue = {
+    number: PARENT,
+    title: "EFI cluster",
+    body: "epic body",
+    url: `https://x/${PARENT}`,
+    labels: [],
+    createdAt: 0,
+    assignees: [],
+  };
+  const epicOpts = {
+    listIssuesImpl: async () => [],
+    getIssueImpl: async (n: number) => (n === PARENT ? parentIssue : null),
+    listSubIssuesImpl: async (n: number) => (n === PARENT ? subIssues : []),
+    listBlockedByImpl: async () => [],
+  };
+
+  test("child based on the integration branch is stamped with the epic parent", async () => {
+    const h = makeHarness(epicOpts);
+    h.store.setEpicRun({
+      repoPath: REPO,
+      parentIssueNumber: PARENT,
+      mode: "auto",
+      status: "running",
+    });
+
+    await h.drain.pump(REPO);
+
+    expect(h.creates).toHaveLength(1);
+    expect(h.creates[0]!.epicParent).toBe(PARENT);
+  });
+
+  test("child DEGRADED onto main (forge without ensureBranch) is NOT stamped", async () => {
+    const h = makeHarness({ ...epicOpts, noEnsureBranch: true });
+    h.store.setEpicRun({
+      repoPath: REPO,
+      parentIssueNumber: PARENT,
+      mode: "auto",
+      status: "running",
+    });
+
+    await h.drain.pump(REPO);
+
+    expect(h.creates).toHaveLength(1);
+    expect(h.creates[0]!.baseBranch).toBe("main");
+    expect(h.creates[0]!.epicParent ?? null).toBeNull();
+  });
+
+  test("label-drain spawn carries no stamp", async () => {
+    const h = makeHarness({ issues: [issue(1)] });
+    await h.drain.pump(REPO);
+    expect(h.creates).toHaveLength(1);
+    expect(h.creates[0]!.epicParent ?? null).toBeNull();
   });
 });

--- a/test/epic-branch.test.ts
+++ b/test/epic-branch.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { epicIntegrationBranch, branchReferencesEpic } from "../src/epic-branch";
+import { epicIntegrationBranch, branchReferencesEpic, isEpicChild } from "../src/epic-branch";
 
 test("builds epic/<#>-<slug> from parent number + title", () => {
   expect(epicIntegrationBranch(327, "EFI / Value-Map cluster — sequencing")).toBe(
@@ -41,4 +41,31 @@ test("branchReferencesEpic: bounded both sides — exact token amid non-digits",
   expect(branchReferencesEpic("epic/a327b", 327)).toBe(true); // letters bound it
   expect(branchReferencesEpic("327", 327)).toBe(true); // whole string
   expect(branchReferencesEpic("epic/0327", 327)).toBe(false); // leading digit
+});
+
+// ── isEpicChild: identity, with the base-branch name as the LEGACY fallback (#2067) ──
+
+test("isEpicChild: legacy row (no stamp, epic/<#>-<slug> base) still reads as an epic child", () => {
+  // Rows written before `epicParent` existed carry null — an epic mid-drain across the deploy
+  // must keep retiring into its integration branch instead of hitting the merge train.
+  expect(isEpicChild({ epicParent: null, baseBranch: "epic/12-foo" })).toBe(true);
+  expect(isEpicChild({ baseBranch: "epic/12" })).toBe(true); // absent === null
+});
+
+test("isEpicChild: non-epic session (no stamp, default-branch base) is NOT an epic child", () => {
+  expect(isEpicChild({ epicParent: null, baseBranch: "main" })).toBe(false);
+  expect(isEpicChild({ baseBranch: "main" })).toBe(false);
+});
+
+test("isEpicChild: a stamped child is a child whatever its base is named", () => {
+  // The whole point: once children stack, the base is a sibling's `shepherd/*` branch and the
+  // name test answers "no". The stamp is what keeps every site correct.
+  expect(isEpicChild({ epicParent: 12, baseBranch: "shepherd/task-1-predecessor" })).toBe(true);
+  expect(isEpicChild({ epicParent: 12, baseBranch: "main" })).toBe(true);
+  expect(isEpicChild({ epicParent: 12, baseBranch: "epic/12-foo" })).toBe(true);
+});
+
+test("isEpicChild: an epic-lookalike base is unchanged from the old name test", () => {
+  expect(isEpicChild({ epicParent: null, baseBranch: "epic/no-number" })).toBe(false);
+  expect(isEpicChild({ epicParent: null, baseBranch: "feature/epic/12-foo" })).toBe(false);
 });

--- a/test/full-auto.test.ts
+++ b/test/full-auto.test.ts
@@ -130,3 +130,26 @@ test("isFullAuto: bare epic base (epic/9) → false too", () => {
   };
   expect(isFullAuto(epicChild, fullAutoCfg)).toBe(false);
 });
+
+test("isFullAuto: stamped epic child on a NON-epic base → false (identity, not branch name)", () => {
+  // #2067: once children stack, a child's base is its predecessor's task branch — the old
+  // `isEpicIntegrationBranch(baseBranch)` test would answer "not a child" and the merge train
+  // would land it INTO that predecessor. The persisted stamp is what keeps it excluded.
+  const stackedChild = {
+    autopilotEnabled: true as boolean | null,
+    autoMergeEnabled: true as boolean | null,
+    baseBranch: "shepherd/task-7-predecessor",
+    epicParent: 9,
+  };
+  expect(isFullAuto(stackedChild, fullAutoCfg)).toBe(false);
+});
+
+test("isFullAuto: unstamped session on the default branch → true (stamp absent ≠ epic child)", () => {
+  const plain = {
+    autopilotEnabled: true as boolean | null,
+    autoMergeEnabled: true as boolean | null,
+    baseBranch: "main",
+    epicParent: null,
+  };
+  expect(isFullAuto(plain, fullAutoCfg)).toBe(true);
+});

--- a/test/standalone-critic.test.ts
+++ b/test/standalone-critic.test.ts
@@ -132,6 +132,9 @@ function makeDeps(
       // PRs)" count. Omitted / unparseable → childCount 0 → the count parenthetical is dropped.
       childrenJson?: string;
     }[];
+    /** #2067: stamped epic-child identity per head branch, keyed `${repo}#${branch}`. Absent →
+     *  every branch resolves to null, i.e. the predicate falls back to the PR's base-branch name. */
+    epicParentByBranch?: Record<string, number>;
   } = {},
 ) {
   const spies: Spies = {
@@ -175,6 +178,10 @@ function makeDeps(
       // shaped just enough for sweep()'s landingPrNumber != null filter + repoPath map.
       listEpicCompleted: (repoPath?: string) =>
         (opts.epicCompleted ?? []).filter((r) => repoPath === undefined || r.repoPath === repoPath),
+      // #2067: the session-less critic's only route to the persisted epic-child fact. A PR with no
+      // Shepherd session (the default here) resolves null → base-branch fallback, as before.
+      getEpicParentByBranch: (repoPath: string, branch: string) =>
+        opts.epicParentByBranch?.[`${repoPath}#${branch}`] ?? null,
     },
     herdr: new (class {
       readonly recorded = spies.stopped; // this-dependent: unbound call loses this.recorded
@@ -918,6 +925,37 @@ test("#1757 ordinary PR (base=main): no epic block", async () => {
   const svc = new StandalonePrCriticService(deps as any);
   await svc.sweep();
   expect(spies.started[0]!.argv.at(-1)!).not.toContain("EPIC CONTEXT");
+});
+
+test("#2067 epic child whose base is NOT an epic branch: the stamp still yields the EPIC block", async () => {
+  const { deps, spies } = makeDeps(
+    {
+      computePatchId: async () => ({ patchId: "p1", baseSha: "deadbeefcafe1234", files: ["x.ts"] }),
+      collectBaseDelta: async () => ({
+        paths: ["src/base-only.ts"],
+        pathsTruncated: 0,
+        commits: ["abc feat: predecessor landed"],
+        commitsTruncated: 0,
+      }),
+    },
+    {
+      criticAllPrs: true,
+      // The child's session carries the stamp, keyed by its head (work) branch.
+      epicParentByBranch: { "/r#shepherd/task-8-child": 1757 },
+    },
+  );
+  // Stacked shape: base is the PREDECESSOR's task branch, so the old base-name test says "not a
+  // child" and the critic would lose its stale-tree context. The persisted fact keeps it.
+  deps.resolveForge = () =>
+    makeForge(spies, {
+      prs: [pr({ number: 8, headRefName: "shepherd/task-8-child", headSha: "childsha" })],
+      meta: async () => ({ ...OPEN_META, baseRefName: "shepherd/task-7-predecessor" }),
+    });
+  const svc = new StandalonePrCriticService(deps as any);
+  await svc.sweep();
+  const prompt = spies.started[0]!.argv.at(-1)!;
+  expect(prompt).toContain("EPIC CONTEXT");
+  expect(prompt).toContain("shepherd/task-7-predecessor");
 });
 
 // ── #1761 epic LANDING PR (head = integration branch, base = main) ────────────────────────────────

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
 import { SessionStore, REVIEWER_SPAWNS_DDL } from "../src/store";
+import { isEpicChild } from "../src/epic-branch";
 import type { PrReview, Recap, ReviewVerdict, SessionLaunchMetadata } from "../src/types";
 import type { SessionUsage } from "../src/usage";
 
@@ -2001,4 +2002,67 @@ test("backfillReviewerSpawnUsage fills unknown totals without touching completed
   // guarded: a second backfill can never overwrite real totals
   expect(s.backfillReviewerSpawnUsage("rev-1", usage({ total: 999, input: 999 }))).toBe(false);
   expect(s.listReviewerSpawns()[0]!.totalTokens).toBe(100);
+});
+
+test("epicParent round-trips at create and defaults to null", () => {
+  const s = mk();
+  const child = s.create({ ...base, baseBranch: "epic/9-x", epicParent: 9 });
+  expect(s.get(child.id)?.epicParent).toBe(9);
+  const plain = s.create({ ...base, herdrAgentId: "term_2", branch: "shepherd/plain" });
+  expect(s.get(plain.id)?.epicParent).toBeNull();
+});
+
+test("getEpicParentByBranch resolves the stamp by work branch, newest row first", () => {
+  const s = mk();
+  // A dead predecessor session on the same branch, spawned before the stamp existed.
+  s.create({ ...base, branch: "shepherd/child-a", baseBranch: "epic/9-x" });
+  const live = s.create({
+    ...base,
+    herdrAgentId: "term_2",
+    branch: "shepherd/child-a",
+    baseBranch: "epic/9-x",
+    epicParent: 9,
+  });
+  expect(live.epicParent).toBe(9);
+  expect(s.getEpicParentByBranch("/r", "shepherd/child-a")).toBe(9);
+  // archived rows still answer — a child's PR outlives its session
+  s.update(live.id, { status: "archived", lastState: "done" });
+  expect(s.getEpicParentByBranch("/r", "shepherd/child-a")).toBe(9);
+  // unknown branch / wrong repo → null (the caller falls back to the base-branch test)
+  expect(s.getEpicParentByBranch("/r", "shepherd/unknown")).toBeNull();
+  expect(s.getEpicParentByBranch("/other", "shepherd/child-a")).toBeNull();
+});
+
+test("session migration: a pre-epicParent row migrates to null and stays an epic child", () => {
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-store-epic-parent-migrate-"));
+  const dbPath = join(dir, "test.db");
+  try {
+    // Pre-create the sessions table as it was BEFORE the epicParent column, holding an epic child
+    // mid-drain (base = the integration branch) — the row shape the deploy has to survive.
+    const raw = new Database(dbPath);
+    raw.run(`CREATE TABLE sessions (
+      id TEXT PRIMARY KEY, desig TEXT NOT NULL, name TEXT NOT NULL, prompt TEXT NOT NULL,
+      repoPath TEXT NOT NULL, baseBranch TEXT NOT NULL, branch TEXT,
+      worktreePath TEXT NOT NULL, isolated INTEGER NOT NULL,
+      herdrSession TEXT NOT NULL, herdrAgentId TEXT NOT NULL,
+      claudeSessionId TEXT NOT NULL DEFAULT '',
+      agentProvider TEXT NOT NULL DEFAULT 'claude',
+      model TEXT, effort TEXT, status TEXT NOT NULL, lastState TEXT NOT NULL,
+      auto INTEGER NOT NULL DEFAULT 0, issueNumber INTEGER,
+      createdAt INTEGER NOT NULL, updatedAt INTEGER NOT NULL, archivedAt INTEGER)`);
+    raw.run(
+      `INSERT INTO sessions (id, desig, name, prompt, repoPath, baseBranch, branch, worktreePath,
+        isolated, herdrSession, herdrAgentId, status, lastState, auto, issueNumber, createdAt, updatedAt)
+       VALUES ('old', 'TASK-01', 'n', 'p', '/r', 'epic/12-foo', 'shepherd/n', '/wt', 1, 'default', 't',
+        'running', 'idle', 1, 44, 1, 1)`,
+    );
+    raw.close();
+    const store = new SessionStore(dbPath);
+    const s = store.get("old")!;
+    expect(s.epicParent).toBeNull();
+    // …and the shared predicate still reads it as an epic child off its base branch.
+    expect(isEpicChild(s)).toBe(true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1106,6 +1106,12 @@ export interface Session {
   egressDegraded: boolean;
   /** Issue number that seeded this session; null when launched without an issue. */
   issueNumber: number | null;
+  /** Epic PARENT issue number this session was spawned as a child of; null/absent on non-epic
+   *  sessions and on rows written before the field existed. Server-side identity fact (it drives
+   *  merge-train exclusion and the epic retire path) mirrored here for type parity — no client
+   *  consumer today, and a raw null does NOT mean "not an epic child" (see the server's
+   *  `isEpicChild`, which falls back to the base-branch name). */
+  epicParent?: number | null;
   /** Launch-time display metadata for the task-id tooltip. Null/absent for legacy rows. */
   launchMetadata?: SessionLaunchMetadata | null;
   /** Web URL of the linked forge issue. Populated **only** by the Done-list endpoint


### PR DESCRIPTION
Closes #2067. Part of #2063 (Step 2 of #2060).

## What

"Is this session an epic child?" was answered at six sites from the *shape of its base branch name*. This persists the answer on the session row and routes every live site through one shared predicate.

- `Session.epicParent` — the epic parent issue number, stamped **at spawn, in the same INSERT** (no post-create setter, so there is no window where the row exists without the fact).
- One predicate in `src/epic-branch.ts`:
  ```ts
  isEpicChild({epicParent, baseBranch}) = epicParent != null || isEpicIntegrationBranch(baseBranch)
  ```
  Pure (no store handle) so `isFullAuto(s, cfg)` keeps its shape; structural param so the session-less standalone critic can call it too. The legacy fallback lives **inside** the predicate — no call site can forget it.

| Site | Change |
| --- | --- |
| `src/full-auto.ts` → `isFullAuto()` | `isEpicChild(s)` |
| `src/drain.ts` → `doRetire()` | `isEpicChild(s)` |
| `src/review.ts` → epic critic context | `isEpicChild(session)` |
| `src/standalone-critic.ts` → `EpicContext` | resolves the fact by PR head branch (`getEpicParentByBranch`), then `isEpicChild(...)` |
| `src/drain-core.ts`, `src/critic-core.ts` | stale doc comments corrected |

The `isEpicIntegrationBranch(pr.headRefName)` eligibility check in `standalone-critic.ts` → `eligible()` tests a PR **head** ref (is this the epic's aggregate landing PR?), not base-branch identity. Correct as-is, kept.

Behaviour-identical: no flag, no stacking, no functional change.

## Decisions worth reviewing

1. **Stamped only when the child actually got the integration branch** (`usingEpicBase`). On a forge without `ensureBranch` (gitea/local) the spawn degrades onto the default branch and today reads as *not* an epic child — the merge train carries it, it retires normally, the epic still progresses. Stamping on `decision.integrationBranch` alone would silently reroute every degraded epic through the squash-into-integration retire path.
2. **`epicParent` is optional on `Session`** (`?: number | null`), following the documented `autoMergeRebaseSteeredAt` precedent. Required would have forced fixture edits across the suite, against the issue's "existing tests pass unmodified" criterion. The store always hydrates a real `number | null`.
3. **No dedicated setter.** The house rule guards against `update()`'s whitelist silently dropping writes — it applies to fields that get updated. This one is immutable spawn identity; nothing updates it. The single accessor added is `getEpicParentByBranch()`, the session-less critic's only route to the fact.
4. **Relaunch carries the stamp only when neither `repoPath` nor `baseBranch` is overridden.** Same repo + same base means the branch-name fallback would have answered identically before this field existed, so it is behaviour-identical; it just stops a bare relaunch from silently dropping the identity. A relaunch that re-points either falls back to the branch test.
5. Three `?? null` sites were written branch-free (`numOrNull` helper in `store.ts`, `carriedEpicParent` helper in `service.ts`, direct passthrough in `create`) because `buildSessionRow` / `hydrate` / the INSERT arrow / `service.create` all sit at their fallow complexity caps — the existing code carries comments saying exactly that.

## Adjacent, deliberately out of scope

`src/merge-teardown.ts` → `recordEpicIntegrationIfChild()` and `src/drain.ts` → `epicChildBaseBlocked()` do **not** use the name heuristic — they compare a merged/actual PR base against the **pinned** integration branch. Untouched here, but those comparisons also stop matching once children stack; they need the recorded integration target, not an identity predicate. Flagged for the stacking step of #2063.

## Verification

- `bun run lint`, `bun run test` (8441 pass), `cd ui && bun run check && bun run test` (4574 pass), `fallow audit --base origin/main --fail-on-issues` clean.
- Every pre-existing epic drain / full-auto / critic test passes **unmodified** — the behaviour-identical evidence. The only edit to an existing test body is one line in the standalone critic's shared fake-store fixture (the new `getEpicParentByBranch` seam) plus one stale comment; no assertion changed.
- New coverage: legacy row (null stamp, `epic/12-foo` base) still reads as a child; non-epic row reads as not a child; a stamped child on a non-epic base is excluded from full-auto and takes the epic retire path; spawn stamps on the epic base and does **not** stamp when degraded; store round-trip + a real pre-column DB migrating to null.
- `grep -rn "isEpicIntegrationBranch" src` → only the definition + the predicate in `epic-branch.ts`, and the head-ref use in `standalone-critic.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)