### PR TITLE
fix(sandbox): let mise reshim in the membrane so wrapped agents can start

### DIFF
--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -484,7 +484,9 @@ export interface PlanGateServiceDeps extends MembraneSeams {
     | "bumpSpawnNoticeSteers"
     | "clearSpawnNotice"
   >;
-  herdr: Pick<HerdrDriver, "start" | "stop" | "list">;
+  /** `readAsync` is OPTIONAL and used on the no-verdict error path only (see `logReviewerTail`),
+   *  so a driver stub without it degrades to today's silent behaviour rather than failing. */
+  herdr: Pick<HerdrDriver, "start" | "stop" | "list"> & Partial<Pick<HerdrDriver, "readAsync">>;
   worktree: Pick<WorktreeMgr, "createDetached" | "remove" | "gitCommonDir">;
   /** Resolve the forge for a repo so begin() can fetch the originating issue's body as UNTRUSTED
    *  reviewer context. Optional + optional-chained: absence ⇒ no issue context (never blocks). */
@@ -1253,6 +1255,23 @@ export class PlanGateService {
     return this.deps.herdr.list().find((a) => a.cwd === worktreePath)?.terminalId ?? "";
   }
 
+  /** A reviewer that produced no verdict has usually been dead since its first seconds — a launcher
+   *  that exited non-zero, an auth wall, a sandbox EROFS. None of that reaches Shepherd: the verdict
+   *  file just never appears, which is indistinguishable from a review still thinking, so the run
+   *  costs a full `timeoutMs` and reports only `no-verdict`. Log the pane's tail on that path — it
+   *  names the cause, and it is the last chance to read it before `finalize`'s `finally` reaps the
+   *  terminal. Best-effort throughout: this is diagnostics, and must never derail finalize. */
+  private async logReviewerTail(f: PlanInFlight): Promise<void> {
+    if (!f.terminalId || !this.deps.herdr.readAsync) return;
+    try {
+      const tail = (await this.deps.herdr.readAsync(f.terminalId, "recent", 40)).trim();
+      if (tail)
+        console.warn(`[plan-gate] no verdict for ${f.sessionId}; reviewer pane tail:\n${tail}`);
+    } catch (err) {
+      console.warn(`[plan-gate] reviewer pane tail unavailable for ${f.sessionId}:`, err);
+    }
+  }
+
   /** A Codex role is a one-shot `codex exec`: after a brief registration grace period, a missing
    * terminal without a verdict means it has already exited. Avoid making the operator wait for the
    * full file timeout; a Herdr read failure remains inconclusive and falls back to that timeout. */
@@ -1303,7 +1322,10 @@ export class PlanGateService {
       const gate = this.buildGate(f, raw);
       if (gate.decision === "approved") await this.applyApproved(f, gate);
       else if (gate.decision === "changes_requested") await this.applyChangesRequested(f, gate);
-      else this.applyError(f, gate); // timeout / unparseable verdict
+      else {
+        this.applyError(f, gate); // timeout / unparseable verdict
+        await this.logReviewerTail(f); // ordered before the `finally` reaps the pane
+      }
       // Persist the reviewer's token total for exact cost attribution (issue #502). Best-effort:
       // a missing/half-written transcript (or a Codex exec, which writes none) completes the row
       // with zeroed totals rather than stranding finalize or leaving `completedAt` null. Safe to

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -333,13 +333,44 @@ function managerRoots(home: string): string[] {
 }
 
 /**
+ * Sub-paths of a manager root that the manager REWRITES on every invocation, and which therefore
+ * cannot sit under the read-only bind above.
+ *
+ * `mise` is the live case (same host change behind #2052). A mise-managed `claude` is reached
+ * through a launcher on PATH that re-runs `mise use`, and mise rebuilds `shims/` as part of that —
+ * under the RO bind the rebuild hits EROFS and mise exits non-zero, so the agent process NEVER
+ * STARTS. Nothing observes
+ * that directly: the role's verdict file simply never appears, the caller waits out its whole
+ * timeout (10 min for the plan gate), records a `no-verdict` error and re-spawns into the same
+ * wall. Every membrane-wrapped role — plan gate, PR critic, doc agent, standalone critic — fails
+ * this way at once.
+ *
+ * A tmpfs is the narrow fix: the rebuild succeeds against throwaway storage, the write never
+ * reaches the host, and `installs/` stays read-only — so a sandboxed role still cannot plant a
+ * binary that a later trusted session would run.
+ *
+ * NOT covered, deliberately: a manager asked for a version the host has not installed yet still
+ * needs to download into the read-only `installs/`, and will still fail. Making that writable would
+ * let an untrusted role pull and execute arbitrary tool versions, which is the opposite of what the
+ * membrane is for. Installing toolchains stays a host-side, trusted-session concern.
+ */
+function managerScratch(home: string): Record<string, string[]> {
+  return { [`${home}/.local/share/mise`]: ["shims"] };
+}
+
+/**
  * Compute the RO toolchain binds for the node binary. Always binds the binary's
  * own directory; additionally binds any known manager root that is a PREFIX of
  * nodeBinReal OR exists on the host. De-dupes so the same path isn't bound twice
  * and a child of an already-bound root is skipped.
+ *
+ * Each bound root is immediately followed by a `--tmpfs` per {@link managerScratch} entry. Order is
+ * load-bearing: bwrap applies operations in sequence, so the tmpfs must come AFTER the `--ro-bind`
+ * it punches through, never before.
  */
 function nodeToolchainFlags(inputs: MembraneInputs, exists: (p: string) => boolean): string[] {
   const binDir = dirname(inputs.nodeBinReal);
+  const scratch = managerScratch(inputs.home);
   const added: string[] = [];
   const flags: string[] = [];
   const isUnder = (p: string, root: string) => p === root || p.startsWith(root + "/");
@@ -347,6 +378,7 @@ function nodeToolchainFlags(inputs: MembraneInputs, exists: (p: string) => boole
     if (added.some((a) => a === p || isUnder(p, a))) return; // already bound or under a bound root
     added.push(p);
     flags.push("--ro-bind-try", p, p);
+    for (const sub of scratch[p] ?? []) flags.push("--tmpfs", `${p}/${sub}`);
   };
 
   // Manager roots first so a binDir under one of them is de-duped away.

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -1032,6 +1032,60 @@ test("timeout with no verdict → error gate, reaped, not released", async () =>
   expect(h.removed).toContain("/wt-detached");
 });
 
+test("a no-verdict finalize reads the reviewer pane tail before the pane is reaped", async () => {
+  // The pane tail is the only place a launch failure (non-zero launcher, auth wall, sandbox EROFS)
+  // is visible — the verdict file just never appears. It must be read while the pane still exists.
+  let t = 1000;
+  const reads: Array<[string, string | undefined, number | undefined]> = [];
+  let stopped = false;
+  const h = harness({
+    readVerdict: () => null,
+    now: () => t,
+    herdr: {
+      start: async () => ({ terminalId: "t1" }),
+      async stop() {
+        stopped = true;
+      },
+      list: () => [],
+      readAsync: async (target: string, source?: string, lines?: number) => {
+        reads.push([target, source, lines]);
+        expect(stopped).toBe(false); // still alive when we read
+        return "mise ERROR Read-only file system (os error 30)\n";
+      },
+    },
+  });
+  await h.svc.consider(planningSession() as any);
+  t = 1000 + 11 * 60 * 1000;
+  await h.svc.tick();
+
+  expect(reads).toEqual([["t1", "recent", 40]]);
+  expect(stopped).toBe(true);
+  expect(h.store.gate.decision).toBe("error");
+});
+
+test("a failing pane read never derails a no-verdict finalize", async () => {
+  let t = 1000;
+  const h = harness({
+    readVerdict: () => null,
+    now: () => t,
+    herdr: {
+      start: async () => ({ terminalId: "t1" }),
+      async stop() {},
+      list: () => [],
+      readAsync: async () => {
+        throw new Error("herdr gone");
+      },
+    },
+  });
+  await h.svc.consider(planningSession() as any);
+  t = 1000 + 11 * 60 * 1000;
+  await h.svc.tick();
+
+  expect(h.store.gate.decision).toBe("error");
+  expect(h.store.gate.summaryCode).toBe("no-verdict");
+  expect(h.removed).toContain("/wt-detached");
+});
+
 test("an exited codex reviewer without a verdict fails before the file timeout", async () => {
   let t = 1000;
   const h = harness({

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -423,6 +423,35 @@ describe("buildMembraneFlags", () => {
     expect(targets.filter((t) => t === binDir).length).toBe(0);
   });
 
+  test("mise root gets a writable tmpfs over shims, immediately after its RO bind", () => {
+    // A mise-managed agent launcher reshims on every invocation; under the bare RO bind that write
+    // is EROFS and the agent never starts (the role then burns its whole verdict timeout in
+    // silence). bwrap applies ops in order, so the tmpfs is only effective AFTER the bind.
+    const f = buildMembraneFlags(fakeMembrane({ home: "/home/me" }), { exists: () => true });
+    const root = "/home/me/.local/share/mise";
+    const bind = f.findIndex((x, j) => x === "--ro-bind-try" && f[j + 1] === root);
+    expect(bind).toBeGreaterThanOrEqual(0);
+    expect(f.slice(bind, bind + 5)).toEqual([
+      "--ro-bind-try",
+      root,
+      root,
+      "--tmpfs",
+      `${root}/shims`,
+    ]);
+  });
+
+  test("mise installs stay read-only — only shims is punched through", () => {
+    const f = buildMembraneFlags(fakeMembrane({ home: "/home/me" }), { exists: () => true });
+    const tmpfsTargets = f.filter((x, j) => f[j - 1] === "--tmpfs" && x.includes("/mise"));
+    expect(tmpfsTargets).toEqual(["/home/me/.local/share/mise/shims"]);
+  });
+
+  test("no mise root on the host -> no scratch tmpfs at all", () => {
+    // detDeps: nothing exists and nodeBinReal is under linuxbrew, so mise is never bound.
+    const f = buildMembraneFlags(fakeMembrane(), detDeps);
+    expect(f.some((x) => x.includes("/mise"))).toBe(false);
+  });
+
   test("setenv HOME/PATH/TERM present", () => {
     const f = buildMembraneFlags(fakeMembrane(), detDeps);
     expect(hasTriple(f, "--setenv", "HOME", "/home/me")).toBe(true);


### PR DESCRIPTION
Plan reviews were starting and never finishing. They were never running at all.

## What happens

Reviewer roles are **always** bwrap-wrapped, even when the parent session is `trusted`. The membrane RO-binds `~/.local/share/mise` (it has to — the node/claude binaries live under it) and puts `~/.local/bin` first on the sandbox PATH. On a host where `claude` is mise-managed, the launcher there re-runs `mise use`, mise rebuilds `~/.local/share/mise/shims/` as part of that, the write hits **EROFS**, and the launcher exits non-zero.

Nothing observes that. The verdict file simply never appears, which is indistinguishable from a review still thinking — so the plan gate waits out its full 10-minute `DEFAULT_TIMEOUT_MS`, records `error / no-verdict`, re-considers, and spawns straight back into the same wall. One session did three such rounds back to back, 30 minutes for nothing. Every membrane-wrapped role fails the same way: plan gate, PR critic, doc agent, standalone critic.

Reproduced outside Shepherd by dumping `buildMembraneFlags` and running `claude --version` under them:

```
mise ERROR failed to rebuild shims
mise ERROR Read-only file system (os error 30)
```

## The fix

`nodeToolchainFlags` now follows each bound manager root with a `--tmpfs` over the sub-path that manager rewrites on every invocation (`mise`: `shims/`). Order is load-bearing — bwrap applies operations in sequence, so the tmpfs must come after the bind it punches through. With it, the same repro prints `2.1.237 (Claude Code)`.

`installs/` deliberately stays read-only: a sandboxed role still cannot plant a binary a later trusted session would run. The residual, called out in the comment, is that a version the host has not installed yet still needs to write to `installs/` and will still fail — making that writable would let an untrusted role pull and execute arbitrary tool versions, so installing toolchains stays a trusted-session concern.

Second, smaller change: a no-verdict finalize now logs the reviewer's pane tail before `finalize`'s `finally` reaps the terminal. That tail is the only place a launch failure is visible, and reading it is what turned this from "no idea" into a root cause.

## Also worth knowing

`detectBackend`'s self-test probes `node --version && git --version` — **not** the agent binary. That is why this host kept reporting a healthy sandbox while every wrapped agent launch died. Left alone here: making the probe launch the agent would degrade the whole membrane to `null` on such a host, which silently drops the sandbox around untrusted plan text. Filed as #2111.

## Verification

- Repro re-run against the real `buildMembraneFlags` output: claude launches.
- `bun run lint`, `bunx tsc --noEmit`, `bun run test` (8714 pass / 0 fail), `fallow audit --base origin/main` — all green.
- New tests cover the tmpfs ordering after the RO bind, that only `shims` is punched through, the no-mise-host case, and both pane-tail paths (read before reap; a failing read never derails finalize).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
