### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs/sandbox-security.md
+++ b/docs/sandbox-security.md
@@ -158,7 +158,8 @@ still stand.
 - **Autonomous task agents** run `--dangerously-skip-permissions`, but behind
   **both** the filesystem and the egress membrane. `standard` auto-spawns are
   refused outright (`src/sandbox.ts` `autoHoldReason`).
-- **Unattended reviewers** (PR critic + plan-gate) run **read-only**, not
+- **Unattended reviewers** (PR critic, plan-gate, and the maintain loop's tier-2
+  diagnosis agent — `src/maintain.ts`) run **read-only**, not
   skip-permissions: `--safe-mode --disable-slash-commands --allowedTools Read
 Grep Glob Bash(git diff *) Bash(git log *) Bash(git show *) Bash(git status)
 Write --permission-mode dontAsk` (`src/transient-agent-argv.ts`,
@@ -211,5 +212,5 @@ dontAsk` can otherwise read nothing but the files Shepherd itself wrote into
 ## See also
 
 - `src/egress.ts`, `src/sandbox.ts`, `src/service.ts`, `src/autopilot.ts`,
-  `src/transient-agent-argv.ts`, `src/task-shape.ts`, `src/untrusted.ts`, `src/tool-guard-hook.ts`,
+  `src/transient-agent-argv.ts`, `src/task-shape.ts`, `src/maintain.ts`, `src/untrusted.ts`, `src/tool-guard-hook.ts`,
   `scripts/tool-guard.mjs`.


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc sync — 2026-09-03

Grounding: `git log -n 40 --stat` back past the last doc sync (`9e5ef1c81`, #2148,
2026-09-01) plus per-commit inspection of everything landed since. Most of that window
already carried its own doc sync (`266ef76ec`, `15b72e61d`, `c50eeb427`, `0ba04bb80`),
so the in-scope pages were largely current. One enumeration was demonstrably stale.

## Changes

- **`docs/sandbox-security.md`** — the "Unattended reviewers" bullet listed only the PR
  critic and plan-gate as read-only reviewer-preset spawns. `c50eeb427`
  (feat(maintain): tiered thresholds that open work, #2157) added a third: the maintain
  loop's tier-2 diagnosis agent, which spawns via `buildTransientAgentArgv("reviewer", …)`
  at `src/maintain.ts:902` — the same argv the bullet describes. Added it to the list and
  to the "See also" file list. No claim about the preset itself was changed.

## Uncertain / needs human judgment

- **`SHEPHERD_HOUSE_RULES_BUDGET_CHARS` is undocumented** in
  `docs-site/src/content/docs/reference/configuration.md`, whose intro promises "every
  environment variable". It is real and operator-settable (`src/config.ts:831`, default
  4000 from `HOUSE_RULES_DEFAULT_BUDGET_CHARS`), and `15b72e61d` widened its effect —
  the budget now also bounds the house-rules block injected into the **critic**, not just
  the author. But it is a long-standing omission rather than new drift, and a number of
  other internal knobs are deliberately absent from that page, so I did not decide on my
  own that it belongs there. Left unchanged.
- **`POST /api/shape` and `POST /api/shape/brief`** (`5d37eb29a`, #2158) are not in
  `docs/external-task-api.md`. They require `full` scope (not in the read/submit
  allowlists in `src/token-scopes.ts`), and the page's subject is submitting and steering
  tasks rather than the pre-session composition helper the UI drives — so I could not tell
  whether it is in scope for that doc. Note the page's scope enumeration is otherwise
  still accurate against `src/token-scopes.ts`.
- **`docs-site/src/content/docs/index.md` "Start here" list** omits the newer reference
  pages — `reference/review-policy.md` (added `15b72e61d`),
  `reference/stacked-epic-children.md`, `reference/keyboard-shortcuts.md`. The list looks
  curated rather than exhaustive (it has omitted the latter two for months), so I treated
  this as an editorial choice, not staleness.
- **Not stale, checked and confirmed current**: the maintain-loop and tier-3 sections plus
  the four-band table in `reference/configuration.md` (vs `0ba04bb80`); every default I
  spot-checked in that page against `src/config.ts` (review timeout, usage hold/downgrade
  percentages, maintain/doc-agent hours, preview ports, reaper prefilters); the glossary's
  first-pass / first-push-CI-green / plan-drift / maintain-loop / band entries (vs
  `037c062db`, `1190022dc`, `c50eeb427`); the herdr 0.8.2 support claim in
  `getting-started.md` (vs `ab98121af`); the `--add-dir` shaping-round residual in
  `sandbox-security.md` (vs `5d37eb29a`); and the absence of any Herd Rundown reference in
  the in-scope pages after `eda3c8375`.