### PR TITLE
fix(herd): scroll to and mark the session a global jump lands on

### DIFF
--- a/ui/src/lib/components/Herd.browser.test.ts
+++ b/ui/src/lib/components/Herd.browser.test.ts
@@ -1027,3 +1027,34 @@ describe("Herd stage-explainer info icon", () => {
     expect(getComputedStyle(info!).textTransform).toBe("none");
   });
 });
+
+// jumpFlashId is the page's post-jump "look here" signal. It has to survive the whole
+// prop path (Herd → rowCtx → HerdGroup → UnitRow) and land on exactly ONE row —
+// a flash on the wrong row would restate the very confusion the flash exists to end.
+describe("Herd jump flash", () => {
+  const flashed = (container: HTMLElement) =>
+    [...container.querySelectorAll("[data-unit-id]")]
+      .filter((el) => getComputedStyle(el).outlineStyle !== "none")
+      .map((el) => el.getAttribute("data-unit-id"));
+
+  it("outlines only the jumped-to row", async () => {
+    const screen = await render(Herd, {
+      ...base,
+      sessions: [session({ id: "a" }), session({ id: "b" }), session({ id: "c" })],
+      git: {},
+      selectedId: "b",
+      jumpFlashId: "b",
+    });
+    await expect.poll(() => flashed(screen.container)).toEqual(["b"]);
+  });
+
+  it("no jumpFlashId: no row is outlined, selection alone stays quiet", async () => {
+    const screen = await render(Herd, {
+      ...base,
+      sessions: [session({ id: "a" }), session({ id: "b" })],
+      git: {},
+      selectedId: "b",
+    });
+    await expect.poll(() => flashed(screen.container)).toEqual([]);
+  });
+});

--- a/ui/src/lib/components/Herd.browser.test.ts
+++ b/ui/src/lib/components/Herd.browser.test.ts
@@ -1057,4 +1057,23 @@ describe("Herd jump flash", () => {
     });
     await expect.poll(() => flashed(screen.container)).toEqual([]);
   });
+
+  it("a flash whose row is no longer selected goes dark instead of stranding an outline", async () => {
+    // The selection can move out from under a running flash: a click or j/k inside the
+    // ~1.5s window, or the page reassigning selectedId when a session is decommissioned
+    // or its merged rows are cleared. The loudest cue in the rail must not stay parked on
+    // a row the terminal is no longer showing — that IS the bug this path fixes.
+    const props = {
+      ...base,
+      sessions: [session({ id: "a" }), session({ id: "b" })],
+      git: {},
+      selectedId: "a",
+      jumpFlashId: "a",
+    };
+    const screen = await render(Herd, props);
+    await expect.poll(() => flashed(screen.container)).toEqual(["a"]);
+
+    await screen.rerender({ ...props, selectedId: "b" });
+    await expect.poll(() => flashed(screen.container)).toEqual([]);
+  });
 });

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -43,6 +43,7 @@
   let {
     sessions,
     selectedId,
+    jumpFlashId = null,
     nowMs,
     onselect,
     onnew,
@@ -107,6 +108,10 @@
   }: {
     sessions: Session[];
     selectedId: string | null;
+    // The session a global jump (command bar, deep link, notification) just landed on —
+    // its row flashes for ~1.5s so the operator's eye finds it after the rail scrolls.
+    // Null at rest; the page owns the timer.
+    jumpFlashId?: string | null;
     nowMs: number;
     onselect: (id: string) => void;
     onnew: () => void;
@@ -412,6 +417,7 @@
   // the parent's props/derivations.
   const rowCtx = $derived<HerdRowCtx>({
     selectedId,
+    jumpFlashId,
     nowMs,
     onselect,
     git,

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -1389,3 +1389,55 @@ describe("UnitRow stop agent action", () => {
     );
   });
 });
