### PR TITLE
fix(commands): surface Claude Code's bundled skills and nested command dirs

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -148,6 +148,74 @@ function safeReaddir(dir: string): string[] {
   }
 }
 
+/** How many directory levels below `commands/` the walk descends.
+ *
+ *  It has to descend at all because Claude Code does: a subdirectory is a namespace joined with
+ *  `:` (`commands/references/handoff-template.md` → `/references:handoff-template`), and a
+ *  subdirectory holding a `SKILL.md` is a skill named after the directory (`commands/ship/SKILL.md`
+ *  → `/ship`). A flat scan silently drops both.
+ *
+ *  It is BOUNDED because entries under `~/.claude` are commonly symlinks into other trees (see
+ *  {@link skillNameFrom}) and `statSync` follows them: a symlink cycle would spin this synchronous
+ *  walk forever inside `handleCommands`, on the one Bun event loop that also pumps the live web
+ *  terminal. Three levels covers every real layout. */
+const MAX_COMMAND_DEPTH = 3;
+
+/** `"dir"` / `"file"` for a `commands/` entry, or null when it is neither or unreadable. */
+function entryKind(path: string): "dir" | "file" | null {
+  try {
+    const stats = statSync(path);
+    return stats.isDirectory() ? "dir" : stats.isFile() ? "file" : null;
+  } catch {
+    return null; // vanished or unreadable → skip, don't fail the whole listing
+  }
+}
+
+/** The command name a `commands/` file contributes, or null when it contributes none. `SKILL.md`
+ *  is excluded because it names the *directory that holds it* — {@link collectCommandSubdir}
+ *  emits that row, and reading it here too would add a bogus `<dir>:SKILL` beside the real one. */
+function commandFileBase(entry: string): string | null {
+  if (!entry.endsWith(".md") || entry === "SKILL.md") return null;
+  return entry.slice(0, -3);
+}
+
+/** One subdirectory of a `commands/` tree: its own `SKILL.md` names the directory (Claude Code
+ *  calls `commands/ship/SKILL.md` just `/ship`), and everything below it is namespaced `<dir>:`. */
+function collectCommandSubdir(
+  dir: string,
+  name: string,
+  scope: SlashCommand["scope"],
+  out: Map<string, SlashCommand>,
+  prefix: string,
+  depth: number,
+) {
+  const md = join(dir, "SKILL.md");
+  const own = existsSync(md) ? readCommand(md, name, scope, prefix, "skill") : null;
+  if (own) out.set(own.name, own);
+  collectCommandDir(dir, scope, out, `${prefix}${name}:`, depth + 1);
+}
+
+/** One level of a `commands/` tree, merging into `out` keyed by name. */
+function collectCommandDir(
+  dir: string,
+  scope: SlashCommand["scope"],
+  out: Map<string, SlashCommand>,
+  prefix: string,
+  depth: number,
+) {
+  for (const entry of safeReaddir(dir)) {
+    const path = join(dir, entry);
+    const kind = entryKind(path);
+    if (kind === "dir") {
+      if (depth < MAX_COMMAND_DEPTH) collectCommandSubdir(path, entry, scope, out, prefix, depth);
+      continue;
+    }
+    const base = kind === "file" ? commandFileBase(entry) : null;
+    const cmd = base === null ? null : readCommand(path, base, scope, prefix);
+    if (cmd) out.set(cmd.name, cmd);
+  }
+}
+
 /** Scan one `.claude`-shaped dir (a real `.claude` or a plugin install root) for
  *  skills + commands, merging into `out` keyed by name. `prefix` namespaces plugin
  *  entries (`fallow:` → `fallow:foo`) so they can't clash with bare user commands. */
@@ -164,18 +232,7 @@ function collect(
     const cmd = readCommand(md, entry, scope, prefix, "skill");
     if (cmd) out.set(cmd.name, cmd);
   }
