### PR TITLE
fix(store): batch schema bootstrap into one transaction

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -1171,6 +1171,19 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     // is sub-second, so the worst-case wait is a brief, bounded stall — not a crash. Keep equal to
     // BUSY_TIMEOUT_MS in scripts/backup.ts.
     this.db.run("PRAGMA busy_timeout = 5000");
+    // Everything below is ONE transaction. A fresh open fires 150 write statements: 43
+    // CREATE TABLE IF NOT EXISTS (41 here, REVIEWER_SPAWNS_DDL, and terminal_claims inside
+    // migrateSessionColumns), 12 index creations (11 here plus that method's partial unique
+    // index), 88 ALTER TABLE column adds behind PRAGMA table_info probes, and 3 seed INSERTs.
+    // Each one left to autocommit pays SQLite's full rollback-journal fsync cycle — 310ms per open
+    // on a fast NVMe, seconds on CI's disk, which is what times out the disk-backed migration
+    // tests in test/store.test.ts. Batched: ~9ms. It also makes migration atomic — a crash mid-boot
+    // now leaves the last consistent schema instead of a half-migrated DB.
+    // Two constraints keep this correct: `PRAGMA foreign_keys` is a no-op inside a transaction,
+    // so it MUST stay above the BEGIN (it does); and nothing in here may VACUUM or set
+    // journal_mode, neither of which can run in a transaction. Nested `this.db.transaction(...)`
+    // calls (migrateBuildQueueStepsPk) are fine — bun:sqlite runs those as SAVEPOINTs.
+    this.db.run("BEGIN");
     this.db.run(`CREATE TABLE IF NOT EXISTS sessions (
       id TEXT PRIMARY KEY, desig TEXT NOT NULL, name TEXT NOT NULL, prompt TEXT NOT NULL,
       repoPath TEXT NOT NULL, baseBranch TEXT NOT NULL, branch TEXT,
@@ -1647,6 +1660,11 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     if (!usageCols.some((c) => c.name === "claudeSessionId")) {
       this.db.run(`ALTER TABLE session_usage ADD COLUMN claudeSessionId TEXT NOT NULL DEFAULT ''`);
     }
+    // Commits the whole bootstrap (see the BEGIN above). No try/ROLLBACK: a throw here escapes the
+    // constructor, so no caller ever holds this store, and SQLite discards the open transaction
+    // when the handle is finalized. Deliberately no wrapping block — that would re-indent the
+    // ~480 lines above and collide with every branch that appends a table here.
+    this.db.run("COMMIT");
   }
 
   // ── settings (key/value) ─────────────────────────────────────────────────


### PR DESCRIPTION
## The flake

`verify` on #2092 failed three tests. All three are in `test/store.test.ts`, all three are
**timeouts against bun's 5000 ms default** — not one assertion failure among them:

| CI duration | Test |
| --- | --- |
| 7101 ms | `repo_config migration: an old row without previewOpenMode gains the ask default` |
| 11277 ms | `session: legacy row (egressApplied/egressDegraded columns defaulting 0) reads as false` |
| 6428 ms | `session: landingRepair migration — pre-existing row without column reads as false` |

They share one shape: `mkdtempSync` a real directory, seed a legacy-schema SQLite file, then
construct `SessionStore` against that **on-disk** path so the migration runs for real.

Pulling per-test timings out of the CI log shows those three are just the unlucky tail. **Every**
disk-backed store construction on the runner costs 2–6 s, and a dozen siblings sit right under the
cliff: 4611 ms (`first-run migration: pre-existing settings (cookieSecret) …`), 4452 ms
(`session: research migration …`), 4341 ms (`migration: store opened on pre-existing DB without
repoMode column …`), 4126 ms (`session migration: a pre-epicParent row …`), 3849 ms, 3768 ms, and
~14 more between 2.3 s and 3.7 s.

`main` is green by luck, not by margin. Any PR can lose this dice roll; #2092 lost it while
carrying nothing but dev-dependency bumps.

## Cause

The `SessionStore` constructor issues **150 separate write statements** on a fresh open. Counted by
instrumenting `Database.prototype.run` around one construction, rather than by grepping:

| Kind | Count |
| --- | --- |
| `CREATE TABLE IF NOT EXISTS` | 43 |
| `CREATE INDEX` / `CREATE UNIQUE INDEX` | 12 |
| `ALTER TABLE … ADD COLUMN` behind `PRAGMA table_info` probes | 88 |
| seed `INSERT` | 3 |

The `ALTER TABLE` bulk fires even on a fresh DB: the baseline `CREATE TABLE IF NOT EXISTS`
statements deliberately hold the original schema, and later columns arrive through
`addMissingColumns()`, `migrateSessionColumns()`, `migrateRepoConfigColumns()` and eleven siblings.
The same instrumentation confirms exactly one `BEGIN`/`COMMIT` pair wraps all 150.

Each one was left to autocommit, and under SQLite's default rollback journal every implicit
transaction means create-journal → fsync → write → fsync → delete-journal → fsync-directory. On
disk that is 150 fsync storms; in memory it is free. Measured locally on a fast NVMe: **310 ms**
per fresh on-disk construct vs **7 ms** in-memory. The runner's slower disk stretches that into
seconds.

## Fix

Bracket the bootstrap in one transaction, so 150 implicit transactions collapse into a single
commit.

| Measurement | Before | After |
| --- | --- | --- |
| Fresh on-disk `new SessionStore(path)` | 310 ms | **8.6 ms** |
| `bun test ./test/store.test.ts` | 6.04 s | **0.90 s** |
| Full root suite (local) | — | **8681 pass / 0 fail** (46 s) |

And on the CI runner itself, the three tests that failed on #2092:

| Test | Before | After |
| --- | --- | --- |
| `repo_config migration: … previewOpenMode gains the ask default` | 7101 ms (timeout) | **20.3 ms** |
| `session: legacy row (egressApplied/egressDegraded …) reads as false` | 11277 ms (timeout) | **19.5 ms** |
| `session: landingRepair migration — pre-existing row …` | 6428 ms (timeout) | **19.0 ms** |

Disk-backed store tests previously held 15+ of the slowest slots on CI at 2.4–4.7 s each and now
appear nowhere in the top 8. The full root suite on CI dropped **206.6 s → 80.1 s** — a side effect
rather than the goal, but it applies to every run from here on.

At ~9 ms per construct the slowest disk-backed test lands roughly 500x under the timeout. The
flake class is gone with margin, not nudged.

Schema migration also becomes **atomic**, which is a real behaviour change worth calling out: a
crash mid-boot now leaves the last consistent schema instead of a half-migrated DB that the next
boot continues from. Safer, and either way the boot failed.

## Why this shape

Two statements plus comments, deliberately **not** an extracted `bootstrapSchema()` method.
Extraction would be more idiomatic here (14 existing `this.db.transaction(...)` call sites) and
would give an explicit `ROLLBACK`, but it re-indents ~480 lines of a constructor that every
feature branch appends a `CREATE TABLE` to — a whitespace-only merge-conflict grenade for no
functional gain. The trade-off accepted instead: a throwing bootstrap discards the transaction
when the handle is finalized rather than via an explicit `ROLLBACK`. Both production construction
sites (`src/index.ts`, `scripts/sweep-house-rules.ts`) are unguarded, so a throw kills the process
regardless and no caller ever holds a half-built store.

`PRAGMA journal_mode = WAL` would fix the symptom too (measured: 204 ms → 7.6 ms on a comparable
synthetic DDL workload, vs 5.3 ms for the transaction) but it changes the production on-disk
format — `-wal`/`-shm` sidecars, interactions with the hourly `VACUUM INTO` backup and with
network filesystems. Out of scope for a flake fix.

Raising bun's `--timeout` was the other option. Rejected: one line and zero risk, but it leaves
the suite ~4x slower than it needs to be and leaves the next slow test to flake.

## Correctness

Two constraints keep the bracket valid, both documented at the `BEGIN`:

- `PRAGMA foreign_keys` is a **no-op inside a transaction**, so it must stay above the `BEGIN`. It
  does — it is the constructor's first statement.
- Nothing in the bootstrap may `VACUUM` or set `journal_mode`; neither can run in a transaction.
  Audited: there are none in the constructor or any of its callees.

Also checked:

- `migrateBuildQueueStepsPk()` already opens `this.db.transaction(...)` for its
  create/copy/drop/rename rebuild. `bun:sqlite` runs a nested `db.transaction()` as a `SAVEPOINT`,
  verified empirically — both writes survive the outer `COMMIT`, and the legacy-PK rebuild test
  passes.
- `PRAGMA table_info` reads inside the transaction see the uncommitted `CREATE TABLE`s, which is
  exactly what the conditional `ALTER TABLE` migrations need.
- No `return` or `throw` between the `BEGIN` and the `COMMIT` in the constructor body, so the
  `COMMIT` is unconditionally reached. (Callee early-returns are harmless — they return from the
  method.)
- **Lock contention improves:** one write lock held for ~9 ms instead of 150 taken and released
  over ~310 ms, so concurrent-open contention against the hourly backup's `VACUUM INTO` — the
  reason `busy_timeout = 5000` exists — gets better, not worse.

## No new test

The ~20 existing disk-backed migration tests are the coverage, and their runtime collapse is the
evidence. A timing assertion would reintroduce exactly the hardware-dependent flake being removed,
and an atomicity test needs a fault-injection seam `SessionStore` does not have.

## Verification

`bun run test` (8680 pass / 0 fail / 15 skip), `bun run lint`, `bun run typecheck`,
`prettier --check src/store.ts` — all clean. `ui/` and `extension/` are untouched by this change;
both suites were run anyway and pass (4646/4646 and full).

Unblocks #2092, which is otherwise a clean dev-dep bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
