### PR TITLE
feat(review): non-blocking plan-drift report fed to the delivery lens (#2155)

### DIFF
--- a/docs-site/src/content/docs/reference/glossary.md
+++ b/docs-site/src/content/docs/reference/glossary.md
@@ -67,6 +67,13 @@ The share of merged tasks that passed review in a single clean round — no rewo
 requested. Tasks that were never reviewed are left out of the calculation
 entirely rather than counted as passes.
 
+### Plan drift
+
+How far a merged change departed from the plan approved before it was written, as
+reported by the PR critic: none, minor or major. It never affects the review's
+verdict — departing from a plan is legitimate. It is measured because a repo that
+drifts constantly is usually writing vague plans, not writing bad code.
+
 ### Inferred
 
 Derived by the recap model from the code — not verified against the real diff.

--- a/scripts/delivery-report.ts
+++ b/scripts/delivery-report.ts
@@ -108,6 +108,12 @@ function rows(st: DeliveryStats): [string, string][] {
     ["Critic errors", String(st.criticErrors)],
     ["Plan rounds (median)", num(st.planRoundsMedian)],
     ["Plan rework rate", pct(st.planReworkRate)],
+    // #2155: over tasks the critic measured against an approved plan; `major` is called out because
+    // a rate alone hides whether the drift is incidental or a different approach altogether.
+    [
+      "Plan drift rate",
+      `${pct(st.planDriftRate)}${st.planDriftMajor > 0 ? ` — ${st.planDriftMajor} major` : ""}`,
+    ],
     ["Time to first review", dur(st.timeToFirstReviewMs)],
     ["Lead time", dur(st.leadTimeMs)],
   ];

--- a/src/critic-core.ts
+++ b/src/critic-core.ts
@@ -11,7 +11,7 @@ import { join } from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { execFileSync, timedAsync } from "./instrument";
-import type { ReviewDecision } from "./types";
+import type { PlanDrift, ReviewDecision } from "./types";
 import type { SessionUsage } from "./usage";
 import { tolerantParseJson } from "./json-tolerant";
 import type { VerdictRead } from "./json-tolerant";
@@ -328,6 +328,9 @@ export function reviewPrompt(
         reviewPolicy: opts.reviewPolicy,
         houseRules: opts.houseRules,
         houseRulesAuthored: true,
+        // #2155: planShown mirrors the `if (opts.plan …)` block above — the drift question is only
+        // asked when there is a plan in the prompt to measure against.
+        planShown: Boolean(opts.plan?.trim()),
       },
     ),
   );