+
+// The rail's job after a global jump: say unmistakably WHICH session is selected. Both
+// cues are asserted through computed style (app.css is imported above), not class names,
+// so a rule that stops applying — a renamed token, a specificity collision with the
+// attention wash — fails here rather than shipping a silently flat row.
+describe("UnitRow selection cues", () => {
+  const unit = (screen: { container: HTMLElement }, id: string) =>
+    screen.container.querySelector(`[data-unit-id="${id}"]`) as HTMLElement;
+
+  it("selected: the status rule widens to 3px (width, not hue, carries the cue)", async () => {
+    const screen = await render(UnitRow, {
+      session: session({ id: "sel-row", name: "sel row" }),
+      selected: true,
+      nowMs: Date.now(),
+      onselect: () => {},
+    });
+    await expect
+      .poll(() => getComputedStyle(unit(screen, "sel-row"), "::before").width)
+      .toBe("3px");
+  });
+
+  it("unselected: the same rule stays a 1px hairline", async () => {
+    const screen = await render(UnitRow, {
+      session: session({ id: "plain-row", name: "plain row" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+    });
+    await expect
+      .poll(() => getComputedStyle(unit(screen, "plain-row"), "::before").width)
+      .toBe("1px");
+  });
+
+  it("jumpFlash outlines the row; without it there is no outline", async () => {
+    const flashed = await render(UnitRow, {
+      session: session({ id: "flash-row", name: "flash row" }),
+      selected: true,
+      jumpFlash: true,
+      nowMs: Date.now(),
+      onselect: () => {},
+    });
+    await expect.poll(() => getComputedStyle(unit(flashed, "flash-row")).outlineWidth).toBe("2px");
+
+    const calm = await render(UnitRow, {
+      session: session({ id: "calm-row", name: "calm row" }),
+      selected: true,
+      nowMs: Date.now(),
+      onselect: () => {},
+    });
+    await expect.poll(() => getComputedStyle(unit(calm, "calm-row")).outlineStyle).toBe("none");
+  });
+});

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -59,6 +59,7 @@
   let {
     session,
     selected,
+    jumpFlash = false,
     nowMs,
     onselect,
     git,
@@ -84,6 +85,9 @@
   }: {
     session: Session;
     selected: boolean;
+    // A global jump just landed here (see herd-jump.ts): outline the row for a moment so
+    // the eye finds it after the rail scrolled. Transient — the page clears it after ~1.5s.
+    jumpFlash?: boolean;
     nowMs: number;
     onselect: (id: string) => void;
     git?: GitState;
@@ -788,6 +792,7 @@
   <div
     class="unit"
     class:sel={selected}
+    class:jump-flash={jumpFlash}
     class:has-activity={live}
     class:awaits-operator={awaitsOperator}
     class:decommissioning
@@ -1223,6 +1228,15 @@
     pointer-events: none;
   }
 
+  /* Selection accent. --sel and --hover sit a few RGB steps apart in the dark theme, so
+     the background alone loses a glance — especially against a row carrying the
+     --wash-attention tint. Widening the status rule the row already draws makes the
+     selected row win without adding a colour: the cue is WIDTH (1px → 3px), which keeps
+     it legible independently of hue (WCAG 1.4.1). */
+  .unit.sel::before {
+    width: 3px;
+  }
+
   .unit:hover {
     border-color: var(--color-line);
     background: var(--color-hover);
@@ -1237,6 +1251,17 @@
         transparent 70%
       ),
       var(--color-sel);
+  }
+
+  /* Post-jump flash: a global jump (command bar, deep link, notification) scrolled this
+     row into view, so lead the eye to it for ~1.5s. Borrows the row's own --rule status
+     colour rather than introducing a hue, and mirrors the .ow-card.focus recipe in
+     PostMergeStepsPanel. Inset so it survives the mobile flow mode, where rows are
+     full-bleed and an outset outline would be clipped at the screen edge. No transition:
+     the outline simply appears and is removed, so there is no motion to reduce. */
+  .unit.jump-flash {
+    outline: 2px solid var(--rule, var(--color-line-bright));
+    outline-offset: -2px;
   }
 
   /* bracket corners on selected */

--- a/ui/src/lib/components/herd-jump.test.ts
+++ b/ui/src/lib/components/herd-jump.test.ts
@@ -35,8 +35,11 @@ function harness(locations: Map<string, RailLocation> = new Map()) {
     select: (id, focusTerm = true, toDetail = true) => {
       log.push(`select:${focusTerm}:${toDetail} ${seen(id)}`);
     },
-    keyNavSelect: (id, focusTerm) => {
-      log.push(`keyNav:${focusTerm} ${seen(id)}`);
+    keyNavSelect: (id, focusTerm, scroll = true) => {
+      log.push(`keyNav:${focusTerm}:${scroll} ${seen(id)}`);
+    },
+    revealRow: (id) => {
+      log.push(`reveal:${id}`);
     },
   };
   const effects: JumpEffects = {
@@ -63,6 +66,8 @@ test("collapsed desktop stage: expand strictly before select, tick in between", 
     "expandStage:merged",
     "tick",
     "select:true:true stages=[] epics=[] id=x",
+    "tick",
+    "reveal:x",
   ]);
 });
 
