### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs/external-task-api.md
+++ b/docs/external-task-api.md
@@ -226,7 +226,8 @@ Once a task exists, an external agent can also drive it:
   subdir must already exist. The same realpath-containment rules apply. Returns
   `{ "path": "<relpath>" }` (a colliding name is given a numeric suffix rather
   than overwriting). `400` on a missing `file` field, `413` when the file
-  exceeds the upload size limit (10 MiB), and `404` on a missing/archived
+  exceeds the upload size limit (250 MiB — `MAX_UPLOAD_BYTES` in
+  `src/uploads.ts`, uniform across every upload endpoint), and `404` on a missing/archived
   session or an out-of-root `path`.
 
 All of these honor the same auth/origin rules as task creation.


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc sync summary

## Changes

- **`docs/external-task-api.md`** — corrected the documented upload size limit for
  `POST /api/sessions/:id/scratchpad/upload` from **10 MiB** to **250 MiB**, and named the
  constant so it stays traceable. Grounded in `src/uploads.ts:8`
  (`MAX_UPLOAD_BYTES = 250 * 1024 * 1024`, "uniform across all upload endpoints"), which the
  route enforces via `src/server.ts:2635` (`deps.maxUploadBytes ?? MAX_UPLOAD_BYTES`). The cap
  moved in `40119cd7` *feat(uploads): accept 250 MB screen-recording video attachments (#1915)*;
  the prose was never updated.

Nothing else was edited — the rest of the in-scope set checks out against current source:

- `docs-site/src/content/docs/reference/configuration.md` — token scopes (`13b475c1`), the
  membrane launch probe (`e4d60f14`) and the doc-agent knobs are all already described; the
  `SHEPHERD_*` rows match `src/config.ts`.
- `docs-site/src/content/docs/getting-started.md` — herdr ceiling 0.8.0 / protocol 19 and the
  `herdrdev/herdr` org rename already landed with `92b80be1`.
- `docs-site/src/content/docs/operating.md` — the **claude install** (mise) section (`0e961046`)
  and the **Agent launch in sandbox** section (`e4d60f14`) are both present and accurate.
- `docs-site/src/content/docs/reference/glossary.md` — carries all 22 ids in
  `ui/src/lib/glossary.ts`, in registry order.
- `docs/sandbox-security.md` — the `#2111` launch-probe section matches
  `src/membrane-launch.ts` / `src/sandbox.ts`.
- `docs-site/src/content/docs/index.md`, `docs/token-usage-analysis.md` — no drift found
  (the latter is a dated historical report, not a live reference).

## Uncertain / needs human judgment

- **`docs/external-task-api.md`, the `images` request field.** The field name is historical:
  since `7d757b62` (#2121) `POST /api/uploads` accepts **any** file type (`src/uploads.ts:173-177`),
  and `validate.ts` calls them "attachments" in its error strings. The row's actual claims
  (≤10 paths — `MAX_IMAGES = 10` — confined to the staging dir) are still correct, so nothing is
  false; whether to re-label the row as generic attachments is an editorial call I left alone.
- **`index.md` acknowledgement link.** It points at `https://github.com/ogulcancelik` (Can Celik's
  personal profile) while the herdr *repo* moved to `herdrdev/herdr` in `92b80be1`. README and
  getting-started kept the same personal-profile link after that commit, so I read this as
  deliberate rather than stale — but flagging it in case the profile also moved.
- **Undocumented env vars in `configuration.md`.** `src/config.ts` reads a number of variables the
  page doesn't list (e.g. `SHEPHERD_SANDBOX_EXTRA_HOSTS`, `SHEPHERD_NODE_BIN`,
  `SHEPHERD_AUTH_MODE`, `SHEPHERD_STANDARD_COMMAND`, `SHEPHERD_SESSION_HOUSEKEEPING`,
  `SHEPHERD_AUTOPILOT_STEP_CAP`, `SHEPHERD_REVIEW_CYCLES_CAP`, the per-role
  `*_CLI`/`*_MODEL`/`*_EFFORT` triples, the VAPID/push knobs). The page's intro claims "every
  environment variable", but these omissions are long-standing curation, not recent drift, so I
  did not bulk-add rows. Worth a deliberate pass if the page is meant to be exhaustive.