@@ -758,6 +761,10 @@ function scopeAndOutputTail(
     /** True only where a Shepherd agent authored the diff under this repo's rules — see
      *  {@link reviewerHouseRulesBlock}. The standalone critic never sets it. */
     houseRulesAuthored?: boolean;
+    /** #2155: an APPROVED PLAN block is present above, so the verdict can carry the non-blocking
+     *  plan-drift measurement. Absent ⇒ no drift block and no extra JSON keys, keeping every
+     *  plan-less prompt (and prReviewPrompt, which never has a plan) byte-identical. */
+    planShown?: boolean;
   } = {},
 ): string[] {
   return [
@@ -890,12 +897,35 @@ function scopeAndOutputTail(
     '- At most 5 NEW findings per review, highest-severity first. This is a PRIORITISATION instruction, never a limit that may lose information: if more than 5 genuine blocking problems exist, emit ALL of them and say so in "summary" (the change needs reworking, not tweaking). NEVER move a blocking problem into `Nits (non-blocking):`, and never drop one, to fit the budget.',
     "- Re-raised prior findings do NOT count against those 5.",
     "",
+    // PLAN-DRIFT REPORT (#2155) — PURE MEASUREMENT, and the only field in this prompt that feeds no
+    // decision anywhere: nothing in the review loop, the auto-address steer or the merge train
+    // reads it. It exists because SYSTEMATIC divergence between approved plans and merged diffs is
+    // a process signal (plans too vague, the gate asking the wrong questions) — a per-PR verdict is
+    // not. Emitted ONLY when a plan was actually shown, so a plan-less prompt stays byte-identical
+    // and a critic with nothing to compare against can never invent a level.
+    //
+    // The non-judgement wording is load-bearing, not decoration: the prompt's own stance is that a
+    // plan is "CONTEXT for intent, never a warrant", and asking about fidelity at all risks
+    // anchoring the reviewer into plan-conformance findings — exactly what that stance forbids.
+    ...(opts.planShown
+      ? [
+          "PLAN-DRIFT REPORT — a MEASUREMENT for the operator, never a judgement about this PR:",
+          '- Report how far the diff departs from the APPROVED PLAN above as "planDrift": "none" (it implements the plan\'s approach), "minor" (same approach, incidental departures — a differently named helper, an extra file, steps done in another order), or "major" (a different approach, a planned piece missing, or substantial work the plan never described).',
+          '- Add "planDriftNote": ONE line, at most 140 characters, naming the single biggest departure. Omit it when planDrift is "none". Write it WITHOUT quotation marks of any kind — it travels inside the JSON file.',
+          '- This changes NOTHING about your review. Drift is never a finding, never affects "decision", and never appears in "findings": a "major" drift on a correct diff is still a clean review, and "none" excuses no defect. Judge the code exactly as you would if this field did not exist.',
+          "- Departing from a plan is legitimate — the plan is context, not a warrant. Report what you observe; do not editorialize and do not ask the author to conform to the plan.",
+          "- DECONFLICTION with the SCOPE-CREEP lens above: the two measure different things, so a departure you reported under `Scope creep / gold-plating (non-blocking):` still counts here. That section is a judgement call addressed to the author; this field is a process metric addressed to the operator.",
+          "",
+        ]
+      : []),
     "When done, write TWO files in the repository root:",
     // Binds the term once: every rule above says `"body"` (sections, citations, stated limitations),
     // and they all now resolve to this file. Cheaper and less drift-prone than restating ~10 rules.
     '1. `.shepherd-review.md` — your full markdown review. Everywhere these instructions say "body" — the named sections, the `path:line` citations, the stated limitations — they mean THIS file. It is NOT JSON: write the prose directly, escape nothing, quote however you like.',
     "2. `.shepherd-review.json` — the structured verdict, with this shape:",
-    '{"decision": "request-changes" | "comment", "summary": "<=100 char one-liner", "findings": ["<discrete actionable item>", ...], "body": "<optional — see below>"}',
+    opts.planShown
+      ? '{"decision": "request-changes" | "comment", "summary": "<=100 char one-liner", "findings": ["<discrete actionable item>", ...], "planDrift": "none" | "minor" | "major", "planDriftNote": "<one line, <=140 chars, no quotation marks — omit when planDrift is none>", "body": "<optional — see below>"}'
+      : '{"decision": "request-changes" | "comment", "summary": "<=100 char one-liner", "findings": ["<discrete actionable item>", ...], "body": "<optional — see below>"}',
     // #2042: the body used to live inside this JSON. A single unescaped `"` before a `:` or `,` —
     // which German `„…":` prose produces constantly — is indistinguishable from a real key/value
     // boundary, so it silently destroyed complete verdicts. Keeping the prose out of JSON entirely
@@ -919,6 +949,9 @@ function scopeAndOutputTail(
  *  scrubStaleVerdictArtifacts). */
 export const VERDICT_FILE = ".shepherd-review.json";
 
+/** Hard cap on the critic's plan-drift note (#2155) — one line, not a second review body. */
+export const PLAN_DRIFT_NOTE_MAX = 140;
+
 /** The critic's verdict BODY, written beside {@link VERDICT_FILE} as plain markdown.
  *
  *  #2042: the body is the one field that is long free prose, and the critic hand-authors its JSON —
@@ -940,6 +973,9 @@ export interface RawVerdict {
   summary?: unknown;
   body?: unknown;
   findings?: unknown;
+  /** #2155 — non-blocking plan-drift measurement; present only when the critic was shown a plan. */
+  planDrift?: unknown;
+  planDriftNote?: unknown;
 }
 
 /** Fingerprint the branch diff with `git patch-id` so a rebase (same diff, new SHA) is a
@@ -1129,6 +1165,25 @@ export function normalizeFindings(raw: unknown): string[] {
     .filter((f): f is string => typeof f === "string")
     .map((f) => f.trim())
     .filter(Boolean);
+}
+
+/** Coerce the critic's `planDrift` field to a known level (#2155). Anything else — a missing field,
+ *  a sentence, a novel level — is `null` = NOT MEASURED, which every consumer excludes rather than
+ *  reading as `none`. Deliberately NOT part of buildVerdictCore: that is shared with the standalone
+ *  PR critic, which is never shown a plan. */
+export function normalizePlanDrift(raw: unknown): PlanDrift | null {
+  if (typeof raw !== "string") return null;
+  const v = raw.trim().toLowerCase();
+  return v === "none" || v === "minor" || v === "major" ? v : null;
+}
+
+/** The one-line drift note, collapsed to a single line and hard-capped at
+ *  {@link PLAN_DRIFT_NOTE_MAX} chars. Empty or non-string → null. Both are enforced here rather
+ *  than merely asked for in the prompt: the note is model-authored free prose that lands in a DB
+ *  column and then in a one-line UI slot, so a paragraph must not arrive intact. */
+export function normalizePlanDriftNote(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  return raw.replace(/\s+/g, " ").trim().slice(0, PLAN_DRIFT_NOTE_MAX) || null;
 }
 
 /** A leading token looks like a repo-relative file path: it has no space AND (contains a `/` OR

--- a/src/delivery-metrics.ts
+++ b/src/delivery-metrics.ts
@@ -9,6 +9,7 @@ import type {
   DeliverySample,
   DeliveryStats,
   DeliveryTaskRow,
+  PlanDrift,
   ReviewerSpawnRow,
   UsageRange,
 } from "./types";
@@ -37,6 +38,10 @@ interface TaskRounds {
   planRounds: number;
   /** Earliest review spawn, whatever its outcome — the review DID start. */
   firstReviewAt: number | null;
+  /** Plan drift as of the LAST review round that measured it (#2155) — the state of the diff
+   *  closest to merge, not an intermediate round's. null = never measured (no plan was shown, or
+   *  every round errored), which keeps the task out of the rate's denominator entirely. */
+  planDrift: PlanDrift | null;
 }
 
 const EMPTY_ROUNDS: TaskRounds = {
@@ -45,6 +50,7 @@ const EMPTY_ROUNDS: TaskRounds = {
   errors: 0,
   planRounds: 0,
   firstReviewAt: null,
+  planDrift: null,
 };
 
 /** Window start for a range; 0 for `all` so the caller filters on `>= 0` rather than on a
@@ -86,6 +92,9 @@ function rate(hits: number, total: number): DeliverySample {
 function applyReviewSpawn(t: TaskRounds, sp: ReviewerSpawnRow): void {
   // The review STARTED regardless of how it ended, so every spawn moves the first-review mark.
   if (t.firstReviewAt == null || sp.spawnedAt < t.firstReviewAt) t.firstReviewAt = sp.spawnedAt;
+  // Last non-null wins: spawns arrive in `spawnedAt` order, so the final measured round stands.
+  // A later round that measured nothing does NOT erase an earlier measurement.
+  if (sp.planDrift != null) t.planDrift = sp.planDrift;
   if (sp.outcome === "error") t.errors += 1;
   else if (sp.outcome === "clean" || sp.outcome === "changes_requested") {
     t.reviewRounds += 1;
@@ -144,6 +153,9 @@ function statsFor(tasks: TaskView[]): DeliveryStats {
   const gated = tasks.filter((t) => t.rounds.planRounds > 0);
   const reworkCycles = reviewed.map((t) => t.rounds.reviewRounds);
   const planRounds = gated.map((t) => t.rounds.planRounds);
+  // Only tasks the critic actually measured — one with no plan (or no verdict) is excluded, never
+  // silently counted as `none`, which would flatter the rate.
+  const drifted = tasks.filter((t) => t.rounds.planDrift != null);
   const ttfr = tasks.map((t) => t.timeToFirstReviewMs).filter((v): v is number => v != null);
   const lead = tasks.map((t) => t.leadTimeMs).filter((v): v is number => v != null);
   return {
@@ -155,6 +167,11 @@ function statsFor(tasks: TaskView[]): DeliveryStats {
     criticErrors: tasks.reduce((n, t) => n + t.rounds.errors, 0),
     planRoundsMedian: sample(planRounds, median),
     planReworkRate: rate(gated.filter((t) => t.rounds.planRounds > 1).length, gated.length),
+    planDriftRate: rate(
+      drifted.filter((t) => t.rounds.planDrift !== "none").length,
+      drifted.length,
+    ),
+    planDriftMajor: drifted.filter((t) => t.rounds.planDrift === "major").length,
     timeToFirstReviewMs: sample(ttfr, median),
     leadTimeMs: sample(lead, median),
   };

--- a/src/review.ts
+++ b/src/review.ts
@@ -39,6 +39,8 @@ import {
   scopeFindings,
   effectiveRound,
   buildVerdictCore,
+  normalizePlanDrift,
+  normalizePlanDriftNote,
   shouldSkipForPatchId,
   captureUsage,
   reapRun,
@@ -221,6 +223,9 @@ interface InFlight {
   priorReviewedPatchIds: string[]; // patch-ids reviewed on this streak before this run (churn/revert dedup set)
   priorSeenNoteIds: string[]; // seen-note set carried in (before this run's fetch)
   seenNoteIds: string[]; // priorSeen + notes fed to THIS run's critic; only "consumed" on a real verdict
+  /** #2155: an APPROVED PLAN block was in this run's prompt, so a plan-drift answer is meaningful.
+   *  False ⇒ the critic had nothing to measure against and any drift it reports is discarded. */
+  planShown: boolean;
   /** RAW `readAsync(terminalId, "visible")` buffer from the previous tick — NOT the collapsed
    *  single-line `readPaneTail()` shape. Backs the unchanged-buffer half of the stuck-pane test,
    *  so it must be the same shape the detector classifies. */
@@ -691,6 +696,7 @@ export class ReviewService {
       startedAt: this.now(),
       ...priorStreakState(prior),
       seenNoteIds,
+      planShown: Boolean(plan?.trim()),
     });
     // Persist the spawn row now (totals NULL until finalize) so review burn is attributable
     // even if the run crashes/times out before producing a verdict (issue #502).
@@ -1268,6 +1274,9 @@ export class ReviewService {
             : verdict.findings.length === 0
               ? "clean"
               : "changes_requested",
+          // #2155: the durable copy. The `reviews` row this verdict also lands on is deleted by
+          // archive(), and every task the delivery metrics count is an archived one.
+          verdict.planDrift,
         );
       } catch (err) {
         console.warn(`[review] outcome accounting failed for ${f.sessionId}:`, err);
@@ -1531,6 +1540,8 @@ export class ReviewService {
     cause: NoVerdictCause | null = null,
   ): ReviewVerdict {
     const core = buildVerdictCore(raw, f.baseSha, f.files, f.patchId, f.sessionId);
+    const drift =
+      f.planShown && core.decision !== "error" ? normalizePlanDrift(raw?.planDrift) : null;
     return {
       sessionId: f.sessionId,
       headSha: f.headSha,
@@ -1558,6 +1569,11 @@ export class ReviewService {
       finalRoundPending: false, // finalize() sets this on a real verdict
       finalRoundTimeoutMs: DEFAULT_FINAL_ROUND_TIMEOUT_MS, // live escalation timeout
       seenNoteIds: f.seenNoteIds, // carry the per-round note dedup set forward
+      // #2155 — non-blocking measurement, read by nothing in this loop. Two guards: a run that was
+      // shown no plan had nothing to compare against, and an `error` verdict measured nothing at
+      // all (there is no reviewed diff behind it), so both record null = not measured.
+      planDrift: drift,
+      planDriftNote: drift ? normalizePlanDriftNote(raw?.planDriftNote) : null,
       updatedAt: this.now(),
     };
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -31,6 +31,7 @@ import type {
   EpicDraftContent,
   ReviewerSpawnRow,
   ReviewerSpawnOutcome,
+  PlanDrift,
   DeliveryFact,
   AgentProvider,
   PrReview,
@@ -364,6 +365,12 @@ function coerceReviewSummaryCode(v: string | null): ReviewSummaryCode | null {
   return v !== null && REVIEW_SUMMARY_CODES.has(v) ? (v as ReviewSummaryCode) : null;
 }
 
+/** Coerce a persisted plan-drift level (#2155): only the three known levels survive; anything else
+ *  (legacy row, a value written before the union changed) → null = "not measured". */
+function coercePlanDrift(v: string | null): PlanDrift | null {
+  return v === "none" || v === "minor" || v === "major" ? v : null;
+}
+
 /** Coerce a persisted tri-state flag: null/undefined stays null (inherit), else a real boolean. */
 function nullableBool(v: unknown): boolean | null {
   return v === null || v === undefined ? null : !!v;
@@ -676,6 +683,8 @@ type ReviewVerdictRow = {
   url: string | null;
   spawnAborted: number | null;
   dismissed: number | null;
+  planDrift: string | null;
+  planDriftNote: string | null;
   updatedAt: number;
 };
 
@@ -1155,7 +1164,8 @@ export const REVIEWER_SPAWNS_DDL = `CREATE TABLE IF NOT EXISTS reviewer_spawns (
   cacheWriteTokens  INTEGER,
   totalTokens       INTEGER,
   providerSessionId TEXT,
-  outcome           TEXT)`;
+  outcome           TEXT,
+  planDrift         TEXT)`;
 
 export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
   private db: Database;
@@ -1307,6 +1317,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       seenNoteIds TEXT NOT NULL DEFAULT '[]',
       finalRoundPending INTEGER NOT NULL DEFAULT 0,
       finalRoundTimeoutMs INTEGER NOT NULL DEFAULT 900000,
+      planDrift TEXT, planDriftNote TEXT,
       url TEXT, updatedAt INTEGER NOT NULL)`);
     this.migrateReviewColumns();
     this.db.run(`CREATE TABLE IF NOT EXISTS pr_reviews (
@@ -3222,6 +3233,11 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       spawnAborted: r.spawnAborted ? true : undefined,
       // Optional flag: true only when the operator dismissed/took over this stalled rework.
       dismissed: r.dismissed ? true : undefined,
+      // Explicit like summaryCode: the raw column is validated, never spread through un-checked.
+      // Absent (undefined) rather than null when nothing was measured, mirroring spawnAborted /
+      // dismissed above — so a verdict that carries no measurement also carries no key.
+      planDrift: coercePlanDrift(r.planDrift) ?? undefined,
+      planDriftNote: r.planDriftNote ?? undefined,
     } as ReviewVerdict;
   }
 
@@ -3229,7 +3245,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     const r = this.db
       .query(
         `SELECT sessionId, headSha, patchId, decision, summary, summaryCode, body, findings, addressRound,
-                addressCap, streakReviews, reviewedPatchIds, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, spawnAborted, dismissed, updatedAt
+                addressCap, streakReviews, reviewedPatchIds, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, spawnAborted, dismissed, planDrift, planDriftNote, updatedAt
               FROM reviews WHERE sessionId = ?`,
       )
       .get(sessionId) as ReviewVerdictRow | null;
@@ -3237,10 +3253,13 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
   }
 
   putReview(v: ReviewVerdict): void {
+    // Destructured with defaults rather than two more `??` in the parameter list below: both are
+    // optional on the verdict and NULL in the column, and the list is already at its budget.
+    const { planDrift = null, planDriftNote = null } = v;
     this.db.run(
       `INSERT INTO reviews (sessionId, headSha, patchId, decision, summary, summaryCode, body, findings, addressRound,
-         addressCap, streakReviews, reviewedPatchIds, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, spawnAborted, dismissed, updatedAt)
-       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+         addressCap, streakReviews, reviewedPatchIds, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, spawnAborted, dismissed, planDrift, planDriftNote, updatedAt)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
        ON CONFLICT(sessionId) DO UPDATE SET headSha=excluded.headSha, patchId=excluded.patchId,
          decision=excluded.decision,
          summary=excluded.summary, summaryCode=excluded.summaryCode,
@@ -3249,7 +3268,8 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
          streakReviews=excluded.streakReviews, reviewedPatchIds=excluded.reviewedPatchIds,
          errorRound=excluded.errorRound, finalRoundPending=excluded.finalRoundPending,
          finalRoundTimeoutMs=excluded.finalRoundTimeoutMs, seenNoteIds=excluded.seenNoteIds,
-         url=excluded.url, spawnAborted=excluded.spawnAborted, dismissed=excluded.dismissed, updatedAt=excluded.updatedAt`,
+         url=excluded.url, spawnAborted=excluded.spawnAborted, dismissed=excluded.dismissed,
+         planDrift=excluded.planDrift, planDriftNote=excluded.planDriftNote, updatedAt=excluded.updatedAt`,
       [
         v.sessionId,
         v.headSha,
@@ -3270,6 +3290,8 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
         v.url ?? null,
         v.spawnAborted ? 1 : 0,
         v.dismissed ? 1 : 0,
+        planDrift,
+        planDriftNote,
         v.updatedAt,
       ],
     );
@@ -3311,7 +3333,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     const rows = this.db
       .query(
         `SELECT sessionId, headSha, patchId, decision, summary, summaryCode, body, findings, addressRound,
-                addressCap, streakReviews, reviewedPatchIds, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, spawnAborted, dismissed, updatedAt FROM reviews`,
+                addressCap, streakReviews, reviewedPatchIds, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, spawnAborted, dismissed, planDrift, planDriftNote, updatedAt FROM reviews`,
       )
       .all() as ReviewVerdictRow[];
     const out: Record<string, ReviewVerdict> = {};
@@ -4197,14 +4219,21 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     return n;
   }
 
-  /** Stamp a reviewer run's terminal outcome (#2151 R1). Separate from `completeReviewerSpawn`
-   *  on purpose: that one is called through the shared `captureUsage` helper by recap, rundown and
-   *  the doc agent too, none of which have a verdict to report. No-op on an unknown id. */
-  setReviewerSpawnOutcome(reviewerSessionId: string, outcome: ReviewerSpawnOutcome): void {
-    this.db.run(`UPDATE reviewer_spawns SET outcome = ? WHERE reviewerSessionId = ?`, [
-      outcome,
-      reviewerSessionId,
-    ]);
+  /** Stamp a reviewer run's terminal outcome (#2151 R1) and, for a review that was shown an
+   *  approved plan, its non-blocking plan-drift measurement (#2155). Separate from
+   *  `completeReviewerSpawn` on purpose: that one is called through the shared `captureUsage` helper
+   *  by recap, rundown and the doc agent too, none of which have a verdict to report. No-op on an
+   *  unknown id. `planDrift` is written on every call, so a caller with no measurement (the plan
+   *  gate, a plan-less review) leaves the column NULL = not measured. */
+  setReviewerSpawnOutcome(
+    reviewerSessionId: string,
+    outcome: ReviewerSpawnOutcome,
+    planDrift: PlanDrift | null = null,
+  ): void {
+    this.db.run(
+      `UPDATE reviewer_spawns SET outcome = ?, planDrift = ? WHERE reviewerSessionId = ?`,
+      [outcome, planDrift, reviewerSessionId],
+    );
   }
 
   // ── delivery facts (#2151 R1) ────────────────────────────────────────────────
@@ -4694,6 +4723,10 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     // summaryCode: sentinel for a server-authored no-verdict reason, rendered per-locale in the UI.
     // Pre-existing rows backfill to NULL (render their stored `summary` prose verbatim).
     add("summaryCode", `summaryCode TEXT`);
+    // planDrift/planDriftNote (#2155): non-blocking plan-fidelity measurement. Pre-existing rows
+    // backfill to NULL = "not measured", which every consumer renders as nothing at all.
+    add("planDrift", `planDrift TEXT`);
+    add("planDriftNote", `planDriftNote TEXT`);
     // Migrate legacy `error` rows that baked the English summary in. They predate the four-way
     // split and recorded no cause, so they can only map to the generic timeout sentinel — which is
     // what the overwhelming majority of them were (the deadline is the common terminal state).
@@ -4749,6 +4782,9 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     // Terminal state of the run, stamped once at finalize (#2151 R1). Legacy rows stay NULL and the
     // delivery metrics skip them — a NULL is "unknown", never "clean".
     add("outcome", `outcome TEXT`);
+    // Non-blocking plan-drift measurement (#2155). NULL on every legacy row and on every spawn that
+    // was shown no plan — the delivery metrics exclude those rather than reading them as `none`.
+    add("planDrift", `planDrift TEXT`);
   }
 
   // ── learnings ─────────────────────────────────────────────────────────────

--- a/src/types.ts
+++ b/src/types.ts
@@ -746,6 +746,13 @@ export interface ReviewVerdict {
   // consumers stop counting it as active rework and attachReviewPush skips it. Reset to false on any
   // new verdict (buildVerdict) and on forceReview. Absent ⇒ false.
   dismissed?: boolean;
+  /** Non-blocking plan-drift measurement for this round (#2155); null when no plan was shown to the
+   *  critic, the run errored, or the answer was unrecognized. Advisory ONLY — nothing in the review
+   *  loop reads it. The durable copy for metrics lives on `reviewer_spawns` (this row dies at
+   *  archive); this one backs the live review popover. */
+  planDrift?: PlanDrift | null;
+  /** The critic's one-line note on the biggest departure, <=140 chars; null when it reported none. */
+  planDriftNote?: string | null;
   updatedAt: number;
 }
 
@@ -961,12 +968,23 @@ export interface ReviewerSpawnRow {
    *  and for a spawn that never finalized (crashed / orphaned) — delivery metrics EXCLUDE those
    *  rather than counting them as rework rounds, which a raw spawn tally would. */
   outcome: ReviewerSpawnOutcome | null;
+  /** Non-blocking plan-fidelity measurement for a `review` spawn that was shown an approved plan
+   *  (#2155). NULL for every other kind, for a plan-less review, and for an errored run. Lives here
+   *  — not only on `reviews` — because `archive()` drops the review row, and the delivery metrics
+   *  read exclusively archive-decoupled tables. */
+  planDrift: PlanDrift | null;
 }
 
 /** Terminal state of one reviewer run. `review` kinds resolve to clean/changes_requested/error;
  *  `plan_gate` kinds to approved/rework/error. The other spawn kinds (recap, rundown, doc_agent)
  *  are never stamped — they have no verdict a delivery metric reads. */
 export type ReviewerSpawnOutcome = "clean" | "changes_requested" | "approved" | "rework" | "error";
+
+/** How far a merged diff departed from the APPROVED PLAN the critic was shown (#2155). Reported by
+ *  the critic as pure MEASUREMENT: it never becomes a finding, never moves a decision, and never
+ *  touches the rework loop. NULL means "not measured" — no plan was shown, the run errored, or the
+ *  critic answered with something unrecognized. */
+export type PlanDrift = "none" | "minor" | "major";
 
 // ── delivery metrics (#2151 R1) ─────────────────────────────────────────────
 
@@ -1018,6 +1036,12 @@ export interface DeliveryStats {
   planRoundsMedian: DeliverySample;
   /** Share (0..1) of gated merged tasks that needed more than one plan round. */
   planReworkRate: DeliverySample;
+  /** Share (0..1) of drift-measured merged tasks whose final review reported `minor` or `major`
+   *  (#2155). Denominator = tasks carrying a drift value at all, i.e. the critic was shown an
+   *  approved plan and answered; a task with no measurement is excluded, never counted as `none`. */
+  planDriftRate: DeliverySample;
+  /** Of those, how many reported `major`. */
+  planDriftMajor: number;
   /** Median ms from PR open to the first critic spawn. */
   timeToFirstReviewMs: DeliverySample;
   /** Median ms from session creation to merge settle. */

--- a/test/critic-core.test.ts
+++ b/test/critic-core.test.ts
@@ -20,6 +20,9 @@ import {
   roundBlock,
   effectiveRound,
   captureUsage,
+  normalizePlanDrift,
+  normalizePlanDriftNote,
+  PLAN_DRIFT_NOTE_MAX,
 } from "../src/critic-core";
 import { tolerantParseJson } from "../src/json-tolerant";
 import { allowedToolsFor } from "../src/transient-agent-argv";
@@ -231,6 +234,72 @@ test("reviewPrompt omits the plan block entirely when no plan is provided (byte-
 test("prReviewPrompt (standalone critic) never carries a plan block — it has no session plan", () => {
   const p = prReviewPrompt("BASE", "My PR", "body");
   expect(p).not.toContain("APPROVED PLAN");
+});
+
+// ── #2155 plan-drift report (session critic, plan-gated, non-blocking) ──────────────────────────
+
+test("reviewPrompt asks for planDrift ONLY when an approved plan is shown", () => {
+  const withPlan = reviewPrompt("BASE", "do the thing", [], [], null, null, {
+    plan: "## Goal\nship it",
+  });
+  expect(withPlan).toContain("PLAN-DRIFT REPORT");
+  expect(withPlan).toContain('"planDrift"');
+  expect(withPlan).toContain('"planDriftNote"');
+  // The non-judgement contract is the whole point: drift must never leak into the review's verdict.
+  expect(withPlan).toContain("never a finding");
+  expect(withPlan).toContain('never affects "decision"');
+  expect(withPlan).toContain("no quotation marks"); // #2042: the note rides in the JSON file
+});
+
+test("a plan-less reviewPrompt (and the standalone critic) never mentions plan drift", () => {
+  for (const p of [
+    reviewPrompt("BASE", "do the thing"),
+    reviewPrompt("BASE", "do the thing", [], [], null, null, { plan: "   " }),
+    prReviewPrompt("b", "t", "body"),
+  ]) {
+    expect(p).not.toContain("PLAN-DRIFT REPORT");
+    expect(p).not.toContain("planDrift");
+  }
+});
+
+test("the plan-drift block sits ABOVE the output contract and leaves the JSON shape's other keys alone", () => {
+  const p = reviewPrompt("BASE", "task", [], [], null, null, { plan: "plan text" });
+  expect(p.indexOf("PLAN-DRIFT REPORT")).toBeLessThan(p.indexOf("When done, write TWO files"));
+  const contract = p.slice(p.indexOf("When done, write TWO files"));
+  // The shape line grows by two keys; everything the parser/backstop keys off is untouched.
+  expect(contract).toContain('"decision": "request-changes" | "comment"');
+  expect(contract).toContain('"findings": ["<discrete actionable item>", ...]');
+  expect(contract).toContain('"body": "<optional — see below>"');
+});
+
+test("normalizePlanDrift accepts only the three levels; everything else is not-measured", () => {
+  expect(normalizePlanDrift("none")).toBe("none");
+  expect(normalizePlanDrift(" Minor ")).toBe("minor");
+  expect(normalizePlanDrift("MAJOR")).toBe("major");
+  for (const junk of [
+    undefined,
+    null,
+    "",
+    "catastrophic",
+    "the diff drifted a lot",
+    2,
+    {},
+    ["major"],
+  ]) {
+    expect(normalizePlanDrift(junk)).toBeNull();
+  }
+});
+
+test("normalizePlanDriftNote collapses to one line, caps at 140 chars, and nulls out empties", () => {
+  expect(normalizePlanDriftNote("  moved the helper  ")).toBe("moved the helper");
+  // A note that arrives as a paragraph must not stretch the one-line slot it renders into.
+  expect(normalizePlanDriftNote("built a service\n\nthe plan said a helper")).toBe(
+    "built a service the plan said a helper",
+  );
+  expect(normalizePlanDriftNote("x".repeat(500))).toBe("x".repeat(PLAN_DRIFT_NOTE_MAX));
+  for (const junk of [undefined, null, "   ", 7, {}]) {
+    expect(normalizePlanDriftNote(junk)).toBeNull();
+  }
 });
 
 // ── #1812 finding B: scope-creep lens (session critic only, two-way routing) ─────────────────────

--- a/test/delivery-metrics.test.ts
+++ b/test/delivery-metrics.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "bun:test";
 import { SessionStore } from "../src/store";
 import { buildDeliveryMetrics } from "../src/delivery-metrics";
-import type { ReviewerSpawnOutcome } from "../src/types";
+import type { PlanDrift, ReviewerSpawnOutcome } from "../src/types";
 
 const DAY = 86_400_000;
 const NOW = 1_800_000_000_000;
@@ -19,7 +19,7 @@ function seedTask(
     createdAt: number;
     prOpenedAt?: number | null;
     mergedAt: number;
-    reviews?: { outcome: ReviewerSpawnOutcome | null; spawnedAt: number }[];
+    reviews?: { outcome: ReviewerSpawnOutcome | null; spawnedAt: number; planDrift?: PlanDrift }[];
     planRounds?: (ReviewerSpawnOutcome | null)[];
   },
 ): void {
@@ -44,7 +44,7 @@ function seedTask(
       model: null,
       spawnedAt: r.spawnedAt,
     });
-    if (r.outcome) store.setReviewerSpawnOutcome(rid, r.outcome);
+    if (r.outcome) store.setReviewerSpawnOutcome(rid, r.outcome, r.planDrift ?? null);
   });
   (opts.planRounds ?? []).forEach((outcome, i) => {
     const rid = `${opts.id}-plan-${i}`;
@@ -66,6 +66,8 @@ function build(store: SessionStore, range: "24h" | "7d" | "30d" | "all" = "7d") 
 
 test("empty store yields null metrics, not zeros", () => {
   const m = build(mk());
+  expect(m.totals.planDriftRate.value).toBeNull();
+  expect(m.totals.planDriftMajor).toBe(0);
   expect(m.totals.mergedTasks).toBe(0);
   expect(m.totals.firstPassRate.value).toBeNull();
   expect(m.totals.firstPassRate.n).toBe(0);
@@ -277,4 +279,76 @@ test("only this task's spawns count toward its rounds", () => {
   const m = build(s);
   expect(m.totals.reworkCyclesMedian).toEqual({ value: 1, n: 1 });
   expect(m.totals.firstPassRate.value).toBe(1);
+});
+
+// ── #2155 plan drift ────────────────────────────────────────────────────────────────────────────
+
+test("plan drift: the LAST measured round wins, and a later unmeasured round does not erase it", () => {
+  const s = mk();
+  seedTask(s, {
+    id: "drifted",
+    createdAt: NOW - DAY,
+    mergedAt: NOW - DAY / 2,
+    reviews: [
+      { outcome: "changes_requested", spawnedAt: NOW - DAY + 1000, planDrift: "major" },
+      { outcome: "clean", spawnedAt: NOW - DAY + 2000, planDrift: "minor" },
+      // A crashed final round measures nothing; the "minor" above still stands.
+      { outcome: "error", spawnedAt: NOW - DAY + 3000 },
+    ],
+  });
+  const m = build(s);
+  expect(m.totals.planDriftRate.value).toBe(1); // minor counts as drift
+  expect(m.totals.planDriftRate.n).toBe(1);
+  expect(m.totals.planDriftMajor).toBe(0); // the final measurement was minor, not major
+});
+
+test("plan drift: unmeasured tasks stay out of the denominator, never counted as `none`", () => {
+  const s = mk();
+  seedTask(s, {
+    id: "measured-none",
+    createdAt: NOW - DAY,
+    mergedAt: NOW - DAY / 2,
+    reviews: [{ outcome: "clean", spawnedAt: NOW - DAY + 1000, planDrift: "none" }],
+  });
+  seedTask(s, {
+    id: "measured-major",
+    createdAt: NOW - DAY,
+    mergedAt: NOW - DAY / 2,
+    reviews: [{ outcome: "clean", spawnedAt: NOW - DAY + 1000, planDrift: "major" }],
+  });
+  // Plan-less (or pre-instrumentation) task: reviewed, but never measured.
+  seedTask(s, {
+    id: "unmeasured",
+    createdAt: NOW - DAY,
+    mergedAt: NOW - DAY / 2,
+    reviews: [{ outcome: "clean", spawnedAt: NOW - DAY + 1000 }],
+  });
+  const m = build(s);
+  expect(m.totals.mergedTasks).toBe(3);
+  expect(m.totals.planDriftRate.value).toBe(0.5); // 1 of the 2 measured tasks drifted
+  expect(m.totals.planDriftRate.n).toBe(2);
+  expect(m.totals.planDriftMajor).toBe(1);
+});
+
+test("plan drift is reported per repo as well as in the totals", () => {
+  const s = mk();
+  seedTask(s, {
+    id: "a",
+    repoPath: "/repos/alpha",
+    createdAt: NOW - DAY,
+    mergedAt: NOW - DAY / 2,
+    reviews: [{ outcome: "clean", spawnedAt: NOW - DAY + 1000, planDrift: "major" }],
+  });
+  seedTask(s, {
+    id: "b",
+    repoPath: "/repos/beta",
+    createdAt: NOW - DAY,
+    mergedAt: NOW - DAY / 2,
+    reviews: [{ outcome: "clean", spawnedAt: NOW - DAY + 1000, planDrift: "none" }],
+  });
+  const m = build(s);
+  const byRepo = Object.fromEntries(m.repos.map((r) => [r.repo, r]));
+  expect(byRepo["alpha"]!.planDriftRate.value).toBe(1);
+  expect(byRepo["beta"]!.planDriftRate.value).toBe(0);
+  expect(m.totals.planDriftRate.value).toBe(0.5);
 });

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -199,6 +199,7 @@ function makeDeps(
   const postedComments: { n: number; body: string }[] = []; // forge.comment() calls (post-merge critic)
   const recordedSpawns: any[] = []; // recordReviewerSpawn calls
   const completedSpawns: any[] = []; // completeReviewerSpawn calls
+  const spawnOutcomes: { id: string; outcome: string; planDrift: string | null }[] = []; // #2151/#2155
   const rec: { event?: string; body?: string } = {};
   const notices = new Map<string, any>();
   const noticeEvents: string[] = [];
@@ -225,6 +226,8 @@ function makeDeps(
       recordReviewerSpawn: (r: any) => recordedSpawns.push(r),
       completeReviewerSpawn: (id: string, u: any, at: number) =>
         completedSpawns.push({ id, u, at }),
+      setReviewerSpawnOutcome: (id: string, outcome: string, planDrift: string | null = null) =>
+        spawnOutcomes.push({ id, outcome, planDrift }),
       // #1944 sidecar — a real in-memory implementation so the wiring seams behave like production.
       putSpawnNotice(n: any) {
         const key = `${n.sessionId}:${n.kind}`;
@@ -334,6 +337,7 @@ function makeDeps(
     postedComments,
     recordedSpawns,
     completedSpawns,
+    spawnOutcomes,
     notices,
     noticeEvents,
     paneReads,
@@ -784,6 +788,105 @@ test("critic prompt omits the plan block when no plan exists (readPlan → null)
   const { deps: d, started } = makeDeps({ readPlan: () => null });
   await new ReviewService(d as any).consider(session(), OPEN_GREEN);
   expect(started[0]!.argv.at(-1)!).not.toContain("APPROVED PLAN");
+});
+
+// ── #2155 plan drift: measured, persisted, and inert ────────────────────────────────────────────
+
+test("a plan-shown verdict records planDrift on both the review row and the spawn row", async () => {
+  const {
+    deps: d,
+    reviews,
+    spawnOutcomes,
+  } = makeDeps({
+    readPlan: () => "## Goal\nship the widget",
+    readVerdict: () => ({
+      decision: "comment",
+      summary: "fine",
+      body: "b",
+      findings: [],
+      planDrift: "Major",
+      planDriftNote: "  built it as a service, plan said a helper  ",
+    }),
+  });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(reviews["s1"]?.planDrift).toBe("major");
+  expect(reviews["s1"]?.planDriftNote).toBe("built it as a service, plan said a helper");
+  // The durable copy: `reviews` dies at archive, and every task the delivery lens counts is archived.
+  expect(spawnOutcomes).toHaveLength(1);
+  expect(spawnOutcomes[0]).toMatchObject({ outcome: "clean", planDrift: "major" });
+});
+
+test("plan drift NEVER touches the verdict: a major-drift clean review stays clean", async () => {
+  const {
+    deps: d,
+    reviews,
+    steers,
+    rec,
+  } = makeDeps({
+    autoAddressEnabled: true,
+    readPlan: () => "## Goal\nship the widget",
+    readVerdict: () => ({
+      decision: "comment",
+      summary: "fine",
+      body: "b",
+      findings: [],
+      planDrift: "major",
+      planDriftNote: "different approach entirely",
+    }),
+  });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(reviews["s1"]?.decision).toBe("commented");
+  expect(reviews["s1"]?.findings).toEqual([]);
+  expect(reviews["s1"]?.streakReviews).toBe(0); // no rework streak advanced
+  expect(reviews["s1"]?.addressRound).toBe(0);
+  expect(steers).toHaveLength(0); // nothing steered back to the agent
+  expect(rec.event).toBe("COMMENT");
+});
+
+test("drift reported without a plan in the prompt is discarded (nothing to measure against)", async () => {
+  const {
+    deps: d,
+    reviews,
+    spawnOutcomes,
+  } = makeDeps({
+    readPlan: () => null,
+    readVerdict: () => ({
+      decision: "comment",
+      summary: "fine",
+      body: "b",
+      findings: [],
+      planDrift: "major",
+      planDriftNote: "invented",
+    }),
+  });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(reviews["s1"]?.planDrift).toBeNull();
+  expect(reviews["s1"]?.planDriftNote).toBeNull();
+  expect(spawnOutcomes[0]!.planDrift).toBeNull();
+});
+
+test("an error verdict measures no drift — there is no reviewed diff behind it", async () => {
+  const {
+    deps: d,
+    reviews,
+    spawnOutcomes,
+  } = makeDeps({
+    readPlan: () => "## Goal\nship the widget",
+    // No decision at all → buildVerdictCore resolves `error`.
+    readVerdict: () => ({ summary: "", body: "", findings: [], planDrift: "minor" }),
+  });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(reviews["s1"]?.decision).toBe("error");
+  expect(reviews["s1"]?.planDrift).toBeNull();
+  expect(spawnOutcomes[0]).toMatchObject({ outcome: "error", planDrift: null });
 });
 
 test("does not review the same head twice", async () => {

--- a/test/server-usage-delivery.test.ts
+++ b/test/server-usage-delivery.test.ts
@@ -36,7 +36,7 @@ function seedMerged(store: SessionStore, id: string): void {
     model: null,
     spawnedAt: NOW - 3_000_000,
   });
-  store.setReviewerSpawnOutcome(`${id}-rev`, "clean");
+  store.setReviewerSpawnOutcome(`${id}-rev`, "clean", "minor");
 }
 
 test("GET /api/usage/delivery?range=7d → 200 with the full indicator set", async () => {
@@ -54,6 +54,9 @@ test("GET /api/usage/delivery?range=7d → 200 with the full indicator set", asy
   expect(body.totals.firstPassRate).toEqual({ value: 1, n: 1 });
   expect(body.totals.leadTimeMs.value).toBe(6_600_000);
   expect(body.totals.timeToFirstReviewMs.value).toBe(600_000);
+  // #2155: the drift measurement travels with the rest of the indicator set.
+  expect(body.totals.planDriftRate).toEqual({ value: 1, n: 1 });
+  expect(body.totals.planDriftMajor).toBe(0);
   expect(body.repos[0].repo).toBe("alpha");
   expect(body.tasks[0].desig).toBe("TASK-01");
   expect(Array.isArray(body.incidents)).toBe(true);
@@ -88,4 +91,5 @@ test("empty install returns nulls, not zeros", async () => {
   expect(body.measuringSince).toBeNull();
   expect(body.totals.firstPassRate.value).toBeNull();
   expect(body.totals.leadTimeMs.value).toBeNull();
+  expect(body.totals.planDriftRate.value).toBeNull();
 });

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -612,6 +612,63 @@ test("reviews: upsert + read by session, snapshot all", () => {
   expect(store.getReview("s1")).toBeNull();
 });
 
+test("reviews: planDrift + note round-trip; unknown levels coerce away (#2155)", () => {
+  const store = new SessionStore(":memory:");
+  const base = {
+    sessionId: "s1",
+    headSha: "abc",
+    patchId: "pid",
+    decision: "commented" as const,
+    summary: "looks fine",
+    summaryCode: null,
+    body: "",
+    findings: [],
+    addressRound: 0,
+    addressCap: 3,
+    streakReviews: 0,
+    reviewedPatchIds: [],
+    errorRound: 0,
+    finalRoundPending: false,
+    finalRoundTimeoutMs: 900_000,
+    seenNoteIds: [],
+    updatedAt: 1,
+  };
+  // A verdict that measured nothing carries no key at all — never a bogus "none".
+  store.putReview(base);
+  expect(store.getReview("s1")?.planDrift).toBeUndefined();
+  expect(store.getReview("s1")?.planDriftNote).toBeUndefined();
+  for (const level of ["none", "minor", "major"] as const) {
+    store.putReview({ ...base, planDrift: level, planDriftNote: "moved the helper" });
+    expect(store.getReview("s1")?.planDrift).toBe(level);
+    expect(store.getReview("s1")?.planDriftNote).toBe("moved the helper");
+  }
+  // A level this build does not know must not reach the lens as a measurement.
+  store.putReview({ ...base, planDrift: "catastrophic" as never });
+  expect(store.getReview("s1")?.planDrift).toBeUndefined();
+});
+
+test("setReviewerSpawnOutcome records the plan-drift measurement beside the outcome (#2155)", () => {
+  const s = mk();
+  const rec = (id: string) =>
+    s.recordReviewerSpawn({
+      reviewerSessionId: id,
+      taskSessionId: "task-1",
+      kind: "review",
+      worktreePath: `/wt-${id}`,
+      model: null,
+      spawnedAt: 1000,
+    });
+  rec("rev-a");
+  rec("rev-b");
+  s.setReviewerSpawnOutcome("rev-a", "clean", "major");
+  // The plan-gate caller passes no drift; that row must stay unmeasured rather than inherit one.
+  s.setReviewerSpawnOutcome("rev-b", "clean");
+  const byId = (id: string) => s.listReviewerSpawns().find((r) => r.reviewerSessionId === id)!;
+  expect(byId("rev-a").planDrift).toBe("major");
+  expect(byId("rev-a").outcome).toBe("clean");
+  expect(byId("rev-b").planDrift).toBeNull();
+});
+
 test("reviews: summaryCode round-trips; unknown sentinels coerce to null", () => {
   const store = new SessionStore(":memory:");
   const base = {
@@ -1552,6 +1609,7 @@ test("recordReviewerSpawn then listReviewerSpawns returns the row with NULL toke
     totalTokens: null,
     providerSessionId: null,
     outcome: null,
+    planDrift: null,
   });
 });
 
@@ -1568,6 +1626,8 @@ test("reviewer_spawns FRESH schema (DDL alone, no migration) already has provide
   expect(cols).toContain("providerSessionId");
   // #2151 R1: same invariant for the delivery-metrics outcome column.
   expect(cols).toContain("outcome");
+  // #2155: and for the plan-drift measurement that rides beside it.
+  expect(cols).toContain("planDrift");
 });
 
 test("reviewer_spawns migration: an old table without providerSessionId gains a NULL column", () => {
@@ -1591,6 +1651,8 @@ test("reviewer_spawns migration: an old table without providerSessionId gains a 
     const row = store.listReviewerSpawns().find((r) => r.reviewerSessionId === "rev-old");
     expect(row).toBeDefined();
     expect(row!.providerSessionId).toBeNull();
+    // #2155: a legacy row reads as "not measured", never as `none`.
+    expect(row!.planDrift).toBeNull();
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3731,5 +3731,13 @@
   "issues_attempt_http": "HTTP {status}",
   "issues_attempt_unknown": "unbekannter Fehler",
   "feat_issue_load_transports_title": "Scheitert das Laden der Issues, steht jetzt da, welcher Weg scheiterte",
-  "feat_issue_load_transports_body": "Shepherd lädt GitHub-Issues über zwei unabhängige Budgets — `gh issue list` auf dem GraphQL-Kontingent und `gh api` auf dem REST-Kontingent — und weicht bei einem Fehler auf den anderen Weg aus. Geben beide auf, sagen das Neue-Aufgabe-Modal und das Issues-Panel nicht mehr bloß „konnten nicht geladen werden“: Sie listen jeden Transport, der wirklich lief, samt Grund (Rate-Limit, nicht angemeldet, HTTP-Status, gh fehlt, Netzwerk). Der Mauszeiger auf einer Zeile zeigt die volle gh-Meldung. Ein „Erneut versuchen“ sagt damit, ob du auf ein Kontingent warten oder deine gh-Anmeldung reparieren musst."
+  "feat_issue_load_transports_body": "Shepherd lädt GitHub-Issues über zwei unabhängige Budgets — `gh issue list` auf dem GraphQL-Kontingent und `gh api` auf dem REST-Kontingent — und weicht bei einem Fehler auf den anderen Weg aus. Geben beide auf, sagen das Neue-Aufgabe-Modal und das Issues-Panel nicht mehr bloß „konnten nicht geladen werden“: Sie listen jeden Transport, der wirklich lief, samt Grund (Rate-Limit, nicht angemeldet, HTTP-Status, gh fehlt, Netzwerk). Der Mauszeiger auf einer Zeile zeigt die volle gh-Meldung. Ein „Erneut versuchen“ sagt damit, ob du auf ein Kontingent warten oder deine gh-Anmeldung reparieren musst.",
+  "usage_delivery_plan_drift": "[[plan-drift|Plan-Abweichung]]",
+  "usage_delivery_plan_drift_major": "{n} Aufgabe(n) wichen im Ansatz vom freigegebenen Plan ab, nicht nur im Detail.",
+  "feat_plan_drift_title": "Plan-Abweichungs-Bericht",
+  "feat_plan_drift_body": "Der PR-Critic meldet jetzt zusätzlich, wie weit eine gemergte Änderung von dem vor ihrer Umsetzung freigegebenen Plan abweicht — keine, gering oder groß, mit einer einzeiligen Notiz. Am Review-Urteil ändert das nichts: Vom Plan abzuweichen ist legitim. Der Tab „Lieferung“ zeigt die Quote, denn ein Repo mit ständiger Abweichung schreibt meist vage Pläne statt schlechten Code.",
+  "gloss_plan_drift_term": "Plan-Abweichung",
+  "gloss_plan_drift_def": "Wie weit eine gemergte Änderung von dem Plan abweicht, der vor ihrer Umsetzung freigegeben wurde — vom PR-Critic gemeldet als keine, gering oder groß. Das Review-Urteil bleibt davon unberührt: Vom Plan abzuweichen ist legitim. Gemessen wird es, weil ein Repo mit ständiger Abweichung meist vage Pläne schreibt, nicht schlechten Code.",
+  "gitrail_plan_drift_minor": "Plan-Abweichung: gering — gleicher Ansatz wie im freigegebenen Plan, mit beiläufigen Abweichungen.",
+  "gitrail_plan_drift_major": "Plan-Abweichung: groß — die Änderung ging einen anderen Weg als der freigegebene Plan."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3731,5 +3731,13 @@
   "issues_attempt_http": "HTTP {status}",
   "issues_attempt_unknown": "unknown error",
   "feat_issue_load_transports_title": "A failed issue load names the path that failed",
-  "feat_issue_load_transports_body": "Shepherd lists GitHub issues over two independent budgets — `gh issue list` on the GraphQL bucket and `gh api` on the REST bucket — and falls back from one to the other. When both give up, the New Task modal and the Issues panel no longer just say “couldn't load”: they list each transport that actually ran and why it stopped (rate limit, not signed in, HTTP status, gh missing, network). Hover a line for the full gh message. So a retry tells you whether to wait for a budget to reset or to fix your gh login."
+  "feat_issue_load_transports_body": "Shepherd lists GitHub issues over two independent budgets — `gh issue list` on the GraphQL bucket and `gh api` on the REST bucket — and falls back from one to the other. When both give up, the New Task modal and the Issues panel no longer just say “couldn't load”: they list each transport that actually ran and why it stopped (rate limit, not signed in, HTTP status, gh missing, network). Hover a line for the full gh message. So a retry tells you whether to wait for a budget to reset or to fix your gh login.",
+  "usage_delivery_plan_drift": "[[plan-drift|Plan drift]]",
+  "usage_delivery_plan_drift_major": "{n} task(s) diverged from the approved plan in approach, not just in detail.",
+  "feat_plan_drift_title": "Plan-drift report",
+  "feat_plan_drift_body": "The PR critic now also reports how far a merged change departed from the plan approved before it was written — none, minor or major, with a one-line note. It changes no review verdict: departing from a plan is legitimate. The Delivery tab shows the rate, because a repo that drifts constantly is usually writing vague plans rather than bad code.",
+  "gloss_plan_drift_term": "plan drift",
+  "gloss_plan_drift_def": "How far a merged change departed from the plan approved before it was written, as reported by the PR critic: none, minor or major. It never affects the review's verdict — departing from a plan is legitimate. It is measured because a repo that drifts constantly is usually writing vague plans, not writing bad code.",
+  "gitrail_plan_drift_minor": "Plan drift: minor — same approach as the approved plan, with incidental departures.",
+  "gitrail_plan_drift_major": "Plan drift: major — the change took a different route than the approved plan."
 }

--- a/ui/src/lib/components/GitRail.browser.test.ts
+++ b/ui/src/lib/components/GitRail.browser.test.ts
@@ -1109,6 +1109,45 @@ describe("GitRail — review popover is a modal dialog with real focus semantics
     );
     expect(document.activeElement, "Shift+Tab wraps first → last").toBe(last);
   });
+
+  // #2155 — plan drift is a MEASUREMENT the operator may read, never a verdict. It renders as a
+  // muted note inside the popover (no chip, no badge) and disappears entirely when nothing drifted.
+  it("shows the plan-drift note when the diff departed from the approved plan", async () => {
+    reviews.apply({
+      id: baseProps.sessionId,
+      review: {
+        ...verdict,
+        planDrift: "major",
+        planDriftNote: "built a service, plan said helper",
+      },
+    });
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = await render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    await expect.element(screen.getByTitle("PR #12345")).toBeVisible();
+
+    const { dialog } = await openReview(h);
+    const drift = dialog.querySelector(".rv-drift");
+    expect(drift, "drift note rendered").not.toBeNull();
+    expect(drift!.textContent).toContain("built a service, plan said helper");
+    // It must not have leaked into the verdict chip — the decision is what that reports.
+    expect(h.querySelector("button.verdict-chip")!.textContent).not.toContain("drift");
+  });
+
+  it("renders nothing for `none` drift or for an unmeasured verdict", async () => {
+    for (const review of [{ ...verdict, planDrift: "none" as const }, verdict]) {
+      reviews.apply({ id: baseProps.sessionId, review });
+      gitStateFn.mockResolvedValue(openPrState);
+      await page.viewport(600, 900);
+      const h = host(600);
+      const screen = await render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+      await expect.element(screen.getByTitle("PR #12345")).toBeVisible();
+
+      const { dialog } = await openReview(h);
+      expect(dialog.querySelector(".rv-drift")).toBeNull();
+    }
+  });
 });
 
 describe("GitRail — manual critic-review trigger", () => {

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -20,6 +20,7 @@
   import { criticChip, criticBadgeLabel, criticTitle } from "./critic-badge";
   import { canTriggerPlanReview } from "./plan-gate-badge";
   import RailStatusActions from "./git-rail/RailStatusActions.svelte";
+  import PlanDriftNote from "./git-rail/PlanDriftNote.svelte";
   import AutomationPanel from "./AutomationPanel.svelte";
   import { automationCount, AUTOMATION_TOTAL } from "./git-rail-automation";
   import { coachTarget, coachTargets } from "$lib/actions/coachTarget.svelte";
@@ -825,6 +826,8 @@
         {#if verdict.summaryCode || verdict.summary}
           <p class="rv-summary">{criticTitle(verdict)}</p>
         {/if}
+        <!-- #2155: renders nothing unless the critic measured a real departure from the plan. -->
+        <PlanDriftNote {verdict} />
         {#if verdict.body}
           <!-- eslint-disable-next-line svelte/no-at-html-tags -- sanitized via DOMPurify above -->
           <div class="rv-body">{@html renderedBody}</div>

--- a/ui/src/lib/components/git-rail/PlanDriftNote.svelte
+++ b/ui/src/lib/components/git-rail/PlanDriftNote.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  // #2155 — the critic's plan-drift measurement, rendered inside the review popover.
+  //
+  // It is a MEASUREMENT, never a verdict: no chip, no badge, no tone that competes with the
+  // decision the popover is actually reporting. Nothing shows when the diff followed the plan, or
+  // when the run measured nothing (no plan shown, or an errored critic).
+  //
+  // Its own component rather than an {#if} in GitRail's markup: that template sits at the Tier-1
+  // Svelte complexity bar, where a branch nested this deep costs far more than the two lines it
+  // renders (see .fallowrc.jsonc thresholdOverrides).
+  import type { ReviewVerdict } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+
+  const { verdict }: { verdict: ReviewVerdict } = $props();
+
+  const drift = $derived(verdict.planDrift);
+  const label = $derived(
+    drift === "major" ? m.gitrail_plan_drift_major() : m.gitrail_plan_drift_minor(),
+  );
+  // The note is the critic's own prose (data), so it is appended rather than interpolated into a
+  // catalog string — nothing to translate in it, and no message key can carry it.
+  const note = $derived(verdict.planDriftNote ? ` — ${verdict.planDriftNote}` : "");
+</script>
+
+{#if drift && drift !== "none"}
+  <p class="rv-drift">{label}{note}</p>
+{/if}
+
+<style>
+  .rv-drift {
+    margin: 0;
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    /* pinned alongside head/footer; only .rv-body scrolls */
+    flex-shrink: 0;
+  }
+</style>

--- a/ui/src/lib/components/usage/DeliveryLens.browser.test.ts
+++ b/ui/src/lib/components/usage/DeliveryLens.browser.test.ts
@@ -22,6 +22,8 @@ const stats = (over: Partial<DeliveryStats> = {}): DeliveryStats => ({
   criticErrors: 0,
   planRoundsMedian: s(null),
   planReworkRate: s(null),
+  planDriftRate: s(null),
+  planDriftMajor: 0,
   timeToFirstReviewMs: s(600_000),
   leadTimeMs: s(23_400_000),
   ...over,
@@ -53,8 +55,8 @@ describe("DeliveryLens", () => {
   it("renders every indicator with its sample size", async () => {
     render(DeliveryLens, { metrics: metrics() });
 
-    // first-pass, rework, plan rework, ttfr, lead time, merged
-    expect(tileValues()).toEqual(["50%", "1.5", "—", "10m", "6h 30m", "4"]);
+    // first-pass, rework, plan rework, plan drift, ttfr, lead time, merged
+    expect(tileValues()).toEqual(["50%", "1.5", "—", "—", "10m", "6h 30m", "4"]);
     expect(document.body.textContent).toContain("n = 4");
   });
 
@@ -80,8 +82,8 @@ describe("DeliveryLens", () => {
     });
     const values = tileValues();
     expect(values[0]).toBe("—");
-    expect(values[3]).toBe("—");
     expect(values[4]).toBe("—");
+    expect(values[5]).toBe("—");
     expect(values).not.toContain("0%");
   });
 
@@ -110,6 +112,21 @@ describe("DeliveryLens", () => {
     // The count cell must keep its intrinsic width, not collapse into a 3rem track.
     const count = incident.lastElementChild as HTMLElement;
     expect(count.getBoundingClientRect().width).toBeGreaterThan(48);
+  });
+
+  it("renders the plan-drift rate and calls out major divergences (#2155)", async () => {
+    render(DeliveryLens, {
+      metrics: metrics({ totals: stats({ planDriftRate: s(0.25, 8), planDriftMajor: 1 }) }),
+    });
+    expect(tileValues()[3]).toBe("25%");
+    expect(document.body.textContent).toContain("n = 8");
+    // The major count is called out only when there is one — a rate alone hides how bad the drift is.
+    expect(document.body.textContent).toContain("approach");
+  });
+
+  it("omits the major-divergence note when nothing drifted that far", async () => {
+    render(DeliveryLens, { metrics: metrics({ totals: stats({ planDriftRate: s(0.25, 8) }) }) });
+    expect(document.body.textContent).not.toContain("approach");
   });
 
   it("lists repos and surfaces critic errors when there are any", async () => {

--- a/ui/src/lib/components/usage/DeliveryLens.svelte
+++ b/ui/src/lib/components/usage/DeliveryLens.svelte
@@ -69,6 +69,12 @@
         note: sampleNote(st.planReworkRate),
       },
       {
+        key: "plan-drift",
+        label: m.usage_delivery_plan_drift(),
+        value: pct(st.planDriftRate),
+        note: sampleNote(st.planDriftRate),
+      },
+      {
         key: "ttfr",
         label: m.usage_delivery_ttfr(),
         value: durationOf(st.timeToFirstReviewMs),
@@ -125,6 +131,12 @@
           </div>
         {/each}
       </div>
+
+      {#if metrics.totals.planDriftMajor > 0}
+        <p class="caption">
+          {m.usage_delivery_plan_drift_major({ n: metrics.totals.planDriftMajor })}
+        </p>
+      {/if}
 
       {#if metrics.totals.criticErrors > 0}
         <p class="caption">

--- a/ui/src/lib/docs-manifest.ts
+++ b/ui/src/lib/docs-manifest.ts
@@ -81,7 +81,7 @@ export const DOCS_PAGES: readonly DocsPage[] = [
     title: "Concepts & glossary",
     path: "/reference/glossary/",
     keywords:
-      "the shepherd-specific and industry terms used throughout the app and these docs. shepherd concepts epic plan gate autopilot critic merge train rework first-pass rate inferred lightweight repo trial weighted units reasoning effort satellite pass host capacity herdr runtime hygiene sandbox membrane spawn prompt access token token scope industry terms pr ci telemetry lead time inode",
+      "the shepherd-specific and industry terms used throughout the app and these docs. shepherd concepts epic plan gate autopilot critic merge train rework first-pass rate plan drift inferred lightweight repo trial weighted units reasoning effort satellite pass host capacity herdr runtime hygiene sandbox membrane spawn prompt access token token scope industry terms pr ci telemetry lead time inode",
   },
   {
     title: "Project house rules",

--- a/ui/src/lib/feature-announcements/entries/v1.48.0-plan-drift.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.48.0-plan-drift.ts
@@ -1,0 +1,11 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "plan-drift",
+  sinceVersion: "1.48.0",
+  titleKey: "feat_plan_drift_title",
+  bodyKey: "feat_plan_drift_body",
+  targetId: "usage-delivery-tab",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/glossary.ts
+++ b/ui/src/lib/glossary.ts
@@ -85,6 +85,12 @@ const glossary: readonly GlossaryTerm[] = [
     bodyKey: "gloss_first_pass_rate_def",
   },
   {
+    id: "plan-drift",
+    kind: "internal",
+    termKey: "gloss_plan_drift_term",
+    bodyKey: "gloss_plan_drift_def",
+  },
+  {
     id: "lead-time",
     kind: "external",
     termKey: "gloss_lead_time_term",

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -816,9 +816,18 @@ export interface ReviewVerdict {
   // Operator dismissed / took over this stalled critic rework; the rework classification skips it.
   // Absent ⇒ false.
   dismissed?: boolean;
+  /** #2155 — how far this round's diff departed from the approved plan the critic was shown.
+   *  Absent = not measured (no plan, or the run errored). ADVISORY: it moves no decision, it is
+   *  shown in the review popover as a note and nowhere else. */
+  planDrift?: PlanDrift | null;
+  /** One line naming the biggest departure (<=140 chars); absent when nothing drifted. */
+  planDriftNote?: string | null;
   url?: string;
   updatedAt: number;
 }
+
+/** Mirror of PlanDrift in src/types.ts — keep in sync. */
+export type PlanDrift = "none" | "minor" | "major";
 /** The per-repo sandbox confinement profile. trusted = no sandbox (default);
  *  standard = filesystem/process membrane (interactive-only, unrestricted network);
  *  autonomous = same membrane + network-egress allowlist (Anthropic + forge),
@@ -1485,6 +1494,8 @@ export interface DeliveryStats {
   criticErrors: number; // critic runs that produced no verdict — never counted as rework
   planRoundsMedian: DeliverySample;
   planReworkRate: DeliverySample; // 0..1, over gated tasks only
+  planDriftRate: DeliverySample; // 0..1, over tasks the critic measured against a plan (#2155)
+  planDriftMajor: number; // of those, how many reported `major`
   timeToFirstReviewMs: DeliverySample;
   leadTimeMs: DeliverySample;
 }


### PR DESCRIPTION
Closes #2155.

Follow-up to #2151 (R3), building on the delivery-metrics substrate shipped in #2153.

The critic answers one extra field when — and only when — it is already shown the `APPROVED PLAN` block: `planDrift: none|minor|major` plus a one-line note. It is pure measurement: never a finding, never moves a decision, never advances the rework streak. Plan-less session prompts and the standalone PR critic stay byte-identical.

## Persisted twice, on purpose

The issue asks for `reviews`. That alone cannot work: `archive()` deletes the review row, and every task the Delivery lens counts is a merged — therefore archived — task, so a reviews-only column would read `null` in the lens 100% of the time.

| Column | Table | Lifetime | Consumer |
| --- | --- | --- | --- |
| `planDrift` | `reviewer_spawns` | archive-decoupled, append-only | Delivery lens + CLI report |
| `planDrift`, `planDriftNote` | `reviews` | dies with `archive()` | live review popover |

`reviewer_spawns` is where #2153 put `outcome` for exactly this reason; the drift rides the same single stamp at finalize.

## Aggregation

The **last measured round** wins — the drift of the diff closest to merge, not an intermediate round's; a later unmeasured round does not erase an earlier measurement. The denominator is tasks that carry a measurement at all, so an unmeasured task is excluded rather than counted as `none`, which would flatter the rate.

## Surfaced

- **Delivery lens**: a `Plan drift` tile with its sample size (em dash, never `0%`, when unmeasured) plus a caption calling out `major` divergences.
- **`bun run delivery-report`**: a `Plan drift rate` row.
- **Review popover**: a muted one-line note (`git-rail/PlanDriftNote.svelte`) — no chip, no badge, nothing that competes with the decision the popover reports. Its own component because a branch nested that deep in `GitRail`'s template costs more complexity than the two lines it renders.

## Notes

- The drift note is collapsed to one line and hard-capped at 140 chars server-side, and the prompt asks for it without quotation marks — it rides the verdict JSON, whose escaping is what #2042 was about. An unrecognized level normalizes to `null` = not measured.
- Two guards discard a drift answer: the run was shown no plan (nothing to measure against), or it errored (no reviewed diff behind it).
- Forward-only, like the rest of the delivery instrumentation; the lens already reports `measuringSince`.

## Verification

`bun run lint`, `bun run test` (8867 pass), `cd ui && bun run check && bun run test` (4741 pass), `fallow audit --base origin/main --fail-on-issues`, glossary / i18n-parity / feature-catalog / docs-manifest gates — all green. The non-blocking guarantee is a test, not a comment: a major-drift, findings-free verdict must still resolve clean, steer nothing and advance no streak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
