### PR TITLE
fix(classifier): make the German abstain rule a positive no-ask test (#2169)

### DIFF
--- a/docs/eval-stop-classifier.md
+++ b/docs/eval-stop-classifier.md
@@ -171,11 +171,10 @@ sees is byte-identical).
 - **Before (German fixtures, operator-language OFF)** — the #1626 baseline already recorded it:
   `de-gate` 4/5, `de-question` 5/5, `de-finished` 5/5 (English prompt against a German tail). Re-run
   it exactly with `--operator-language-off`.
-- **After (German directive live)** — **PENDING capture.** Run both legs (locally with a key, or via
-  the workflow) and transcribe the `--json` here. The gate: every German gating fixture stays
-  majority-correct at `T=9`, gating accuracy ≥ floor, and `de-ambiguous-unknown` holds `unknown`
-  majority. This eval is **manual/nightly, never a per-PR gate** (paid, keyed, nondeterministic), so
-  the PR declares the after-run as a manual step and must not merge until it is green.
+- **After (German directive live)** — captured under **[#2169](#german-abstain-bucket-rewrite-2169)**,
+  which also rewrote the directive being measured. Every German gating fixture is majority-correct at
+  `T=9` and gating accuracy is `27/27 = 100%` across two runs. This eval is **manual/nightly, never a
+  per-PR gate** (paid, keyed, nondeterministic).
 
 ### Noise band (react to signal, not model noise)
 
@@ -183,6 +182,14 @@ At `temperature = 1.0` a single-run `T=5` majority can flip on one trial of samp
 German gating fixtures run at **`T=9`**, and a shift between legs counts as **signal** only when it
 **crosses the majority boundary** OR moves by **≥2 trials**, AND survives a **confirmation re-run**. A
 lone ±1-trial wobble is noise — never reword the directive in response to it.
+
+> **#2169 amendment — this band is too narrow for `T=9`.** `de-ambiguous-unknown` produced `9, 7, 4,
+6, 8, 8` out of 9 on the _same_ prompt, so a "≥2-trial move surviving a confirmation run" is
+> reachable by sampling alone: the #2169 criterion was met in the bad direction by a fixture whose
+> pooled rate turned out to be ordinary. Treat a single `T=9` run as a coarse filter only. To
+> compare two prompt variants, **pool ≥27 trials per condition** (a fixture's pinned `trials`
+> overrides `--trials`, so pool repeated runs rather than raising the flag) and measure both
+> conditions in the same session — model-side drift between sessions is not controlled for.
 
 ### Verification split — what the eval does and does NOT cover
 
@@ -201,6 +208,105 @@ If the after-run shows a promoted German fixture below majority (past the noise 
 to baseline **only** with an explicit justification recorded as a known gap — exactly the treatment
 `gate-spec-first` received. Re-pin `GATING_ACCURACY_FLOOR` only if the adjustment rule
 (`round_down(observed − 0.15)` to 0.05) requires, with a commit note.
+
+## German abstain-bucket rewrite (#2169)
+
+`de-ambiguous-unknown` lost its `unknown` majority (`unknown:9` → `gate:2 unknown:7` →
+`gate:5 unknown:4`) while its English twin held 9/9, and was filed as #2169. All numbers below are
+`claude-haiku-4-5`, temperature `1.0`, 2026-09-02, with **zero** `no-tool` / `parse-fail` anywhere —
+every `unknown` is a genuine verdict, never a masked mechanical miss.
+
+### The prompt had already drifted under the baseline
+
+The 9/9 datum was measured **before** commit `561e577c` (#2002), which hoisted
+`UNTRUSTED_CONTENT_DIRECTIVE` out of `fenceUntrusted`: the tail fence went from carrying ~250 chars
+of in-band prose to label + nonce only. That is the **only** edit to `classifierPrompt` between the
+#1626/#1627 baseline and the eroded runs, and it lands directly on Anchor A — the splice point of
+the German input-robustness line. So "the classifier prompt was not touched" is true of #2156's
+harness work, but **not** of the interval between the two measurements. English lost the same prose
+and did not collapse, so this is context for reading the baseline, not the cause.
+
+### Diagnostic: was the German directive the cure or the cause?
+
+`--filter ambiguous --trials 9`, both A/B legs, on the unmodified prompt:
+
+| leg                             | `ambiguous-unknown` (en) | `de-ambiguous-unknown`   |
+| ------------------------------- | ------------------------ | ------------------------ |
+| OFF (`--operator-language-off`) | `unknown:9` — 9/9        | `unknown:8 gate:1` — 8/9 |
+| ON (German directive live)      | `unknown:9` — 9/9        | `unknown:6 gate:3` — 6/9 |
+
+Pooled to 27 trials per condition (3 × `T=9`, because a fixture's pinned `trials` overrides
+`--trials` — the flag cannot thicken these fixtures):
+
+| condition                              | `de-ambiguous-unknown` | runs      |
+| -------------------------------------- | ---------------------- | --------- |
+| OFF — no German lines at all           | **24/27** (89%)        | 8 / 7 / 9 |
+| V0 — the directive as #1627 shipped it | **22/27** (81%)        | 6 / 8 / 8 |
+| `ambiguous-unknown` (en), same session | 25/27 (93%)            | 9 / 9 / 7 |
+
+**Two conclusions, and the second corrects the issue's premise.**
+
+1. The directive as written was doing nothing useful — 22/27 with it, 24/27 without it. A line added
+   to _protect_ the abstain bucket did not measurably protect it.
+2. **The English twin is not rock-solid either.** It posted `gate:1 question:1 unknown:7` in the same
+   session — its first sub-9/9 result on record. Pooled today, `en` 25/27 vs `de` 22/27 is well
+   inside noise. The fixture's `9 → 7 → 4` history is the tail of a wide distribution, not a clean
+   language-specific signal, and the `4/9` that triggered the issue was its extreme.
+
+### What changed and why
+
+The directive's original closing clause — _"never upgrade an uncertain read to a confident `gate` or
+`question` just to avoid abstaining"_ — is an abstract instruction about the model's own confidence,
+and it names `gate` twice inside a negation. It was replaced with a **positive, checkable test**
+applied to the tail itself: `gate` and `question` both presuppose that the agent RAISED something, so
+a tail that only narrates progress can be neither.
+
+The closing clause (_"if such a tail also does not clearly report finished or delivered work"_) is
+load-bearing. Without it the rule collapses to "raises no question → `unknown`", which would swallow
+the legitimately question-free `finished` and `complete` tails — `de-finished-pr` asks nothing either.
+That would trade the `finished` bucket for the `unknown` one: the same erosion, inverted.
+`test/autopilot-llm.test.ts` pins the clause so it cannot be silently shortened.
+
+### Results
+
+Screen on `de-ambiguous-unknown`, 3 × `T=9`: **27/27** (9 / 9 / 9). Since nothing can beat a perfect
+screen, the remaining candidates (anchor-move-only, and removing the line entirely) were not run.
+
+Validation — the full German set, twice, `--filter de- --trials 5`:
+
+| id                     | seg      | expected | T   | run A              | run B                     |
+| ---------------------- | -------- | -------- | --- | ------------------ | ------------------------- |
+| `de-gate-commit`       | gating   | gate     | 9   | `gate:9` — 9/9     | `gate:9` — 9/9            |
+| `de-question-approach` | gating   | question | 9   | `question:9` — 9/9 | `question:9` — 9/9        |
+| `de-ambiguous-unknown` | gating   | unknown  | 9   | `unknown:9` — 9/9  | `unknown:9` — 9/9         |
+| `de-gate-spec`         | baseline | gate     | 5   | `gate:5` — 5/5     | `gate:2 question:3` — 2/5 |
+| `de-finished-pr`       | baseline | finished | 5   | `finished:5` — 5/5 | `finished:5` — 5/5        |
+
+- **Gating accuracy `27/27 = 100%` in both runs; `RESULT: PASS`.** `GATING_ACCURACY_FLOOR` is
+  unchanged at `0.80` — the adjustment rule (`round_down(observed − 0.15)` to 0.05) would allow
+  `0.85`, but one fixture set measured twice is a thin basis for tightening a catastrophe-catcher,
+  and raising it buys nothing this PR needs.
+- **`de-ambiguous-unknown`: 45/45 `unknown`** across screen + both validation runs, against 22/27
+  for the shipped directive. This is the datum the issue asked for.
+- **No bucket trading.** `de-finished-pr` held `finished:5` in both runs — the specific risk the
+  scoping clause exists to prevent did not materialize.
+- **`de-gate-spec` is unchanged, not regressed.** Four runs under the new wording: 5/5, 2/5, 4/5,
+  2/5 = **13/20**, straddling its own 4/5 baseline and the 2/5 its English twin `gate-spec-first`
+  posts. It remains the recorded known gap, still non-gating, and no claim is made that this change
+  moved it either way.
+
+### Deliberate limits of this change
+
+- **The rule is not German-specific, but ships only on the `de` path.** "A tail that raises nothing
+  is not a `gate`" would arguably help English too. It is not applied there: the `en` prompt must
+  stay byte-identical so the English gating baseline survives by construction, and the English twin
+  is at 25/27 with nothing to fix. The `de` and `en` prompts are therefore now semantically
+  divergent, not merely translated — recorded here deliberately.
+- **`en` byte-identity is verified, not assumed.** The shipped prompt was diffed against its
+  pre-change form at `HEAD` for both the default and explicit `"en"` calls (nonce normalized);
+  both identical. `test/autopilot-llm.test.ts` pins it going forward.
+- **Only `kind` is measured.** As elsewhere in this doc, nothing here verifies that `summary`
+  actually renders in German.
 
 ## Fidelity caveats
 

--- a/src/autopilot-classify-core.ts
+++ b/src/autopilot-classify-core.ts
@@ -51,6 +51,20 @@ export function preClassify(tail: string[]): AutopilotVerdict | null {
  *  - INPUT: input-robustness — a German/mixed tail must NOT erode the `unknown` abstain bucket, and
  *    a non-English tail is never itself a reason to guess a confident kind. Injected next to the
  *    terminal-tail fence (it governs how to READ the tail).
+ *
+ *    Issue #2169 rewrote this line after `de-ambiguous-unknown` lost its `unknown` majority. Its
+ *    first form closed with "never upgrade an uncertain read to a confident `gate` or `question`
+ *    just to avoid abstaining" — an abstract instruction about confidence that named `gate` twice
+ *    inside a negation, and measured no better than injecting nothing at all (22/27 vs 24/27
+ *    `unknown` on the eroding fixture). It is now a POSITIVE, checkable test the model can apply
+ *    to the tail in front of it: `gate` and `question` both presuppose the agent RAISED something,
+ *    so a tail that only narrates progress cannot be either. Measured 45/45 on that fixture with
+ *    no bucket trading — see docs/eval-stop-classifier.md.
+ *
+ *    The final clause ("if such a tail also does not clearly report finished or delivered work") is
+ *    LOAD-BEARING, not hedging: without it the rule reads as "no question asked -> unknown", which
+ *    would swallow the legitimately question-free `finished` and `complete` tails (`de-finished-pr`
+ *    asks nothing either). It scopes the no-ask rule to the two kinds that presuppose an ask.
  *  - OUTPUT: render `summary` in German while PINNING `kind` to the exact English enum — a
  *    translated/off-enum kind silently collapses to `unknown` via `normalize`'s `KINDS.includes`.
  *    Injected next to the enum block (before the terminal "then stop" line) so it is not discounted
@@ -59,9 +73,10 @@ export function preClassify(tail: string[]): AutopilotVerdict | null {
 const CLASSIFIER_INPUT_ROBUSTNESS_DE =
   "The terminal tail above may be written in German or a mix of German and English. Classify by " +
   "what the agent actually MEANS, not by matching English phrasing — a non-English tail is never " +
-  "itself a reason to choose a kind. When the wording leaves the agent's intent genuinely unclear, " +
-  'prefer "unknown"; never upgrade an uncertain read to a confident "gate" or "question" just to ' +
-  "avoid abstaining.";
+  'itself a reason to choose a kind. Both "gate" and "question" require the agent to have actually ' +
+  "RAISED something: a tail that only narrates progress or announces that it is carrying on has " +
+  "asked you nothing, so it is neither. If such a tail also does not clearly report finished or " +
+  'delivered work, answer "unknown".';
 const CLASSIFIER_OUTPUT_LANGUAGE_DE =
   "Write the `summary` field in German. Keep `kind` as one of the exact English enum values above " +
   '("gate" | "question" | "finished" | "complete" | "unknown") — Shepherd matches it literally, and ' +

--- a/test/autopilot-llm.test.ts
+++ b/test/autopilot-llm.test.ts
@@ -93,9 +93,20 @@ test("classifierPrompt de injects the summary→German + verbatim-kind-pin + inp
   expect(p).toContain("Write the `summary` field in German");
   // kind is pinned to the exact English enum — a translated kind collapses to unknown via normalize.
   expect(p).toContain("never translate it");
-  // input-robustness: a German/mixed tail must not erode the unknown abstain bucket.
+  // input-robustness: a German/mixed tail must not erode the unknown abstain bucket. Re-pinned in
+  // #2169 — the old sentinel ("avoid abstaining") belonged to the abstract confidence phrasing that
+  // measured no better than injecting nothing; the rule is now a positive no-ask test.
   expect(p).toContain("The terminal tail above may be written in German");
-  expect(p).toContain("avoid abstaining");
+  expect(p).toContain("require the agent to have actually RAISED something");
+});
+
+test("classifierPrompt de scopes the no-ask rule to gate/question — finished/complete keep their bucket", () => {
+  // #2169 REGRESSION GUARD, not a prose check. The no-ask rule must never be shortened to
+  // "raises no question -> unknown": `finished` and `complete` tails legitimately ask nothing
+  // either (`de-finished-pr` is exactly such a tail), so dropping this clause would trade the
+  // finished bucket for the unknown one — the same erosion the rule exists to prevent, inverted.
+  const p = classifierPrompt(["Mit dem ersten Teil fertig. Ich mache weiter."], "task", "de");
+  expect(p).toContain("does not clearly report finished or delivered work");
 });
 
 test("classifierPrompt de places the kind-pin BEFORE the terminal 'then stop' line (not post-stop chrome)", () => {


### PR DESCRIPTION
Closes #2169.

Rewrites the German input-robustness directive in `classifierPrompt` after measuring that the line was not doing its job — and corrects two things the issue's premise got wrong.

## The diagnostic came back the other way round

`--filter ambiguous --trials 9`, both A/B legs, on the **unmodified** prompt. Pooled to 27 trials per condition (a fixture's pinned `trials` overrides `--trials`, so this is 3 × `T=9`, not one thick run):

| condition | `de-ambiguous-unknown` | runs |
| --- | --- | --- |
| OFF — no German lines at all | **24/27** (89%) | 8 / 7 / 9 |
| V0 — the directive as #1627 shipped it | **22/27** (81%) | 6 / 8 / 8 |
| `ambiguous-unknown` (en), same session | 25/27 (93%) | 9 / 9 / 7 |

The line added to *protect* the abstain bucket measured no better than injecting nothing. Zero `no-tool`/`parse-fail` anywhere, so every `unknown` is a genuine verdict.

## Two corrections to the record

**1. The prompt had already drifted under the 9/9 baseline.** That datum predates `561e577c` (#2002), which hoisted `UNTRUSTED_CONTENT_DIRECTIVE` out of `fenceUntrusted` — the tail fence went from ~250 chars of in-band prose to label + nonce only, landing directly on this directive's splice point. "The classifier prompt was not touched" is true of #2156's harness work but not of the interval between the two measurements.

**2. The erosion is not cleanly language-specific.** The English twin posted `gate:1 question:1 unknown:7` in the same session — its first sub-9/9 on record. Pooled, `en` 25/27 vs `de` 22/27 is well inside noise. The `9 → 7 → 4` history is the tail of a wide distribution, and the `4/9` that triggered the issue was its extreme.

## What changed

The closing clause was an abstract instruction about the model's own confidence — *"never upgrade an uncertain read to a confident `gate` or `question` just to avoid abstaining"* — naming `gate` twice inside a negation. It is now a **positive, checkable test applied to the tail**: `gate` and `question` both presuppose the agent RAISED something, so a tail that only narrates progress can be neither.

The trailing scoping clause is **load-bearing, not hedging**. Without it the rule collapses to "raises no question → `unknown`", which swallows the legitimately question-free `finished`/`complete` tails — `de-finished-pr` asks nothing either. That trades the `finished` bucket for the `unknown` one: the same erosion, inverted. A test pins the clause so it can't be silently shortened.

## Results

Screen: **27/27** on `de-ambiguous-unknown`. Since nothing beats a perfect screen, the remaining candidates (anchor-move-only, removal) were not run — recorded in the doc.

Validation, full German set, twice:

| id | seg | exp | T | run A | run B |
| --- | --- | --- | --- | --- | --- |
| `de-gate-commit` | gating | gate | 9 | `gate:9` — 9/9 | `gate:9` — 9/9 |
| `de-question-approach` | gating | question | 9 | `question:9` — 9/9 | `question:9` — 9/9 |
| `de-ambiguous-unknown` | gating | unknown | 9 | `unknown:9` — 9/9 | `unknown:9` — 9/9 |
| `de-gate-spec` | baseline | gate | 5 | `gate:5` — 5/5 | `gate:2 question:3` — 2/5 |
| `de-finished-pr` | baseline | finished | 5 | `finished:5` — 5/5 | `finished:5` — 5/5 |

- Gating accuracy **27/27 = 100%** in both runs, `RESULT: PASS`.
- **45/45** `unknown` on the target fixture across screen + both validation runs, vs 22/27 for the shipped directive.
- **No bucket trading** — `de-finished-pr` held `finished:5` both times.
- `de-gate-spec` (non-gating known gap) across four runs: 5/5, 2/5, 4/5, 2/5 = 13/20, straddling its own 4/5 baseline and its English twin's 2/5. No claim that this change moved it.

## Scope and limits

- **`en` is byte-identical**, verified by diffing the rendered prompt against pre-change `HEAD` (nonce normalized) for both the default and explicit `"en"` calls — re-verified after the prettier hook reformatted the file. The English baseline survives by construction; no English calls were purchased.
- **The rule is not German-specific but ships only on the `de` path.** "A tail that raises nothing is not a `gate`" would arguably help English too, but the `en` prompt must stay byte-identical and the English twin has nothing to fix. The two prompts are now semantically divergent, not merely translated — recorded deliberately.
- `GATING_ACCURACY_FLOOR` **unchanged** at `0.80`. The adjustment rule would permit `0.85`, but one fixture set measured twice is a thin basis for tightening a catastrophe-catcher.
- The doc's **noise band is amended**: `de-ambiguous-unknown` produced `9, 7, 4, 6, 8, 8` out of 9 on the *same* prompt, so "≥2-trial move surviving a confirmation run" is reachable by sampling alone — #2169's own trigger criterion was met by a fixture whose pooled rate turned out ordinary. Pool ≥27 trials per condition, same session.

## Note for #2168

That PR is still open and touches zero files under `src/`, so there is no code conflict. But it commits `scripts/eval-fingerprints.json`, and this PR changes `classifierPrompt` — the classifier fingerprint will be stale after it rebases, and `check:eval-fingerprints` will (correctly) fail until regenerated. On `main` `de-ambiguous-unknown` is still `gating: true`, so nothing needed re-promoting here; #2168's demotion of it should be reconsidered in light of these numbers.

## Verification

`bun run lint`, `bunx tsc --noEmit`, `bun run test` (8879 pass, 0 fail), `bunx fallow audit --base origin/main --fail-on-issues` (✓ no issues in 3 changed files) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
