### PR TITLE
fix(site): register HRB 36940 in imprint, link imprint from docs site

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -67,7 +67,11 @@
     // Head overrides Starlight's `Head` slot to append Vercel Web Analytics. Loaded
     // via the `components: { Head: "./src/components/Head.astro" }` string path in
     // astro.config.mjs — same string-path-root class as SiteBacklink above.
-    "docs-site/src/components/Head.astro"
+    "docs-site/src/components/Head.astro",
+    // Footer overrides Starlight's `Footer` slot to append the § 5 DDG imprint link.
+    // Loaded via the `components: { Footer: "./src/components/Footer.astro" }` string
+    // path in astro.config.mjs — same string-path-root class as Head above.
+    "docs-site/src/components/Footer.astro"
   ],
 
   // sw.js is the service worker: never imported statically — the browser fetches

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -39,6 +39,9 @@ export default defineConfig({
         // Re-render the default Head + append Vercel Web Analytics. See
         // src/components/Head.astro for why an override (vs the `head` config option).
         Head: "./src/components/Head.astro",
+        // Re-render the default Footer + append the § 5 DDG imprint link. See
+        // src/components/Footer.astro.
+        Footer: "./src/components/Footer.astro",
       },
       // Generate the TypeScript API reference from the server package (../src)
       // with TypeDoc, so it CANNOT drift from source. Like syncDocs() above, this

--- a/docs-site/src/components/Footer.astro
+++ b/docs-site/src/components/Footer.astro
@@ -1,0 +1,54 @@
+---
+// Override of Starlight's `Footer` component (registered in astro.config.mjs).
+// Re-renders the default footer unchanged, then appends a legal line.
+//
+// Why an override: docs.shepherd.run is a German-operated site, so a § 5 DDG
+// legal notice has to be clearly labelled and directly reachable from every
+// page. Starlight has no footer-links config option, and `Footer` is the only
+// site-wide slot below the content — so the override follows the same
+// re-render-the-default pattern as src/components/Head.astro and
+// src/components/SiteBacklink.astro.
+//
+// The link points at the single imprint on the marketing site instead of
+// duplicating the company details here: one version, nothing to drift. Same-tab
+// (no target="_blank"), matching the header back-link to shepherd.run.
+//
+// The default renders EditLink, LastUpdated and Pagination itself, so those
+// survive untouched. `<slot />` is forwarded anyway, as Starlight's override
+// guide prescribes: @astrojs/starlight@0.41's Footer.astro drops slotted content
+// today, but forwarding keeps this override correct if that changes.
+//
+// The legal line is a SIBLING of the default's `<footer>`, not a child — the
+// default exposes no slot to nest into, and wrapping it in a second `<footer>`
+// would add a duplicate landmark to every page.
+import Default from "@astrojs/starlight/components/Footer.astro";
+
+const IMPRESSUM_URL = "https://shepherd.run/impressum";
+---
+
+<Default>
+  <slot />
+</Default>
+
+<p class="docs-legal">
+  <a href={IMPRESSUM_URL}>Imprint</a>
+</p>
+
+<style>
+  /* Theme-var only (no raw hex), matching src/styles/custom.css. Muted like the
+     rest of the footer chrome, accented on hover/focus. */
+  .docs-legal {
+    margin-top: 1.5rem;
+    font-size: var(--sl-text-sm);
+  }
+
+  .docs-legal a {
+    color: var(--sl-color-gray-3);
+    text-decoration: none;
+  }
+
+  .docs-legal a:hover,
+  .docs-legal a:focus-visible {
+    color: var(--sl-color-accent-high);
+  }
+</style>

--- a/docs-site/src/components/Footer.astro
+++ b/docs-site/src/components/Footer.astro
@@ -35,15 +35,17 @@ const IMPRESSUM_URL = "https://shepherd.run/impressum";
 </p>
 
 <style>
-  /* Theme-var only (no raw hex), matching src/styles/custom.css. Muted like the
-     rest of the footer chrome, accented on hover/focus. */
+  /* Theme-var only (no raw hex), matching src/styles/custom.css. gray-2 (not the
+     gray-3 Starlight uses for its own non-interactive footer meta): on the dark
+     brand surface gray-3 lands at ~2.6:1, under the 3:1 floor for interactive
+     text. Same rung as the .site-backlink in custom.css. */
   .docs-legal {
     margin-top: 1.5rem;
     font-size: var(--sl-text-sm);
   }
 
   .docs-legal a {
-    color: var(--sl-color-gray-3);
+    color: var(--sl-color-gray-2);
     text-decoration: none;
   }
 

--- a/site/src/pages/impressum.astro
+++ b/site/src/pages/impressum.astro
@@ -51,7 +51,7 @@ const ERWINS_ENKEL_URL = "https://www.erwins-enkel.dev/";
         <p>
           Entry in the Commercial Register.<br />
           Registering court: Amtsgericht Wiesbaden<br />
-          Registration number: HRB [to be provided]
+          Registration number: HRB 36940
         </p>
       </section>
 


### PR DESCRIPTION
Erwins Enkel GmbH ist im Handelsregister eingetragen: **Amtsgericht Wiesbaden, HRB 36940**.

## Was drin ist

- **`site/src/pages/impressum.astro`** — `Registration number: HRB [to be provided]` → `HRB 36940`. Das war die einzige Stelle im Repo mit dem Platzhalter.
- **`docs-site`** — `docs.shepherd.run` hatte bisher **gar keine** Impressumsverlinkung (§ 5 DDG). Neuer Starlight-`Footer`-Override hängt eine Legal-Zeile `Imprint` an, die auf `shepherd.run/impressum` zeigt — statt die Firmendaten ein zweites Mal zu pflegen, wo sie auseinanderlaufen können. Muster wie bei den bestehenden Overrides (`Head.astro`, `SiteBacklink.astro`).
- **`.fallowrc.jsonc`** — der Override wird nur über einen String-Pfad in `astro.config.mjs` geladen, ist für Fallow also eine "unused file"; Eintrag in derselben Liste wie `Head.astro` und `SiteBacklink.astro`.

## Bewusst nicht drin

Die **USt-IdNr. bleibt `DE [to be provided]`** — die Nummer liegt noch nicht vor. Kein Versehen.

## Verifikation

- `site`: `bun run build` + `bun run check:artifacts` grün; im gebauten `dist/impressum/index.html` steht `HRB 36940`, und `[to be provided]` kommt nur noch einmal vor (VAT).
- `docs-site`: `bun run check` (0 errors) + `bun run build` (1936 Seiten) grün; der Imprint-Link ist in gebauten Doc-Seiten **und** auf der Splash-Startseite vorhanden, Pagination/EditLink des Default-Footers bleiben erhalten (der Starlight-Default rendert sie selbst; `<slot />` wird trotzdem durchgereicht, wie es die Override-Doku vorsieht).
- Root: `bun run lint`, `bun run test` (8765 pass), `fallow audit --base origin/main` grün.

## Angrenzender Befund, hier nicht mitgelöst

`docs.shepherd.run` lädt Vercel Web Analytics, hat aber keinen Datenschutz-Link; `site/src/pages/privacy.astro` deckt nur die Capture-Extension ab. Eigene Aufgabe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
