### PR TITLE
feat(site): mark Shepherd as an Erwins Enkel undertaking in the footer

### DIFF
--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -58,6 +58,23 @@ const HERDR_AUTHOR_URL = "https://github.com/ogulcancelik";
       Not affiliated with Anthropic or OpenAI. Claude and Anthropic are
       trademarks of Anthropic, PBC. OpenAI and Codex are trademarks of OpenAI.
     </p>
+
+    <a
+      class="absender"
+      href={ERWINS_ENKEL_URL}
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <svg class="signet" viewBox="0 0 32 32" fill="currentColor" aria-hidden="true">
+        <rect x="4" y="6" width="4" height="4"></rect>
+        <rect x="12" y="6" width="16" height="4"></rect>
+        <rect x="4" y="14" width="4" height="4"></rect>
+        <rect x="12" y="14" width="10" height="4"></rect>
+        <rect x="4" y="22" width="4" height="4"></rect>
+        <rect x="12" y="22" width="14" height="4"></rect>
+      </svg>
+      An undertaking by Erwins Enkel
+    </a>
   </div>
 </footer>
 
@@ -154,10 +171,43 @@ const HERDR_AUTHOR_URL = "https://github.com/ogulcancelik";
     max-width: 40rem;
   }
 
+  /* Kennzeichnung der Tochter: dasselbe Signet wie das Haus, klein und am Fuß.
+     Kein eigenes Zeichen, nie neben oder über dem Produktlogo. */
+  .absender {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55em;
+    align-self: flex-start;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    letter-spacing: 0.04em;
+    color: var(--ink-muted);
+    transition: color 0.15s ease;
+  }
+
+  .absender:hover {
+    color: var(--ink);
+  }
+
+  .absender:focus-visible {
+    outline: 2px solid var(--green);
+    outline-offset: 3px;
+    border-radius: 2px;
+  }
+
+  /* Schutzraum ringsum ist eine Balkenhöhe (⅛ der Zeichenhöhe); die Mindestgröße
+     von 16 px hält das Zeichen auf ganzen Pixeln. */
+  .signet {
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+  }
+
   @media (prefers-reduced-motion: reduce) {
     .flinks a,
     .license a,
-    .credit a {
+    .credit a,
+    .absender {
       transition: none;
     }
   }


### PR DESCRIPTION
## Summary

Applies the parent brand's subsidiary rule to shepherd.run. Erwins Enkel's brand book is explicit that a subsidiary gets **no mark of its own** — it gets one small sender line at the foot: the house signet plus "an undertaking by Erwins Enkel". Nothing in the header, nothing next to or over the product logo.

Concretely, in `site/src/components/Footer.astro`:

- the signet inlined as SVG — six bars on the 32-unit grid, `currentColor`, drawn at 16 px so every edge lands on a whole pixel;
- the line "An undertaking by Erwins Enkel" as the footer's last element, linked to erwins-enkel.dev;
- muted ink, mono, hover to full ink, shared focus ring, transition suppressed under `prefers-reduced-motion`.

The existing BUSL license line keeps carrying the legal name ("Erwins Enkel GmbH") — that one is a legal notice, this one is the brand mark. `site/public/favicon.svg` is untouched.

The German source line is "Eine Unternehmung von Erwins Enkel"; shepherd.run is English-only, so it ships translated.

## Checklist

- [x] Conventional-commit PR title (`feat`, `fix`, `chore`, `docs`, …) — enforced in CI.
- [x] Branch is cut from latest `main` and kept linear (rebase, no merge commits).
- [x] `bun run lint` and `bun test` pass — full pre-push gate green (`cd site && bun run check && bun run build && bun run check:artifacts` too).
- [ ] User-facing text routes through the i18n catalogs — n/a, the marketing site is not i18n'd.
- [ ] `[no-feature-entry]` — marketing-site copy, not an app feature.
- [x] New UI follows the design system — follows the *parent's* brand book, which governs this mark.
- [ ] Docs updated — n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)