### PR TITLE
fix(review): never review or persist a stale head (#2175)

### DIFF
--- a/src/critic-core.ts
+++ b/src/critic-core.ts
@@ -12,6 +12,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { execFileSync, timedAsync } from "./instrument";
 import type { PlanDrift, ReviewDecision } from "./types";
+import type { PrStatus } from "./forge/types";
 import type { SessionUsage } from "./usage";
 import { tolerantParseJson } from "./json-tolerant";
 import type { VerdictRead } from "./json-tolerant";
@@ -1411,6 +1412,24 @@ export async function captureUsage(
   } catch (err) {
     console.warn(`[review] usage capture failed for ${logLabel}:`, err);
   }
+}
+
+/**
+ * Has the head we are about to review — or have just reviewed — been superseded by a newer push?
+ *
+ * The poller's `GitState` is a CACHED snapshot (a full sweep can be 300s cold), so the head it
+ * carries can already be stale by the time a critic spawns, and can go stale again during the
+ * ~8 minutes one runs. Reviewing a superseded head costs a spawn, delivers a `changes_requested`
+ * round the author has nothing to fix, and burns a rework round against the cap (issue #2175).
+ *
+ * FAILS OPEN on purpose: only a CONFIRMED, still-`open` PR carrying a DIFFERENT `headSha` counts as
+ * superseded. No forge, a forge that threw (`live` undefined), a payload without `headSha`, or a
+ * non-`open` state all return false — behave exactly as before. A forge blip must never be able to
+ * permanently suppress review, and merged/closed PRs already have their own moot handling that this
+ * predicate must not pre-empt.
+ */
+export function headSuperseded(reviewedSha: string, live: PrStatus | undefined): boolean {
+  return live?.state === "open" && !!live.headSha && live.headSha !== reviewedSha;
 }
 
 /** Terminal + disposable-worktree teardown for a finished critic run.

--- a/src/delivery-metrics.ts
+++ b/src/delivery-metrics.ts
@@ -87,8 +87,9 @@ function rate(hits: number, total: number): DeliverySample {
 }
 
 /** Group the reviewer-spawn log by task session, keeping only the two kinds a delivery indicator
- *  reads. A NULL `outcome` is a legacy row or a spawn that never finalized: it is UNKNOWN, so it
- *  is excluded from every round count — counting it would inflate rework with crashed runs. */
+ *  reads. A NULL `outcome` is a legacy row, a spawn that never finalized, or one whose verdict was
+ *  discarded as superseded (#2175): it is UNKNOWN, so it is excluded from every round count —
+ *  counting it would inflate rework with crashed runs and with reviews of code already replaced. */
 function applyReviewSpawn(t: TaskRounds, sp: ReviewerSpawnRow): void {
   // The review STARTED regardless of how it ended, so every spawn moves the first-review mark.
   if (t.firstReviewAt == null || sp.spawnedAt < t.firstReviewAt) t.firstReviewAt = sp.spawnedAt;

--- a/src/review.ts
+++ b/src/review.ts
@@ -42,6 +42,7 @@ import {
   normalizePlanDrift,
   normalizePlanDriftNote,
   shouldSkipForPatchId,
+  headSuperseded,
   captureUsage,
   reapRun,
   VERDICT_FILE,
@@ -502,6 +503,13 @@ export class ReviewService {
     // Claim the slot synchronously, BEFORE begin()'s await, so a concurrent consider bails.
     this.starting.add(session.id);
     try {
+      // #2175: `git` is the poller's CACHED snapshot (up to a full idle sweep old), so a push can
+      // have landed since it was taken — the critic would then review superseded code and steer a
+      // findings round the author has already fixed. Re-read the live head and decline; the next
+      // poll picks the new head up normally (and that push reset CI to pending anyway, so the
+      // green-checks precondition has genuinely lapsed too). Deliberately INSIDE the claim: this
+      // await must not open a window for a second consider()/forceReview() to reach begin().
+      if (await this.headMoved(session, git.headSha!)) return "skipped";
       await this.begin(session, git, force);
     } finally {
       this.starting.delete(session.id);
@@ -512,6 +520,26 @@ export class ReviewService {
     // this return, so the non-force churn-skip "error" is irrelevant there; it's authoritative
     // only for the manual/force path.
     return this.inflight.has(session.id) ? "started" : "error";
+  }
+
+  /** Is the head we are about to review already superseded on the forge? One `prStatus` round-trip,
+   *  trivial next to the critic run it guards, and only reached once every cheap gate has passed.
+   *  Fails OPEN (see {@link headSuperseded}): no forge, or a forge that throws, spawns as before. */
+  private async headMoved(session: Session, headSha: string): Promise<boolean> {
+    const forge = this.deps.resolveForge(session.repoPath);
+    if (!forge) return false;
+    let live: PrStatus | undefined;
+    try {
+      live = await forge.prStatus(session.branch!);
+    } catch (err) {
+      console.warn(`[review] pre-spawn head recheck failed for ${session.id}:`, err);
+      return false;
+    }
+    if (!headSuperseded(headSha, live)) return false;
+    console.warn(
+      `[review] skipping ${session.id}: head moved ${headSha} → ${live!.headSha} before the spawn`,
+    );
+    return true;
   }
 
   private async begin(session: Session, git: GitState, force: boolean): Promise<void> {
@@ -1260,68 +1288,23 @@ export class ReviewService {
     // (a forge/store/steer failure must not strand them).
     try {
       const verdict = this.buildVerdict(f, raw, cause ?? null);
-      // Stamp the spawn's terminal outcome for the delivery metrics (#2151 R1). Deliberately
-      // BEFORE the moot-verdict branch below: the critic did run and did conclude, so the spawn
-      // row must say so even when the verdict isn't persisted as session state. `findings` — not
-      // `decision` — is what drives rework here, mirroring the auto-address loop, so a
-      // findings-free "comment" verdict is a clean first pass. Best-effort: an accounting write
-      // must never strand finalize.
-      try {
-        this.deps.store.setReviewerSpawnOutcome(
-          f.criticSessionId,
-          verdict.decision === "error"
-            ? "error"
-            : verdict.findings.length === 0
-              ? "clean"
-              : "changes_requested",
-          // #2155: the durable copy. The `reviews` row this verdict also lands on is deleted by
-          // archive(), and every task the delivery metrics count is an archived one.
-          verdict.planDrift,
+      // ONE live PR read for this finalize, shared by the supersession check below and by the
+      // publish/error arms (which each used to fetch their own — mutually exclusive, so this is
+      // still a single round-trip). One snapshot ⇒ head and state can never disagree.
+      const live = await this.livePr(f);
+      // #2175: a push landed while the critic ran, so this verdict was computed against superseded
+      // code. Drop it whole — persisting it would post a review and steer a findings round the
+      // author has already fixed, and charge that round against the cap. Nothing is written (not
+      // even the spawn's outcome, which would otherwise count as rework in the delivery metrics):
+      // the prior verdict row still stands, and the next poll reviews the new head normally.
+      // captureUsage + the finally-reap below still run, so the spawn's cost is attributed and its
+      // terminal/worktree reaped.
+      if (headSuperseded(f.headSha, live)) {
+        console.warn(
+          `[review] verdict discarded for ${f.sessionId}: head moved ${f.headSha} → ${live!.headSha} during the review (superseded)`,
         );
-      } catch (err) {
-        console.warn(`[review] outcome accounting failed for ${f.sessionId}:`, err);
-      }
-      // A verdict for a PR that's no longer open is moot. The real branch handles that inside
-      // publishVerdict(); the error branch needs its own gate (finalizeErrorVerdict) since it
-      // never reaches publishVerdict. When persist is false we skip persisting the verdict as
-      // session review state — see below.
-      let persist = true;
-      if (verdict.decision === "error") {
-        persist = await this.finalizeErrorVerdict(f, verdict);
       } else {
-        // Per-streak review accounting — independent of publish/steer outcome and of
-        // autoAddressEnabled (review token spend happens whether or not findings are steered).
-        // A clean verdict (findings:[]) resets the streak; any findings-bearing verdict
-        // increments it and appends this run's patch-id (deduped) to the churn-skip set.
-        if (verdict.findings.length === 0) {
-          verdict.streakReviews = 0;
-          verdict.reviewedPatchIds = [];
-        } else {
-          verdict.streakReviews = f.priorStreakReviews + 1;
-          verdict.reviewedPatchIds = [...new Set([...f.priorReviewedPatchIds, f.patchId])];
-          // Escalate once, when the streak first reaches the ceiling (2*cap). `>=` with a
-          // crossing guard (priorStreakReviews < ceiling) so a cap lowered between runs still
-          // fires rather than being stepped over, while reviews past the ceiling don't
-          // re-signal every tick (consider() bails before re-spawning anyway). Mirrors the
-          // errorRound crossing-guard pattern below in the error path.
-          const ceiling = 2 * this.cap;
-          if (verdict.streakReviews >= ceiling && f.priorStreakReviews < ceiling) {
-            this.deps.store.addSignal({
-              repoPath: f.repoPath,
-              sessionId: f.sessionId,
-              kind: "stall",
-              payload: `critic reviewed this PR ${verdict.streakReviews} times without reaching clean — auto-review paused; needs human attention`,
-            });
-          }
-        }
-        await this.publishVerdict(f, verdict);
-      }
-      // Skipped only for a moot post-merge error verdict (persist=false above): it must not
-      // become the session's review state. captureUsage + the finally-reap below still run, so
-      // the critic spawn's token cost is attributed and its terminal/worktree are reaped.
-      if (persist) {
-        this.deps.store.putReview(verdict);
-        this.deps.onChange(f.sessionId, verdict);
+        await this.settleVerdict(f, verdict, live);
       }
       // Persist the critic's token total for exact cost attribution (issue #502). Best-effort:
       // a missing/half-written transcript leaves the spawn row's totals null rather than
@@ -1345,6 +1328,82 @@ export class ReviewService {
   }
 
   /**
+   * Everything a NON-superseded verdict does: stamp the spawn outcome, run the streak/error
+   * accounting, publish (or suppress) its outward effects, and persist it as the session's review
+   * state. `live` is finalize()'s single PR-state read, threaded in so both arms see one snapshot.
+   */
+  private async settleVerdict(
+    f: InFlight,
+    verdict: ReviewVerdict,
+    live: PrStatus | undefined,
+  ): Promise<void> {
+    // Stamp the spawn's terminal outcome for the delivery metrics (#2151 R1). Deliberately
+    // BEFORE the moot-verdict branch below: the critic did run and did conclude, so the spawn
+    // row must say so even when the verdict isn't persisted as session state. (A SUPERSEDED run
+    // never reaches here at all — finalize() drops it before this, so it stays out of the metrics.)
+    // `findings` — not `decision` — is what drives rework here, mirroring the auto-address loop, so
+    // a findings-free "comment" verdict is a clean first pass. Best-effort: an accounting write
+    // must never strand finalize.
+    try {
+      this.deps.store.setReviewerSpawnOutcome(
+        f.criticSessionId,
+        verdict.decision === "error"
+          ? "error"
+          : verdict.findings.length === 0
+            ? "clean"
+            : "changes_requested",
+        // #2155: the durable copy. The `reviews` row this verdict also lands on is deleted by
+        // archive(), and every task the delivery metrics count is an archived one.
+        verdict.planDrift,
+      );
+    } catch (err) {
+      console.warn(`[review] outcome accounting failed for ${f.sessionId}:`, err);
+    }
+    // A verdict for a PR that's no longer open is moot. The real branch handles that inside
+    // publishVerdict(); the error branch needs its own gate (finalizeErrorVerdict) since it
+    // never reaches publishVerdict. When persist is false we skip persisting the verdict as
+    // session review state — see below.
+    let persist = true;
+    if (verdict.decision === "error") {
+      persist = await this.finalizeErrorVerdict(f, verdict, live);
+    } else {
+      // Per-streak review accounting — independent of publish/steer outcome and of
+      // autoAddressEnabled (review token spend happens whether or not findings are steered).
+      // A clean verdict (findings:[]) resets the streak; any findings-bearing verdict
+      // increments it and appends this run's patch-id (deduped) to the churn-skip set.
+      if (verdict.findings.length === 0) {
+        verdict.streakReviews = 0;
+        verdict.reviewedPatchIds = [];
+      } else {
+        verdict.streakReviews = f.priorStreakReviews + 1;
+        verdict.reviewedPatchIds = [...new Set([...f.priorReviewedPatchIds, f.patchId])];
+        // Escalate once, when the streak first reaches the ceiling (2*cap). `>=` with a
+        // crossing guard (priorStreakReviews < ceiling) so a cap lowered between runs still
+        // fires rather than being stepped over, while reviews past the ceiling don't
+        // re-signal every tick (consider() bails before re-spawning anyway). Mirrors the
+        // errorRound crossing-guard pattern below in the error path.
+        const ceiling = 2 * this.cap;
+        if (verdict.streakReviews >= ceiling && f.priorStreakReviews < ceiling) {
+          this.deps.store.addSignal({
+            repoPath: f.repoPath,
+            sessionId: f.sessionId,
+            kind: "stall",
+            payload: `critic reviewed this PR ${verdict.streakReviews} times without reaching clean — auto-review paused; needs human attention`,
+          });
+        }
+      }
+      await this.publishVerdict(f, verdict, live);
+    }
+    // Skipped only for a moot post-merge error verdict (persist=false above): it must not
+    // become the session's review state. captureUsage + the finally-reap below still run, so
+    // the critic spawn's token cost is attributed and its terminal/worktree are reaped.
+    if (persist) {
+      this.deps.store.putReview(verdict);
+      this.deps.onChange(f.sessionId, verdict);
+    }
+  }
+
+  /**
    * Bookkeeping for a transient critic *error* verdict (timeout / unparseable). Returns whether
    * the verdict should be persisted as session review state.
    *
@@ -1357,15 +1416,19 @@ export class ReviewService {
    * transient REVIEW ERR if the PR did merge but the recheck couldn't see it (logged so the field
    * cause is distinguishable; self-clears at archive).
    */
-  private async finalizeErrorVerdict(f: InFlight, verdict: ReviewVerdict): Promise<boolean> {
-    const live = await this.livePrState(f);
-    if (live === "merged" || live === "closed") {
+  private async finalizeErrorVerdict(
+    f: InFlight,
+    verdict: ReviewVerdict,
+    live: PrStatus | undefined,
+  ): Promise<boolean> {
+    const state = live?.state;
+    if (state === "merged" || state === "closed") {
       console.warn(
-        `[review] error verdict suppressed for ${f.sessionId}: PR ${live} before finalize (moot)`,
+        `[review] error verdict suppressed for ${f.sessionId}: PR ${state} before finalize (moot)`,
       );
       return false;
     }
-    if (live === undefined)
+    if (state === undefined)
       console.warn(
         `[review] error verdict kept for ${f.sessionId}: live PR state unconfirmable (fail-open) — may surface a transient REVIEW ERR if the PR already merged`,
       );
@@ -1401,16 +1464,17 @@ export class ReviewService {
   }
 
   /**
-   * Live PR state for the at-finalize recheck. `undefined` when it can't be confirmed (no forge,
-   * or the forge throws) — callers treat that as "unconfirmable" and decide their own fail mode.
-   * Mirrors the fetch publishVerdict() does for real verdicts; the error branch uses it too so a
-   * transient critic error finishing AFTER the merge isn't persisted as a stale REVIEW ERR.
+   * Live PR status for the at-finalize rechecks — both the state (merged/closed ⇒ the verdict is
+   * moot) and the head (moved ⇒ the verdict is superseded, #2175). `undefined` when it can't be
+   * confirmed (no forge, or the forge throws) — callers treat that as "unconfirmable" and decide
+   * their own fail mode. Fetched ONCE per finalize and threaded into both arms, so the state and
+   * the head a single verdict is judged against always come from the same snapshot.
    */
-  private async livePrState(f: InFlight): Promise<PrStatus["state"] | undefined> {
+  private async livePr(f: InFlight): Promise<PrStatus | undefined> {
     const forge = this.deps.resolveForge(f.repoPath);
     if (!forge) return undefined;
     try {
-      return (await forge.prStatus(f.branch))?.state;
+      return await forge.prStatus(f.branch);
     } catch (err) {
       console.warn(`[review] PR-state recheck failed for ${f.sessionId}:`, err);
       return undefined;
@@ -1420,7 +1484,8 @@ export class ReviewService {
   /**
    * Emit a real verdict's outward effects, branching on the PR's LIVE state. Critic spawn and
    * PR merge both fire on CI-green, so they race by construction: the critic can finish AFTER
-   * the PR merged/closed. Live fetch (not the cached snapshot — the 120s poll can lag the merge).
+   * the PR merged/closed. `live` is finalize()'s live read (not the poller's cached snapshot, which
+   * can lag the merge by a full sweep).
    *  - open   → full effects: post the review, steer findings to the agent, record the critic
    *             signal, set finalRoundPending. (Unchanged.)
    *  - merged → the critic lost the race. We can't request-changes on a merged PR, so when there
@@ -1431,14 +1496,13 @@ export class ReviewService {
    * Fail-closed: if we can't confirm the state (no forge / forge throws / unexpected state) we
    * emit nothing. The verdict row itself is still persisted by the caller.
    */
-  private async publishVerdict(f: InFlight, verdict: ReviewVerdict): Promise<void> {
+  private async publishVerdict(
+    f: InFlight,
+    verdict: ReviewVerdict,
+    live: PrStatus | undefined,
+  ): Promise<void> {
     const forge = this.deps.resolveForge(f.repoPath);
-    let state: PrStatus["state"] | undefined;
-    try {
-      state = (await forge?.prStatus(f.branch))?.state;
-    } catch (err) {
-      console.warn(`[review] PR-state recheck failed for ${f.sessionId}:`, err);
-    }
+    const state = live?.state;
     if (!forge) return; // no forge → can't confirm anything, emit nothing
     if (state === "merged") {
       // Critic finished after the PR merged: record findings (if any) as a post-merge comment so

--- a/test/critic-core.test.ts
+++ b/test/critic-core.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   scopeBackstop,
+  headSuperseded,
   shouldSkipForPatchId,
   scopeFindings,
   attributeFinding,
@@ -1561,4 +1562,30 @@ test("#2154 both blocks together keep the shared verdict-output contract identic
   expect(outputContract(a)).toBe(
     outputContract(reviewPrompt("b", "task")), // and identical to the no-blocks prompt
   );
+});
+
+// ── headSuperseded (#2175) ────────────────────────────────────────────────────
+
+const openAt = (headSha?: string) => ({ state: "open", checks: "success", headSha }) as any;
+
+test("headSuperseded: a different head on a still-open PR is superseded", () => {
+  expect(headSuperseded("abc", openAt("def"))).toBe(true);
+});
+
+test("headSuperseded: the same head is not superseded", () => {
+  expect(headSuperseded("abc", openAt("abc"))).toBe(false);
+});
+
+test("headSuperseded fails OPEN on every unconfirmable shape", () => {
+  expect(headSuperseded("abc", undefined)).toBe(false); // no forge, or the forge threw
+  expect(headSuperseded("abc", openAt(undefined))).toBe(false); // payload carries no headSha
+  expect(headSuperseded("abc", { state: "open", checks: "success", headSha: "" } as any)).toBe(
+    false, // empty sha is not evidence of a move
+  );
+});
+
+test("headSuperseded ignores non-open states (their own moot handling owns those)", () => {
+  for (const state of ["merged", "closed", "none"] as const) {
+    expect(headSuperseded("abc", { state, checks: "success", headSha: "def" } as any)).toBe(false);
+  }
 });

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -2271,7 +2271,11 @@ describe("classifyPreviewProbes (#1912)", () => {
   it("the probe reads the LIVE cell health, not a fresh backend (frozen-cell detection)", async () => {
     // Probe reports ok (its own spawn succeeds within the 5s budget), but the live
     // cell is frozen by 3s refresh timeouts → the check must still warn.
+    // `healthyDeps()` like every sibling: without it the untouched deps fall through to their REAL
+    // probes (gh auth, herdr liveness, tailscale serve, bwrap membrane), which on a host lacking
+    // those binaries burn retries and blow the 5s per-test budget. Only the preview rows matter here.
     const svc = new DiagnosticsService({
+      ...healthyDeps(),
       runPreviewProbe: async () => "ok",
       probeHealth: () => ({ state: "stale", driven: true }),
     });

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -192,6 +192,7 @@ function makeDeps(
   const started: { name: string; cwd: string; argv: string[]; env?: Record<string, string> }[] = [];
   const stopped: string[] = [];
   const removed: string[] = [];
+  const created: string[] = []; // head SHAs passed to worktree.createDetached (probe allocations)
   const bumped: { id: string; headSha: string }[] = []; // bumpReviewHead calls (rebase-skip)
   const steers: { id: string; text: string }[] = [];
   const signals: { kind: string; payload: string }[] = [];
@@ -201,6 +202,11 @@ function makeDeps(
   const completedSpawns: any[] = []; // completeReviewerSpawn calls
   const spawnOutcomes: { id: string; outcome: string; planDrift: string | null }[] = []; // #2151/#2155
   const rec: { event?: string; body?: string } = {};
+  // The forge's LIVE head, as the staleness guards read it. Defaults to OPEN_GREEN's, and `atHead`
+  // moves it in step with the poller snapshot a test considers — so snapshot and live head agree by
+  // construction, and only a test that MEANS to diverge them (a push landing mid-review) does. A
+  // fixed live sha here would read as "head moved" for every test considering a non-"abc" head.
+  const live = { head: OPEN_GREEN.headSha! };
   const notices = new Map<string, any>();
   const noticeEvents: string[] = [];
   const base = {
@@ -288,7 +294,10 @@ function makeDeps(
     })(),
     worktree: new (class {
       readonly recorded = removed; // this-dependent: unbound call loses this.recorded
-      createDetached = async () => ({ worktreePath: "/review-wt", branch: null, isolated: true });
+      createDetached = async (_repo: string, _branch: string, sha: string) => {
+        created.push(sha);
+        return { worktreePath: "/review-wt", branch: null, isolated: true };
+      };
       remove(p: string) {
         this.recorded.push(p); // this.recorded → throws TypeError if called unbound
       }
@@ -301,7 +310,7 @@ function makeDeps(
         rec,
         opts.comments ?? [],
         commentCalls,
-        opts.prStatus,
+        opts.prStatus ?? (async () => ({ ...OPEN_GREEN, headSha: live.head }) as PrStatus),
         opts.noCommentApi ? undefined : postedComments,
       ),
     onChange: () => {},
@@ -330,6 +339,7 @@ function makeDeps(
     started,
     stopped,
     removed,
+    created,
     bumped,
     steers,
     signals,
@@ -342,6 +352,12 @@ function makeDeps(
     noticeEvents,
     paneReads,
     rec,
+    live,
+    /** Poller snapshot at `sha`, with the forge's live head moved to match. */
+    atHead: (sha: string): GitState => {
+      live.head = sha;
+      return { ...OPEN_GREEN, headSha: sha };
+    },
   };
 }
 
@@ -1572,6 +1588,7 @@ test("rebase with identical diff: skips the critic, re-points head, preserves th
     started,
     removed,
     bumped,
+    atHead,
   } = makeDeps({
     computePatchId: async () => ({ patchId: "pid-same", baseSha: "base-pid-same", files: ["f"] }),
   });
@@ -1579,7 +1596,7 @@ test("rebase with identical diff: skips the critic, re-points head, preserves th
   // but its diff is identical → same patch-id.
   reviews["s1"] = priorReview({ patchId: "pid-same", headSha: "old" });
   const svc = new ReviewService(d as any);
-  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  await svc.consider(session(), atHead("newsha"));
   expect(started).toHaveLength(0); // no critic spawned
   expect(removed).toEqual(["/review-wt"]); // the probe worktree is reaped
   expect(bumped).toEqual([{ id: "s1", headSha: "newsha" }]); // head re-pointed
@@ -1594,12 +1611,13 @@ test("new commit (different diff): reviews and records the new fingerprint", asy
     reviews,
     started,
     bumped,
+    atHead,
   } = makeDeps({
     computePatchId: async () => ({ patchId: "pid-new", baseSha: "base-pid-new", files: ["f"] }),
   });
   reviews["s1"] = priorReview({ patchId: "pid-old", headSha: "old" });
   const svc = new ReviewService(d as any);
-  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  await svc.consider(session(), atHead("newsha"));
   expect(bumped).toHaveLength(0); // not a skip
   expect(started).toHaveLength(1); // critic spawned
   await svc.tick();
@@ -1627,11 +1645,12 @@ test("unresolvable fingerprint never skips: reviews even with a prior verdict", 
     reviews,
     started,
     bumped,
+    atHead,
   } = makeDeps({ computePatchId: async () => ({ patchId: null, baseSha: null, files: [] }) });
   // prior has a real patch-id, but this run can't fingerprint (git failed / empty diff)
   reviews["s1"] = priorReview({ patchId: "pid-old", headSha: "old" });
   const svc = new ReviewService(d as any);
-  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  await svc.consider(session(), atHead("newsha"));
   expect(bumped).toHaveLength(0); // safety default → do not skip
   expect(started).toHaveLength(1); // reviewed
 });
@@ -1642,13 +1661,14 @@ test("prior error verdict never rebase-skips (retries the transient failure)", a
     reviews,
     started,
     bumped,
+    atHead,
   } = makeDeps({
     computePatchId: async () => ({ patchId: "pid-same", baseSha: "base-pid-same", files: ["f"] }),
   });
   // an errored prior that (legacy row / defensive) still carries a matching fingerprint
   reviews["s1"] = priorReview({ decision: "error", patchId: "pid-same", headSha: "old" });
   const svc = new ReviewService(d as any);
-  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  await svc.consider(session(), atHead("newsha"));
   expect(bumped).toHaveLength(0); // not skipped despite identical fingerprint
   expect(started).toHaveLength(1); // re-reviewed instead of inheriting the stale error
 });
@@ -1665,12 +1685,13 @@ test("error verdict records no fingerprint (so a later head always re-reviews)",
   expect(reviews["s1"]?.patchId).toBe(""); // no fingerprint persisted on a failed run
 });
 
-test("rebase-skip short-circuits before any forge call (no author-notes fetch)", async () => {
+test("rebase-skip short-circuits before the author-notes fetch", async () => {
   const {
     deps: d,
     reviews,
     started,
     commentCalls,
+    atHead,
   } = makeDeps(
     {
       computePatchId: async () => ({ patchId: "pid-same", baseSha: "base-pid-same", files: ["f"] }),
@@ -1679,9 +1700,187 @@ test("rebase-skip short-circuits before any forge call (no author-notes fetch)",
   );
   reviews["s1"] = priorReview({ patchId: "pid-same", headSha: "old" }); // has findings
   const svc = new ReviewService(d as any);
-  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  await svc.consider(session(), atHead("newsha"));
   expect(started).toHaveLength(0); // skipped
   expect(commentCalls).toEqual([]); // skip happened before fetchAuthorNotes
+  // (the pre-spawn head recheck DOES call the forge first — it runs ahead of rebase-skip)
+});
+
+// ── stale head: pre-spawn re-validation (#2175) ───────────────────────────────
+
+test("head moved since the poller snapshot: declines the spawn entirely", async () => {
+  const { deps: d, started, created, reviews, live } = makeDeps({});
+  live.head = "pushed-since"; // a push landed after the snapshot the poller handed us
+  const svc = new ReviewService(d as any);
+  expect(await svc.consider(session(), OPEN_GREEN)).toBe("skipped");
+  expect(started).toHaveLength(0); // no critic
+  expect(created).toEqual([]); // …and not even the probe worktree
+  expect(reviews["s1"]).toBeUndefined(); // nothing persisted: the next poll reviews the new head
+});
+
+test("live head matching the snapshot spawns normally", async () => {
+  const { deps: d, started, created } = makeDeps({});
+  expect(await new ReviewService(d as any).consider(session(), OPEN_GREEN)).toBe("started");
+  expect(started).toHaveLength(1);
+  expect(created).toEqual(["abc"]);
+});
+
+test("pre-spawn recheck fails OPEN: a throwing forge still spawns", async () => {
+  const { deps: d, started } = makeDeps(
+    {},
+    {
+      prStatus: async () => {
+        throw new Error("gh unavailable");
+      },
+    },
+  );
+  await new ReviewService(d as any).consider(session(), OPEN_GREEN);
+  expect(started).toHaveLength(1); // a forge blip must never suppress review
+});
+
+test("pre-spawn recheck fails OPEN: a payload without headSha still spawns", async () => {
+  const { deps: d, started } = makeDeps(
+    {},
+    { prStatus: async () => ({ ...OPEN_GREEN, headSha: undefined }) as any },
+  );
+  await new ReviewService(d as any).consider(session(), OPEN_GREEN);
+  expect(started).toHaveLength(1);
+});
+
+test("forceReview also declines a moved head (but its hygiene reset still stands)", async () => {
+  const { deps: d, started, reviews, live } = makeDeps({});
+  reviews["s1"] = priorReview({ headSha: "old", errorRound: 2, streakReviews: 4 });
+  live.head = "pushed-since";
+  expect(await new ReviewService(d as any).forceReview(session(), OPEN_GREEN)).toBe("skipped");
+  expect(started).toHaveLength(0);
+  expect(reviews["s1"]!.errorRound).toBe(0); // reset persisted BEFORE consider() — it stays
+  expect(reviews["s1"]!.streakReviews).toBe(0);
+});
+
+test("the recheck runs UNDER the starting claim: a concurrent consider can't double-spawn", async () => {
+  let release!: () => void;
+  const gate = new Promise<void>((r) => {
+    release = r;
+  });
+  let calls = 0;
+  const {
+    deps: d,
+    started,
+    created,
+  } = makeDeps(
+    {},
+    {
+      prStatus: async () => {
+        // Suspend only the FIRST recheck; a second consider() must bail on the claim, not queue here.
+        if (++calls === 1) await gate;
+        return OPEN_GREEN as PrStatus;
+      },
+    },
+  );
+  const svc = new ReviewService(d as any);
+  const first = svc.consider(session(), OPEN_GREEN);
+  expect(await svc.consider(session(), OPEN_GREEN)).toBe("skipped"); // claim held across the await
+  release();
+  await first;
+  expect(calls).toBe(1); // the second call never reached the recheck
+  expect(started).toHaveLength(1);
+  expect(created).toEqual(["abc"]);
+});
+
+// ── stale head: at-finalize supersession discard (#2175) ──────────────────────
+
+/** prStatus that answers the pre-spawn recheck with `spawn`, then every later call with `finalize`
+ *  — i.e. a push that lands AFTER the critic started. */
+const headMovesDuringReview = (spawn: string, finalize: string) => {
+  let call = 0;
+  return async () => ({ ...OPEN_GREEN, headSha: ++call === 1 ? spawn : finalize }) as PrStatus;
+};
+
+test("head moved during the review: verdict is dropped, not persisted or steered", async () => {
+  const {
+    deps: d,
+    reviews,
+    steers,
+    signals,
+    rec,
+    spawnOutcomes,
+    completedSpawns,
+    stopped,
+    removed,
+  } = makeDeps(
+    {
+      readVerdict: () => ({
+        decision: "request-changes",
+        summary: "x",
+        body: "b",
+        findings: ["fix x"],
+      }),
+    },
+    { autoAddressEnabled: true, prStatus: headMovesDuringReview("abc", "def") },
+  );
+  reviews["s1"] = priorReview({ headSha: "old", addressRound: 1, streakReviews: 1 });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick(); // finalize: the live head is no longer the one we reviewed
+  expect(rec.event).toBeUndefined(); // nothing posted to the PR
+  expect(steers).toHaveLength(0); // nothing steered at the author
+  expect(signals).toHaveLength(0); // no critic/stall signal
+  expect(spawnOutcomes).toHaveLength(0); // unstamped → stays out of the delivery metrics
+  // the prior verdict row stands untouched — no round, streak or findings churn
+  expect(reviews["s1"]!.headSha).toBe("old");
+  expect(reviews["s1"]!.addressRound).toBe(1);
+  expect(reviews["s1"]!.streakReviews).toBe(1);
+  // …but the run is still fully cleaned up and its cost attributed
+  expect(stopped).toContain("rt");
+  expect(removed).toContain("/review-wt");
+  expect(completedSpawns).toHaveLength(1);
+});
+
+test("head moved during the review: an ERROR verdict is dropped without bumping errorRound", async () => {
+  const {
+    deps: d,
+    reviews,
+    signals,
+    spawnOutcomes,
+  } = makeDeps(
+    { readVerdict: () => null }, // critic produced no verdict
+    { prStatus: headMovesDuringReview("abc", "def") },
+  );
+  reviews["s1"] = priorReview({ headSha: "old", errorRound: 2 });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(reviews["s1"]!.decision).toBe("changes_requested"); // no REVIEW ERR row
+  expect(reviews["s1"]!.errorRound).toBe(2); // a superseded run earns no error progress
+  expect(signals).toHaveLength(0);
+  expect(spawnOutcomes).toHaveLength(0);
+});
+
+test("head unchanged at finalize: the verdict lands exactly as before", async () => {
+  const {
+    deps: d,
+    reviews,
+    steers,
+    rec,
+    spawnOutcomes,
+  } = makeDeps(
+    {
+      readVerdict: () => ({
+        decision: "request-changes",
+        summary: "x",
+        body: "b",
+        findings: ["fix x"],
+      }),
+    },
+    { autoAddressEnabled: true },
+  );
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(rec.event).toBe("REQUEST_CHANGES");
+  expect(steers).toHaveLength(1);
+  expect(reviews["s1"]!.headSha).toBe("abc");
+  expect(spawnOutcomes[0]!.outcome).toBe("changes_requested");
 });
 
 // ── auto-address loop ─────────────────────────────────────────────────────────
@@ -2472,6 +2671,7 @@ test("forget() during the getIssue await aborts the spawn and reaps the worktree
   } = makeDeps({
     resolveForge: () =>
       ({
+        prStatus: async () => OPEN_GREEN,
         getIssue: async () => {
           await gate;
           return { body: "ISSUE_BODY_XYZ" };
@@ -2641,6 +2841,7 @@ test("ceiling reached: does NOT spawn (no worktree allocated, no re-signal)", as
     started,
     removed,
     signals,
+    atHead,
   } = makeDeps(
     { computePatchId: async () => ({ patchId: "pid-new", baseSha: "base-pid-new", files: ["f"] }) },
     { autoAddressEnabled: true },
@@ -2648,7 +2849,7 @@ test("ceiling reached: does NOT spawn (no worktree allocated, no re-signal)", as
   // cap default 3 → ceiling 6; a streak already AT the ceiling with outstanding findings.
   reviews["s1"] = priorReview({ streakReviews: 6, headSha: "old" });
   const svc = new ReviewService(d as any);
-  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  await svc.consider(session(), atHead("newsha"));
   expect(started).toHaveLength(0); // critic not spawned
   expect(removed).toEqual([]); // bailed BEFORE allocating the probe worktree
   // the stall signal fired on crossing (in finalize), not here on the blocked tick
@@ -2660,6 +2861,7 @@ test("ceiling crossing emits exactly one stall signal", async () => {
     deps: d,
     reviews,
     signals,
+    atHead,
   } = makeDeps(
     {
       computePatchId: async () => ({
@@ -2679,7 +2881,7 @@ test("ceiling crossing emits exactly one stall signal", async () => {
   // one review short of the ceiling (6); this run finalizes the 6th → crosses.
   reviews["s1"] = priorReview({ streakReviews: 5, headSha: "old" });
   const svc = new ReviewService(d as any);
-  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  await svc.consider(session(), atHead("newsha"));
   await svc.tick();
   expect(reviews["s1"]?.streakReviews).toBe(6); // reached the ceiling
   const paused = signals.filter(
@@ -2699,6 +2901,7 @@ test("a higher live cap raises the ceiling: a streak at 6 still spawns + the sig
     reviews,
     started,
     signals,
+    atHead,
   } = makeDeps(
     {
       cap: 4, // ceiling = 8
@@ -2714,7 +2917,7 @@ test("a higher live cap raises the ceiling: a streak at 6 still spawns + the sig
   );
   reviews["s1"] = priorReview({ streakReviews: 7, headSha: "old" }); // one short of 8
   const svc = new ReviewService(d as any);
-  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  await svc.consider(session(), atHead("newsha"));
   expect(started).toHaveLength(1); // under the raised ceiling → spawns
   await svc.tick();
   expect(reviews["s1"]?.streakReviews).toBe(8); // crosses the raised ceiling
@@ -2727,13 +2930,14 @@ test("under the ceiling still spawns normally", async () => {
     deps: d,
     reviews,
     started,
+    atHead,
   } = makeDeps(
     { computePatchId: async () => ({ patchId: "pid-new", baseSha: "base-pid-new", files: ["f"] }) },
     { autoAddressEnabled: true },
   );
   reviews["s1"] = priorReview({ streakReviews: 3, headSha: "old" }); // well under 6
   const svc = new ReviewService(d as any);
-  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  await svc.consider(session(), atHead("newsha"));
   expect(started).toHaveLength(1); // budget remains → critic spawns
 });
 
@@ -2749,6 +2953,7 @@ test("ceiling is strict for findings reviews but NOT total spawns: an error verd
     deps: d,
     reviews,
     started,
+    atHead,
   } = makeDeps(
     { computePatchId: async () => ({ patchId: "pid-new", baseSha: "base-pid-new", files: ["f"] }) },
     { autoAddressEnabled: true },
@@ -2760,12 +2965,16 @@ test("ceiling is strict for findings reviews but NOT total spawns: an error verd
     headSha: "old",
   });
   const svc = new ReviewService(d as any);
-  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  await svc.consider(session(), atHead("newsha"));
   expect(started).toHaveLength(1); // not blocked by the findings-review ceiling
 });
 
 test("clean verdict resets streakReviews and reviewedPatchIds (un-suppresses)", async () => {
-  const { deps: d, reviews } = makeDeps(
+  const {
+    deps: d,
+    reviews,
+    atHead,
+  } = makeDeps(
     {
       computePatchId: async () => ({
         patchId: "pid-clean-run",
@@ -2782,7 +2991,7 @@ test("clean verdict resets streakReviews and reviewedPatchIds (un-suppresses)", 
     headSha: "old",
   });
   const svc = new ReviewService(d as any);
-  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  await svc.consider(session(), atHead("newsha"));
   await svc.tick();
   expect(reviews["s1"]?.streakReviews).toBe(0); // streak reset
   expect(reviews["s1"]?.reviewedPatchIds).toEqual([]); // churn set cleared
@@ -2796,6 +3005,7 @@ test("revert to an earlier (not immediately-prior) reviewed patch-id skips", asy
     reviews,
     started,
     bumped,
+    atHead,
   } = makeDeps({
     computePatchId: async () => ({ patchId: "pid-a", baseSha: "base-pid-a", files: ["f"] }), // bounced back to a diff reviewed earlier this streak
   });
@@ -2806,7 +3016,7 @@ test("revert to an earlier (not immediately-prior) reviewed patch-id skips", asy
     reviewedPatchIds: ["pid-a", "pid-b", "pid-c"],
   });
   const svc = new ReviewService(d as any);
-  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  await svc.consider(session(), atHead("newsha"));
   expect(started).toHaveLength(0); // set-membership match → skipped
   expect(bumped).toEqual([{ id: "s1", headSha: "newsha" }]); // head re-pointed, verdict preserved
   expect(reviews["s1"]?.findings).toEqual(["fix the race in worker.ts"]); // outstanding findings held
@@ -2818,6 +3028,7 @@ test("after a clean verdict cleared the set, a pre-clean patch-id is reviewed ag
     reviews,
     started,
     bumped,
+    atHead,
   } = makeDeps({
     computePatchId: async () => ({ patchId: "pid-a", baseSha: "base-pid-a", files: ["f"] }),
   });
@@ -2831,20 +3042,24 @@ test("after a clean verdict cleared the set, a pre-clean patch-id is reviewed ag
     headSha: "old",
   });
   const svc = new ReviewService(d as any);
-  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  await svc.consider(session(), atHead("newsha"));
   expect(bumped).toHaveLength(0); // not skipped — the set was cleared
   expect(started).toHaveLength(1); // reviewed again (a revert to a buggy earlier state)
 });
 
 test("error verdict does not poison the dedup set (same diff re-reviews)", async () => {
-  const { deps: d, reviews } = makeDeps({
+  const {
+    deps: d,
+    reviews,
+    atHead,
+  } = makeDeps({
     computePatchId: async () => ({ patchId: "pid-x", baseSha: "base-pid-x", files: ["f"] }),
     // first run errors on pid-x; it must NOT be added to reviewedPatchIds.
     readVerdict: () => ({ decision: "junk", summary: "boom", body: "" }),
   });
   reviews["s1"] = priorReview({ headSha: "old", reviewedPatchIds: [] });
   const svc = new ReviewService(d as any);
-  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  await svc.consider(session(), atHead("newsha"));
   await svc.tick();
   expect(reviews["s1"]?.decision).toBe("error");
   // errored patch-id NOT added → a later head with the SAME diff re-reviews (rebaseSkip
@@ -2871,6 +3086,7 @@ test("clean prior verdict still rebase-skips on a same-patch-id force-push (OR-b
     reviews,
     started,
     bumped,
+    atHead,
   } = makeDeps({
     computePatchId: async () => ({ patchId: "pid-clean", baseSha: "base-pid-clean", files: ["f"] }),
   });
@@ -2885,7 +3101,7 @@ test("clean prior verdict still rebase-skips on a same-patch-id force-push (OR-b
     headSha: "old",
   });
   const svc = new ReviewService(d as any);
-  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  await svc.consider(session(), atHead("newsha"));
   expect(started).toHaveLength(0); // skipped via the patchId OR-branch
   expect(bumped).toEqual([{ id: "s1", headSha: "newsha" }]); // head re-pointed
 });
@@ -2894,7 +3110,11 @@ test("clean prior verdict still rebase-skips on a same-patch-id force-push (OR-b
 
 test("critic prompt embeds the originating issue body (UNTRUSTED) when issueNumber is set", async () => {
   const { deps: d, started } = makeDeps({
-    resolveForge: () => ({ getIssue: async () => ({ body: "ISSUE_BODY_XYZ" }) }) as any,
+    resolveForge: () =>
+      ({
+        prStatus: async () => OPEN_GREEN,
+        getIssue: async () => ({ body: "ISSUE_BODY_XYZ" }),
+      }) as any,
   });
   await new ReviewService(d as any).consider(session({ issueNumber: 99 }), OPEN_GREEN);
   const prompt = started[0]!.argv.at(-1)!;
@@ -2905,7 +3125,11 @@ test("critic prompt embeds the originating issue body (UNTRUSTED) when issueNumb
 
 test("no issue block when issueNumber is null", async () => {
   const { deps: d, started } = makeDeps({
-    resolveForge: () => ({ getIssue: async () => ({ body: "ISSUE_BODY_XYZ" }) }) as any,
+    resolveForge: () =>
+      ({
+        prStatus: async () => OPEN_GREEN,
+        getIssue: async () => ({ body: "ISSUE_BODY_XYZ" }),
+      }) as any,
   });
   await new ReviewService(d as any).consider(session({ issueNumber: null }), OPEN_GREEN);
   const prompt = started[0]!.argv.at(-1)!;
@@ -2922,7 +3146,7 @@ test("degrades cleanly when getIssue is absent / returns null / throws (no block
     },
   ]) {
     const { deps: d, started } = makeDeps({
-      resolveForge: () => ({ getIssue }) as any,
+      resolveForge: () => ({ prStatus: async () => OPEN_GREEN, getIssue }) as any,
     });
     await new ReviewService(d as any).consider(session({ issueNumber: 99 }), OPEN_GREEN);
     expect(started).toHaveLength(1); // no throw → critic still spawns
@@ -3066,13 +3290,14 @@ test("forceReview: aborts an in-flight run (finalizing=false), reaps it, then re
     started,
     stopped,
     removed,
+    atHead,
   } = makeDeps({
     onReviewing: (id: string, reviewing: boolean) => events.push({ id, reviewing }),
   });
   const svc = new ReviewService(d as any);
   await svc.consider(session(), OPEN_GREEN); // now in-flight (terminal "rt", worktree /review-wt)
   expect(svc.reviewingIds()).toEqual(["s1"]);
-  const outcome = await svc.forceReview(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  const outcome = await svc.forceReview(session(), atHead("newsha"));
   expect(outcome).toBe("started");
   // old run reaped: its terminal stopped + worktree removed; onReviewing(false) emitted
   expect(stopped).toContain("rt");
@@ -3084,12 +3309,12 @@ test("forceReview: aborts an in-flight run (finalizing=false), reaps it, then re
 });
 
 test("forceReview: finalizing in-flight run → skipped, does NOT reap (tick owns teardown)", async () => {
-  const { deps: d, started, stopped, removed } = makeDeps({});
+  const { deps: d, started, stopped, removed, atHead } = makeDeps({});
   const svc = new ReviewService(d as any);
   await svc.consider(session(), OPEN_GREEN);
   // tick()'s finalize already owns this run's teardown + verdict.
   (svc as any).inflight.get("s1").finalizing = true;
-  const outcome = await svc.forceReview(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  const outcome = await svc.forceReview(session(), atHead("newsha"));
   expect(outcome).toBe("skipped");
   expect(stopped).toEqual([]); // not reaped — finalize() owns it
   expect(removed).toEqual([]);


### PR DESCRIPTION
Closes #2175.

`ReviewService.consider()` took its `headSha` from the PR poller's cached `GitState` and nothing re-read the tip before the spawn, so a push landing in that window made the critic check out **superseded code** — and its `changes_requested` verdict was persisted and steered to the author as if current. Observed on PR #2172: review #2 spawned 69s *after* the fixing push, reviewed the head before it, and re-reported four already-fixed findings — a wasted ~8-minute spawn, a confusing steer, and a rework round burned against the cap on a false premise.

## Two guards, one predicate

`headSuperseded(reviewedSha, live)` (`src/critic-core.ts`) is true only for a **confirmed, still-`open`** PR carrying a **different** `headSha`. Everything else — no forge, a forge that threw, a payload without `headSha`, a non-`open` state — is false, i.e. **fails open** and behaves exactly as before. A forge blip must never permanently suppress review, and merged/closed PRs already have their own moot handling this must not pre-empt.

**1. Pre-spawn re-validation** (`consider()` → `headMoved()`). One `prStatus` round-trip, then decline if the head moved; the next poll picks the new head up normally. It sits **inside the `try`, after `this.starting.add()`** — the slot claim must stay synchronous, or a suspended `consider()` would let a second call (it is fire-and-forget from `onSessionGit` / `reKickReapedReview`, and `forceReview()` gates re-entry solely on `starting.has`) reach `begin()`: two worktrees, two spawns, and the second `inflight.set` orphaning the first run's terminal and worktree. Covered by a test.

**2. At-finalize supersession discard** (`finalize()`). A verdict whose reviewed head is no longer the tip is dropped whole: nothing posted, nothing steered, no signal, no streak/round/error accounting, and no `reviewer_spawns.outcome` stamp — so a superseded run stays out of the delivery metrics rather than counting as rework the author never received. The prior verdict row stands untouched. `captureUsage` and the terminal/worktree reap run exactly as before, so the spawn's cost is still attributed. This is the backstop no pre-spawn check can replace: a genuine mid-review push.

Error verdicts are discarded on the same terms — a superseded run earns no `errorRound` progress.

## Incidental

`finalize()`'s live PR read (`livePrState` → `livePr`, now returning the whole `PrStatus`) is fetched **once** and threaded into both the error and publish arms, which each used to fetch their own. Those arms are mutually exclusive, so this is still one round-trip per finalize — but state and head now always come from the same snapshot.

Net forge traffic: +1 `gh` call per would-be spawn, on a path that has already cleared every other gate.

## Test harness

`fakeForge`'s default `prStatus` returned a fixed `headSha: "abc"` while 15 tests considered `"newsha"` — with guard 1 in place that reads as "head moved" and would have silently skipped them all. The default now echoes a live-head box that an `atHead(sha)` helper moves in step with the poller snapshot, so the two agree by construction and only a test that *means* to diverge them does. Four partial forge fakes (`{ getIssue }` only) gained a `prStatus` so they no longer fail open through a `TypeError`.

## Unrelated CI fix carried here

`verify` went red on `diagnostics.test.ts` → "the probe reads the LIVE cell health" timing out at 5s. That test built `DiagnosticsService` without `healthyDeps()`, so every dep it didn't override fell through to its REAL probe (gh auth, herdr liveness, tailscale serve, bwrap membrane); on a runner without those binaries the retries blow the per-test budget. It now spreads `healthyDeps()` like its siblings — assertions unchanged. Nothing to do with the guards; it just had to be green for the critic to review this.

## Verification

`bun run lint`, `bun run test` (8906 tests), `bunx tsc --noEmit`, `ui/ bun run check`, and `bunx fallow audit --base origin/main --fail-on-issues` all pass. New tests cover: declined spawn on a moved head (no critic, no probe worktree, no state) · the re-check under the starting claim rejecting a concurrent `consider()` · `forceReview` declining a moved head while its hygiene reset still stands · fail-open on a throwing forge and on a payload without `headSha` · discard of a findings verdict and of an error verdict at finalize, with the prior row, the round budget and the metrics untouched but the run still reaped and costed · plus the unchanged-head control paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