-  const cmdsDir = join(claudeDir, "commands");
-  for (const entry of safeReaddir(cmdsDir)) {
-    if (!entry.endsWith(".md")) continue;
-    const file = join(cmdsDir, entry);
-    try {
-      if (!statSync(file).isFile()) continue;
-    } catch {
-      continue;
-    }
-    const cmd = readCommand(file, entry.slice(0, -3), scope, prefix);
-    if (cmd) out.set(cmd.name, cmd);
-  }
+  collectCommandDir(join(claudeDir, "commands"), scope, out, prefix, 0);
 }
 
 /**

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -182,15 +182,67 @@ function collect(
  * Curated built-in slash commands that work as an initial prompt for a spawned
  * session. Purely-interactive ones (/clear, /config, /model, /compact) are
  * excluded — they do nothing useful as a first message. Maintained by hand.
+ *
+ * WHY BY HAND, and why this list is the ONLY channel for these: the scans above read the
+ * filesystem, and Claude Code's own bundled skills are not on it — they live inside the `claude`
+ * binary. Nothing under `~/.claude` or a repo can ever surface `/design`; it reaches the picker
+ * here or not at all.
+ *
+ * Discovering them at runtime was measured and rejected: `claude` only emits the full set (its
+ * `init` message's `slash_commands`) during a real `-p --output-format stream-json` run — an empty
+ * stdin exits before it — so reading it costs an API call, and `handleCommands` in `server.ts` is a
+ * sync handler on the single Bun event loop that also pumps the live web terminal.
+ *
+ * THE COST OF THAT CHOICE, and the only guard against it: the list goes stale in both directions.
+ * It shipped `/review` and `/pr-comments` for releases after Claude Code dropped them, handing the
+ * operator a task that opens with a command nothing resolves. Re-check against reality with
+ *
+ *     claude -p --output-format stream-json --verbose hi | head -8
+ *
+ * and diff `init.slash_commands` against `listCommands()`. Note also that some bundled skills are
+ * account-gated (`verify`, `debug`, `batch`, `deep-research`, … appear only for some accounts), so
+ * only broadly-available ones belong here — a gated name would be the `/review` failure again.
  */
 const BUILTINS: ReadonlyArray<{ name: string; description: string }> = [
   { name: "init", description: "Initialize a new CLAUDE.md with codebase documentation" },
-  { name: "review", description: "Review a pull request" },
   {
     name: "security-review",
     description: "Complete a security review of the pending changes on the current branch",
   },
-  { name: "pr-comments", description: "Get comments from a GitHub pull request" },
+  {
+    name: "design",
+    description: "Create a design canvas — a multi-artboard visual design published as an Artifact",
+  },
+  {
+    name: "simplify",
+    description:
+      "Review the changed code for reuse, simplification, and efficiency, then apply the fixes",
+  },
+  { name: "run", description: "Launch and drive this project's app to see a change working" },
+  {
+    name: "dataviz",
+    description: "Design guidance for charts, dashboards, and data visualizations",
+  },
+  {
+    name: "update-config",
+    description:
+      "Configure the Claude Code harness via settings.json — hooks, permissions, env vars",
+  },
+  {
+    name: "fewer-permission-prompts",
+    description: "Scan transcripts and add a prioritized Bash/MCP allowlist to project settings",
+  },
+  {
+    name: "claude-api",
+    description:
+      "Reference for the Claude API / Anthropic SDK — model ids, pricing, params, tool use",
+  },
+  { name: "workflow-authoring", description: "Reference for writing a Workflow tool script" },
+  { name: "loop", description: "Run a prompt or slash command on a recurring interval" },
+  {
+    name: "schedule",
+    description: "Create, update, list, or run scheduled cloud agents (routines)",
+  },
 ];
 
 type CodexConfig = { skills?: { config?: Array<{ path?: unknown; enabled?: unknown }> } };

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -133,9 +133,19 @@ test("missing dirs → builtins only, no throw", () => {
 
 test("curated builtins are always present and scoped builtin", () => {
   const cmds = commands(repo, userClaude);
-  const review = cmds.find((c) => c.name === "review");
-  expect(review?.scope).toBe("builtin");
+  const design = cmds.find((c) => c.name === "design");
+  expect(design?.scope).toBe("builtin");
+  expect(design?.description).not.toBe("");
+  expect(design?.invocations.claude).toBe("/design");
   expect(cmds.some((c) => c.name === "security-review" && c.scope === "builtin")).toBe(true);
+});
+
+// Claude Code dropped /review and /pr-comments; a builtin it no longer resolves opens the spawned
+// session with a dead command, so the list must not carry names that outlive the CLI.
+test("builtins Claude Code no longer ships are gone", () => {
+  const names = commands(repo, userClaude).map((c) => c.name);
+  expect(names).not.toContain("review");
+  expect(names).not.toContain("pr-comments");
 });
 
 test("front-matter argument-hint is surfaced", () => {

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -148,6 +148,46 @@ test("builtins Claude Code no longer ships are gone", () => {
   expect(names).not.toContain("pr-comments");
 });
 
+// Claude Code walks `commands/` recursively: a subdirectory is a `:`-joined namespace, and one
+// holding a SKILL.md is a skill named after the directory. A flat scan drops both silently.
+test("a commands/ subdirectory namespaces its files with a colon", () => {
+  mkdirSync(join(userClaude, "commands", "references"), { recursive: true });
+  writeFileSync(
+    join(userClaude, "commands", "references", "handoff-template.md"),
+    "---\ndescription: handoff shape\n---\nprompt",
+  );
+  const cmd = commands(null, userClaude).find((c) => c.name === "references:handoff-template");
+  expect(cmd?.scope).toBe("user");
+  expect(cmd?.kind).toBe("command");
+  expect(cmd?.description).toBe("handoff shape");
+  expect(cmd?.invocations.claude).toBe("/references:handoff-template");
+});
+
+test("a commands/ subdirectory holding SKILL.md is one skill named after the directory", () => {
+  mkdirSync(join(userClaude, "commands", "ship"), { recursive: true });
+  writeFileSync(
+    join(userClaude, "commands", "ship", "SKILL.md"),
+    "---\nname: ship\ndescription: one-shot shipping workflow\n---\nbody",
+  );
+  const cmds = commands(null, userClaude);
+  expect(cmds.find((c) => c.name === "ship")?.kind).toBe("skill");
+  // the dir's own identity, not a nested command
+  expect(cmds.map((c) => c.name)).not.toContain("ship:SKILL");
+});
+
+test("the commands/ walk is depth-bounded", () => {
+  const deep = join(userClaude, "commands", "a", "b", "c", "d");
+  mkdirSync(deep, { recursive: true });
+  writeFileSync(join(deep, "toodeep.md"), "---\ndescription: past the budget\n---\n");
+  writeFileSync(
+    join(userClaude, "commands", "a", "b", "c", "reached.md"),
+    "---\ndescription: within the budget\n---\n",
+  );
+  const names = commands(null, userClaude).map((c) => c.name);
+  expect(names).toContain("a:b:c:reached");
+  expect(names).not.toContain("a:b:c:d:toodeep");
+});
+
 test("front-matter argument-hint is surfaced", () => {
   command(
     userClaude,


### PR DESCRIPTION
Typing `/design` in the New Task dialog matched `/codebase-design`, `/frontend-design` and
`/shopify-design` — but never `/design` itself, which Claude Code has offered for a while.

## Why it was missing

`listCommands()` builds the picker's list purely from the filesystem — `~/.claude/skills/`,
`~/.claude/commands/`, the plugin cache, `<repo>/.claude/`. Claude Code's **bundled** skills are not
on the filesystem: they live inside the `claude` binary. No scan can ever reach them; the
hand-maintained `BUILTINS` list is their only channel, and it held four entries.

Measured against what `claude` itself reports (`init.slash_commands` from a
`-p --output-format stream-json` run, same repo, same config):

| | before | after |
| --- | --- | --- |
| Shepherd lists | 129 | 139 |
| Claude Code offers | 174 | 174 |

Two separate causes, one commit each.

## 1 · Bundled skills (and two ghosts)

Added the bundled skills that work as an *initial prompt* for a spawned session — `design`,
`simplify`, `run`, `dataviz`, `update-config`, `fewer-permission-prompts`, `claude-api`,
`workflow-authoring`, `loop`, `schedule`. Purely-interactive and administrative commands
(`/clear`, `/config`, `/model`, `/usage`, `/doctor`, …) stay out, which is the criterion the
comment above `BUILTINS` already prescribed.

Removed `/review` and `/pr-comments`: **Claude Code 2.1.250 ships neither**. Picking one opened a
task whose first message was a command nothing resolves — the same staleness this list is prone to
in the other direction. The comment now records how to re-check it (diff `init.slash_commands`
against `listCommands()`), and why runtime discovery was rejected: `claude` only emits that list
during a real `-p` run (empty stdin exits before it), so reading it costs an API call, and
`handleCommands` is a *sync* handler on the one Bun event loop that also pumps the live web
terminal.

Also excluded deliberately: `verify`, `debug`, `batch`, `deep-research`, `design-sync`,
`run-skill-generator` — account-gated, and with no documented description a row for them would be
invented text.

## 2 · Nested `.claude/commands/` directories

`collect()` read only top-level `*.md`. Claude Code walks the tree: a subdirectory is a namespace
joined with `:`, and a subdirectory holding a `SKILL.md` is a skill named after the directory.

```
commands/references/handoff-template.md  →  /references:handoff-template
commands/ship/SKILL.md                   →  /ship
```

Both were dropped silently, so the picker disagreed with the CLI for anyone whose `commands/` has
any structure. `collectCommandDir()` now walks it, **bounded at three levels**: entries under
`~/.claude` are commonly symlinks into other trees and `statSync` follows them, so an unbounded
walk would spin that synchronous handler forever on a cycle.

## Verification

- `bun run lint`, `bun run typecheck`, `bun run test` (8805 pass) — all green.
- Six new/changed assertions in `test/commands.test.ts`: the builtin pin, the two ghosts' absence,
  colon namespacing, `SKILL.md`-names-the-directory (and no bogus `ship:SKILL` row), and the depth
  bound.
- Against the operator's real `~/.claude` **and** the CLI's own list: every added builtin present,
  described and invokable; `review`/`pr-comments` gone; `ship` and `references:handoff-template`
  found.
- The picker's actual ranking function (`filterCommands` in `ui/src/lib/slash.ts`) on the real
  payload — typing `/design` now returns `/design` first, ahead of the four substring matches from
  the bug report. I did not boot a second Shepherd server for a screenshot: that would have run a
  worktree build against the live instance's shared state.

One known, pre-existing and untouched discrepancy remains in the other direction:
`~/.claude/commands/createissue.md` is listed by Shepherd but not by Claude Code, for no pattern I
could find. Unrelated to this change.