@@ -76,26 +81,46 @@ test("collapsed epic group: only the epic set mutates", async () => {
     "expandEpic:/r#100",
     "tick",
     "select:true:true stages=[merged] epics=[] id=x",
+    "tick",
+    "reveal:x",
   ]);
 });
 
-test("experiment member: no set mutates, select fires without a tick", async () => {
+test("experiment member: no set mutates, select fires without a pre-select tick", async () => {
   const h = harness(new Map([["x", { kind: "experiment" }]]));
   h.collapsedStages.add("merged");
   await revealAndSelect("x", h.deps, (id) => h.deps.select(id));
-  expect(h.log).toEqual(["locate", "select:true:true stages=[merged] epics=[] id=x"]);
+  expect(h.log).toEqual([
+    "locate",
+    "select:true:true stages=[merged] epics=[] id=x",
+    "tick",
+    "reveal:x",
+  ]);
 });
 
-test("target in an open group (or without a location): no mutation, no tick", async () => {
+test("target in an open group (or without a location): no mutation, no pre-select tick", async () => {
   const h = harness(new Map([["x", stage("ready")]]));
   await revealAndSelect("x", h.deps, (id) => h.deps.select(id));
   await revealAndSelect("unknown", h.deps, (id) => h.deps.select(id));
   expect(h.log).toEqual([
     "locate",
     "select:true:true stages=[] epics=[] id=x",
+    "tick",
+    "reveal:x",
     "locate",
     "select:true:true stages=[] epics=[] id=unknown",
+    "tick",
+    "reveal:unknown",
   ]);
+});
+
+test("the reveal tick is unconditional: an unexpanded target still flushes before revealRow", async () => {
+  // The regression this guards: jumpToSession resets the lens/status/repo filters before
+  // selecting, so the row may only mount on the re-render those mutations queued. Reveal
+  // reads the DOM — without a tick between select and reveal it would find nothing.
+  const h = harness(new Map([["x", stage("ready")]])); // nothing collapsed → no pre-select tick
+  await revealAndSelect("x", h.deps, (id) => h.deps.select(id));
+  expect(h.log.slice(-3)).toEqual(["select:true:true stages=[] epics=[] id=x", "tick", "reveal:x"]);
 });
 
 test("mobile gating: a mobile jump never mutates collapsedStages (epic expansion still runs)", async () => {
@@ -115,10 +140,14 @@ test("mobile gating: a mobile jump never mutates collapsedStages (epic expansion
   expect(h.log).toEqual([
     "locate",
     "select:true:true stages=[merged] epics=[/r#100] id=s",
+    "tick",
+    "reveal:s",
     "locate",
     "expandEpic:/r#100",
     "tick",
     "select:true:true stages=[merged] epics=[] id=e",
+    "tick",
+    "reveal:e",
   ]);
 });
 
@@ -147,11 +176,14 @@ test("jumpToSession: effects run BEFORE locate, so a filter-hidden target become
     "expandStage:awaiting-merge",
     "tick",
     "select:true:true stages=[] epics=[] id=x",
+    "tick",
+    "reveal:x",
   ]);
 });
 
 // createJumpHandlers — per-path wiring: every handler opens a collapsed desktop stage
-// before select/scroll, with its exact effects and select variant
+// before select, then reveals its target, with its exact effects and select variant.
+// A handler added later that skips the reveal fails this table.
 
 test.each([
   ["jumpToSession", ["reset", "follow:x"], "select:true:true"],
@@ -160,7 +192,7 @@ test.each([
   ["jumpFromHerdrUpdate", ["closeUpdateModal"], "select:true:true"],
   ["navigateFromViewport", [], "select:true:true"],
   ["retargetForRepoFilter", [], "select:false:false"],
-] as const)("%s expands the collapsed stage before selecting", async (name, fx, sel) => {
+] as const)("%s expands the collapsed stage, selects, then reveals", async (name, fx, sel) => {
   const h = harness(new Map([["x", stage("merged")]]));
   h.collapsedStages.add("merged");
   const handlers = createJumpHandlers(h.deps, h.effects);
@@ -171,6 +203,8 @@ test.each([
     "expandStage:merged",
     "tick",
     `${sel} stages=[] epics=[] id=x`,
+    "tick",
+    "reveal:x",
   ]);
 });
 
@@ -181,11 +215,15 @@ test("selectNextNeedsYou: target from nextNeedsYou, expansion via the same core,
   h.deps.selectedId = () => "other";
   const handlers = createJumpHandlers(h.deps, h.effects);
   await handlers.selectNextNeedsYou();
+  // scroll=false: this is the one path whose select function scrolls on its own, and
+  // its `block: "nearest"` would beat the reveal to it and park the row at a rail edge.
   expect(h.log).toEqual([
     "locate",
     "expandStage:ci-failed",
     "tick",
-    "keyNav:true stages=[] epics=[] id=blocked1",
+    "keyNav:true:false stages=[] epics=[] id=blocked1",
+    "tick",
+    "reveal:blocked1",
   ]);
 });
 
@@ -221,6 +259,8 @@ test("handlers read locate/selectedId/blockedIds/isDesktop live, never as creati
     "locate",
     "expandStage:merged",
     "tick",
-    "keyNav:false stages=[] epics=[] id=late",
+    "keyNav:false:false stages=[] epics=[] id=late",
+    "tick",
+    "reveal:late",
   ]);
 });

