### PR TITLE
feat(issues): name the gh transports behind a failed issue load

### DIFF
--- a/src/forge/gh-attempt.ts
+++ b/src/forge/gh-attempt.ts
@@ -1,0 +1,119 @@
+/**
+ * Per-transport failure record for a `gh`-backed listing.
+ *
+ * `GithubForge.listIssues` draws on two INDEPENDENT GitHub budgets (`gh issue list`
+ * on the GraphQL bucket, `gh api` on the REST bucket) and falls back between them.
+ * When the listing fails, the operator sees only "couldn't load issues" — which
+ * transport was tried, and why each one gave up, dies in the forge. These helpers
+ * carry that trail out on the thrown error so `/api/issues` can report it and the
+ * UI's retry state can name the paths instead of guessing at a rate limit.
+ */
+
+import { isRateLimitError } from "./rate-limit";
+
+/** Which `gh` transport produced the failure. */
+export type GhTransport = "cli" | "rest";
+
+/** Classified cause of one failed transport. `http` is the catch-all for a status
+ *  we don't name specially; `unknown` for output that carries no status at all. */
+export type GhFailureReason =
+  "rate_limit" | "auth" | "not_found" | "gh_missing" | "network" | "http" | "unknown";
+
+/** One executed-and-failed transport, as reported to the UI. */
+export interface GhFetchAttempt {
+  transport: GhTransport;
+  reason: GhFailureReason;
+  /** HTTP status when `gh` reported one (`(HTTP 403)`); absent otherwise. */
+  status?: number;
+  /** Sanitized `gh` output for the UI's hover tooltip. May be empty. */
+  detail: string;
+}
+
+/** Cap on `detail`: enough for a full `gh` error line, short of pasting a stack. */
+const DETAIL_MAX = 300;
+
+/** Token shapes `gh` could echo back (`gh auth token` output pasted into an env,
+ *  a PAT in a remote URL). This text is newly leaving the server for the browser,
+ *  so redact before it travels rather than trusting `gh` to keep quiet. */
+const TOKEN_PATTERNS: RegExp[] = [
+  /\bgh[pousr]_[A-Za-z0-9]{16,}/g,
+  /\bgithub_pat_[A-Za-z0-9_]{16,}/g,
+];
+
+// eslint-disable-next-line no-control-regex -- stripping ANSI SGR sequences requires \x1b
+const ANSI = /\x1b\[[0-9;]*[A-Za-z]/g;
+
+/** Raw text of a `gh` failure: execFile rejections carry stderr, everything else
+ *  falls back to the message. */
+function errorText(err: unknown): string {
+  const e = err as Record<string, unknown> | null | undefined;
+  const stderr = typeof e?.stderr === "string" ? e.stderr : "";
+  const message = typeof e?.message === "string" ? e.message : "";
+  return stderr.trim() || message.trim() || String(err ?? "").trim();
+}
+
+/** ANSI-free, single-line, length-capped, token-redacted view of a `gh` failure. */
+export function sanitizeDetail(raw: string): string {
+  let out = raw.replace(ANSI, "").replace(/\s+/g, " ").trim();
+  for (const p of TOKEN_PATTERNS) out = out.replace(p, "<redacted>");
+  return out.length > DETAIL_MAX ? `${out.slice(0, DETAIL_MAX - 1)}…` : out;
+}
+
+/** First HTTP status `gh` names in its output (`(HTTP 403)`, `HTTP 404:`). */
+function httpStatus(text: string): number | undefined {
+  const m = /\bHTTP (\d{3})\b/i.exec(text);
+  return m ? Number(m[1]) : undefined;
+}
+
+function reasonFor(err: unknown, text: string, status: number | undefined): GhFailureReason {
+  // Binary missing beats every text heuristic — the subprocess never ran, so any
+  // HTTP-looking text would be from somewhere else entirely.
+  if ((err as NodeJS.ErrnoException | null)?.code === "ENOENT") return "gh_missing";
+  // Before the status check: GitHub answers a drained budget with 403, which would
+  // otherwise be reported as a bare permission error.
+  if (isRateLimitError(err)) return "rate_limit";
+  if (status === 401) return "auth";
+  if (status === 404) return "not_found";
+  if (/bad credentials|gh auth login|not logged in|authentication/i.test(text)) return "auth";
+  if (/ENOTFOUND|ECONNREFUSED|ETIMEDOUT|ECONNRESET|EAI_AGAIN/i.test(text)) return "network";
+  if (status !== undefined) return "http";
+  return "unknown";
+}
+
+/** Classify one failed transport for display. */
+export function classifyGhError(transport: GhTransport, err: unknown): GhFetchAttempt {
+  const text = errorText(err);
+  const status = httpStatus(text);
+  const reason = reasonFor(err, text, status);
+  return {
+    transport,
+    reason,
+    // Only carry a status where it adds something the reason doesn't already say.
+    ...(status !== undefined && reason !== "gh_missing" ? { status } : {}),
+    detail: sanitizeDetail(text),
+  };
+}
+
+/** Symbol key so the trail never shows up in `JSON.stringify(err)`, a log line, or
+ *  an equality check on the error's own enumerable properties. */
+const ATTEMPTS = Symbol.for("shepherd.gh.attempts");
+
+/** Attach a transport trail to an error on its way out of the forge. Returns the
+ *  same error (a non-object throw is wrapped, since a symbol can't ride a string). */
+export function attachAttempts(err: unknown, attempts: GhFetchAttempt[]): unknown {
+  const target = typeof err === "object" && err !== null ? err : new Error(String(err));
+  Object.defineProperty(target, ATTEMPTS, {
+    value: attempts,
+    enumerable: false,
+    configurable: true,
+  });
+  return target;
+}
+
+/** Read a transport trail off an error, or null when it carries none (every non-`gh`
+ *  forge, and any failure raised outside the listing itself). */
+export function attemptsOf(err: unknown): GhFetchAttempt[] | null {
+  if (typeof err !== "object" || err === null) return null;
+  const v = (err as Record<symbol, unknown>)[ATTEMPTS];
+  return Array.isArray(v) && v.length > 0 ? (v as GhFetchAttempt[]) : null;
+}

--- a/src/forge/gh-attempt.ts
+++ b/src/forge/gh-attempt.ts
@@ -32,12 +32,31 @@ export interface GhFetchAttempt {
 /** Cap on `detail`: enough for a full `gh` error line, short of pasting a stack. */
 const DETAIL_MAX = 300;
 
-/** Token shapes `gh` could echo back (`gh auth token` output pasted into an env,
- *  a PAT in a remote URL). This text is newly leaving the server for the browser,
- *  so redact before it travels rather than trusting `gh` to keep quiet. */
-const TOKEN_PATTERNS: RegExp[] = [
-  /\bgh[pousr]_[A-Za-z0-9]{16,}/g,
-  /\bgithub_pat_[A-Za-z0-9_]{16,}/g,
+/**
+ * Credential shapes that can ride along in `gh`/git diagnostics. This text is newly
+ * leaving the server for the browser, so redact before it travels rather than
+ * trusting `gh` to keep quiet about what it echoes.
+ *
+ * The label-preserving rules come first: a header or a remote URL keeps its shape
+ * (so the message still reads as a diagnosis) while its secret half goes. Token
+ * literals are matched last, catching anything the shaped rules didn't frame.
+ *
+ * Deliberately NOT matched: a bare 40-hex string. That is the shape of a legacy
+ * OAuth token AND of every git SHA in the output — redacting it would gut the
+ * diagnosis to cover a token type GitHub deprecated in 2021.
+ */
+const REDACTIONS: Array<[RegExp, string]> = [
+  // `Authorization: token …` / `Bearer …` — gh prints request headers under GH_DEBUG=api.
+  [/\b(authorization\s*:\s*)[^\s,;]+(?:\s+[^\s,;]+)?/gi, "$1<redacted>"],
+  // Credentials in a remote URL: https://user:pat@github.com/… (also x-access-token:…).
+  [/\b([a-z][a-z0-9+.-]*:\/\/)[^/\s@]+@/gi, "$1<redacted>@"],
+  // Token-carrying env assignments echoed back in an error line.
+  [/\b((?:GH|GITHUB)(?:_ENTERPRISE)?_TOKEN\s*=\s*)[^\s]+/g, "$1<redacted>"],
+  // GitHub App / installation JWTs (header.payload.signature).
+  [/\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g, "<redacted>"],
+  // gh token literals: ghp_/gho_/ghu_/ghs_/ghr_ and fine-grained PATs.
+  [/\bgh[pousr]_[A-Za-z0-9]{16,}/g, "<redacted>"],
+  [/\bgithub_pat_[A-Za-z0-9_]{16,}/g, "<redacted>"],
 ];
 
 // eslint-disable-next-line no-control-regex -- stripping ANSI SGR sequences requires \x1b
@@ -52,10 +71,11 @@ function errorText(err: unknown): string {
   return stderr.trim() || message.trim() || String(err ?? "").trim();
 }
 
-/** ANSI-free, single-line, length-capped, token-redacted view of a `gh` failure. */
+/** ANSI-free, single-line, credential-redacted, length-capped view of a `gh` failure.
+ *  Redaction runs BEFORE the cap so a secret can never survive as a truncated head. */
 export function sanitizeDetail(raw: string): string {
   let out = raw.replace(ANSI, "").replace(/\s+/g, " ").trim();
-  for (const p of TOKEN_PATTERNS) out = out.replace(p, "<redacted>");
+  for (const [pattern, replacement] of REDACTIONS) out = out.replace(pattern, replacement);
   return out.length > DETAIL_MAX ? `${out.slice(0, DETAIL_MAX - 1)}…` : out;
 }
 

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -12,6 +12,12 @@ import {
 import { classifyPr } from "./pr-kind";
 import { labelColorsFrom } from "./labels";
 import {
+  attachAttempts,
+  classifyGhError,
+  type GhFetchAttempt,
+  type GhTransport,
+} from "./gh-attempt";
+import {
   graphRateLimit,
   isGraphqlBucketCall,
   isRateLimitError,
@@ -823,21 +829,25 @@ export class GithubForge implements GitForge {
    *    itself (the default runner calls `graphRateLimit.noteLimitError`).
    *
    * Both failing rethrows the PREFERRED transport's error — it describes the path
-   * we expected to work, so it is the more useful diagnosis.
+   * we expected to work, so it is the more useful diagnosis. Every transport that
+   * actually ran and failed is recorded on that error ({@link attachAttempts}) so
+   * `/api/issues` can name the paths instead of leaving the operator to guess at a
+   * rate limit. The trail is built as we go, so it always describes what was really
+   * attempted — never a second transport that never ran.
    */
   async listIssues(): Promise<Issue[]> {
-    const restFirst = graphRateLimit.blocked();
-    const preferred = restFirst ? () => this.listIssuesRest() : () => this.listIssuesCli();
-    const fallback = restFirst ? () => this.listIssuesCli() : () => this.listIssuesRest();
-    try {
-      return await preferred();
-    } catch (err) {
+    const order: GhTransport[] = graphRateLimit.blocked() ? ["rest", "cli"] : ["cli", "rest"];
+    const attempts: GhFetchAttempt[] = [];
+    let preferredErr: unknown;
+    for (const [i, transport] of order.entries()) {
       try {
-        return await fallback();
-      } catch {
-        throw err;
+        return await (transport === "rest" ? this.listIssuesRest() : this.listIssuesCli());
+      } catch (err) {
+        attempts.push(classifyGhError(transport, err));
+        if (i === 0) preferredErr = err;
       }
     }
+    throw attachAttempts(preferredErr, attempts);
   }
 
   async getIssue(issueNumber: number): Promise<Issue | null> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -157,6 +157,7 @@ import type {
 import { DEPENDABOT_REBASE_COMMAND, EmptyDiffError, MergeNotCompletedError } from "./forge/types";
 import { buildIssueUrl } from "./forge";
 import { MERGE_ASYNC_MAX_WAIT_MS } from "./forge/github";
+import { attemptsOf } from "./forge/gh-attempt";
 import type { GithubRateLimitPayload } from "./forge/github-rate-limit";
 import { BaseCheckoutBusyError, MergeConflictError } from "./forge/local";
 import { recordEpicIntegrationIfChild, settleMergedSession } from "./merge-teardown";
@@ -5940,6 +5941,50 @@ async function handleRepoInitEmptyCommit({ req, parts }: Ctx): Promise<Response 
   }
 }
 
+/** The GET /api/issues body for a resolved forge: the open listing, or an empty list
+ *  flagged as a failure. Split out of the route so the handler stays a router. */
+async function issuesResponse(forge: GitForge): Promise<Response> {
+  // A lightweight repo answers with an empty list and a null slug BY DESIGN — the
+  // operator turned the mode on themselves. Without this flag the UI can't tell that
+  // apart from a forge repo missing an upstream, and sends them hunting on GitHub for
+  // a state Shepherd is holding. Reported on the failure branch too: the mode is a
+  // property of the repo, not of the request that just failed.
+  const lightweight = forge.isLightweight === true;
+  try {
+    const issues = await listIssuesWithBlockers(forge);
+    return json({
+      slug: forge.slug,
+      webUrl: forge.webUrl ?? null,
+      issues,
+      // The operator's own login, so the UI's "mine & unassigned" filter (#824)
+      // knows who "me" is. Cached in the forge, so no per-request gh cost after
+      // the first call. null when the host can't resolve it (fail open → show all).
+      viewer: (await forge.currentUser?.()) ?? null,
+      lightweight,
+    });
+  } catch (err) {
+    // missing/un-authed CLI, network error, or a rate-limited forge (both gh
+    // transports exhausted — listIssues already tries GraphQL and REST) → empty
+    // list, but flag it as a fetch failure so the UI can say "couldn't load"
+    // instead of the indistinguishable "no open issues".
+    //
+    // `attempts` names the gh transports that actually ran and how each one gave
+    // up, so the retry state can say *which* path failed. Present only when the
+    // error carries a trail (GithubForge listings) — a Gitea/local failure, or one
+    // raised outside listIssues, keeps the response exactly as it was.
+    const attempts = attemptsOf(err);
+    return json({
+      slug: forge.slug,
+      webUrl: forge.webUrl ?? null,
+      issues: [],
+      viewer: null,
+      error: "fetch_failed",
+      lightweight,
+      ...(attempts ? { attempts } : {}),
+    });
+  }
+}
+
 async function handleIssues({ req, parts, url, deps }: Ctx): Promise<Response | null> {
   if (req.method === "GET" && parts[0] === "api" && parts[1] === "issues" && !parts[2]) {
     const dir = safeRepoDir(url.searchParams.get("repo") ?? "", config.repoRoot);
@@ -5947,38 +5992,7 @@ async function handleIssues({ req, parts, url, deps }: Ctx): Promise<Response | 
     const forge = deps.resolveForge?.(dir) ?? null;
     if (!forge)
       return json({ slug: null, webUrl: null, issues: [], viewer: null, lightweight: false });
-    // A lightweight repo answers with an empty list and a null slug BY DESIGN — the
-    // operator turned the mode on themselves. Without this flag the UI can't tell that
-    // apart from a forge repo missing an upstream, and sends them hunting on GitHub for
-    // a state Shepherd is holding. Reported on the failure branch too: the mode is a
-    // property of the repo, not of the request that just failed.
-    const lightweight = forge.isLightweight === true;
-    try {
-      const issues = await listIssuesWithBlockers(forge);
-      return json({
-        slug: forge.slug,
-        webUrl: forge.webUrl ?? null,
-        issues,
-        // The operator's own login, so the UI's "mine & unassigned" filter (#824)
-        // knows who "me" is. Cached in the forge, so no per-request gh cost after
-        // the first call. null when the host can't resolve it (fail open → show all).
-        viewer: (await forge.currentUser?.()) ?? null,
-        lightweight,
-      });
-    } catch {
-      // missing/un-authed CLI, network error, or a rate-limited forge (both gh
-      // transports exhausted — listIssues already tries GraphQL and REST) → empty
-      // list, but flag it as a fetch failure so the UI can say "couldn't load"
-      // instead of the indistinguishable "no open issues".
-      return json({
-        slug: forge.slug,
-        webUrl: forge.webUrl ?? null,
-        issues: [],
-        viewer: null,
-        error: "fetch_failed",
-        lightweight,
-      });
-    }
+    return issuesResponse(forge);
   }
   return null;
 }

--- a/test/forge/gh-attempt.test.ts
+++ b/test/forge/gh-attempt.test.ts
@@ -72,11 +72,57 @@ test("sanitizeDetail: strips ANSI, collapses whitespace, caps at 300 chars", () 
   expect(long.endsWith("…")).toBe(true);
 });
 
-test("sanitizeDetail: redacts token shapes before they reach the browser", () => {
+test("sanitizeDetail: redacts token literals before they reach the browser", () => {
   const out = sanitizeDetail(
     "gh: bad credentials for ghp_abcdefghijklmnopqrstuvwxyz0123 and github_pat_ABCDEFGHIJKLMNOPQRSTUV",
   );
   expect(out).toBe("gh: bad credentials for <redacted> and <redacted>");
+  // The other four prefixes are credentials too, not just ghp_.
+  expect(sanitizeDetail("gho_ABCDEFGHIJKLMNOPQRSTUV ghs_ABCDEFGHIJKLMNOPQRSTUV")).toBe(
+    "<redacted> <redacted>",
+  );
+});
+
+test("sanitizeDetail: redacts the secret half of a header, URL or env assignment", () => {
+  // gh prints request headers under GH_DEBUG=api — the label survives, the value does not.
+  expect(sanitizeDetail("> Authorization: token ghp_abcdefghijklmnopqrstuvwxyz0123")).toBe(
+    "> Authorization: <redacted>",
+  );
+  expect(sanitizeDetail("Authorization: Bearer a-token-with-no-known-prefix")).toBe(
+    "Authorization: <redacted>",
+  );
+  // Credentials embedded in a remote URL, including the Actions x-access-token form.
+  expect(sanitizeDetail("fatal: could not read https://kai:hunter2@github.com/o/r.git")).toBe(
+    "fatal: could not read https://<redacted>@github.com/o/r.git",
+  );
+  expect(sanitizeDetail("https://x-access-token:ghs_ABCDEFGHIJKLMNOPQRSTUV@github.com/o/r")).toBe(
+    "https://<redacted>@github.com/o/r",
+  );
+  expect(sanitizeDetail("GH_TOKEN=sekrit is not valid; GITHUB_TOKEN=other too")).toBe(
+    "GH_TOKEN=<redacted> is not valid; GITHUB_TOKEN=<redacted> too",
+  );
+  // GitHub App / installation JWT.
+  expect(
+    sanitizeDetail("jwt eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiIxMjM0NTYifQ.c2lnbmF0dXJlLWhlcmU"),
+  ).toBe("jwt <redacted>");
+});
+
+test("sanitizeDetail: leaves an ordinary diagnosis — URLs and SHAs — readable", () => {
+  // A credential-free URL must survive intact, or the tooltip stops being a diagnosis.
+  expect(sanitizeDetail("gh: Not Found (https://api.github.com/repos/o/r/issues)")).toBe(
+    "gh: Not Found (https://api.github.com/repos/o/r/issues)",
+  );
+  // 40-hex is a git SHA far more often than a legacy token; redacting it would gut
+  // the message. Pinned so a future widening has to argue with this test.
+  const sha = "0123456789abcdef0123456789abcdef01234567";
+  expect(sanitizeDetail(`gh: commit ${sha} not found`)).toBe(`gh: commit ${sha} not found`);
+});
+
+test("sanitizeDetail: a secret cannot survive the length cap as a truncated head", () => {
+  // Redaction runs before truncation: the cap must never slice a token in half and
+  // ship the front of it.
+  const out = sanitizeDetail(`${"x".repeat(290)} ghp_abcdefghijklmnopqrstuvwxyz0123`);
+  expect(out).not.toContain("ghp_");
 });
 
 test("attachAttempts/attemptsOf: round-trips without touching enumerable properties", () => {

--- a/test/forge/gh-attempt.test.ts
+++ b/test/forge/gh-attempt.test.ts
@@ -1,0 +1,104 @@
+import { test, expect } from "bun:test";
+import {
+  attachAttempts,
+  attemptsOf,
+  classifyGhError,
+  sanitizeDetail,
+  type GhFetchAttempt,
+} from "../../src/forge/gh-attempt";
+
+/** execFile-shaped rejection: `gh` writes its diagnosis to stderr. */
+function ghError(stderr: string, extra: Record<string, unknown> = {}): Error {
+  return Object.assign(new Error("Command failed: gh"), { stderr, ...extra });
+}
+
+test("classifyGhError: a drained budget reads as rate_limit, not a bare 403", () => {
+  // GitHub answers an exhausted bucket with 403; without the rate-limit check
+  // running first the operator would be told they lack permission.
+  const a = classifyGhError("rest", ghError("gh: API rate limit exceeded for user (HTTP 403)"));
+  expect(a).toEqual({
+    transport: "rest",
+    reason: "rate_limit",
+    status: 403,
+    detail: "gh: API rate limit exceeded for user (HTTP 403)",
+  });
+});
+
+test("classifyGhError: HTTP 401 and credential text both read as auth", () => {
+  expect(classifyGhError("cli", ghError("gh: Bad credentials (HTTP 401)")).reason).toBe("auth");
+  expect(
+    classifyGhError("cli", ghError("To get started with GitHub CLI, please run: gh auth login"))
+      .reason,
+  ).toBe("auth");
+});
+
+test("classifyGhError: HTTP 404 reads as not_found", () => {
+  const a = classifyGhError("rest", ghError("gh: Not Found (HTTP 404)"));
+  expect(a.reason).toBe("not_found");
+  expect(a.status).toBe(404);
+});
+
+test("classifyGhError: ENOENT reads as gh_missing and carries no status", () => {
+  const a = classifyGhError("cli", Object.assign(new Error("spawn gh ENOENT"), { code: "ENOENT" }));
+  expect(a.reason).toBe("gh_missing");
+  expect(a.status).toBeUndefined();
+});
+
+test("classifyGhError: connection failures read as network", () => {
+  expect(
+    classifyGhError("rest", ghError("dial tcp: lookup api.github.com: ENOTFOUND")).reason,
+  ).toBe("network");
+  expect(classifyGhError("rest", ghError("connect ECONNREFUSED 127.0.0.1:443")).reason).toBe(
+    "network",
+  );
+});
+
+test("classifyGhError: an unnamed status falls through to http; no status at all to unknown", () => {
+  const http = classifyGhError("rest", ghError("gh: Server Error (HTTP 502)"));
+  expect(http.reason).toBe("http");
+  expect(http.status).toBe(502);
+  expect(classifyGhError("cli", ghError("gh: something went sideways")).reason).toBe("unknown");
+});
+
+test("classifyGhError: falls back to the message when there is no stderr", () => {
+  expect(classifyGhError("cli", new Error("cli boom")).detail).toBe("cli boom");
+  expect(classifyGhError("cli", "plain throw").detail).toBe("plain throw");
+});
+
+test("sanitizeDetail: strips ANSI, collapses whitespace, caps at 300 chars", () => {
+  expect(sanitizeDetail("\x1b[31mgh:\x1b[0m  API\n rate  limit")).toBe("gh: API rate limit");
+  const long = sanitizeDetail("x".repeat(500));
+  expect(long).toHaveLength(300);
+  expect(long.endsWith("…")).toBe(true);
+});
+
+test("sanitizeDetail: redacts token shapes before they reach the browser", () => {
+  const out = sanitizeDetail(
+    "gh: bad credentials for ghp_abcdefghijklmnopqrstuvwxyz0123 and github_pat_ABCDEFGHIJKLMNOPQRSTUV",
+  );
+  expect(out).toBe("gh: bad credentials for <redacted> and <redacted>");
+});
+
+test("attachAttempts/attemptsOf: round-trips without touching enumerable properties", () => {
+  const attempts: GhFetchAttempt[] = [{ transport: "cli", reason: "rate_limit", detail: "boom" }];
+  const err = new Error("cli boom");
+  expect(attachAttempts(err, attempts)).toBe(err);
+  expect(attemptsOf(err)).toEqual(attempts);
+  // The trail must not leak into logs or serialized error payloads.
+  expect(Object.keys(err)).toEqual([]);
+  expect(JSON.stringify(err)).toBe("{}");
+});
+
+test("attachAttempts: a non-object throw is wrapped so the trail survives", () => {
+  const attempts: GhFetchAttempt[] = [{ transport: "rest", reason: "unknown", detail: "nope" }];
+  const wrapped = attachAttempts("nope", attempts);
+  expect(wrapped).toBeInstanceOf(Error);
+  expect((wrapped as Error).message).toBe("nope");
+  expect(attemptsOf(wrapped)).toEqual(attempts);
+});
+
+test("attemptsOf: null for an untagged error, a non-object, and an empty trail", () => {
+  expect(attemptsOf(new Error("plain"))).toBeNull();
+  expect(attemptsOf("nope")).toBeNull();
+  expect(attemptsOf(attachAttempts(new Error("plain"), []))).toBeNull();
+});

--- a/test/forge/github.test.ts
+++ b/test/forge/github.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "bun:test";
 import { GithubForge, reviewerStatesFromReviews } from "../../src/forge/github";
 import { graphRateLimit } from "../../src/forge/rate-limit";
+import { attemptsOf } from "../../src/forge/gh-attempt";
 import { CRITIC_REVIEW_MARKER, EmptyDiffError } from "../../src/forge/types";
 import type { PullRequest, PrReviewerState, PrStatus } from "../../src/forge/types";
 import type { GhReview } from "../../src/forge/github";
@@ -339,6 +340,56 @@ test("GithubForge.listIssues: both transports failing rethrows the preferred pat
   };
   unblockGraphql();
   await expect(new GithubForge("o/r", {}, run).listIssues()).rejects.toThrow("cli boom");
+});
+
+// The trail is what /api/issues reports to the operator's retry state, so it must
+// name the transports that ACTUALLY ran, in the order they ran — the rethrown error
+// only ever describes one of them.
+test("GithubForge.listIssues: the rethrown error carries both failed transports in order", async () => {
+  const run = async (args: string[]): Promise<string> => {
+    throw new Error(
+      args[0] === "issue" ? "gh: Bad credentials (HTTP 401)" : "gh: Not Found (HTTP 404)",
+    );
+  };
+  unblockGraphql();
+  const err = await new GithubForge("o/r", {}, run).listIssues().catch((e: unknown) => e);
+  expect(attemptsOf(err)).toEqual([
+    { transport: "cli", reason: "auth", status: 401, detail: "gh: Bad credentials (HTTP 401)" },
+    { transport: "rest", reason: "not_found", status: 404, detail: "gh: Not Found (HTTP 404)" },
+  ]);
+});
+
+test("GithubForge.listIssues: during a GraphQL backoff the trail leads with REST", async () => {
+  const run = async (args: string[]): Promise<string> => {
+    throw new Error(args[0] === "issue" ? "cli boom" : "gh: API rate limit exceeded (HTTP 403)");
+  };
+  blockGraphql();
+  try {
+    const err = await new GithubForge("o/r", {}, run).listIssues().catch((e: unknown) => e);
+    expect((err as Error).message).toBe("gh: API rate limit exceeded (HTTP 403)");
+    expect(attemptsOf(err)?.map((a) => [a.transport, a.reason])).toEqual([
+      ["rest", "rate_limit"],
+      ["cli", "unknown"],
+    ]);
+  } finally {
+    unblockGraphql();
+  }
+});
+
+test("GithubForge.listIssues: a transport that answers leaves no trail behind", async () => {
+  // Only a failure carries a trail: when the fallback answers there is nothing to
+  // explain, and the successful path must not look like an error to any caller.
+  const run = async (args: string[]): Promise<string> => {
+    if (args[0] === "issue") throw new Error("cli boom");
+    if (args.includes("repos/o/r/issues"))
+      return JSON.stringify([
+        { number: 7, title: "From REST", html_url: "u7", created_at: ISSUE_CREATED_AT },
+      ]);
+    return "[]";
+  };
+  unblockGraphql();
+  const issues = await new GithubForge("o/r", {}, run).listIssues();
+  expect(issues.map((i) => i.number)).toEqual([7]);
 });
 
 test("GithubForge.listIssues: requests the assignees field from gh (#824)", async () => {

--- a/test/server-issues.test.ts
+++ b/test/server-issues.test.ts
@@ -6,6 +6,7 @@ import type { SessionStore } from "../src/store";
 import type { SessionService } from "../src/service";
 import type { EventHub } from "../src/events";
 import type { GitForge, Issue } from "../src/forge/types";
+import { attachAttempts, type GhFetchAttempt } from "../src/forge/gh-attempt";
 import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import { config } from "../src/config";
 
@@ -122,7 +123,9 @@ test("GET /api/issues flags forge errors → {slug, issues:[], error}", async ()
   const res = await app.fetch(req(repoDir));
   expect(res.status).toBe(200);
   // Empty issues but error set, so the UI can say "couldn't load" instead of
-  // the indistinguishable "no open issues" (e.g. a rate-limited forge).
+  // the indistinguishable "no open issues" (e.g. a rate-limited forge). An error
+  // with no gh transport trail (Gitea/local, or a failure raised outside the
+  // listing) must leave the body exactly as it was — hence the whole-body compare.
   expect(await res.json()).toEqual({
     slug: "team/proj",
     webUrl: null,
@@ -131,6 +134,47 @@ test("GET /api/issues flags forge errors → {slug, issues:[], error}", async ()
     error: "fetch_failed",
     lightweight: false,
   });
+});
+
+// The gh transport trail is what lets the retry state say WHICH path failed instead of
+// guessing at a rate limit. It rides the thrown error, so the handler must pass it on.
+test("GET /api/issues reports the gh transports that failed", async () => {
+  const attempts: GhFetchAttempt[] = [
+    { transport: "cli", reason: "rate_limit", status: 403, detail: "gh: API rate limit exceeded" },
+    { transport: "rest", reason: "auth", status: 401, detail: "gh: Bad credentials" },
+  ];
+  const app = makeApp(
+    makeDeps(() =>
+      fakeForge({
+        listIssues: async () => {
+          throw attachAttempts(new Error("gh: API rate limit exceeded"), attempts);
+        },
+      }),
+    ),
+  );
+  const res = await app.fetch(req(repoDir));
+  const body = await res.json();
+  expect(body.error).toBe("fetch_failed");
+  expect(body.attempts).toEqual(attempts);
+});
+
+test("GET /api/issues reports a single transport when only one ran", async () => {
+  // A trail of one is a real outcome, not a truncated pair — the response must not
+  // imply a second transport was tried.
+  const attempts: GhFetchAttempt[] = [
+    { transport: "cli", reason: "gh_missing", detail: "spawn gh ENOENT" },
+  ];
+  const app = makeApp(
+    makeDeps(() =>
+      fakeForge({
+        listIssues: async () => {
+          throw attachAttempts(new Error("spawn gh ENOENT"), attempts);
+        },
+      }),
+    ),
+  );
+  const body = await (await app.fetch(req(repoDir))).json();
+  expect(body.attempts).toEqual(attempts);
 });
 
 // A lightweight repo's empty list and null slug are DELIBERATE. Without this flag the UI

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3719,5 +3719,17 @@
   "gloss_lead_time_term": "Durchlaufzeit",
   "gloss_lead_time_def": "Wie lange eine Aufgabe von Anfang bis Ende gedauert hat: vom Anlegen der Session bis zum Merge ihres Pull Requests. Der Begriff stammt aus der schlanken Produktion, wo er die Spanne zwischen Anforderung und Lieferung misst.",
   "feat_delivery_metrics_title": "Liefer-Metriken",
-  "feat_delivery_metrics_body": "Die Nutzungsansicht hat einen neuen Tab „Lieferung“: Erst-Durchlauf-Quote, Nacharbeits-Runden, Plan-Nacharbeit, Zeit bis zum ersten Review und Durchlaufzeit — pro Repository und im Zeitverlauf. Die Kosten-Linsen zeigen, was eine Aufgabe verbraucht hat; diese zeigt, ob der Prozess besser wird. Die Erfassung beginnt jetzt, die Zahlen füllen sich mit jedem Merge."
+  "feat_delivery_metrics_body": "Die Nutzungsansicht hat einen neuen Tab „Lieferung“: Erst-Durchlauf-Quote, Nacharbeits-Runden, Plan-Nacharbeit, Zeit bis zum ersten Review und Durchlaufzeit — pro Repository und im Zeitverlauf. Die Kosten-Linsen zeigen, was eine Aufgabe verbraucht hat; diese zeigt, ob der Prozess besser wird. Die Erfassung beginnt jetzt, die Zahlen füllen sich mit jedem Merge.",
+  "issues_attempts_label": "Versucht:",
+  "issues_transport_cli": "gh issue list (GraphQL)",
+  "issues_transport_rest": "gh api (REST)",
+  "issues_attempt_rate_limit": "Rate-Limit",
+  "issues_attempt_auth": "nicht angemeldet",
+  "issues_attempt_not_found": "Repo nicht gefunden",
+  "issues_attempt_gh_missing": "gh nicht installiert",
+  "issues_attempt_network": "Netzwerkfehler",
+  "issues_attempt_http": "HTTP {status}",
+  "issues_attempt_unknown": "unbekannter Fehler",
+  "feat_issue_load_transports_title": "Scheitert das Laden der Issues, steht jetzt da, welcher Weg scheiterte",
+  "feat_issue_load_transports_body": "Shepherd lädt GitHub-Issues über zwei unabhängige Budgets — `gh issue list` auf dem GraphQL-Kontingent und `gh api` auf dem REST-Kontingent — und weicht bei einem Fehler auf den anderen Weg aus. Geben beide auf, sagen das Neue-Aufgabe-Modal und das Issues-Panel nicht mehr bloß „konnten nicht geladen werden“: Sie listen jeden Transport, der wirklich lief, samt Grund (Rate-Limit, nicht angemeldet, HTTP-Status, gh fehlt, Netzwerk). Der Mauszeiger auf einer Zeile zeigt die volle gh-Meldung. Ein „Erneut versuchen“ sagt damit, ob du auf ein Kontingent warten oder deine gh-Anmeldung reparieren musst."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3719,5 +3719,17 @@
   "gloss_lead_time_term": "lead time",
   "gloss_lead_time_def": "How long a task took end to end: from the moment the session was created to the moment its pull request merged. Borrowed from lean manufacturing, where it measures the delay between a request and its delivery.",
   "feat_delivery_metrics_title": "Delivery metrics",
-  "feat_delivery_metrics_body": "Usage has a new Delivery tab: first-pass rate, rework rounds, plan rework, time to first review and lead time — per repository and over time. The cost lenses tell you what a task spent; this one tells you whether the process is improving. Recording starts now, so the numbers fill in as tasks merge."
+  "feat_delivery_metrics_body": "Usage has a new Delivery tab: first-pass rate, rework rounds, plan rework, time to first review and lead time — per repository and over time. The cost lenses tell you what a task spent; this one tells you whether the process is improving. Recording starts now, so the numbers fill in as tasks merge.",
+  "issues_attempts_label": "Tried:",
+  "issues_transport_cli": "gh issue list (GraphQL)",
+  "issues_transport_rest": "gh api (REST)",
+  "issues_attempt_rate_limit": "rate limit",
+  "issues_attempt_auth": "not signed in",
+  "issues_attempt_not_found": "repo not found",
+  "issues_attempt_gh_missing": "gh not installed",
+  "issues_attempt_network": "network error",
+  "issues_attempt_http": "HTTP {status}",
+  "issues_attempt_unknown": "unknown error",
+  "feat_issue_load_transports_title": "A failed issue load names the path that failed",
+  "feat_issue_load_transports_body": "Shepherd lists GitHub issues over two independent budgets — `gh issue list` on the GraphQL bucket and `gh api` on the REST bucket — and falls back from one to the other. When both give up, the New Task modal and the Issues panel no longer just say “couldn't load”: they list each transport that actually ran and why it stopped (rate limit, not signed in, HTTP status, gh missing, network). Hover a line for the full gh message. So a retry tells you whether to wait for a budget to reset or to fix your gh login."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -5,6 +5,7 @@ import type {
   HeldResult,
   RepoEntry,
   Issue,
+  IssueFetchAttempt,
   PullRequest,
   ActivityEntry,
   SessionUsage,
@@ -1195,6 +1196,10 @@ export async function listIssues(repoPath: string): Promise<{
    *  `GitForge.isLightweight` — absent ⇒ falsy ⇒ not lightweight — so callers must
    *  test it as `=== true`. The server always sends an explicit boolean. */
   lightweight?: boolean;
+  /** The gh transports that ran and failed, in the order they ran — so the retry
+   *  state can name the path that gave up instead of guessing at a rate limit.
+   *  GitHub listings only, and only alongside `error`; absent everywhere else. */
+  attempts?: IssueFetchAttempt[];
 }> {
   const r = await fetch(`/api/issues?repo=${encodeURIComponent(repoPath)}`);
   if (!r.ok) throw await failed(r, "issues");

--- a/ui/src/lib/components/IssueLoadAttempts.svelte
+++ b/ui/src/lib/components/IssueLoadAttempts.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+  /**
+   * The gh transports that ran and failed behind a "couldn't load issues" state.
+   *
+   * GitHub answers issue listings over two INDEPENDENT budgets (`gh issue list` on
+   * the GraphQL bucket, `gh api` on the REST bucket) and Shepherd falls back from one
+   * to the other, so "couldn't load" alone leaves the operator guessing at a rate
+   * limit when the real cause may be an expired login. Each line names one transport
+   * that actually ran, in the order it ran; hovering reveals the full gh message.
+   *
+   * Renders ONLY the trail — the failure sentence and the retry control stay with the
+   * caller, whose type scale and padding differ (the modal runs on --fs-meta, the
+   * panel on --fs-base), which is why sizing here is inherited rather than set.
+   */
+  import type { IssueFetchAttempt } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  import { statusTip } from "$lib/actions/statusTip.svelte";
+
+  const {
+    attempts,
+    /** Suppress the tooltip's entrance animation on motion-free surfaces (New Task). */
+    still = false,
+  }: { attempts: IssueFetchAttempt[]; still?: boolean } = $props();
+
+  function transportLabel(a: IssueFetchAttempt): string {
+    switch (a.transport) {
+      case "cli":
+        return m.issues_transport_cli();
+      case "rest":
+        return m.issues_transport_rest();
+      // Wire data: a transport this build doesn't know is shown verbatim rather than
+      // dropped — naming an unfamiliar path still beats naming none.
+      default:
+        return a.transport;
+    }
+  }
+
+  function reasonLabel(a: IssueFetchAttempt): string {
+    switch (a.reason) {
+      case "rate_limit":
+        return m.issues_attempt_rate_limit();
+      case "auth":
+        return m.issues_attempt_auth();
+      case "not_found":
+        return m.issues_attempt_not_found();
+      case "gh_missing":
+        return m.issues_attempt_gh_missing();
+      case "network":
+        return m.issues_attempt_network();
+      // `http` without a status would render "HTTP undefined"; fall through instead.
+      case "http":
+        return a.status === undefined
+          ? m.issues_attempt_unknown()
+          : m.issues_attempt_http({ status: a.status });
+      default:
+        return m.issues_attempt_unknown();
+    }
+  }
+</script>
+
+{#if attempts.length > 0}
+  <div class="attempts">
+    <span class="attempts-label">{m.issues_attempts_label()}</span>
+    <ul class="attempt-list">
+      <!-- Keyed by index: the trail is a short, positional record of one fetch, and
+           the same transport can legitimately appear twice across future orders. -->
+      {#each attempts as a, i (i)}
+        <li class="attempt" use:statusTip={a.detail ? { text: a.detail, still, wide: true } : null}>
+          <span class="attempt-transport">{transportLabel(a)}</span>
+          <span class="attempt-arrow" aria-hidden="true">→</span>
+          <span class="attempt-reason">{reasonLabel(a)}</span>
+        </li>
+      {/each}
+    </ul>
+  </div>
+{/if}
+
+<style>
+  .attempts {
+    /* Inherit the caller's type scale — this block is a continuation of its
+       failure sentence, not a surface of its own. */
+    font-family: var(--font-mono);
+    font-size: inherit;
+    color: var(--color-faint);
+    margin-top: 6px;
+  }
+
+  .attempts-label {
+    display: block;
+  }
+
+  .attempt-list {
+    list-style: none;
+    margin: 0;
+    padding: 0 0 0 12px;
+  }
+
+  .attempt {
+    /* Fits the widest line without wrapping mid-reason on a narrow panel. */
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    width: fit-content;
+    max-width: 100%;
+  }
+
+  .attempt-transport {
+    /* One step brighter than the surrounding faint text: the command name is the
+       part the operator scans for. */
+    color: var(--color-muted);
+  }
+</style>

--- a/ui/src/lib/components/IssuesPanel.browser.test.ts
+++ b/ui/src/lib/components/IssuesPanel.browser.test.ts
@@ -215,6 +215,80 @@ describe("IssuesPanel empty vs fetch-failed", () => {
       .toContain(m.common_issues_load_failed());
     expect(document.querySelector(".issues-list")?.textContent).not.toContain(m.common_loading());
   });
+
+  // The two gh transports draw on independent budgets, so "couldn't load" alone
+  // doesn't say whether to wait for a reset or fix a login. Name what actually ran.
+  it("names each gh transport that failed, in the order it ran", async () => {
+    mockListIssues.mockResolvedValue({
+      slug: "owner/repo",
+      webUrl: null,
+      issues: [],
+      viewer: null,
+      error: "fetch_failed",
+      attempts: [
+        {
+          transport: "rest",
+          reason: "rate_limit",
+          status: 403,
+          detail: "gh: rate limit (HTTP 403)",
+        },
+        { transport: "cli", reason: "auth", status: 401, detail: "gh: Bad credentials (HTTP 401)" },
+      ],
+    });
+    mockGetEpics.mockResolvedValue({ epics: [], subIssues: [] });
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
+
+    await expect
+      .poll(() => document.querySelector(".issues-list")?.textContent)
+      .toContain(m.issues_attempts_label());
+    const lines = Array.from(document.querySelectorAll(".issues-list .attempt")).map(
+      (el) => el.textContent?.replace(/\s+/g, " ").trim() ?? "",
+    );
+    expect(lines).toEqual([
+      `${m.issues_transport_rest()} → ${m.issues_attempt_rate_limit()}`,
+      `${m.issues_transport_cli()} → ${m.issues_attempt_auth()}`,
+    ]);
+  });
+
+  it("drops the transport trail once a retry succeeds", async () => {
+    // The trail explains one failed fetch; leaving it up over recovered data would
+    // report a state that no longer exists.
+    mockListIssues
+      .mockResolvedValueOnce({
+        slug: "owner/repo",
+        webUrl: null,
+        issues: [],
+        viewer: null,
+        error: "fetch_failed",
+        attempts: [{ transport: "cli", reason: "network", detail: "ECONNREFUSED" }],
+      })
+      .mockResolvedValueOnce({
+        slug: "owner/repo",
+        webUrl: null,
+        issues: [
+          {
+            number: 42,
+            title: "Recovered issue",
+            body: "",
+            url: "https://example.com/issues/42",
+            labels: [],
+            createdAt: 0,
+            assignees: [],
+          },
+        ],
+        viewer: null,
+      });
+    mockGetEpics.mockResolvedValue({ epics: [], subIssues: [] });
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
+
+    await expect.poll(() => document.querySelectorAll(".issues-list .attempt").length).toBe(1);
+    (document.querySelector(".issues-list .retry-link") as HTMLButtonElement).click();
+
+    await expect
+      .poll(() => document.querySelector(".issues-list")?.textContent)
+      .toContain("Recovered issue");
+    expect(document.querySelectorAll(".issues-list .attempt")).toHaveLength(0);
+  });
 });
 
 describe("IssuesPanel compact issue rows", () => {

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -3,7 +3,7 @@
   import { steers } from "$lib/steers.svelte";
   import { repos } from "$lib/repos.svelte";
   import { steerAppliesToRepo } from "$lib/steer-scope";
-  import type { Issue, Steer, EpicSummary, Epic, DrainStatus } from "$lib/types";
+  import type { Issue, IssueFetchAttempt, Steer, EpicSummary, Epic, DrainStatus } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import {
     filterIssues,
@@ -24,6 +24,7 @@
   import IssueRow from "./issues-panel/IssueRow.svelte";
   import IssueFilterPopover from "./IssueFilterPopover.svelte";
   import RepoLink from "./RepoLink.svelte";
+  import IssueLoadAttempts from "./IssueLoadAttempts.svelte";
   import { SvelteSet, SvelteMap } from "svelte/reactivity";
   import { tick, untrack } from "svelte";
 
@@ -78,6 +79,9 @@
   // the empty issues[] is a fetch failure, not a genuine zero. Mirrors
   // PromptSources — distinguishes "couldn't load" from "no open issues".
   let loadError = $state(false);
+  /** The gh transports that ran and failed behind `loadError` (GitHub repos only).
+   *  Set wherever loadError is, so a stale trail can never outlive its failure. */
+  let loadAttempts = $state<IssueFetchAttempt[]>([]);
   // True when the repo runs in lightweight (local-only) mode — the empty issues[] and
   // null slug are deliberate. Mirrors PromptSources: without it the panel blames a
   // missing git host for a mode the operator switched on in Shepherd.
@@ -221,6 +225,7 @@
     const rp = repoPath;
     loading = true;
     loadError = false;
+    loadAttempts = [];
     lightweight = false;
     filter = "";
     selectedAuthor = null;
@@ -244,6 +249,7 @@
         viewer = r.viewer;
         viewerCache.set(rp, r.viewer);
         loadError = r.error != null;
+        loadAttempts = r.attempts ?? [];
         lightweight = r.lightweight === true;
         loading = false;
       })
@@ -253,6 +259,7 @@
         // sticky load-failed banner onto the data now showing.
         if (rp !== repoPath || issuesTicket !== issuesSeq) return;
         loadError = true;
+        loadAttempts = [];
         loading = false;
       });
     const epicsTicket = ++epicsSeq;
@@ -299,6 +306,7 @@
   function retryIssues() {
     loading = true;
     loadError = false;
+    loadAttempts = [];
     softRefresh(repoPath);
   }
 
@@ -314,6 +322,7 @@
         if (r.error != null) {
           if (loading) {
             loadError = true;
+            loadAttempts = r.attempts ?? [];
             loading = false;
           }
           return;
@@ -324,6 +333,7 @@
         viewer = r.viewer;
         viewerCache.set(rp, r.viewer);
         loadError = false;
+        loadAttempts = [];
         lightweight = r.lightweight === true;
         // This result is now the newest state — display it even if the (superseded)
         // mount fetch never settled; otherwise fresh data hides behind the skeleton.
@@ -333,6 +343,7 @@
         if (rp !== repoPath || issuesTicket !== issuesSeq) return;
         if (loading) {
           loadError = true;
+          loadAttempts = [];
           loading = false;
         }
       });
@@ -527,6 +538,9 @@
       <div class="muted">
         {m.common_issues_load_failed()}
         <button type="button" class="retry-link" onclick={retryIssues}>{m.common_retry()}</button>
+        <!-- Which gh transport gave up, and why — so a retry isn't a blind coin flip
+             between waiting for a budget and fixing a login. -->
+        <IssueLoadAttempts attempts={loadAttempts} />
       </div>
     {:else if lightweight}
       <!-- MUST precede the slug===null branch: LocalForge reports a null slug too, so

--- a/ui/src/lib/components/PromptSources.browser.test.ts
+++ b/ui/src/lib/components/PromptSources.browser.test.ts
@@ -256,6 +256,100 @@ describe("PromptSources filter bar (popover + sticky coverage)", () => {
     expect(mockListIssues).toHaveBeenCalledTimes(2);
   });
 
+  // "Couldn't load" alone leaves the operator guessing at a rate limit when the real
+  // cause may be an expired login — so name the gh transports that actually ran.
+  it("Issues tab: the load-failed state names each gh transport that failed", async () => {
+    mockListIssues.mockResolvedValue({
+      slug: "owner/repo",
+      webUrl: null,
+      issues: [],
+      viewer: null,
+      error: "fetch_failed",
+      attempts: [
+        {
+          transport: "cli",
+          reason: "rate_limit",
+          status: 403,
+          detail: "gh: API rate limit exceeded (HTTP 403)",
+        },
+        { transport: "rest", reason: "http", status: 502, detail: "gh: Server Error (HTTP 502)" },
+      ],
+    });
+
+    render(PromptSources, {
+      repoPath: "/repo",
+      issueData: makeIssueData("/repo"),
+      onpick: noop,
+      onpickissue: noop,
+    });
+
+    await expect
+      .poll(() => document.querySelector(".ps-body")?.textContent)
+      .toContain(m.issues_attempts_label());
+    const lines = Array.from(document.querySelectorAll(".ps-body .attempt")).map(
+      (el) => el.textContent?.replace(/\s+/g, " ").trim() ?? "",
+    );
+    // Preferred transport first: the order is the diagnosis.
+    expect(lines).toEqual([
+      `${m.issues_transport_cli()} → ${m.issues_attempt_rate_limit()}`,
+      `${m.issues_transport_rest()} → ${m.issues_attempt_http({ status: 502 })}`,
+    ]);
+    // The raw gh message rides along for AT and for hover, without polluting the DOM text.
+    expect(document.querySelector(".ps-body .attempt")?.getAttribute("aria-description")).toBe(
+      "gh: API rate limit exceeded (HTTP 403)",
+    );
+  });
+
+  it("Issues tab: a single executed transport is reported as one line, not a truncated pair", async () => {
+    mockListIssues.mockResolvedValue({
+      slug: "owner/repo",
+      webUrl: null,
+      issues: [],
+      viewer: null,
+      error: "fetch_failed",
+      attempts: [{ transport: "cli", reason: "gh_missing", detail: "spawn gh ENOENT" }],
+    });
+
+    render(PromptSources, {
+      repoPath: "/repo",
+      issueData: makeIssueData("/repo"),
+      onpick: noop,
+      onpickissue: noop,
+    });
+
+    await expect.poll(() => document.querySelectorAll(".ps-body .attempt").length).toBe(1);
+    expect(document.querySelector(".ps-body .attempt")?.textContent).toContain(
+      m.issues_attempt_gh_missing(),
+    );
+  });
+
+  it("Issues tab: a failure without a transport trail reads exactly as before", async () => {
+    // Gitea/local forges and client-side rejections carry no trail — the failure
+    // sentence and the retry must still stand alone.
+    mockListIssues.mockResolvedValue({
+      slug: "owner/repo",
+      webUrl: null,
+      issues: [],
+      viewer: null,
+      error: "fetch_failed",
+    });
+
+    render(PromptSources, {
+      repoPath: "/repo",
+      issueData: makeIssueData("/repo"),
+      onpick: noop,
+      onpickissue: noop,
+    });
+
+    await expect
+      .poll(() => document.querySelector(".ps-body")?.textContent)
+      .toContain(m.common_issues_load_failed());
+    expect(document.querySelector(".ps-body")?.textContent).not.toContain(
+      m.issues_attempts_label(),
+    );
+    expect(document.querySelectorAll(".ps-body .attempt")).toHaveLength(0);
+  });
+
   it("Commands tab: search-input bar covers the rows behind it", async () => {
     mockListIssues.mockResolvedValue({
       slug: "owner/repo",

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -32,6 +32,7 @@
   import { repos } from "$lib/repos.svelte";
   import { steerAppliesToRepo } from "$lib/steer-scope";
   import IssueLabelChips from "./IssueLabelChips.svelte";
+  import IssueLoadAttempts from "./IssueLoadAttempts.svelte";
 
   let {
     repoPath,
@@ -484,6 +485,9 @@
           <button type="button" class="retry-link" onclick={() => issueData.load(repoPath)}
             >{m.common_retry()}</button
           >
+          <!-- Which gh transport gave up, and why — so a retry isn't a blind coin flip
+               between waiting for a budget and fixing a login. -->
+          <IssueLoadAttempts attempts={issueData.attempts} still />
         </div>
       {:else if lightweight}
         <!-- MUST precede the slug===null branch: LocalForge reports a null slug too, so

--- a/ui/src/lib/components/new-task/issue-data.svelte.ts
+++ b/ui/src/lib/components/new-task/issue-data.svelte.ts
@@ -1,5 +1,5 @@
 import { listIssues } from "$lib/api";
-import type { Issue } from "$lib/types";
+import type { Issue, IssueFetchAttempt } from "$lib/types";
 import { viewerCache } from "$lib/viewer-cache.svelte";
 
 /**
@@ -27,6 +27,10 @@ export class IssueData {
    *  and null slug are deliberate, so the UI names the mode instead of blaming a
    *  missing GitHub upstream. False whenever the fetch didn't settle cleanly. */
   lightweight = $state(false);
+  /** The gh transports that ran and failed, in the order they ran (GitHub repos only).
+   *  Empty when the server sent none — including when the request itself failed, where
+   *  the server never got to say anything. */
+  attempts = $state<IssueFetchAttempt[]>([]);
 
   #generation = 0;
 
@@ -37,6 +41,7 @@ export class IssueData {
     this.viewer = null;
     this.loadError = false;
     this.lightweight = false;
+    this.attempts = [];
     if (!repoPath) {
       this.loading = false;
       return;
@@ -51,6 +56,7 @@ export class IssueData {
         viewerCache.set(repoPath, r.viewer);
         this.loadError = r.error != null;
         this.lightweight = r.lightweight === true;
+        this.attempts = r.attempts ?? [];
         this.loading = false;
       })
       .catch(() => {
@@ -60,6 +66,7 @@ export class IssueData {
         this.viewer = null;
         this.loadError = true;
         this.lightweight = false;
+        this.attempts = [];
         this.loading = false;
       });
   }

--- a/ui/src/lib/feature-announcements/entries/v1.48.0-issue-load-transports.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.48.0-issue-load-transports.ts
@@ -1,0 +1,14 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  // A failed issue listing used to report only "couldn't load — maybe a rate limit".
+  // The New Task modal and the Issues panel now list the gh transports that actually
+  // ran (`gh issue list` on the GraphQL budget, `gh api` on the REST budget) and why
+  // each one stopped, with the full gh message on hover.
+  id: "issue-load-transports",
+  sinceVersion: "1.48.0",
+  titleKey: "feat_issue_load_transports_title",
+  bodyKey: "feat_issue_load_transports_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -293,6 +293,20 @@ export interface Issue {
   blockedBy?: number[];
 }
 
+/** One `gh` transport that ran and failed while listing issues, as reported by
+ *  /api/issues. Mirrors the server `GhFetchAttempt` (`src/forge/gh-attempt.ts`).
+ *  GitHub lists issues over two independent budgets (`gh issue list` on GraphQL,
+ *  `gh api` on REST) and falls back between them; the trail names the paths that
+ *  were really tried, in the order they were tried. */
+export interface IssueFetchAttempt {
+  transport: "cli" | "rest";
+  reason: "rate_limit" | "auth" | "not_found" | "gh_missing" | "network" | "http" | "unknown";
+  /** HTTP status when gh reported one; absent otherwise. */
+  status?: number;
+  /** Sanitized gh output for the hover tooltip. May be empty. */
+  detail: string;
+}
+
 /** Subset of an Issue attached to a task by reference (body rides out-of-band). */
 export interface IssueRef {
   number: number;


### PR DESCRIPTION
Clicking **Erneut versuchen** on a failed issue load told the operator nothing about what
Shepherd was actually doing. The screenshot that started this: *"Issues konnten nicht geladen
werden – evtl. GitHub-Rate-Limit."* — so is the answer to wait an hour, or to re-run `gh auth
login`? No way to tell.

The information already existed server-side and was thrown away.

## What was happening

`GithubForge.listIssues` lists issues over two transports on two **independent** GitHub budgets —
`gh issue list` (GraphQL bucket) and `gh api` (REST bucket) — and falls back between them in
whichever order the GraphQL backoff prefers. When both gave up, it rethrew the preferred
transport's error, and `handleIssues` caught it in an argument-less `catch {}` that answered with
nothing but `error: "fetch_failed"`. The diagnosis died there.

## What this changes

`listIssues` now keeps a trail of the transports that **actually ran** and failed, built as it
goes, and attaches it to the escaping error under a symbol key (so it never shows up in a log line
or a serialized error). A run that ends after a single transport reports one entry rather than
claiming a second. `/api/issues` passes the trail on as an optional `attempts` field, and both
retry surfaces render it:

```
Issues konnten nicht geladen werden – evtl. GitHub-Rate-Limit.  Erneut versuchen
Versucht:
  gh issue list (GraphQL) → Rate-Limit
  gh api (REST) → HTTP 403
```

Lines appear in execution order, so what was tried *first* is visible without extra words.
Hovering a line reveals the full `gh` message. Reasons are classified into rate limit / not signed
in / repo not found / gh not installed / network / HTTP status / unknown — and where the
classification is a guess (a bare 403 is reported as `HTTP 403`), the raw message in the tooltip
is the escape hatch.

Surfaces: the New Task modal (`PromptSources.svelte`) and the Issues panel
(`IssuesPanel.svelte`). Up Next is untouched — it aggregates several repos into one server
snapshot and would need per-repo folding.

## Safety

The raw `gh` output reaches the browser for the first time, so it is sanitized server-side before
it travels: ANSI stripped, whitespace collapsed, capped at 300 characters, and token shapes
(`ghp_…`, `github_pat_…`) redacted. Covered by tests.

Responses that carry no trail — Gitea, local forges, a client-side rejection, or a failure raised
outside the listing itself — are **byte-identical** to before, and the existing whole-body
`toEqual` test in `test/server-issues.test.ts` guards that.

## Note on the diff

`handleIssues` crossed the complexity gate once the failure branch grew, so its body moved into
`issuesResponse(forge)` and the handler is now just its route guards. Pure move, no behaviour
change.

## Verification

- `bun run lint`, `bun run test` (root)
- `cd ui && bun run check`, `bun run check:i18n`, `bun run test`
- New: `test/forge/gh-attempt.test.ts` (classification, truncation, redaction, symbol round-trip);
  extended `test/forge/github.test.ts` (trail in both transport orders, preferred error still
  rethrown, no trail on a successful fallback), `test/server-issues.test.ts` (one entry, two
  entries, none), and browser tests in both components (two lines, one line, no trail).
