### PR TITLE
fix(spawn): pre-trust aux worktrees so reviewers don't wedge on the trust dialog

### DIFF
--- a/src/claude-trust.ts
+++ b/src/claude-trust.ts
@@ -76,3 +76,12 @@ export async function trustRepoRoot(configPath: string, dir: string): Promise<vo
   await writeFile(tmp, JSON.stringify(j), "utf8");
   await rename(tmp, configPath);
 }
+
+/**
+ * Read-gated {@link trustRepoRoot}: seed the flag only when it is not already set, so a repeat
+ * spawn in an already-trusted dir costs one read and no write. The pairing is what every caller
+ * wants; having it in one place keeps the gate from drifting between them.
+ */
+export async function ensureRepoRootTrusted(configPath: string, dir: string): Promise<void> {
+  if (!(await readRepoRootTrusted(configPath, dir))) await trustRepoRoot(configPath, dir);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,7 @@ import {
 } from "./learnings-lifecycle";
 import { Promoter } from "./promote";
 import { DocAgentService } from "./doc-agent";
+import { ensureRepoRootTrusted } from "./claude-trust";
 import { GitignoreAdopter } from "./gitignore-adopt";
 import { attachSignalCapture } from "./signals";
 import { HookIngest } from "./hooks-ingest";
@@ -650,6 +651,13 @@ const resolveForge = makeProductionForgeResolver(store, config.forges);
 // after ALL core services exist and just before serve() — runSpawnHooks is a safe no-op
 // until then (no spawn can be requested over HTTP before the server boots).
 const pluginRegistry = new PluginRegistry({ pluginsDir: config.pluginsDir, store, events });
+
+/** Pre-accept Claude Code's workspace-trust dialog for a reviewer-style spawn's cwd (#2112). Each
+ *  aux role runs in a fresh detached worktree, so without this Claude asks "do you trust this
+ *  folder?" on a pane no one is watching and the role hangs to its timeout. `spawn-membrane`
+ *  resolves which config file the spawn will actually read and passes it as `cfg`. NOT wired for
+ *  SessionService: an operator-facing session pane can answer the dialog, and does not raise it. */
+const trustAuxDir = (dir: string, cfg: string) => ensureRepoRootTrusted(cfg, dir);
 
 // Usage-aware model downgrade: the cheap model to force on a spawn when live usage has crossed the
 // downgrade threshold, or null (leave the configured model). Hoisted so both the main-session path
@@ -1436,6 +1444,7 @@ const docAgent = new DocAgentService({
   resolveForge,
   // Plugin onSpawn hooks fire for the doc-agent spawn too (issue #1205); no-op until loadAll.
   runSpawnHooks: (d) => pluginRegistry.runSpawnHooks(d),
+  trustDir: trustAuxDir,
   repos: () => listRepos(config.repoRoot).map((r) => r.path),
   store,
   gitState: (id) => prPoller.get(id),
@@ -1463,6 +1472,7 @@ const reviewService = new ReviewService({
   resolveForge,
   // Plugin onSpawn hooks fire for reviewer-style aux spawns too (issue #1205); no-op until loadAll.
   runSpawnHooks: (d) => pluginRegistry.runSpawnHooks(d),
+  trustDir: trustAuxDir,
   // Per-role critic environment thunk (read per spawn so a settings change applies without restart).
   env: () => roleEnv(config.criticCli, config.criticModel, config.criticEffort),
   onChange: (id, verdict) => events.emit("session:review", { id, review: verdict }),
@@ -1502,6 +1512,7 @@ const standaloneCritic = new StandalonePrCriticService({
   resolveForge,
   // Plugin onSpawn hooks fire for reviewer-style aux spawns too (issue #1205); no-op until loadAll.
   runSpawnHooks: (d) => pluginRegistry.runSpawnHooks(d),
+  trustDir: trustAuxDir,
   // Same per-role critic environment as reviewService (read per spawn → live settings).
   env: () => roleEnv(config.criticCli, config.criticModel, config.criticEffort),
   timeoutMs: config.reviewTimeoutMs,
@@ -1533,6 +1544,7 @@ const planGate = new PlanGateService({
   resolveForge,
   // Plugin onSpawn hooks fire for reviewer-style aux spawns too (issue #1205); no-op until loadAll.
   runSpawnHooks: (d) => pluginRegistry.runSpawnHooks(d),
+  trustDir: trustAuxDir,
   // Raw steer, delivered THROUGH resumeThenSteer (paneAlive/resume/deferSteer below): findings now
   // revive an exited planner before landing rather than holding the round on a dead pane. This is
   // what makes a Codex planner (which exits after its turn) actually receive the findings and revise.

--- a/src/spawn-membrane.ts
+++ b/src/spawn-membrane.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { config } from "./config";
+import { claudeConfigPath } from "./claude-trust";
 import { apiKeyMembraneFields, apiKeyPassthroughEnv } from "./spawn-auth";
 import { PluginSpawnAborted, type SpawnDescriptor, type SpawnPatch } from "./plugins/types";
 import { toolGuardMembranePaths } from "./tool-guard-hook";
@@ -40,6 +41,18 @@ export interface MembraneSeams {
    *  validate-and-skip a plugin's patched credentialDir that does not exist on host (the
    *  wrapped membrane hard `--ro-bind`s it — bwrap would crash on a missing source). */
   pathExists?: (p: string) => boolean;
+  /** Pre-accept Claude Code's workspace-trust dialog for an aux spawn's cwd (issue #2112).
+   *
+   *  Every reviewer-style role runs in a FRESH detached worktree, so its cwd is never in
+   *  `.claude.json`'s `projects` and Claude opens "Is this a project you trust?" on a pane no one
+   *  is watching. The role then hangs to its full timeout and reports no verdict — the same
+   *  end-state as a crashed launcher, which is why it hid behind #2110. Claude only skips the
+   *  dialog in non-interactive mode (`-p` / no TTY), which a pane-hosted role cannot use, and no
+   *  flag or settings key suppresses it; pre-seeding the flag is the only unattended path (#1075).
+   *
+   *  Absent ⇒ no seeding (same convention as `runSpawnHooks`), which keeps tests off the real
+   *  `$HOME`: this is the one seam here that WRITES to host state. Wired in index.ts. */
+  trustDir?: (dir: string, configPath: string) => Promise<void>;
 }
 
 /** Backend probe: injected seam (tests) or the real cached self-test. */
@@ -245,7 +258,42 @@ export async function resolveAuxPatch(
 
   const folded = await foldAuxPatch(args, baseEnv);
   if ("aborted" in folded) return folded;
+
+  // Pre-accept the workspace-trust dialog for the spawn's cwd — see MembraneSeams.trustDir. Uses
+  // the SAME effective env as the spawn will, so a plugin-routed (or api-key mirror)
+  // CLAUDE_CONFIG_DIR is seeded in the config file Claude will actually read, not the default one.
+  // Best-effort: a failed seed costs a wedged review, but a THROWN seed would cost the spawn.
+  if (args.seams.trustDir) {
+    const env = resolveMembraneEnv(args.seams);
+    const claudeDir =
+      mergeAuxEnv(backend, baseEnv, folded.patchEnv).CLAUDE_CONFIG_DIR ?? env.claudeDir;
+    try {
+      await args.seams.trustDir(args.worktreePath, claudeConfigPath(env.home, claudeDir));
+    } catch (err) {
+      console.warn(`[spawn] could not pre-trust ${args.worktreePath}:`, err);
+    }
+  }
+
   return { backend, baseEnv, patchEnv: folded.patchEnv, extraArgs: folded.extraArgs };
+}
+
+/** The spawn's effective env. Normally patchEnv LAST so a patched CLAUDE_CONFIG_DIR wins over
+ *  apiKeyPassthroughEnv's mirror. EXCEPTION (#1213): api-key + NO backend — baseEnv is truthy ONLY
+ *  then (the credential-less mirror) and there is NO sandbox to mask creds, so a pool
+ *  CLAUDE_CONFIG_DIR (real .credentials.json on host) would reintroduce the "Use custom API key?"
+ *  prompt / misbill the pool's OAuth subscription. There the mirror WINS; credential routing onto
+ *  a pool account requires a sandbox backend (which masks creds in place).
+ *
+ *  Shared so the trust seed above and {@link assembleAuxSpawn} can never disagree about which
+ *  config dir the spawn ends up using. */
+function mergeAuxEnv(
+  backend: SandboxBackend,
+  baseEnv: Record<string, string> | undefined,
+  patchEnv: Record<string, string>,
+): Record<string, string> {
+  return backend === null && baseEnv
+    ? { ...patchEnv, ...baseEnv }
+    : { ...(baseEnv ?? {}), ...patchEnv };
 }
 
 /** SYNC half: assemble the membrane around `argv` and merge the spawn env. Pure with respect to
@@ -275,16 +323,8 @@ export function assembleAuxSpawn(
     extraEnv: patch.patchEnv,
   });
 
-  // Merge order. Normally patchEnv LAST so a patched CLAUDE_CONFIG_DIR wins over
-  // apiKeyPassthroughEnv's mirror. EXCEPTION (#1213): api-key + NO backend — baseEnv is truthy ONLY
-  // then (the credential-less mirror) and there is NO sandbox to mask creds, so a pool
-  // CLAUDE_CONFIG_DIR (real .credentials.json on host) would reintroduce the "Use custom API key?"
-  // prompt / misbill the pool's OAuth subscription. There the mirror WINS; credential routing onto
-  // a pool account requires a sandbox backend (which masks creds in place).
-  const merged =
-    patch.backend === null && patch.baseEnv
-      ? { ...patch.patchEnv, ...patch.baseEnv }
-      : { ...(patch.baseEnv ?? {}), ...patch.patchEnv };
+  // Merge order lives in mergeAuxEnv — shared with resolveAuxPatch's trust seed.
+  const merged = mergeAuxEnv(patch.backend, patch.baseEnv, patch.patchEnv);
   const spawnEnv = Object.keys(merged).length ? merged : undefined;
   return { wrapped, spawnEnv };
 }

--- a/test/claude-trust.test.ts
+++ b/test/claude-trust.test.ts
@@ -2,7 +2,12 @@ import { test, expect } from "bun:test";
 import { mkdtemp, readFile, writeFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { claudeConfigPath, readRepoRootTrusted, trustRepoRoot } from "../src/claude-trust";
+import {
+  claudeConfigPath,
+  ensureRepoRootTrusted,
+  readRepoRootTrusted,
+  trustRepoRoot,
+} from "../src/claude-trust";
 
 async function withTmp<T>(fn: (dir: string) => Promise<T>): Promise<T> {
   const dir = await mkdtemp(join(tmpdir(), "claude-trust-"));
@@ -97,5 +102,37 @@ test("trust writes compact JSON (no pretty-print reflow)", async () => {
     const raw = await readFile(cfg, "utf8");
     expect(raw).not.toContain("\n"); // compact — single line
     expect(JSON.parse(raw).projects["/repo"].hasTrustDialogAccepted).toBe(true);
+  });
+});
+
+test("ensureRepoRootTrusted seeds an untrusted dir and leaves a trusted one untouched", async () => {
+  await withTmp(async (dir) => {
+    const cfg = join(dir, ".claude.json");
+    await writeFile(cfg, JSON.stringify({ projects: {} }));
+
+    await ensureRepoRootTrusted(cfg, "/repo");
+    expect(await readRepoRootTrusted(cfg, "/repo")).toBe(true);
+
+    // Already trusted → read-gated, so the file is not rewritten. Byte-compare rather than
+    // trusting mtime: the second call is sub-ms after the first.
+    const before = await readFile(cfg, "utf8");
+    await ensureRepoRootTrusted(cfg, "/repo");
+    expect(await readFile(cfg, "utf8")).toBe(before);
+  });
+});
+
+test("ensureRepoRootTrusted preserves unrelated project state", async () => {
+  await withTmp(async (dir) => {
+    const cfg = join(dir, ".claude.json");
+    await writeFile(
+      cfg,
+      JSON.stringify({ projects: { "/other": { history: ["x"] } }, hasCompletedOnboarding: true }),
+    );
+
+    await ensureRepoRootTrusted(cfg, "/repo");
+    const j = JSON.parse(await readFile(cfg, "utf8"));
+    expect(j.projects["/other"].history).toEqual(["x"]);
+    expect(j.hasCompletedOnboarding).toBe(true);
+    expect(j.projects["/repo"].hasTrustDialogAccepted).toBe(true);
   });
 });

--- a/test/spawn-membrane.test.ts
+++ b/test/spawn-membrane.test.ts
@@ -572,3 +572,93 @@ describe("#1944 resolveAuxPatch + assembleAuxSpawn", () => {
     expect(assembleAuxSpawn(patch, args)).toEqual(oneShot);
   });
 });
+
+// ── #2112: workspace-trust pre-seed ────────────────────────────────────────────
+//
+// Every aux role runs in a fresh detached worktree, so Claude's "do you trust this folder?" dialog
+// fires on a pane no one is watching and the role hangs to its timeout. resolveAuxPatch pre-accepts
+// it. The seam is opt-in precisely so these tests never touch the real $HOME.
+
+describe("#2112 trustDir pre-seed", () => {
+  const seams = (extra?: Record<string, unknown>) => ({
+    detectBackend: () => "bwrap" as const,
+    membraneEnv: () => stubEnv,
+    pathExists: () => true,
+    ...extra,
+  });
+
+  const baseArgs = (over?: Record<string, unknown>) => ({
+    argv: ["claude", "-p", "PROMPT"],
+    worktreePath: "/wt/task",
+    repoPath: "/repo",
+    worktree: worktreeStub(),
+    seams: seams(),
+    descriptor: { sessionId: "s-1", kind: "review" as const },
+    ...over,
+  });
+
+  test("seeds the spawn cwd against the default config file", async () => {
+    const calls: Array<[string, string]> = [];
+    const patch = await resolveAuxPatch(
+      baseArgs({
+        seams: seams({ trustDir: async (d: string, c: string) => void calls.push([d, c]) }),
+      }),
+    );
+    if ("aborted" in patch) throw new Error("unexpected abort");
+    // stubEnv.claudeDir is NOT `${home}/.claude`, so claudeConfigPath puts the file INSIDE it.
+    expect(calls).toEqual([["/wt/task", "/stub/.claude/.claude.json"]]);
+  });
+
+  test("follows a plugin-routed credentialDir to the file that spawn will actually read", async () => {
+    // Seeding the default config here would leave the pool account's dialog unanswered — the
+    // role would still wedge, and the write would land in a file nobody reads.
+    const calls: Array<[string, string]> = [];
+    const patch = await resolveAuxPatch(
+      baseArgs({
+        seams: seams({
+          trustDir: async (d: string, c: string) => void calls.push([d, c]),
+          runSpawnHooks: async () => ({ credentialDir: "/pool/acct" }),
+        }),
+      }),
+    );
+    if ("aborted" in patch) throw new Error("unexpected abort");
+    expect(calls).toEqual([["/wt/task", "/pool/acct/.claude.json"]]);
+  });
+
+  test("a throwing seed never fails the spawn", async () => {
+    const patch = await resolveAuxPatch(
+      baseArgs({
+        seams: seams({
+          trustDir: async () => {
+            throw new Error("config unwritable");
+          },
+        }),
+      }),
+    );
+    if ("aborted" in patch) throw new Error("unexpected abort");
+    expect(patch.backend).toBe("bwrap");
+  });
+
+  test("no seam → no host writes attempted", async () => {
+    // The absent-seam default is what keeps every other test in this file off the real $HOME.
+    const patch = await resolveAuxPatch(baseArgs());
+    if ("aborted" in patch) throw new Error("unexpected abort");
+    expect(patch.backend).toBe("bwrap");
+  });
+
+  test("an aborted spawn seeds nothing", async () => {
+    let called = false;
+    const patch = await resolveAuxPatch(
+      baseArgs({
+        seams: seams({
+          trustDir: async () => void (called = true),
+          runSpawnHooks: async () => {
+            throw new PluginSpawnAborted("nope", "test-plugin");
+          },
+        }),
+      }),
+    );
+    expect("aborted" in patch).toBe(true);
+    expect(called).toBe(false);
+  });
+});


### PR DESCRIPTION
Second blocker in the chain that #2110 opened up. That PR fixed the launcher; the reviewer now starts — and stops dead on Claude Code's workspace-trust dialog.

```
Accessing workspace:
/home/patrick/Work/.shepherd-worktrees/topmedia-website-review-aef1c47a-…

Quick safety check: Is this a project you created or one you trust? …
 ❯ 1. Yes, I trust this folder
```

Nobody answers it. Same end-state as before — no verdict file, full timeout, `error / no-verdict`, respawn — which is exactly why one masked the other.

## Why it is every reviewer, every time

Aux roles run in a **fresh detached worktree per spawn**, so their cwd is never in `.claude.json`'s `projects` and Claude asks on every single run. On this host: 9180 project entries, **zero** review worktrees.

Ruled out on the way:

- Not repo-root trust — `oxidone` is marked untrusted and its plan review completed normally on 2026-08-20 (4.4m, 1M tokens).
- Not session spawns — this session's own worktree is absent from `projects` and never saw the dialog. Only pane-hosted aux roles are affected, which is why `trustDir` is deliberately **not** wired for `SessionService`.
- No flag or settings key suppresses it. `claude --help` is explicit that the dialog is skipped only in non-interactive mode (`-p`, or stdout not a TTY), which a pane-hosted role cannot use. I checked the 2.1.237 bundle for a settings key; there isn't one.

Pre-seeding `projects[dir].hasTrustDialogAccepted` is the only unattended path — the same conclusion as #1075, which is why `src/claude-trust.ts` already exists. It was wired for recap, the usage probe and diagnostics, but not for the four roles whose cwd is exactly the case it was written for.

## The change

`resolveAuxPatch` seeds the flag for the spawn's cwd before the spawn. One place, all four roles.

- **Opt-in seam.** `trustDir` absent ⇒ no seeding, matching `runSpawnHooks`. This is the only seam here that writes host state, and the convention is what keeps the existing tests off the real `$HOME`.
- **Follows a routed config dir.** A plugin-routed (#1213) or api-key-mirror `CLAUDE_CONFIG_DIR` means the spawn reads a *different* `.claude.json`; seeding the default one would leave the dialog unanswered and write where nobody reads. The merge that decides this is now `mergeAuxEnv`, shared with `assembleAuxSpawn` so the seed and the spawn can never disagree.
- **Best-effort.** A failed seed costs a wedged review; a thrown seed would cost the spawn.

## Verification

Reproduced and fixed outside Shepherd, under a pty, with the real `buildMembraneFlags` around it:

- fresh git dir, no `projects` entry → trust dialog
- after `trustRepoRoot` → Claude boots straight to the REPL

`bun run lint`, `bunx tsc --noEmit`, `bun run test` (8722 pass / 0 fail), `fallow audit --base origin/main` all green. New tests cover the default config path, following a routed `credentialDir`, a throwing seed not failing the spawn, the absent-seam default, and an aborted spawn seeding nothing.

I will not call this fixed until I have watched a real review complete with tokens booked — I made that mistake on #2110.

## Notes

- Second PR from this session (the first was #2110, merged). Per Shepherd's one-session-one-PR rule this one gets no automatic critic unless `criticAllPrs` is set.
- **Adjacent, not fixed here:** `~/.claude.json` is 15.5 MB / 9180 entries, **9126 of which point at directories that no longer exist**. Claude writes an entry per cwd and never prunes, and Shepherd hands it a brand-new ephemeral path on every recap and every review. It is read at every startup. Called out in #2112; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
