### PR TITLE
fix(recap): carry recap body + blocks as sidecar files (#2045)

### DIFF
--- a/src/operator-language.ts
+++ b/src/operator-language.ts
@@ -137,7 +137,7 @@ const backtickList = (fields: readonly string[]): string =>
 /**
  * Return an instruction paragraph telling the agent, when it authors the
  * `VisualBlock[]` JSON (used by both the plan sidecar `.shepherd-plan-blocks.json`
- * and the recap `.shepherd-recap.json`), which fields to write in the operator's
+ * and the recap sidecar `.shepherd-recap-blocks.json`), which fields to write in the operator's
  * language and which to leave verbatim — or `null` for "en" (nothing to inject).
  * Positively enumerates the translatable fields and prohibits everything else,
  * plus the conditional cell-by-cell rule for `table.columns`/`table.rows`.
@@ -147,7 +147,7 @@ export function visualBlockLanguageLine(lang: OperatorLanguage): string | null {
   const name = LANGUAGE_NAMES[lang];
   return (
     `When authoring VisualBlock[] JSON (the plan sidecar .shepherd-plan-blocks.json or the recap ` +
-    `.shepherd-recap.json), write ONLY these natural-language fields in ${name}: ` +
+    `sidecar .shepherd-recap-blocks.json), write ONLY these natural-language fields in ${name}: ` +
     `${backtickList(VISUAL_BLOCK_TRANSLATE_FIELDS)}. ` +
     `Leave every other field exactly as you would in English — never translate: ` +
     `${backtickList(VISUAL_BLOCK_VERBATIM_FIELDS)}. An off-enum or reworded identifier/path/enum ` +

--- a/src/recap-core.ts
+++ b/src/recap-core.ts
@@ -13,6 +13,34 @@ export const RECAP_VERDICTS: readonly RecapVerdict[] = ["ready", "parked", "need
 export const RECAP_HEADLINE_MAX = 100;
 export const RECAP_DIGEST_MAX_CHARS = 4000;
 
+/** The recap `body`, written beside the verdict JSON as plain markdown.
+ *
+ *  #2045 (the recap half of #2042): the recap agent hand-authors its verdict JSON, so every `"` in
+ *  the body has to be escaped by the model. It only has to miss once. The unrecoverable shape is a
+ *  bare `"` immediately before `:` or `,` (`…nicht mehr": drei Dinge`), which is byte-identical to a
+ *  real key/value boundary — jsonrepair cannot resolve that ambiguity, and no repairer could. German
+ *  prose produces it constantly via `„…":` / `„…",`, and it has already destroyed a complete recap
+ *  in production.
+ *
+ *  Carrying the body as its own file removes the escaping obligation entirely: markdown has no
+ *  reserved characters, so no prose can break the read. What remains in the JSON (verdict, headline,
+ *  openItems) is short and structured, where the model's escaping is reliable in practice.
+ *
+ *  Unlike the critic's equivalent, this needs NO pre-seed scrub: the recap spawn's cwd is a fresh
+ *  mkdtemp directory (see defaultMakeTmpDir in recap.ts), never an untrusted PR-head checkout. */
+export const RECAP_BODY_FILE = ".shepherd-recap.md";
+
+/** The recap `blocks`, written beside the verdict JSON as a bare `VisualBlock[]` — mirroring the
+ *  plan gate's `.shepherd-plan-blocks.json` sidecar.
+ *
+ *  Blocks are still JSON, so moving them out cannot remove the escaping hazard the way the markdown
+ *  body does. What it removes is the BLAST RADIUS: `rich-text.markdown`, `callout.markdown`,
+ *  `diff.annotations[].note` and quote-dense `wireframe.html` are exactly as prose-heavy as the body
+ *  was, and inline they could sink the entire recap. In their own file a mangled write costs only
+ *  the visual cards — the verdict, headline and body still land (see readRecapBlocks in recap.ts,
+ *  which falls back rather than failing). */
+export const RECAP_BLOCKS_FILE = ".shepherd-recap-blocks.json";
+
 /** Recover the recap object from a parse that an unattended agent's chatty output mangled.
  *  jsonrepair turns prose-wrapped JSON ("Here is the recap:\n{…}" or "{…}\nDone.") into an
  *  ARRAY (e.g. `["Here is the recap:", {…}]`); pull the first recap-shaped element back out so a
@@ -26,6 +54,29 @@ function unwrapRecapObject(raw: unknown): Record<string, unknown> | null {
   }
   if (raw && typeof raw === "object") return raw as Record<string, unknown>;
   return null;
+}
+
+/** Splice the sidecar payloads (#2045) onto a freshly-parsed recap verdict.
+ *
+ *  `body` / `blocks` are `null` for "no sidecar contribution" — the inline field then survives
+ *  untouched, which is what keeps a Codex recap (answers in chat, writes no files) and any run
+ *  already in flight across a server restart working unchanged. A present sidecar WINS: it is the
+ *  format the prompt asks for whenever files are writable, and the one that cannot have been
+ *  mangled by escaping.
+ *
+ *  Goes through unwrapRecapObject so it also lands on the jsonrepair array shape
+ *  (`["Here is the recap:", {…}]`); that unwrap is idempotent with parseRecapVerdict downstream.
+ *  Returns `raw` untouched when there is nothing to splice or the shape is unrecoverable.
+ *
+ *  `blocks` is `unknown` rather than `VisualBlock[]` on purpose: shape validation belongs to
+ *  parseVisualBlocks downstream, which already tolerates anything. */
+export function spliceRecapSidecars(raw: unknown, body: string | null, blocks: unknown): unknown {
+  if (body === null && blocks === null) return raw;
+  const obj = unwrapRecapObject(raw);
+  if (!obj) return raw;
+  if (body !== null) obj.body = body;
+  if (blocks !== null) obj.blocks = blocks;
+  return obj;
 }
 
 /** Normalize a verdict to the enum, tolerating formatting variance (case, surrounding
@@ -94,8 +145,9 @@ export function buildTranscriptDigest(
 }
 
 /** The instruction prompt for the recap spawn. Tells the agent to summarize a COMPLETED
- *  coding session for an operator deciding whether to merge, and to Write a
- *  `.shepherd-recap.json` file with {verdict, headline, body, openItems}. */
+ *  coding session for an operator deciding whether to merge, and to Write the prose to
+ *  `.shepherd-recap.md`, any visual blocks to `.shepherd-recap-blocks.json`, and
+ *  `.shepherd-recap.json` LAST with {verdict, headline, openItems}. */
 export function buildRecapPrompt(input: {
   taskPrompt: string;
   plan: string; // "" when no .shepherd-plan.md
@@ -150,7 +202,7 @@ export function buildRecapPrompt(input: {
     "- body: concise markdown covering what changed, key decisions made, and merge-readiness",
     "- openItems: string[] of anything left to do or worth noting for the next session ([] if none)",
     "",
-    "Optionally, include a `blocks` array to render the recap as a scannable visual document instead",
+    "Optionally, add `blocks` to render the recap as a scannable visual document instead",
     "of plain markdown. Omit `blocks` entirely if plain `body` suffices — blocks are not required.",
     "",
     "Block types (Phase 1):",
@@ -183,11 +235,27 @@ export function buildRecapPrompt(input: {
     "- Redact secrets (API keys, tokens, passwords) in any summary/markdown/annotation — use",
     "  placeholders like `sk-•••` / `<redacted>`.",
     "",
-    `Write the result as JSON to the file \`.shepherd-recap.json\` in your CWD with EXACTLY this shape`,
-    "(the `blocks` field is optional — omit it entirely if not useful; the file must be strict, valid",
-    "JSON with no comments):",
-    `{"verdict": "ready" | "parked" | "needs_attention", "headline": "<string>", "body": "<markdown>", "openItems": ["<string>", ...], "blocks": [ ... ]}`,
-    "Write the file as your final action, then stop.",
+    "When done, write these files in your CWD:",
+    // Binds the term once: every rule above says `body` / `blocks`, and they all now resolve to
+    // these files. Cheaper and less drift-prone than restating each rule.
+    `1. \`${RECAP_BODY_FILE}\` — the \`body\`. Everywhere these instructions say "body", they mean THIS file. It is NOT JSON: write the markdown directly, escape nothing, quote however you like.`,
+    `2. \`${RECAP_BLOCKS_FILE}\` — OPTIONAL. The \`blocks\` described above as a bare JSON array (\`[ {…}, {…} ]\`, no wrapper object). Omit the file entirely when plain markdown suffices.`,
+    `3. \`.shepherd-recap.json\` — the structured verdict. It must be strict, valid JSON with no comments, with EXACTLY this shape:`,
+    `{"verdict": "ready" | "parked" | "needs_attention", "headline": "<string>", "openItems": ["<string>", ...]}`,
+    // #2045: `body` and `blocks` used to live inside this JSON. A single unescaped `"` before a `:`
+    // or `,` — which German `„…":` prose produces constantly — is indistinguishable from a real
+    // key/value boundary, so it silently destroyed complete recaps. Keeping the prose out of the
+    // JSON entirely is the only fix that cannot regress.
+    //
+    // They stay DOCUMENTED OPTIONAL fields, not removed ones: a Codex recap answers in chat and
+    // writes no files at all (its verdict is recovered from the `-o` last-message capture — see
+    // readRoleResultText and defaultReadVerdict in recap.ts). For that provider no sidecar can
+    // exist, so dropping them from the shape would produce a recap with no text in it.
+    `OMIT "body" and "blocks" from that JSON when you wrote the files above — the files always win. Include them inline ONLY if you cannot write files at all (you are answering in chat): then put the markdown in "body", the array in "blocks", and escape every \`"\` inside them as \`\\"\`.`,
+    `Escaping matters ONLY in \`.shepherd-recap.json\`, and — when you wrote the markdown file — it is short: inside "headline" and each "openItems" entry every \`"\` must be written \`\\"\`. If that feels error-prone, phrase them without quotation marks; the markdown file is where quoting is free.`,
+    // Ordering is load-bearing: the server finalizes as soon as the JSON parses, so the JSON must be
+    // written LAST — otherwise a tick landing between the writes finalizes with an empty body.
+    `Write \`${RECAP_BODY_FILE}\` (and \`${RECAP_BLOCKS_FILE}\`, if any) FIRST and \`.shepherd-recap.json\` LAST — the JSON file is the completion signal — then stop.`,
   );
 
   if (input.operatorLanguage === "de") {

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -52,6 +52,9 @@ import {
   buildRecapPrompt,
   isSettledIdle,
   needsRecap,
+  spliceRecapSidecars,
+  RECAP_BODY_FILE,
+  RECAP_BLOCKS_FILE,
 } from "./recap-core";
 import { groundBlocks, type VisualBlock } from "./visual-blocks";
 import {
@@ -177,9 +180,42 @@ export function defaultReadVerdict(cwd: string): VerdictRead<unknown> {
   const text = readRoleResultText(cwd, RECAP_VERDICT_FILE, CODEX_LAST_MESSAGE_FILE);
   if (text === null) return { status: "absent" };
   const r = tolerantParseJson(text);
-  return r.status === "ok"
-    ? { status: "parsed", value: r.value, repaired: r.repaired }
-    : { status: "unparseable", raw: text }; // carry bytes so tick() can log WHY it failed
+  if (r.status !== "ok") return { status: "unparseable", raw: text }; // bytes → tick() logs WHY
+  // #2045: body + blocks travel as sidecar files. Splice them in from the SAME cwd; a missing
+  // sidecar is not an error (the inline field stays valid), so an older prompt, a run already in
+  // flight across a restart, and the Codex chat path all keep working unchanged. Deliberately NOT
+  // reached when the JSON is unparseable: `verdict` is a UI-switched enum that exists only in the
+  // JSON, so there is nothing to salvage the prose onto — the recap stays fail-closed.
+  const value = spliceRecapSidecars(r.value, readRecapBody(cwd), readRecapBlocks(cwd));
+  return { status: "parsed", value, repaired: r.repaired };
+}
+
+/** Read the sidecar body written beside the verdict JSON. null when absent/unreadable (mid-write) —
+ *  never throws, so a sidecar problem can only cost the body, never the whole verdict. */
+function readRecapBody(cwd: string): string | null {
+  const p = join(cwd, RECAP_BODY_FILE);
+  if (!existsSync(p)) return null;
+  try {
+    return readFileSync(p, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+/** Read the sidecar `VisualBlock[]` written beside the verdict JSON. null when absent, unreadable,
+ *  OR unparseable — a mangled blocks file falls back to the inline field (normally absent → `[]`
+ *  via parseVisualBlocks) rather than failing the recap. That fallback IS the point of the file:
+ *  block prose is as quote-heavy as the body, and inline it could sink the whole verdict. Shape
+ *  validation stays downstream in parseVisualBlocks, so anything JSON-ish is passed through. */
+function readRecapBlocks(cwd: string): unknown {
+  const p = join(cwd, RECAP_BLOCKS_FILE);
+  if (!existsSync(p)) return null;
+  try {
+    const r = tolerantParseJson(readFileSync(p, "utf8"));
+    return r.status === "ok" ? r.value : null;
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/test/recap-core.test.ts
+++ b/test/recap-core.test.ts
@@ -11,6 +11,9 @@ import {
   RECAP_VERDICTS,
   RECAP_HEADLINE_MAX,
   RECAP_DIGEST_MAX_CHARS,
+  RECAP_BODY_FILE,
+  RECAP_BLOCKS_FILE,
+  spliceRecapSidecars,
 } from "../src/recap-core";
 import { defaultReadVerdict } from "../src/recap";
 import { tolerantParseJson } from "../src/json-tolerant";
@@ -803,4 +806,164 @@ test("de: buildRecapPrompt carries the VisualBlock verbatim-fields rule (visualB
   for (const field of ["type", "tone", "mermaid.source"]) {
     expect(p).toContain(field);
   }
+});
+
+// ── #2045: prose sidecars (the recap half of the critic's #2042 fix) ────────────────────────────
+//
+// The recap agent hand-authors its verdict JSON, so a bare `"` immediately before `:` or `,` —
+// byte-identical to a real key/value boundary, and produced constantly by German `„…":` prose — is
+// unrecoverable even by jsonrepair. It destroyed a complete recap in production. `body` now travels
+// as markdown (no reserved characters, so no prose can break the read) and `blocks` as its own JSON
+// file (still JSON, but a mangled write can no longer sink the whole verdict).
+
+const RECAP_JSON = ".shepherd-recap.json";
+
+/** Verdict JSON in the post-#2045 shape: no inline body, no inline blocks. */
+function bareVerdict(extra: Record<string, unknown> = {}): string {
+  return JSON.stringify({ verdict: "ready", headline: "h", openItems: [], ...extra });
+}
+
+test("#2045: body sidecar becomes the recap body", () => {
+  const dir = mkdtempSync(join(tmpdir(), "recap-2045-body-"));
+  writeFileSync(join(dir, RECAP_JSON), bareVerdict());
+  writeFileSync(join(dir, ".shepherd-recap.md"), "## What changed\n\nEverything.");
+
+  const read = defaultReadVerdict(dir);
+  if (read.status !== "parsed") throw new Error("expected parsed");
+  expect(parseRecapVerdict(read.value)!.body).toBe("## What changed\n\nEverything.");
+});
+
+test("#2045: body sidecar wins over an inline body (the file is the un-mangled one)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "recap-2045-wins-"));
+  writeFileSync(join(dir, RECAP_JSON), bareVerdict({ body: "stale inline" }));
+  writeFileSync(join(dir, ".shepherd-recap.md"), "sidecar body");
+
+  const read = defaultReadVerdict(dir);
+  if (read.status !== "parsed") throw new Error("expected parsed");
+  expect(parseRecapVerdict(read.value)!.body).toBe("sidecar body");
+});
+
+test("#2045: no sidecar → inline body survives (old prompt / in-flight restart / Codex chat)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "recap-2045-inline-"));
+  writeFileSync(
+    join(dir, RECAP_JSON),
+    JSON.stringify({
+      verdict: "parked",
+      headline: "h",
+      body: "inline body",
+      openItems: ["x"],
+      blocks: [{ type: "rich-text", id: "a", markdown: "inline block" }],
+    }),
+  );
+
+  const read = defaultReadVerdict(dir);
+  if (read.status !== "parsed") throw new Error("expected parsed");
+  const parsed = parseRecapVerdict(read.value)!;
+  expect(parsed.body).toBe("inline body");
+  expect(parsed.blocks).toHaveLength(1);
+  expect(parsed.openItems).toEqual(["x"]);
+});
+
+test("#2045 regression: the unescapable German shape round-trips byte-for-byte via the sidecar", () => {
+  const dir = mkdtempSync(join(tmpdir(), "recap-2045-german-"));
+  // Inline, this exact shape is unrecoverable: the `"` before `:` reads as a key/value boundary.
+  const body = 'Das ist „so nicht mehr": drei Dinge,\nund „auch das", plus ein `"` im Code.';
+  writeFileSync(join(dir, RECAP_JSON), bareVerdict());
+  writeFileSync(join(dir, ".shepherd-recap.md"), body);
+
+  const read = defaultReadVerdict(dir);
+  if (read.status !== "parsed") throw new Error("expected parsed");
+  const parsed = parseRecapVerdict(read.value)!;
+  expect(parsed.verdict).toBe("ready");
+  expect(parsed.body).toBe(body); // byte-for-byte, not merely "contains"
+});
+
+test("#2045: blocks sidecar is parsed and replaces the (absent) inline field", () => {
+  const dir = mkdtempSync(join(tmpdir(), "recap-2045-blocks-"));
+  writeFileSync(join(dir, RECAP_JSON), bareVerdict());
+  writeFileSync(
+    join(dir, ".shepherd-recap-blocks.json"),
+    JSON.stringify([
+      { type: "rich-text", id: "a", markdown: "from the sidecar" },
+      { type: "callout", id: "b", tone: "risk", markdown: "and this" },
+    ]),
+  );
+
+  const read = defaultReadVerdict(dir);
+  if (read.status !== "parsed") throw new Error("expected parsed");
+  const parsed = parseRecapVerdict(read.value)!;
+  expect(parsed.blocks).toHaveLength(2);
+  expect(parsed.blocks[0]).toMatchObject({ type: "rich-text", markdown: "from the sidecar" });
+});
+
+test("#2045: a garbage blocks sidecar costs only the blocks — the recap still lands", () => {
+  const dir = mkdtempSync(join(tmpdir(), "recap-2045-bad-blocks-"));
+  writeFileSync(join(dir, RECAP_JSON), bareVerdict());
+  writeFileSync(join(dir, ".shepherd-recap.md"), "body survived");
+  writeFileSync(join(dir, ".shepherd-recap-blocks.json"), "   \n  "); // irreparable
+
+  const read = defaultReadVerdict(dir);
+  expect(read.status).toBe("parsed");
+  if (read.status !== "parsed") throw new Error("unreachable");
+  const parsed = parseRecapVerdict(read.value)!;
+  expect(parsed.verdict).toBe("ready");
+  expect(parsed.body).toBe("body survived");
+  expect(parsed.blocks).toEqual([]);
+});
+
+test("#2045: unparseable verdict JSON still fails closed even with a valid body sidecar", () => {
+  const dir = mkdtempSync(join(tmpdir(), "recap-2045-failclosed-"));
+  writeFileSync(join(dir, RECAP_JSON), "   \n  "); // irreparable
+  writeFileSync(join(dir, ".shepherd-recap.md"), "a perfectly good recap body");
+
+  // `verdict` is a UI-switched enum that exists ONLY in the JSON, so there is nothing to salvage
+  // the prose onto — inventing one would fake a result.
+  expect(defaultReadVerdict(dir).status).toBe("unparseable");
+});
+
+test("#2045: sidecars splice onto the jsonrepair array shape (chatty agent + sidecar)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "recap-2045-array-"));
+  // jsonrepair turns a prose-wrapped verdict into an ARRAY; the splice must still find the object.
+  writeFileSync(join(dir, RECAP_JSON), `Here is the recap:\n${bareVerdict()}\nDone.`);
+  writeFileSync(join(dir, ".shepherd-recap.md"), "spliced into the unwrapped object");
+
+  const read = defaultReadVerdict(dir);
+  if (read.status !== "parsed") throw new Error("expected parsed");
+  const parsed = parseRecapVerdict(read.value)!;
+  expect(parsed.verdict).toBe("ready");
+  expect(parsed.body).toBe("spliced into the unwrapped object");
+});
+
+test("#2045: prompt names all three files and states the md-first / json-last ordering", () => {
+  const p = buildRecapPrompt({
+    taskPrompt: "t",
+    plan: "",
+    changedFiles: [],
+    digest: "",
+    context: "",
+  });
+  expect(p).toContain(RECAP_BODY_FILE);
+  expect(p).toContain(RECAP_BLOCKS_FILE);
+  expect(p).toContain(RECAP_JSON);
+  // Ordering is load-bearing: the JSON is the completion signal, so it must be written LAST or a
+  // tick landing between the writes finalizes with an empty body.
+  expect(p).toContain(`FIRST and \`${RECAP_JSON}\` LAST`);
+  // The documented shape must no longer carry the prose fields…
+  expect(p).toContain('{"verdict": "ready" | "parked" | "needs_attention", "headline"');
+  expect(p).not.toContain('"body": "<markdown>"');
+  // …but they stay documented as the chat-only fallback (Codex writes no files at all).
+  expect(p).toContain('OMIT "body" and "blocks"');
+});
+
+test("#2045 splice helper: null means no contribution; non-object shapes pass through", () => {
+  expect(spliceRecapSidecars({ verdict: "ready", body: "keep" }, null, null)).toEqual({
+    verdict: "ready",
+    body: "keep",
+  });
+  expect(spliceRecapSidecars({ verdict: "ready", body: "keep" }, "override", null)).toEqual({
+    verdict: "ready",
+    body: "override",
+  });
+  expect(spliceRecapSidecars("not an object", "x", null)).toBe("not an object");
+  expect(spliceRecapSidecars(null, "x", null)).toBeNull();
 });


### PR DESCRIPTION
Closes #2045.

`RecapService` hand-authored its verdict JSON exactly the way the critic did before #2042, so it carried the identical failure: a bare `"` immediately before `:` or `,` is byte-identical to a real key/value boundary. `jsonrepair` cannot resolve that ambiguity — no repairer could — and German prose produces it constantly via `„…":` / `„…",`. It has already thrown away a complete, correct recap in production.

## What changed

- **`body` → `.shepherd-recap.md`.** Markdown has no reserved characters, so the escaping obligation disappears entirely rather than being made more reliable.
- **`blocks` → `.shepherd-recap-blocks.json`**, read tolerantly. Blocks are still JSON, so moving them cannot remove the hazard the way the markdown body does — what it removes is the blast radius. `rich-text.markdown`, `callout.markdown`, `diff.annotations[].note` and quote-dense `wireframe.html` are exactly as prose-heavy as the body was, and inline they could sink the entire verdict. In their own file a mangled write costs only the visual cards.
- What stays in the verdict JSON — `verdict`, `headline`, `openItems[]` — is short and structured, where the model's escaping is reliable in practice. Mirrors the critic's `summary`/`findings` containment.

Went wider than the issue proposed, deliberately: a body-only fix would have left an equally live path to the same total loss.

## Compatibility

`body` and `blocks` stay **documented optional inline fields**, not removed ones:

- A Codex recap answers in chat and writes no files at all — its verdict arrives through the `-o` last-message capture, where no sidecar can exist. Dropping the fields would give that provider a recap with no text.
- The same fallback keeps a run already in flight across a server restart working unchanged.

The prompt states the write ordering explicitly (markdown first, JSON **last**) because `.shepherd-recap.json` is the completion signal `tick()` finalizes on.

## Deliberate non-changes

- **No pre-seed scrub.** The issue asked for this to be checked rather than copied. The recap spawn's cwd is `mkdtempSync(tmpdir(), "shepherd-recap-")` — a fresh empty directory, never an untrusted PR-head checkout. The critic needs `scrubStaleVerdictArtifacts` because its worktree *is* the untrusted head; that attack has no analogue here.
- **Still fail-closed.** An unparseable verdict JSON fails even when a valid markdown sidecar is present. `verdict` is a UI-switched enum that exists only in the JSON, so there is nothing to salvage the prose onto — synthesizing one would fake a result.
- The issue's second observation (archive → `forget()` → `dropReview()` making a healthy review indistinguishable from a failed one) was filed as an observation with no change proposed, and is untouched.

## Verification

Ten new tests in `test/recap-core.test.ts`, including the exact killer shape (`Das ist „so nicht mehr": drei Dinge`) round-tripping byte-for-byte through the sidecar, a garbage blocks sidecar still yielding a `ready` recap, and the no-salvage guarantee. Root `bun run lint` clean, `bun run test` 8731 pass / 0 fail, `tsc --noEmit` clean, `fallow audit --base origin/main` gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