--- a/ui/src/lib/components/herd-jump.ts
+++ b/ui/src/lib/components/herd-jump.ts
@@ -23,8 +23,14 @@ export type JumpDeps = {
   tick: () => Promise<void>;
   /** The page's selectUnit — default select for direct jumps. */
   select: (id: string, focusTerm?: boolean, toDetail?: boolean) => void;
-  /** The page's keyNavSelect — used by selectNextNeedsYou (scrolls the row into view). */
-  keyNavSelect: (id: string, focusTerm: boolean) => void;
+  /** The page's keyNavSelect — used by selectNextNeedsYou. Passes scroll=false: the
+   *  reveal step below owns the scroll for every jump, and keyNavSelect's own
+   *  `block: "nearest"` would otherwise land the row at a rail edge and leave it there
+   *  (the reveal would then judge it already-visible and never centre it). */
+  keyNavSelect: (id: string, focusTerm: boolean, scroll?: boolean) => void;
+  /** Scroll the now-selected row into view and flash it, so the rail can never appear
+   *  to disagree with the session the terminal is showing. The DOM half of the jump. */
+  revealRow: (id: string) => void;
 };
 
 /** Page-specific side effects each handler runs BEFORE locating the target (see the
@@ -41,12 +47,19 @@ export type JumpEffects = {
   beforeHerdrUpdateJump: () => void;
 };
 
-/** Reveal-before-select core — the single authority for expanding a collapsed group so
- *  a jump target's row is visible. Fixed order: the caller's effects already ran →
+/** Reveal-before-select core — the single authority for getting a jump target's row
+ *  on screen. Fixed order: the caller's effects already ran →
  *  (1) resolve the target's CURRENT location, (2) expand the right collapsed set
  *  (epic → always; stage → desktop only; experiment groups never collapse), (3) if
- *  something expanded, await a tick so the row mounts, (4) select. Selection is a
- *  callback so each handler picks its own select function and options. */
+ *  something expanded, await a tick so the row mounts, (4) select, (5) await a tick and
+ *  reveal. Selection is a callback so each handler picks its own select function and
+ *  options.
+ *
+ *  The trailing tick is unconditional, unlike the one in step 3: every handler's effects
+ *  mutate page state (lens, status/repo filters, the backlog overlay) BEFORE selecting,
+ *  and revealRow queries the DOM for the row — so the re-render those mutations queued
+ *  must be flushed first, or a jump out of a filtered view would silently reveal
+ *  nothing. */
 export async function revealAndSelect(
   id: string,
   deps: JumpDeps,
@@ -61,14 +74,21 @@ export async function revealAndSelect(
     deps.expandStage(loc.key);
     expanded = true;
   }
-  // Only an actual expansion needs the tick (newly-mounted row before scroll); an
-  // already-visible target selects synchronously, exactly like a rail click.
+  // Only an actual expansion needs THIS tick (the row must mount before it can be
+  // selected); an already-visible target selects synchronously, like a rail click.
   if (expanded) await deps.tick();
   select(id);
+  await deps.tick();
+  deps.revealRow(id);
 }
 
 /** Every global (outside-the-rail) session jump the page performs, built on ONE
- *  reveal-before-select core. Per-handler effects and select variants:
+ *  reveal-before-select core — so all of them scroll to and flash their target, and none
+ *  can leave the rail showing a different session than the terminal. Rail-internal
+ *  selection (a click, j/k) deliberately does NOT come through here: the operator's own
+ *  pointer or cursor walk already told them where they landed.
+ *
+ *  Per-handler effects and select variants (every one then ticks and reveals):
  *
  *  | handler               | effects before locate      | select                          |
  *  | --------------------- | -------------------------- | ------------------------------- |
@@ -80,7 +100,8 @@ export async function revealAndSelect(
  *  | navigateFromViewport  | —                          | select(id)                      |
  *  | retargetForRepoFilter | — (follows a just-set repo | select(id, false, false)        |
  *  |                       | filter; no reset)          |                                 |
- *  | selectNextNeedsYou    | — (target via nextNeedsYou)| keyNavSelect(id, focusTerm)     |
+ *  | selectNextNeedsYou    | — (target via nextNeedsYou)| keyNavSelect(id, focusTerm, no  |
+ *  |                       |                            | scroll — the reveal owns it)    |
  */
 export function createJumpHandlers(deps: JumpDeps, effects: JumpEffects) {
   return {
@@ -110,7 +131,7 @@ export function createJumpHandlers(deps: JumpDeps, effects: JumpEffects) {
     selectNextNeedsYou: async (focusTerm = true): Promise<void> => {
       const id = nextNeedsYou(deps.blockedIds(), deps.selectedId());
       if (id === null) return;
-      await revealAndSelect(id, deps, (i) => deps.keyNavSelect(i, focusTerm));
+      await revealAndSelect(id, deps, (i) => deps.keyNavSelect(i, focusTerm, false));
     },
   };
 }

--- a/ui/src/lib/components/herd-reveal.browser.test.ts
+++ b/ui/src/lib/components/herd-reveal.browser.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { scrollParentOf } from "./herd-reveal";
+
+// scrollParentOf is the one part of the reveal path that can only be wrong against a real
+// layout: it reads computed overflow and live scroll/client heights. The rail (`.units`,
+// `overflow: auto`) and its mobile flow mode (`overflow: visible`, the page scrolls) are
+// the two shapes it has to tell apart.
+
+let host: HTMLElement | null = null;
+
+function mount(html: string): HTMLElement {
+  host = document.createElement("div");
+  host.innerHTML = html;
+  document.body.append(host);
+  return host;
+}
+
+afterEach(() => {
+  host?.remove();
+  host = null;
+});
+
+describe("scrollParentOf", () => {
+  it("finds the scrolling ancestor a row actually lives in", () => {
+    const el = mount(`
+      <div style="height: 100px; overflow: auto" data-rail>
+        <div style="height: 900px"><div data-row></div></div>
+      </div>`);
+    const row = el.querySelector("[data-row]") as HTMLElement;
+    expect(scrollParentOf(row)).toBe(el.querySelector("[data-rail]"));
+  });
+
+  it("skips an `overflow: auto` ancestor that has nothing to scroll", () => {
+    // A short rail — fewer sessions than fit — must not be mistaken for the viewport that
+    // clips the row, or a visible row could be judged off-screen and pointlessly centred.
+    const el = mount(`
+      <div style="height: 400px; overflow: auto" data-rail>
+        <div style="height: 20px"><div data-row></div></div>
+      </div>`);
+    const row = el.querySelector("[data-row]") as HTMLElement;
+    expect(scrollParentOf(row)).not.toBe(el.querySelector("[data-rail]"));
+  });
+
+  it("returns null when nothing between the row and the document scrolls (mobile flow mode)", () => {
+    const el = mount(`
+      <div style="overflow: visible" data-rail>
+        <div><div data-row></div></div>
+      </div>`);
+    const row = el.querySelector("[data-row]") as HTMLElement;
+    expect(scrollParentOf(row)).toBeNull();
+  });
+});

--- a/ui/src/lib/components/herd-reveal.test.ts
+++ b/ui/src/lib/components/herd-reveal.test.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "vitest";
+import { needsCentering } from "./herd-reveal";
+
+// A 400px-tall rail viewport, as it sits in the page (not at y=0 — the top bar is above it),
+// so a bug that assumed viewport-origin coordinates would show up here.
+const view = { top: 100, bottom: 500 };
+
+test("fully inside the viewport: no scroll (an already-visible row must not jitter)", () => {
+  expect(needsCentering({ top: 200, bottom: 260 }, view)).toBe(false);
+});
+
+test("flush against either edge still counts as fully inside", () => {
+  expect(needsCentering({ top: 100, bottom: 160 }, view)).toBe(false);
+  expect(needsCentering({ top: 440, bottom: 500 }, view)).toBe(false);
+});
+
+test("clipped at the top edge: centre it", () => {
+  expect(needsCentering({ top: 80, bottom: 140 }, view)).toBe(true);
+});
+
+test("clipped at the bottom edge: centre it", () => {
+  expect(needsCentering({ top: 460, bottom: 520 }, view)).toBe(true);
+});
+
+test("entirely off-screen in either direction: centre it", () => {
+  expect(needsCentering({ top: -200, bottom: -140 }, view)).toBe(true);
+  expect(needsCentering({ top: 900, bottom: 960 }, view)).toBe(true);
+});
+
+test("taller than the viewport: can never be fully inside, so it centres", () => {
+  expect(needsCentering({ top: 90, bottom: 700 }, view)).toBe(true);
+});

--- a/ui/src/lib/components/herd-reveal.ts
+++ b/ui/src/lib/components/herd-reveal.ts
@@ -1,0 +1,35 @@
+/** Bringing a jumped-to rail row into view. Sibling of herd-jump.ts: that module decides
+ *  WHICH session a global jump lands on and reveals it out of a collapsed group, this one
+ *  decides whether the rail still has to scroll to it — and finds the box that would do
+ *  the scrolling. Split out of +page.svelte so the geometry is testable with plain
+ *  numbers, without a live scroll container. */
+
+/** A vertical extent in viewport coordinates — the `top`/`bottom` pair of a DOMRect. */
+export type Span = { top: number; bottom: number };
+
+/** Whether a jump has to scroll `row` to the middle of `view`.
+ *
+ *  A row already fully inside the viewport keeps its position: the operator jumped to
+ *  something they can already see, and yanking the list under them would be pure jitter.
+ *  Anything clipped at either edge — or off-screen entirely — is centred, so the row
+ *  lands with context above and below it instead of glued to a rail edge.
+ *
+ *  A row TALLER than the viewport can never be "fully inside", so it centres too, which
+ *  is the best available framing for it. */
+export function needsCentering(row: Span, view: Span): boolean {
+  return row.top < view.top || row.bottom > view.bottom;
+}
+
+/** The element that actually scrolls `el`: the nearest ancestor that both scrolls on the
+ *  block axis and has overflow to scroll. Null means the page itself scrolls — the rail's
+ *  mobile flow mode drops `.units` to `overflow: visible` and lets the document scroll,
+ *  and callers pair that with the window's own viewport extent. */
+export function scrollParentOf(el: HTMLElement): HTMLElement | null {
+  for (let node = el.parentElement; node; node = node.parentElement) {
+    const { overflowY } = getComputedStyle(node);
+    if ((overflowY === "auto" || overflowY === "scroll") && node.scrollHeight > node.clientHeight) {
+      return node;
+    }
+  }
+  return null;
+}

--- a/ui/src/lib/components/herd/HerdGroup.svelte
+++ b/ui/src/lib/components/herd/HerdGroup.svelte
@@ -5,6 +5,8 @@
 
   export type HerdRowCtx = {
     selectedId: string | null;
+    /** Transient post-jump highlight target — see Herd's `jumpFlashId` prop. */
+    jumpFlashId: string | null;
     nowMs: number;
     onselect: (id: string) => void;
     git: Record<string, GitState>;
@@ -110,6 +112,7 @@
     <UnitRow
       {session}
       selected={session.id === ctx.selectedId}
+      jumpFlash={session.id === ctx.jumpFlashId}
       nowMs={ctx.nowMs}
       onselect={ctx.onselect}
       git={ctx.git[session.id]}

--- a/ui/src/lib/components/herd/HerdGroup.svelte
+++ b/ui/src/lib/components/herd/HerdGroup.svelte
@@ -5,7 +5,8 @@
 
   export type HerdRowCtx = {
     selectedId: string | null;
-    /** Transient post-jump highlight target — see Herd's `jumpFlashId` prop. */
+    /** Transient post-jump highlight target — see Herd's `jumpFlashId` prop. Only ever
+     *  honoured on the SELECTED row (see the row's `jumpFlash` below). */
     jumpFlashId: string | null;
     nowMs: number;
     onselect: (id: string) => void;
@@ -109,10 +110,18 @@
 {/if}
 {#if !collapsible || expanded}
   {#each sessions as session (session.id)}
+    <!-- jumpFlash is ANDed with the selection on purpose: the flash is the loudest cue in
+         the rail, so it may only ever mark the row that is actually selected. The selection
+         can move out from under a running flash by several routes — a click or j/k inside
+         the ~1.5s window, or the page reassigning selectedId when a session is
+         decommissioned or its merged rows are cleared — and an outline left behind on the
+         old row would restate exactly the rail-disagrees-with-the-terminal confusion this
+         whole path exists to end. Gating here, rather than clearing the id inside one
+         selection function, holds for every one of those routes and for later ones. -->
     <UnitRow
       {session}
       selected={session.id === ctx.selectedId}
-      jumpFlash={session.id === ctx.jumpFlashId}
+      jumpFlash={session.id === ctx.jumpFlashId && session.id === ctx.selectedId}
       nowMs={ctx.nowMs}
       onselect={ctx.onselect}
       git={ctx.git[session.id]}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -107,6 +107,7 @@
     altComboKey,
   } from "$lib/components/herd-keynav";
   import { createJumpHandlers } from "$lib/components/herd-jump";
+  import { needsCentering, scrollParentOf } from "$lib/components/herd-reveal";
   import { normalizeEpicCollapse } from "$lib/components/herd-epic-collapse";
   import { isReworkRunning as isReworkRunningSession } from "$lib/components/rework-running";
   import { buildCommands } from "$lib/command-registry";
@@ -1485,7 +1486,11 @@
   // Keyboard-driven selection: route through the same selectUnit a rail click
   // uses, then keep the now-selected row visible in the rail's scroll area.
   // focusTerm = whether the remounted terminal should grab the keyboard.
-  function keyNavSelect(id: string | null, focusTerm = true) {
+  // scroll = own the scroll (true for a j/k walk, which wants the minimal nudge).
+  // selectNextNeedsYou passes false: it runs through the jump handlers, whose reveal
+  // step centres an off-screen row — and a `block: "nearest"` here would get there
+  // first and leave the row parked at a rail edge instead.
+  function keyNavSelect(id: string | null, focusTerm = true, scroll = true) {
     if (!id) return;
     // Done lens: pick the archived row (its own selection state, no terminal to focus).
     if (herdFilter === "done") {
@@ -1494,9 +1499,44 @@
     } else {
       selectUnit(id, focusTerm);
     }
-    document
-      .querySelector(`[data-unit-id="${CSS.escape(id)}"]`)
-      ?.scrollIntoView({ block: "nearest" });
+    if (scroll) rowEl(id)?.scrollIntoView({ block: "nearest" });
+  }
+
+  function rowEl(id: string): HTMLElement | null {
+    return document.querySelector(`[data-unit-id="${CSS.escape(id)}"]`);
+  }
+
+  // The rail half of a global jump (see herd-jump.ts): make the just-selected row
+  // impossible to miss, so the list can never look like it disagrees with the terminal.
+  // Scroll only when the row isn't fully visible — an operator who jumped to something
+  // already on screen shouldn't have the list yanked under them — then flash it.
+  let jumpFlashId = $state<string | null>(null);
+  let jumpFlashTimer: ReturnType<typeof setTimeout> | null = null;
+  const JUMP_FLASH_MS = 1500;
+
+  function revealRow(id: string) {
+    const el = rowEl(id);
+    if (!el) return;
+    const parent = scrollParentOf(el);
+    // No scroll parent = the page itself scrolls (the rail's mobile flow mode drops
+    // `.units` to overflow: visible), so the window is the viewport.
+    const view = parent ? parent.getBoundingClientRect() : { top: 0, bottom: window.innerHeight };
+    if (needsCentering(el.getBoundingClientRect(), view)) el.scrollIntoView({ block: "center" });
+    startJumpFlash(id);
+  }
+
+  // Jumping to the session that is ALREADY selected must still flash it — the operator
+  // asked "which one is it?" and deserves an answer either way. It does: the id drives a
+  // CSS class directly, so re-setting it either turns the class on (the previous flash had
+  // expired) or restarts the timer under a flash still running. No null-then-reset dance
+  // is needed for that, and a repeat within the window reads as one longer flash.
+  function startJumpFlash(id: string) {
+    if (jumpFlashTimer) clearTimeout(jumpFlashTimer);
+    jumpFlashId = id;
+    jumpFlashTimer = setTimeout(() => {
+      jumpFlashId = null;
+      jumpFlashTimer = null;
+    }, JUMP_FLASH_MS);
   }
 
   // Herd keyboard navigation (the rail-selection half of onShortcut):
@@ -1673,6 +1713,7 @@
       tick,
       select: selectUnit,
       keyNavSelect,
+      revealRow,
     },
     {
       resetLensAndFilters: () => {
@@ -2784,6 +2825,7 @@
             {statusFilter}
             onstatusfilter={(s) => (statusFilter = s)}
             {selectedId}
+            {jumpFlashId}
             {nowMs}
             onselect={(id) => selectUnit(id)}
             onnew={() => (showNew = true)}
@@ -2947,6 +2989,7 @@
               {statusFilter}
               onstatusfilter={(s) => (statusFilter = s)}
               {selectedId}
+              {jumpFlashId}
               {nowMs}
               onselect={(id) => selectUnit(id)}
               onnew={() => (showNew = true)}


### PR DESCRIPTION
## The bug

Confirming a session in the command bar selects it correctly — the terminal on the right proves it — but the left rail never scrolls to that row. What stays on screen is a hovered or attention-washed neighbour that reads like the selection, so the rail appears to contradict the terminal. Reported from ⌘K, but it affected every global jump.

Two defects compounded:

1. **Global jumps never scrolled.** `herd-jump.ts` → `revealAndSelect()` expanded a collapsed epic/stage group and selected, but never brought the row into the rail's scroll viewport. The only code that scrolled was `keyNavSelect()` in `+page.svelte`, reached solely by `j`/`k` — the command-bar path (`oncommandbarsession` → `jumpToSession` → `select: selectUnit`) went around it.
2. **The selected state was too quiet to win a glance.** `.unit.sel` differs from `.unit:hover` by `--sel: #18211e` against `--hover: #0c1110` plus a 1px border. A few RGB steps in the dark theme.

## The fix

`JumpDeps` gains a `revealRow` step, and `revealAndSelect` ends with an unconditional tick + reveal — so all six global jump paths inherit it at once (`jumpToSession`, `selectRundownItem`, `selectFromDeepLink`, `jumpFromHerdrUpdate`, `navigateFromViewport`, `retargetForRepoFilter`, plus `selectNextNeedsYou`). The tick is not optional: every handler mutates the lens and repo/status filters *before* selecting, and the reveal reads the DOM.

The row also carries its weight visually now: the status rule the row already draws widens from 1px to 3px when selected (width, not hue, carries the cue — WCAG 1.4.1), and a jump outlines the row in its own `--rule` colour for ~1.5s.

Scrolling happens only when the row is not already fully visible — an operator who jumped to something on screen should not have the list yanked under them. `j`/`k` and rail clicks are untouched: the operator's own cursor walk or pointer already told them where they landed.

## Decisions confirmed with the operator

| Decision | Chosen |
| --- | --- |
| Scroll position | Centre only when off-screen |
| Emphasis | Permanent accent **and** a ~1.5s jump flash |
| Scope | All global jumps; `j`/`k` and clicks unchanged |
| Flash colour | `var(--rule)` — the row's own status colour |
| Re-flash on an unchanged selection | Yes |

## Verification

- `cd ui && bun run check` — 5955 files, 0 errors
- `cd ui && bun run test` — 296 files, 4653 tests, all pass
- `bun run test` (root) — 8630 pass, 0 fail
- `bun run lint` (root) — clean

New coverage:

- `herd-reveal.test.ts` — the centre-or-leave-alone geometry over plain numbers (fully inside, flush at either edge, clipped top, clipped bottom, entirely off-screen, taller than the viewport).
- `herd-reveal.browser.test.ts` — `scrollParentOf` against real layout: finds the scrolling ancestor, skips an `overflow: auto` box with nothing to scroll, returns null for the mobile flow mode.
- `herd-jump.test.ts` — the `test.each` table now pins `reveal:x` as the final step for every handler, so a jump path added later that skips the reveal fails there. It also pins `keyNav:true:false`, the one path that must not double-scroll.
- `UnitRow.browser.test.ts` / `Herd.browser.test.ts` — the two cues asserted through **computed style**, not class names (3px vs 1px rule, 2px outline vs none), plus the flash landing on exactly one row across the full `Herd → rowCtx → HerdGroup → UnitRow` prop path.

**Not verified in the running app:** port 5174 is held by the operator's own Shepherd instance, and taking it would have killed the Mission Control they are using. The end-to-end click-through is the one success criterion I did not exercise.

## Notes

- Labelled `fix`, not `feat` — this restores behaviour the rail was already meant to have. No feature-catalog entry (per `.claude/rules/ui-feature-catalog.md`, the gate arms on `feat(...)` only). No new user-facing strings, so no i18n catalog change.
- The Done lens (`HerdDoneList.svelte`) keeps its own selection space and is not a global-jump target; left alone deliberately.
