### PR TITLE
feat(maintain): tier 3 opens a PR for the dead-code fix class (#2171)

### DIFF
--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -289,10 +289,16 @@ tokens and has no prompt to be injected into. The run:
 3. re-measures in that pristine checkout and stands down if there is nothing to fix (the
    sweep's reading came from the live checkout, which can carry uncommitted edits);
 4. runs `bunx fallow@<pinned> fix --yes --no-create-config`;
-5. **verifies fail-closed** — `bun run typecheck` must pass and a re-run of `fallow dead-code`
-   must report no auto-fixable findings left. It also **refuses** to commit when the fix touched
-   any `package.json` or lockfile: `fallow fix` removes unused *dependencies* too, and that needs
-   a lockfile regen a background loop must not do;
+5. **verifies fail-closed** — the type-check of **every package the diff touches** must pass, and
+   a re-run of `fallow dead-code` must report no auto-fixable findings left. Per package, not just
+   the root: `bun run typecheck` is `tsc` against a tsconfig that excludes `ui`, `extension`,
+   `site` and `docs-site`, while fallow analyses all of them, so a root-only gate would pass
+   vacuously for a fix under `ui/src`. The root uses `bun run typecheck`; `ui` and `extension` use
+   their own `bun run check`. The run also **refuses** to commit when the fix touched any
+   `package.json` or lockfile (`fallow fix` removes unused *dependencies* too, and that needs a
+   lockfile regen a background loop must not do), or anything under `site/` or `docs-site/`, whose
+   dependencies are not installed in the fix worktree and which therefore cannot be verified at
+   all;
 6. commits `--no-verify`, pushes, and opens the PR.
 
 Any failed gate opens nothing, records an `error` outcome and throws the branch away. **Nothing

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -247,36 +247,69 @@ one (a per-repo in-flight guard means at most one run per repo at a time):
 
 ## Maintain loop (self-health bands)
 
-Opt-in, default-off, and fully inert when off. Once per local day Shepherd scores three
+Opt-in, default-off, and fully inert when off. Once per local day Shepherd scores four
 **bands** over its **own** health data and escalates by tier: **tier 1** logs the reading,
 **tier 2** spawns a read-only diagnosis agent that drafts a backlog issue which the trusted
 server files **against Shepherd's own repo** — never a managed repo, so nothing lands in
 someone else's backlog. The agent itself never touches a forge: it writes a JSON draft in a
-disposable worktree and nothing else. There is no tier 3 (no automatic fix PR).
+disposable worktree and nothing else. **Tier 3** skips the issue and opens a **pull request**
+— see below.
 
 | Band | Measures | Window | Tier 1 | Tier 2 |
 | --- | --- | --- | --- | --- |
 | `critic_error_rate` | Share of outcome-bearing review spawns that errored (produced no verdict) | 7 days, min sample 10 | ≥ `0.15` | ≥ `0.30` |
 | `incident_spike` | `signals` per kind — needs **both** an occurrence count and a distinct-session count, so one thrashing task can't trip it. The `reply` kind is excluded (operator corrections are high-volume by design) | 7 days | ≥ 10 occurrences **and** ≥ 3 sessions | ≥ 25 occurrences **and** ≥ 5 sessions |
 | `first_pass_collapse` | Per-repo first-pass review rate — direction is **inverted**, a lower rate is worse | 30 days, min sample 8 | ≤ `0.60` | ≤ `0.40` |
+| `dead_code_drift` | Auto-fixable dead-code findings in Shepherd's own checkout (`fallow dead-code`). Point-in-time, no window and no minimum sample. Declares a tier-3 fix class, so its tier-2 breach is **promoted to tier 3** | now | ≥ 1 finding | ≥ 3 findings |
 
 A band below its minimum sample reports "below min sample" rather than a misleading number.
 Every band's live value is persisted and surfaced on the **Delivery lens** whether or not it
 breached — the starting thresholds are calibrated guesses, and observed values are what let
 you retune them.
 
-**Spend bounds.** At most **one** tier-2 diagnosis spawn per sweep (the rest wait for the next
-day), and after a diagnosis run **completes** — filed, skipped or errored — its band is
-suppressed for **14 days**. The cooldown anchors on the run, not on a filed issue, precisely
-so observe mode (which files nothing) still suppresses.
+**Spend bounds.** At most **one** band action per sweep — a tier-2 diagnosis spawn *or* a
+tier-3 fix, whichever band is more severe; the rest wait for the next day. After a run
+**completes** — published, skipped or errored — its band is suppressed for **14 days**. The
+cooldown anchors on the run, not on a published issue or PR, precisely so observe mode (which
+publishes nothing) still suppresses. A still-open issue or PR from the band's last run extends
+the suppression past the cooldown.
 
-**Phased soak (`observe → act`)**, mirroring the doc agent:
+### Tier 3 — the pre-approved fix class
+
+A band may declare a **pre-approved fix class**: a remediation mechanical enough that no
+judgement is needed, so the loop produces the diff itself and opens a PR instead of asking you
+to read a drafted issue first. Exactly one class exists — `dead_code`, on `dead_code_drift`.
+
+**No agent is involved.** The fix is `fallow fix`'s verbatim output, so a tier-3 run costs no
+tokens and has no prompt to be injected into. The run:
+
+1. creates a branch worktree `shepherd/maintain-fix-<8hex>` off `origin/<default branch>`;
+2. runs `bun install --frozen-lockfile` in the root, `ui/` and `extension/` — **load-bearing**:
+   without installed dependencies fallow cannot resolve imports and reports live code as dead;
+3. re-measures in that pristine checkout and stands down if there is nothing to fix (the
+   sweep's reading came from the live checkout, which can carry uncommitted edits);
+4. runs `bunx fallow@<pinned> fix --yes --no-create-config`;
+5. **verifies fail-closed** — `bun run typecheck` must pass and a re-run of `fallow dead-code`
+   must report no auto-fixable findings left. It also **refuses** to commit when the fix touched
+   any `package.json` or lockfile: `fallow fix` removes unused *dependencies* too, and that needs
+   a lockfile regen a background loop must not do;
+6. commits `--no-verify`, pushes, and opens the PR.
+
+Any failed gate opens nothing, records an `error` outcome and throws the branch away. **Nothing
+is ever auto-merged.** If `openPr` fails after the push, the branch is deleted from the remote
+rather than left orphaned.
+
+**Phased soak (`observe → act → pr`)**, mirroring the doc agent:
 
 1. **Observe** — `SHEPHERD_MAINTAIN_LOOP=1` alone. Bands are evaluated, readings persisted,
    breaches logged and the tier-2 diagnosis spawns, but finalize is **log-only**: it logs
    `[maintain] <band>: would file issue "<title>" (act is off)` and calls the forge never.
 2. **Act** — additionally set `SHEPHERD_MAINTAIN_ACT=1` to escalate finalize to actually
    opening the labelled issue. Meaningful only when `SHEPHERD_MAINTAIN_LOOP` is also on.
+3. **PR** — additionally set `SHEPHERD_MAINTAIN_PR=1` to let a tier-3 run open its pull
+   request. **Independent of `SHEPHERD_MAINTAIN_ACT`**: arming issue-filing never implicitly
+   arms PR-opening. Without it a tier-3 run still installs, fixes and verifies, then logs
+   `would open a PR removing …` and discards the branch — so the log names the real diff.
 
 `POST /api/maintain/sweep` runs an evaluation on demand (it `404`s when the flag is off, the
 same unadvertised contract as the doc-agent route). It skips the hour/presence/once-a-day
@@ -287,11 +320,12 @@ its worktree reclaimed by the boot reconcile; the breach is re-diagnosed on the 
 | --- | --- | --- |
 | `SHEPHERD_MAINTAIN_LOOP` | `0` (off) | Set `1` to arm the loop (**observe**): band evaluation, tier-1 logging, and the tier-2 read-only diagnosis spawn. The drafted issue is only **logged** until `SHEPHERD_MAINTAIN_ACT` is also set |
 | `SHEPHERD_MAINTAIN_ACT` | `0` (off) | **Act.** Set `1` to escalate finalize to actually filing the labelled issue against Shepherd's own repo. Meaningful only when `SHEPHERD_MAINTAIN_LOOP` is also on |
+| `SHEPHERD_MAINTAIN_PR` | `0` (off) | **Tier 3.** Set `1` to let a tier-3 fix open a pull request against Shepherd's own repo. Never auto-merges. Meaningful only when `SHEPHERD_MAINTAIN_LOOP` is also on, and **independent of** `SHEPHERD_MAINTAIN_ACT` |
 | `SHEPHERD_MAINTAIN_HOUR` | `4` | Local hour (0–23) at/after which the once-a-day band sweep may run — an hour after the doc agent's nightly so the two spawns don't land together. Invalid values fall back to `4` |
 | `SHEPHERD_MAINTAIN_CLI` | `inherit` | Agent CLI for the diagnosis spawn: `inherit` follows the global default provider, or pin `claude` / `codex`. Env-only (not persisted or UI-configurable) |
 | `SHEPHERD_MAINTAIN_MODEL` | `default` | Model for the diagnosis spawn: `default` follows the global default model, or pin a `<model alias>`. Env-only |
 | `SHEPHERD_MAINTAIN_EFFORT` | `default` | Reasoning-effort tier for the diagnosis spawn: `default` follows the CLI's own effort, or pin a tier (`low` / `medium` / `high` / `xhigh` / `max`). Env-only |
-| `SHEPHERD_MAINTAIN_THRESHOLDS` | _(unset)_ | JSON object deep-merged over the threshold table above, so a recalibration ships without a deploy. Parsed field-by-field and **fail-soft**: an unparseable value or a typo in one number falls back to that default rather than disarming a band. E.g. `{"critic_error_rate":{"tier1":0.2}}` |
+| `SHEPHERD_MAINTAIN_THRESHOLDS` | _(unset)_ | JSON object deep-merged over the threshold table above, so a recalibration ships without a deploy. Parsed field-by-field and **fail-soft**: an unparseable value or a typo in one number falls back to that default rather than disarming a band. E.g. `{"critic_error_rate":{"tier1":0.2}}`. Retunes numbers only — a band's tier-3 fix class is not overridable, because `SHEPHERD_MAINTAIN_PR` is the one switch that disarms tier 3 |
 
 ## Anonymous usage telemetry
 

--- a/docs-site/src/content/docs/reference/glossary.md
+++ b/docs-site/src/content/docs/reference/glossary.md
@@ -86,14 +86,17 @@ drifts constantly is usually writing vague plans, not writing bad code.
 
 A daily check of Shepherd's own health signals against declared thresholds. A
 mild breach is logged; a sustained one spawns a read-only agent that drafts a
-backlog issue for you to triage. It watches Shepherd itself — never a production
-system.
+backlog issue for you to triage. For one pre-approved class of mechanical fix it
+skips the issue and opens a pull request instead. It watches Shepherd itself —
+never a production system.
 
 ### Band
 
 One health signal plus the thresholds that decide what happens when it is
-crossed: tier 1 logs a reading, tier 2 spawns a diagnosis. A band below its
-minimum sample size reports nothing rather than a misleading number.
+crossed: tier 1 logs a reading, tier 2 spawns a diagnosis. A band whose
+remediation is mechanical enough to be pre-approved is promoted to tier 3
+instead, which opens a pull request. A band below its minimum sample size reports
+nothing rather than a misleading number.
 
 ### Inferred
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -744,6 +744,11 @@ export const config = {
   // Phase-1 escalation; meaningful only with `maintainLoopEnabled`. When off, finalize logs the
   // issue it WOULD file and calls createIssue never.
   maintainLoopAct: process.env.SHEPHERD_MAINTAIN_ACT === "1",
+  // Tier-3 escalation (#2171); meaningful only with `maintainLoopEnabled`. When off, a Tier-3 fix
+  // runs and verifies in its worktree, logs the PR it WOULD open, and throws the branch away.
+  // DELIBERATELY INDEPENDENT of `maintainLoopAct`: arming issue-filing must never implicitly arm
+  // PR-opening, so this is its own flag rather than a second meaning for that one.
+  maintainLoopPr: process.env.SHEPHERD_MAINTAIN_PR === "1",
   // Local hour (0–23) at/after which the once-a-day band sweep may run. Default 4 (≈04:00 local),
   // an hour after the doc agent's so the two nightly spawns don't land together.
   maintainLoopHour: parseHour(process.env.SHEPHERD_MAINTAIN_HOUR, 4),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1600,8 +1600,9 @@ const planGate = new PlanGateService({
   onActivity: (id, summary) => events.emit("session:plangate-activity", { id, summary }),
   cap: () => config.planReviewCyclesCap,
 });
-// Maintain loop (#2157, from #2151 R5). Opt-in and two-phase like the doc agent
-// (config.maintainLoopEnabled / maintainLoopAct). Constructed unconditionally and ABOVE
+// Maintain loop (#2157, from #2151 R5). Opt-in and three-phase like the doc agent
+// (maintainLoopEnabled arms it, maintainLoopAct files issues, maintainLoopPr opens tier-3 PRs).
+// Constructed unconditionally and ABOVE
 // sweepStaleReviewWorktrees — its `inflightWorktrees()` is unioned into that sweep's
 // protectedPaths below, and the const must exist before the sweep closure runs.
 const maintainService = new MaintainService({
@@ -1617,6 +1618,8 @@ const maintainService = new MaintainService({
   repoDelivery: () =>
     buildDeliveryMetrics({ store, range: FIRST_PASS_RANGE, now: Date.now() }).repos,
   act: config.maintainLoopAct,
+  // Tier 3 (#2171): armed separately from `act`, so filing issues never implies opening PRs.
+  pr: config.maintainLoopPr,
   sweepHour: config.maintainLoopHour,
   isPresent: () => presence.isActive(),
   env: () => roleEnv(config.maintainCli, config.maintainModel, config.maintainEffort),

--- a/src/maintain-core.ts
+++ b/src/maintain-core.ts
@@ -6,8 +6,16 @@
  * Shepherd's OWN health data:
  *   Tier 1 — log the reading.
  *   Tier 2 — spawn a read-only diagnosis agent that drafts a backlog issue.
- * Tier 3 (open a PR for a pre-approved fix class) is deliberately absent — the only such class the
- * report names is doc drift, which the doc agent already owns.
+ *   Tier 3 — for a band declaring a pre-approved fix class, open a PR instead (#2171).
+ *
+ * TIER 3 IS NOT A FOURTH THRESHOLD. A reading that crosses its band's tier-2 threshold is PROMOTED
+ * to tier 3 when — and only when — that band's config declares a `tier3` fix class. Making it a
+ * higher threshold would be backwards: you would need MORE dead code to earn the cheap mechanical
+ * fix. Promotion keeps the ladder monotonic and leaves no band with an unreachable rung.
+ *
+ * Exactly one class exists (`dead_code`), on exactly one band (`dead_code_drift`). #2171 forbids
+ * generalising ahead of a named class, so `tier3` lives on {@link CountBandConfig} alone — the
+ * three v1 bands have no mechanical remediation and do not get an inert `tier3?` field.
  *
  * SCOPE GUARD: internal signals only. No production ingress, and no statistical control bands —
  * report §4 rules both out. The threshold table below IS the "version-controlled config" the
@@ -44,11 +52,21 @@ const FIRST_PASS_WINDOW_DAYS = 30;
  */
 const INCIDENT_KIND_EXCLUDED: SignalKind = "reply";
 
-/** How long a band is suppressed after a diagnosis run COMPLETES, whatever its outcome. */
+/** How long a band is suppressed after a run COMPLETES, whatever its outcome or tier. */
 export const DEFAULT_COOLDOWN_MS = 14 * 24 * 60 * 60 * 1000;
 
-/** At most this many Tier-2 diagnosis spawns per sweep. The rest wait for the next day. */
-export const MAX_DIAGNOSES_PER_SWEEP = 1;
+/** At most this many band ACTIONS (a Tier-2 diagnosis spawn or a Tier-3 fix) per sweep. The rest
+ *  wait for the next day. */
+export const MAX_ACTIONS_PER_SWEEP = 1;
+
+/**
+ * The pinned fallow release the `dead_code_drift` band measures and fixes with (#2171).
+ *
+ * KEEP IN SYNC with the other pin sites — `.github/workflows/ci.yml`, `scripts/pre-push.ts` and
+ * `CONTRIBUTING.md` (they carry sync banners of their own). A different version changes what counts
+ * as a finding, so a drifted pin would have the band measure one thing while CI gates another.
+ */
+export const FALLOW_VERSION = "2.100.0";
 
 /** A rate band: breach when the measured rate crosses the tier in the band's direction. */
 interface RateBandConfig {
@@ -65,10 +83,40 @@ interface IncidentBandConfig {
   tier2: { occurrences: number; sessions: number };
 }
 
+/**
+ * The pre-approved remediation classes a band may declare (#2171). Exactly one exists, and adding
+ * a second is a deliberate act: each class needs a mechanism that can produce the diff without an
+ * operator in the loop, and an operator willing to see that diff arrive as a PR with no issue
+ * first. Do NOT widen this speculatively.
+ */
+type FixClass = "dead_code";
+
+/** A band's Tier-3 declaration: the pre-approved fix class its tier-2 breach escalates to. */
+interface Tier3Config {
+  class: FixClass;
+}
+
+/** A count band: breach when the measured count reaches the tier. No minimum sample — a count of
+ *  N is exactly as trustworthy at N=1 as at N=100. */
+interface CountBandConfig {
+  tier1: number;
+  tier2: number;
+  /**
+   * Present ⇒ a tier-2 breach is promoted to tier 3 and routed to the fix path instead of the
+   * diagnosis path. Absent on every band without a mechanical remediation, which is why this field
+   * lives here and not on the rate/incident configs.
+   *
+   * NOT operator-overridable: `SHEPHERD_MAINTAIN_THRESHOLDS` can retune the numbers, but disarming
+   * Tier 3 is what `SHEPHERD_MAINTAIN_PR` is for. One disarm switch, not two.
+   */
+  tier3?: Tier3Config;
+}
+
 export interface BandThresholds {
   critic_error_rate: RateBandConfig;
   incident_spike: IncidentBandConfig;
   first_pass_collapse: RateBandConfig;
+  dead_code_drift: CountBandConfig;
 }
 
 /**
@@ -87,6 +135,12 @@ export const DEFAULT_BAND_THRESHOLDS: BandThresholds = {
   },
   // Per repo over 30d. Direction is INVERTED: a LOWER rate is worse.
   first_pass_collapse: { minSample: 8, tier1: 0.6, tier2: 0.4 },
+  // Auto-fixable dead-code findings in Shepherd's own checkout, right now (#2171). A point-in-time
+  // count, not a window: `fallow fix` either has something to remove or it does not.
+  //
+  // Why tier2 sits as low as 3: the remediation is deterministic and free, so the cost of acting is
+  // a PR nobody had to write. One stray export is not worth the round trip; a handful is.
+  dead_code_drift: { tier1: 1, tier2: 3, tier3: { class: "dead_code" } },
 };
 
 function isFiniteNumber(v: unknown): v is number {
@@ -101,6 +155,18 @@ function mergeRateBand(base: RateBandConfig, raw: unknown): RateBandConfig {
     minSample: isFiniteNumber(o.minSample) && o.minSample >= 0 ? o.minSample : base.minSample,
     tier1: isFiniteNumber(o.tier1) ? o.tier1 : base.tier1,
     tier2: isFiniteNumber(o.tier2) ? o.tier2 : base.tier2,
+  };
+}
+
+/** Merge the count band's overrides. `tier3` is deliberately NOT mergeable — see
+ *  {@link CountBandConfig.tier3}; the base's class declaration is carried through untouched. */
+function mergeCountBand(base: CountBandConfig, raw: unknown): CountBandConfig {
+  if (raw === null || typeof raw !== "object") return base;
+  const o = raw as Record<string, unknown>;
+  return {
+    tier1: isFiniteNumber(o.tier1) ? o.tier1 : base.tier1,
+    tier2: isFiniteNumber(o.tier2) ? o.tier2 : base.tier2,
+    ...(base.tier3 ? { tier3: base.tier3 } : {}),
   };
 }
 
@@ -138,6 +204,7 @@ export function mergeThresholds(raw: unknown): BandThresholds {
       DEFAULT_BAND_THRESHOLDS.first_pass_collapse,
       o.first_pass_collapse,
     ),
+    dead_code_drift: mergeCountBand(DEFAULT_BAND_THRESHOLDS.dead_code_drift, o.dead_code_drift),
   };
 }
 
@@ -149,6 +216,89 @@ export function thresholdsFromEnv(raw: string | undefined): BandThresholds {
   return mergeThresholds(parsed.value);
 }
 
+// ── dead-code report ─────────────────────────────────────────────────────────
+
+/** What `fallow dead-code --format json` told us, reduced to what the band needs. */
+export interface DeadCodeReading {
+  /** Findings fallow can remove itself — the ONLY ones the band counts, because `fallow fix` is
+   *  what remediates them and it drives exactly this number to zero. */
+  autoFixable: number;
+  /** Every finding, auto-fixable or not. Carried as the band's `sampleN` so the lens can show
+   *  "1 of 3" rather than implying the other two do not exist. */
+  total: number;
+  /** Auto-fixable count per fallow category (`unused_exports`, …), for the PR body. Bounded by
+   *  fallow's own category list. */
+  byCategory: Record<string, number>;
+}
+
+/**
+ * Reduce a `fallow dead-code --format json` payload to a {@link DeadCodeReading}, or null when the
+ * payload is not a dead-code report at all.
+ *
+ * NULL IS LOAD-BEARING, in two places. The band renders it as "no data" rather than as a clear
+ * 0 — a fallow that failed to run must never read as "no dead code". And the Tier-3 verify gate
+ * requires `autoFixable === 0` from a REAL report, so a post-fix run whose output stopped parsing
+ * fails the gate instead of passing it.
+ *
+ * Category-agnostic on purpose: fallow's report carries ~30 finding arrays and grows new ones
+ * between releases, so this walks every top-level array of `{ actions: [...] }` objects rather than
+ * hard-coding a list that would silently stop counting a newly added category. `next_steps` (the
+ * only other top-level array) has no `actions` and is skipped by the same rule.
+ */
+export function parseDeadCodeReport(text: string | null): DeadCodeReading | null {
+  if (text === null) return null;
+  const parsed = tolerantParseJson(text);
+  if (parsed.status !== "ok" || parsed.value === null || typeof parsed.value !== "object") {
+    return null;
+  }
+  const o = parsed.value as Record<string, unknown>;
+  // Guard the discriminator: an error envelope or a different subcommand's output must not reduce
+  // to a confident zero.
+  if (o.kind !== "dead-code") return null;
+  const out: DeadCodeReading = { autoFixable: 0, total: 0, byCategory: {} };
+  for (const [category, value] of Object.entries(o)) {
+    if (!Array.isArray(value)) continue;
+    const tally = tallyFindings(value);
+    out.total += tally.total;
+    if (tally.fixable > 0) {
+      out.autoFixable += tally.fixable;
+      out.byCategory[category] = (out.byCategory[category] ?? 0) + tally.fixable;
+    }
+  }
+  return out;
+}
+
+/** Count one fallow category array: how many entries are findings, and how many of those fallow
+ *  can fix itself. An entry with no `actions` array is not a finding — `next_steps` is the live
+ *  example, and counting it would inflate every reading. */
+function tallyFindings(items: unknown[]): { total: number; fixable: number } {
+  let total = 0;
+  let fixable = 0;
+  for (const item of items) {
+    if (item === null || typeof item !== "object") continue;
+    const actions = (item as Record<string, unknown>).actions;
+    if (!Array.isArray(actions)) continue;
+    total += 1;
+    if (actions.some(isAutoFixableAction)) fixable += 1;
+  }
+  return { total, fixable };
+}
+
+function isAutoFixableAction(a: unknown): boolean {
+  return (
+    a !== null && typeof a === "object" && (a as Record<string, unknown>).auto_fixable === true
+  );
+}
+
+/** Human-readable one-liner for a reading's auto-fixable breakdown, for the PR body and the log.
+ *  Categories are fallow's own snake_case names, spelled out. */
+export function describeDeadCode(reading: DeadCodeReading): string {
+  const parts = Object.entries(reading.byCategory)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([category, n]) => `${n} ${category.replace(/_/g, " ")}`);
+  return parts.length > 0 ? parts.join(", ") : "no auto-fixable findings";
+}
+
 /** What one sweep measured, assembled by the caller from the store + delivery metrics. */
 export interface BandInput {
   /** Outcome-bearing review spawns in the critic window. */
@@ -157,6 +307,8 @@ export interface BandInput {
   incidents: DeliveryIncidentRow[];
   /** Per-repo delivery rows over `FIRST_PASS_RANGE`. */
   repos: DeliveryRepoRow[];
+  /** The self repo's dead-code reading, or null when fallow could not be run or read. */
+  deadCode: DeadCodeReading | null;
 }
 
 /** Highest tier a value crosses on a band where HIGHER is worse. */
@@ -179,12 +331,29 @@ function incidentTier(row: DeliveryIncidentRow, cfg: IncidentBandConfig): Mainta
   return 0;
 }
 
+/**
+ * Tier 3 is a PROMOTION of a tier-2 breach, not a threshold above it: a band that declares a fix
+ * class routes its breach to the fix path instead of the diagnosis path. Every other tier passes
+ * through untouched.
+ *
+ * The single place this happens, so no caller can reach a tier-2 reading on a fix-class band and
+ * spawn a diagnosis for work the loop is about to do deterministically.
+ */
+function promote(tier: MaintainTier, tier3: Tier3Config | undefined): MaintainTier {
+  return tier === 2 && tier3 ? 3 : tier;
+}
+
 /** The measurement window a band is scored over, in days — what the diagnosis prompt must state.
- *  `first_pass_collapse` reads the 30d delivery range; the other two use their 7d windows. Derived
- *  here rather than passed by the caller so the prompt can never quote a window the band does not
- *  actually use (which would land in the filed issue as the agent's reasoning). */
+ *  `first_pass_collapse` reads the 30d delivery range; the two incident/rate bands use their 7d
+ *  windows. Derived here rather than passed by the caller so the prompt can never quote a window
+ *  the band does not actually use (which would land in the filed issue as the agent's reasoning).
+ *
+ *  `dead_code_drift` has no window — it is a point-in-time count — and reports 0. Unreachable by
+ *  construction: only {@link buildDiagnosisPrompt} calls this, only a tier-2 reading reaches it,
+ *  and that band's tier-2 breach is always promoted to 3. */
 export function windowDaysFor(bandId: BandId): number {
   if (bandId === "first_pass_collapse") return FIRST_PASS_WINDOW_DAYS;
+  if (bandId === "dead_code_drift") return 0;
   return CRITIC_WINDOW_MS / 86_400_000;
 }
 
@@ -262,7 +431,33 @@ export function evaluateBands(
     });
   }
 
+  // ── dead_code_drift (global, self repo) ─────────────────────────────────────
+  const dcCfg = thresholds.dead_code_drift;
+  const dc = input.deadCode;
+  out.push({
+    key: bandKey("dead_code_drift"),
+    bandId: "dead_code_drift",
+    repoPath: null,
+    subject: null,
+    value: dc?.autoFixable ?? 0,
+    // Total findings, not a denominator: the lens shows "N of M", where M-N are the ones fallow
+    // will not touch (unused FILES, which it marks not-auto-fixable) and a human still owns.
+    sampleN: dc?.total ?? 0,
+    tier: dc === null ? 0 : promote(countTier(dc.autoFixable, dcCfg), dcCfg.tier3),
+    // A fallow that could not be run or read is "no data", NEVER a clear 0 — see
+    // parseDeadCodeReport.
+    belowMinSample: dc === null,
+    evaluatedAt: now,
+  });
+
   return out;
+}
+
+/** Highest tier a count crosses. Shares the higher-is-worse direction with the rate bands. */
+function countTier(value: number, cfg: CountBandConfig): MaintainTier {
+  if (value >= cfg.tier2) return 2;
+  if (value >= cfg.tier1) return 1;
+  return 0;
 }
 
 /** Breached readings, most severe first — the order Tier-2 candidates are considered in. */
@@ -276,10 +471,14 @@ export function breaches(readings: BandReading[]): BandReading[] {
 export function describeReading(r: BandReading): string {
   const where = r.subject ? ` [${r.subject}]` : "";
   const pct = (v: number) => `${(v * 100).toFixed(1)}%`;
-  const value =
-    r.bandId === "incident_spike"
-      ? `${r.value} occurrence(s) across ${r.sampleN} session(s)`
-      : `${pct(r.value)} (n=${r.sampleN})`;
+  let value: string;
+  if (r.bandId === "incident_spike") {
+    value = `${r.value} occurrence(s) across ${r.sampleN} session(s)`;
+  } else if (r.bandId === "dead_code_drift") {
+    value = `${r.value} auto-fixable of ${r.sampleN} finding(s)`;
+  } else {
+    value = `${pct(r.value)} (n=${r.sampleN})`;
+  }
   return `${r.bandId}${where}: ${value} → tier ${r.tier}`;
 }
 
@@ -448,6 +647,59 @@ export function renderIssueBody(draft: MaintainDraft, reading: BandReading): str
   if (draft.subsystem) lines.push("", "## Affected subsystem", "", draft.subsystem);
   if (draft.openQuestions.length > 0) {
     lines.push("", "## Open questions", "", ...draft.openQuestions.map((q) => `- ${q}`));
+  }
+  lines.push(
+    "",
+    "---",
+    "",
+    `Band \`${reading.key}\` · ${describeReading(reading)} · measured ${new Date(
+      reading.evaluatedAt,
+    ).toISOString()}`,
+  );
+  return lines.join("\n");
+}
+
+// ── tier 3: the dead-code fix ────────────────────────────────────────────────
+
+/** Commit subject and PR title for a Tier-3 dead-code fix. Conventional-commit shaped: the repo's
+ *  `pr-title` workflow gates PR titles, and this one is opened without a human to fix it. */
+export const DEAD_CODE_COMMIT_MSG = "chore(maintain): remove auto-fixable dead code";
+
+/**
+ * The Tier-3 PR body.
+ *
+ * Says three things an operator needs before reading the diff: a machine opened this, the diff is
+ * `fallow fix`'s output rather than anyone's judgement, and the non-auto-fixable findings this run
+ * deliberately left alone are still there. The pinned fallow version is named because the diff is
+ * only reproducible against it.
+ */
+export function renderFixPrBody(before: DeadCodeReading, reading: BandReading): string {
+  const remaining = before.total - before.autoFixable;
+  const lines = [
+    "> Opened automatically by Shepherd's maintain loop (tier 3). The diff is the verbatim output",
+    `> of \`fallow fix\` — no agent wrote it. Review it as you would any deletion.`,
+    "",
+    "## What this removes",
+    "",
+    `${describeDeadCode(before)} — found by \`fallow@${FALLOW_VERSION} dead-code\` against this`,
+    "repository's `.fallowrc.jsonc`.",
+    "",
+    "## Verified before opening",
+    "",
+    "- `bun install --frozen-lockfile` in the root, `ui/` and `extension/` — without installed",
+    "  dependencies fallow cannot resolve imports and reports findings that are not real.",
+    "- `bun run typecheck` passes on the result.",
+    "- A re-run of `fallow dead-code` reports no auto-fixable findings left.",
+  ];
+  if (remaining > 0) {
+    lines.push(
+      "",
+      "## Left alone",
+      "",
+      `${remaining} finding(s) are not auto-fixable — fallow flags unused FILES as unsafe to delete`,
+      "automatically, because deletion can remove runtime behaviour static analysis cannot see.",
+      "Those remain for a human.",
+    );
   }
   lines.push(
     "",

--- a/src/maintain-core.ts
+++ b/src/maintain-core.ts
@@ -290,6 +290,51 @@ function isAutoFixableAction(a: unknown): boolean {
   );
 }
 
+/**
+ * The packages a Tier-3 fix can type-check, cheapest first.
+ *
+ * `root` is `bun run typecheck` (`tsc --noEmit`), whose tsconfig EXCLUDES `ui`, `extension`,
+ * `site` and `docs-site` — each is its own package with its own check command. So a root
+ * typecheck alone says nothing about a fix under `ui/src`, which is most of what fallow analyses.
+ */
+export type FixPackage = "root" | "ui" | "extension";
+
+/** Cheapest-first, so a failing gate short-circuits before the slow svelte-checks. */
+const PACKAGE_ORDER: FixPackage[] = ["root", "extension", "ui"];
+
+/** Trees fallow analyses that a Tier-3 run CANNOT verify: their dependencies are not installed in
+ *  the fix worktree and no check command is wired for them. A fix touching one is refused rather
+ *  than committed unverified. */
+const UNVERIFIABLE_PREFIXES = ["site/", "docs-site/"];
+
+/**
+ * Which packages a set of changed paths implicates, and which paths nothing can verify.
+ *
+ * WHY THIS EXISTS: fallow's entry list spans the root, `ui/`, `extension/`, `site/` and
+ * `docs-site/`, while `bun run typecheck` covers only the first. Verifying with the root
+ * typecheck alone would pass VACUOUSLY for a `fallow fix` that deleted a live export under
+ * `ui/src/lib` — and that diff would then be committed, pushed and opened as a PR.
+ */
+export function packagesFor(changed: string[]): {
+  packages: FixPackage[];
+  unverifiable: string[];
+} {
+  const touched = new Set<FixPackage>();
+  const unverifiable: string[] = [];
+  for (const path of changed) {
+    if (UNVERIFIABLE_PREFIXES.some((prefix) => path.startsWith(prefix))) {
+      unverifiable.push(path);
+    } else if (path.startsWith("ui/")) {
+      touched.add("ui");
+    } else if (path.startsWith("extension/")) {
+      touched.add("extension");
+    } else {
+      touched.add("root");
+    }
+  }
+  return { packages: PACKAGE_ORDER.filter((p) => touched.has(p)), unverifiable };
+}
+
 /** Human-readable one-liner for a reading's auto-fixable breakdown, for the PR body and the log.
  *  Categories are fallow's own snake_case names, spelled out. */
 export function describeDeadCode(reading: DeadCodeReading): string {
@@ -673,8 +718,13 @@ export const DEAD_CODE_COMMIT_MSG = "chore(maintain): remove auto-fixable dead c
  * deliberately left alone are still there. The pinned fallow version is named because the diff is
  * only reproducible against it.
  */
-export function renderFixPrBody(before: DeadCodeReading, reading: BandReading): string {
+export function renderFixPrBody(
+  before: DeadCodeReading,
+  reading: BandReading,
+  packages: FixPackage[],
+): string {
   const remaining = before.total - before.autoFixable;
+  const checked = packages.map((p) => `\`${p}\``).join(", ") || "none";
   const lines = [
     "> Opened automatically by Shepherd's maintain loop (tier 3). The diff is the verbatim output",
     `> of \`fallow fix\` — no agent wrote it. Review it as you would any deletion.`,
@@ -688,7 +738,8 @@ export function renderFixPrBody(before: DeadCodeReading, reading: BandReading): 
     "",
     "- `bun install --frozen-lockfile` in the root, `ui/` and `extension/` — without installed",
     "  dependencies fallow cannot resolve imports and reports findings that are not real.",
-    "- `bun run typecheck` passes on the result.",
+    `- The type-check of every package this diff touches (${checked}) passes. The root`,
+    "  `tsc` excludes `ui` and `extension`, so each is checked with its own command.",
     "- A re-run of `fallow dead-code` reports no auto-fixable findings left.",
   ];
   if (remaining > 0) {

--- a/src/maintain.ts
+++ b/src/maintain.ts
@@ -31,7 +31,7 @@ import type { SessionStore } from "./store";
 import type { HerdrDriver } from "./herdr";
 import { HerdrUnavailableError } from "./herdr";
 import type { WorktreeMgr } from "./worktree";
-import type { GitForge } from "./forge/types";
+import { EmptyDiffError, type GitForge } from "./forge/types";
 import type { BandReading, MaintainOutcome, MaintainRun, SignalKind } from "./types";
 import type { RoleEnvironment } from "./default-model";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
@@ -47,19 +47,25 @@ import {
 import { readSessionUsage, type SessionUsage } from "./usage";
 import {
   CRITIC_WINDOW_MS,
+  DEAD_CODE_COMMIT_MSG,
   DEFAULT_BAND_THRESHOLDS,
   DEFAULT_COOLDOWN_MS,
+  FALLOW_VERSION,
   INCIDENT_WINDOW_MS,
   MAINTAIN_DRAFT_FILE,
-  MAX_DIAGNOSES_PER_SWEEP,
+  MAX_ACTIONS_PER_SWEEP,
   breaches,
   buildDiagnosisPrompt,
+  describeDeadCode,
   describeReading,
   evaluateBands,
+  parseDeadCodeReport,
   readMaintainDraft,
+  renderFixPrBody,
   renderIssueBody,
   type BandInput,
   type BandThresholds,
+  type DeadCodeReading,
   type EvidenceLine,
   type MaintainDraft,
 } from "./maintain-core";
@@ -70,6 +76,113 @@ export const MAINTAIN_AGENT_LABEL = "__maintain__";
 
 /** The label put on a filed issue, so the operator can filter the backlog for machine-opened work. */
 export const MAINTAIN_ISSUE_LABEL = "shepherd:maintain";
+
+/** Worktree/branch name stem for a Tier-3 fix. `worktree.create()` prepends `shepherd/`, so the
+ *  branch is `shepherd/maintain-fix-<8hex>`; `reapOrphans` matches the same prefix. */
+const FIX_BRANCH_PREFIX = "maintain-fix-";
+const FIX_BRANCH_FULL_PREFIX = `shepherd/${FIX_BRANCH_PREFIX}`;
+
+/**
+ * The packages whose dependencies must be installed before fallow is trusted (#2171).
+ *
+ * LOAD-BEARING, not a nicety. Measured on this repo: `fallow dead-code` in a fresh worktree with no
+ * `node_modules` reports 14 findings (6 unused files, 6 unused exports) where the same tree with
+ * these three installed reports 3. Without imports it can resolve, fallow calls live code dead —
+ * and `fallow fix` would then delete it. Mirrors what CI installs before its own `fallow audit`.
+ */
+const FIX_INSTALL_DIRS = [".", "ui", "extension"] as const;
+
+/** Files whose modification by `fallow fix` aborts the run. It also removes unused DEPENDENCIES,
+ *  and a manifest edit without a matching lockfile regen lands the PR CI-red — that needs a human,
+ *  not a background loop. Matched against `git status --porcelain` paths in any package. */
+const MANIFEST_RE = /(^|\/)(package\.json|bun\.lock|bun\.lockb|package-lock\.json)$/;
+
+/** Every Tier-3 subprocess is bounded: a cold `bunx fallow@…` download that hangs must not hold a
+ *  worktree (and the band's in-flight claim) forever. Same posture as the pre-push fallow lane. */
+const FIX_SUBPROCESS_TIMEOUT_MS = 5 * 60_000;
+
+/**
+ * The subprocess surface of a Tier-3 fix, behind one seam so the whole path is testable without
+ * running bun, fallow or tsc. Everything here is deliberately dumb: it runs a command and either
+ * resolves or throws, leaving every decision to {@link MaintainService.runFix}.
+ */
+export interface FixRunner {
+  /** `bun install --frozen-lockfile` in each of {@link FIX_INSTALL_DIRS}. Throws on failure —
+   *  `--frozen-lockfile` also means a lockfile that does not match its manifest fails here rather
+   *  than silently rewriting itself into the diff we are about to commit. */
+  install(worktreePath: string): Promise<void>;
+  /** `fallow dead-code --format json`; raw stdout, or null when the run failed. Null is NOT an
+   *  empty report — see `parseDeadCodeReport`. */
+  deadCode(worktreePath: string): Promise<string | null>;
+  /** `fallow fix --yes --no-create-config`. Throws on failure. */
+  fix(worktreePath: string): Promise<void>;
+  /** `bun run typecheck`. Throws when it does not pass. */
+  typecheck(worktreePath: string): Promise<void>;
+}
+
+const execFileP = promisify(execFile);
+
+/**
+ * Recover a fallow report from a NON-ZERO exit, or null when the output cannot be trusted.
+ *
+ * `fallow dead-code` exits **1 whenever it finds anything** — which is every single time the band
+ * has something to say. Treating that rejection as "could not measure" would make `dead_code_drift`
+ * read "no data" exactly when it matters, leave tier 3 permanently unreachable, and fail every
+ * post-fix verification. The report is on stdout either way, so the exit code is not the signal.
+ *
+ * A KILLED process is different: a timeout or a `maxBuffer` overflow leaves stdout truncated
+ * mid-document, and `tolerantParseJson` would happily repair that into a shape-valid report with a
+ * SMALLER finding count — which the verify gate could read as a clean tree. So a killed run yields
+ * null, and null fails the gate.
+ */
+export function reportFromFailedExit(err: unknown): string | null {
+  const e = err as { stdout?: unknown; killed?: boolean };
+  if (e.killed) return null;
+  return typeof e.stdout === "string" && e.stdout.length > 0 ? e.stdout : null;
+}
+
+/** The real runner. Every call is async — a synchronous subprocess here would freeze the web
+ *  terminal for the length of an install (house rule: no blocking subprocess on the Bun loop). */
+const defaultFixRunner: FixRunner = {
+  async install(worktreePath) {
+    for (const dir of FIX_INSTALL_DIRS) {
+      await execFileP("bun", ["install", "--frozen-lockfile"], {
+        cwd: join(worktreePath, dir),
+        timeout: FIX_SUBPROCESS_TIMEOUT_MS,
+      });
+    }
+  },
+  async deadCode(worktreePath) {
+    try {
+      const { stdout } = await execFileP(
+        "bunx",
+        [`fallow@${FALLOW_VERSION}`, "dead-code", "--format", "json"],
+        {
+          cwd: worktreePath,
+          timeout: FIX_SUBPROCESS_TIMEOUT_MS,
+          // A findings-bearing report is large; the default 1MB cap would truncate it into
+          // unparseable JSON, which reads as "could not measure" rather than as a false zero.
+          maxBuffer: 32 * 1024 * 1024,
+        },
+      );
+      return stdout;
+    } catch (err) {
+      return reportFromFailedExit(err);
+    }
+  },
+  async fix(worktreePath) {
+    await execFileP("bunx", [`fallow@${FALLOW_VERSION}`, "fix", "--yes", "--no-create-config"], {
+      cwd: worktreePath,
+      timeout: FIX_SUBPROCESS_TIMEOUT_MS,
+    });
+  },
+  async typecheck(worktreePath) {
+    await execFileP("bun", ["run", "typecheck"], {
+      cwd: worktreePath,
+      timeout: FIX_SUBPROCESS_TIMEOUT_MS,
+    });
+  },
+};
 
 const DEFAULT_TIMEOUT_MS = 15 * 60_000;
 /** Signal payloads offered to the diagnosis agent as evidence: the band's own window, and a read
@@ -118,7 +231,10 @@ export interface MaintainDeps extends MembraneSeams {
     HerdrDriver,
     "start" | "stop" | "list" | "paneForegroundProcs" | "tabsAsync" | "closeTab"
   >;
-  worktree: Pick<WorktreeMgr, "createDetached" | "remove" | "ensureBaseRef" | "gitCommonDir">;
+  worktree: Pick<
+    WorktreeMgr,
+    "create" | "createDetached" | "remove" | "ensureBaseRef" | "gitCommonDir"
+  >;
   store: MaintainStore;
   /** Shepherd's OWN checkout — the repo the diagnosis reads and the issue is filed against. */
   selfRepoPath: string;
@@ -128,6 +244,12 @@ export interface MaintainDeps extends MembraneSeams {
   repoDelivery: () => BandInput["repos"];
   /** Phase-1 escalation. false (the default) ⇒ a parsed draft is logged, never filed. */
   act?: boolean;
+  /** Tier-3 escalation (#2171). false (the default) ⇒ a fix run does all its work and logs the PR
+   *  it WOULD open, then throws the branch away. Deliberately INDEPENDENT of `act`: arming
+   *  issue-filing must never implicitly arm PR-opening. */
+  pr?: boolean;
+  /** The Tier-3 subprocess seam (default {@link defaultFixRunner}). */
+  fixRunner?: FixRunner;
   /** Local hour (0–23) at/after which a sweep may run. */
   sweepHour?: number;
   /** Operator presence — a daily sweep that spawns an agent waits for someone to be around. */
@@ -154,9 +276,11 @@ interface InFlight {
   finalizing: boolean;
 }
 
-const SWEEP_DAY_KEY = "maintain:last-sweep-day";
+/** Why a Tier-3 fix stopped before opening a PR. Every one of these is a deliberate, logged exit —
+ *  none of them opens anything. */
+type FixAbort = { outcome: "skipped"; why: string } | { outcome: "error"; why: string };
 
-const execFileP = promisify(execFile);
+const SWEEP_DAY_KEY = "maintain:last-sweep-day";
 
 async function defaultGit(cwd: string, args: string[]): Promise<string> {
   const { stdout } = await execFileP("git", args, { cwd });
@@ -168,6 +292,18 @@ function defaultDayKey(now: number): string {
   const m = String(d.getMonth() + 1).padStart(2, "0");
   const day = String(d.getDate()).padStart(2, "0");
   return `${d.getFullYear()}-${m}-${day}`;
+}
+
+/**
+ * The local branch a Tier-3 worktree path belongs to, or null when the path is not one.
+ *
+ * Derived rather than stored: `worktree.create` names the checkout `<repo>-<name>` and the branch
+ * `shepherd/<name>`, so the path already carries the branch. The hex-only match doubles as the
+ * argv guard — a branch name reaching `git branch -D` can never start with `-`.
+ */
+function fixBranchOf(worktreePath: string): string | null {
+  const m = /maintain-fix-([0-9a-f]{8})$/.exec(basename(worktreePath));
+  return m ? `${FIX_BRANCH_FULL_PREFIX}${m[1]}` : null;
 }
 
 function defaultReadDraft(worktreePath: string): string | null {
@@ -192,8 +328,13 @@ function thresholdNote(reading: BandReading, t: BandThresholds): string {
 
 export class MaintainService {
   private inflight = new Map<string, InFlight>();
-  /** Claimed synchronously before `beginDiagnosis`'s awaits so a manual trigger racing the daily
-   *  sweep cannot double-spawn the same band. */
+  /** Live Tier-3 fix runs, bandKey → worktree path. Kept apart from `inflight` on purpose: a fix
+   *  run finalizes itself inside one awaited call and has no draft, no pane and nothing for
+   *  `tick()` to do, so putting it in the map `tick()` walks would only invite a poll that
+   *  finalizes it twice. */
+  private fixInflight = new Map<string, string>();
+  /** Claimed synchronously before `beginDiagnosis`'s / `beginFix`'s awaits so a manual trigger
+   *  racing the daily sweep cannot double-start the same band. */
   private starting = new Set<string>();
   private readonly now: () => number;
   private readonly dayKey: (now: number) => string;
@@ -204,6 +345,7 @@ export class MaintainService {
   private readonly cooldownMs: number;
   private readonly timeoutMs: number;
   private readonly sweepHour: number;
+  private readonly fixRunner: FixRunner;
   private readonly log: (msg: string) => void;
 
   constructor(private deps: MaintainDeps) {
@@ -216,6 +358,7 @@ export class MaintainService {
     this.cooldownMs = deps.cooldownMs ?? DEFAULT_COOLDOWN_MS;
     this.timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.sweepHour = deps.sweepHour ?? 4;
+    this.fixRunner = deps.fixRunner ?? defaultFixRunner;
     this.log = deps.log ?? ((msg) => console.log(msg));
   }
 
@@ -230,7 +373,13 @@ export class MaintainService {
    *  therefore union this into that sweep's `protectedPaths`, exactly as it does for the plan gate
    *  and the two critics; without it a long run has its checkout deleted underneath it. */
   inflightWorktrees(): string[] {
-    return [...this.inflight.values()].map((f) => f.run.worktreePath);
+    return [
+      ...[...this.inflight.values()].map((f) => f.run.worktreePath),
+      // A Tier-3 checkout is `shepherd/maintain-fix-…`-shaped, so the `-review-` sweeper never
+      // sees it — but it IS one of this service's live worktrees, and any future sweeper reading
+      // this list must be told about it.
+      ...this.fixInflight.values(),
+    ];
   }
 
   /** Latest reading per band + the recent run log — the Delivery lens's band card. */
@@ -250,14 +399,14 @@ export class MaintainService {
     const now = this.now();
     if (!opts?.force && !this.claimToday(now)) return;
 
-    const readings = evaluateBands(this.gather(now), this.thresholds, now);
+    const readings = evaluateBands(await this.gather(now), this.thresholds, now);
     for (const r of readings) this.deps.store.upsertMaintainReading(r);
 
     // Tier 1 IS this log line plus the persisted reading — deliberately not a `signals` row.
     const breached = breaches(readings);
     for (const r of breached) this.log(`[maintain] ${describeReading(r)}`);
 
-    await this.diagnoseTop(breached, now);
+    await this.actOnTop(breached, now);
   }
 
   /** The daily cadence gate: hour, presence, and a once-per-local-day claim. Returns false when
@@ -273,60 +422,116 @@ export class MaintainService {
     return true;
   }
 
-  /** Spawn a diagnosis for the most severe suppression-clear Tier-2 breach, up to the per-sweep
-   *  cap. Bands are already ordered most-severe-first, so this takes the head of the list. */
-  private async diagnoseTop(breached: BandReading[], now: number): Promise<void> {
-    let spawned = 0;
+  /**
+   * Act on the most severe suppression-clear breach, up to the per-sweep cap. Bands arrive ordered
+   * most-severe-first, so tier 3 is considered before tier 2 and this takes the head of the list.
+   *
+   * The cap counts BOTH kinds of action. A Tier-3 fix is cheap (no agent, no tokens) but it still
+   * pushes a branch and opens a PR, and one of those per sweep is the point.
+   */
+  private async actOnTop(breached: BandReading[], now: number): Promise<void> {
+    let acted = 0;
     for (const reading of breached) {
-      if (spawned >= MAX_DIAGNOSES_PER_SWEEP) break;
+      if (acted >= MAX_ACTIONS_PER_SWEEP) break;
       if (reading.tier < 2) continue;
       // Claim the band SYNCHRONOUSLY, before the first await. `suppressionFor` awaits a forge
       // round-trip, so without the claim a manual `force` sweep racing the daily tick could pass
       // the in-flight check in both calls and spawn the same band twice.
-      if (this.starting.has(reading.key) || this.inflight.has(reading.key)) {
-        this.log(`[maintain] ${reading.key} tier 2 suppressed: a run is already in flight`);
+      if (this.isRunning(reading.key)) {
+        this.log(
+          `[maintain] ${reading.key} tier ${reading.tier} suppressed: a run is already in flight`,
+        );
         continue;
       }
       this.starting.add(reading.key);
       try {
         const suppression = await this.suppressionFor(reading.key, now);
         if (suppression) {
-          this.log(`[maintain] ${reading.key} tier 2 suppressed: ${suppression}`);
+          this.log(`[maintain] ${reading.key} tier ${reading.tier} suppressed: ${suppression}`);
           continue;
         }
-        if (await this.beginDiagnosis(reading)) spawned += 1;
+        const started =
+          reading.tier === 3 ? await this.beginFix(reading) : await this.beginDiagnosis(reading);
+        if (started) acted += 1;
       } finally {
         this.starting.delete(reading.key);
       }
     }
   }
 
-  /** Assemble the three bands' inputs. */
-  private gather(now: number): BandInput {
+  /** True when this band has a STARTED run of either tier under way in this process. Deliberately
+   *  excludes the `starting` claim: {@link suppressionFor} runs while its own caller holds that
+   *  claim, so folding it in here would make every band suppress itself. */
+  private hasLiveRun(bandKey: string): boolean {
+    return this.inflight.has(bandKey) || this.fixInflight.has(bandKey);
+  }
+
+  /** {@link hasLiveRun} plus the pre-await claim — the check a would-be starter makes. */
+  private isRunning(bandKey: string): boolean {
+    return this.starting.has(bandKey) || this.hasLiveRun(bandKey);
+  }
+
+  /**
+   * Assemble every band's input.
+   *
+   * `deadCode` is measured in the LIVE checkout, not in a pristine worktree: the sweep needs a
+   * reading for the lens on every band whether or not it breaches, and standing up a worktree per
+   * sweep to get one would be absurd. The cost is that uncommitted local edits can colour the
+   * reading — which is fine, because {@link runFix} re-measures in a clean checkout of
+   * `origin/<base>` and stands down when that says there is nothing to fix.
+   */
+  private async gather(now: number): Promise<BandInput> {
     return {
       reviewOutcomes: this.deps.store.countReviewOutcomes(now - CRITIC_WINDOW_MS),
       incidents: this.deps.store.countSignalsByKind(now - INCIDENT_WINDOW_MS),
       repos: this.deps.repoDelivery(),
+      deadCode: parseDeadCodeReport(
+        await this.fixRunner.deadCode(this.deps.selfRepoPath).catch(() => null),
+      ),
     };
   }
 
   /**
-   * Why this band may not diagnose right now, or null when it may. Three rules, checked cheapest
+   * Why this band may not act right now, or null when it may. Three rules, checked cheapest
    * first; rule 2 is the one that holds in observe mode.
    */
   private async suppressionFor(bandKey: string, now: number): Promise<string | null> {
-    if (this.inflight.has(bandKey)) return "a run is already in flight";
+    if (this.hasLiveRun(bandKey)) return "a run is already in flight";
     const last = this.deps.store.lastCompletedMaintainRun(bandKey);
     if (last?.completedAt != null && now - last.completedAt < this.cooldownMs) {
       const days = Math.ceil((this.cooldownMs - (now - last.completedAt)) / 86_400_000);
       return `cooling down for ${days} more day(s)`;
     }
     // Only ever EXTENDS suppression past the cooldown; it can never shorten it. A forge failure
-    // here must not block a diagnosis, so it degrades to the cooldown alone.
-    if (last?.issueNumber != null && (await this.issueStillOpen(last.issueNumber))) {
-      return `issue #${last.issueNumber} is still open`;
+    // here must not block a run, so it degrades to the cooldown alone.
+    if (last?.issueNumber != null && (await this.publishedStillOpen(last))) {
+      const what = last.outcome === "opened" ? "PR" : "issue";
+      return `${what} #${last.issueNumber} is still open`;
     }
     return null;
+  }
+
+  /** Whether the artifact the band's last run published is still open — an issue for a `filed`
+   *  Tier-2 run, a PR for an `opened` Tier-3 one. Re-opening a second PR for dead code the operator
+   *  has not merged yet is the exact pile-up this prevents. */
+  private async publishedStillOpen(last: MaintainRun): Promise<boolean> {
+    if (last.issueNumber == null) return false;
+    return last.outcome === "opened"
+      ? this.prStillOpen(last.issueNumber)
+      : this.issueStillOpen(last.issueNumber);
+  }
+
+  /** Fail-open like {@link issueStillOpen}: a forge blip degrades to the plain cooldown, never to
+   *  a daily re-push. */
+  private async prStillOpen(prNumber: number): Promise<boolean> {
+    const forge = this.deps.resolveForge(this.deps.selfRepoPath);
+    if (!forge) return false;
+    try {
+      return (await forge.listPullRequests()).some((p) => p.number === prNumber);
+    } catch (err) {
+      this.log(`[maintain] could not check PR #${prNumber}: ${String(err)}`);
+      return false;
+    }
   }
 
   private async issueStillOpen(issueNumber: number): Promise<boolean> {
@@ -373,6 +578,261 @@ export class MaintainService {
       this.log(`[maintain] ${reading.key}: diagnosis failed to start: ${String(err)}`);
       return false;
     }
+  }
+
+  // ── tier 3: the pre-approved fix (#2171) ───────────────────────────────────
+
+  /**
+   * Run the band's pre-approved fix and, when armed, open a PR for it.
+   *
+   * Structurally unlike Tier 2: no agent, so no herdr pane, no membrane, no draft file, no
+   * `reviewer_spawns` cost row and no `tick()` participation. The whole run lives inside this one
+   * awaited call. That is the point of a pre-approved class — the remediation is mechanical enough
+   * that nothing has to be reasoned about, so nothing has to be spawned.
+   *
+   * Returns true when a run happened (the band consumed its per-sweep action), false when it could
+   * not be started at all.
+   */
+  private async beginFix(reading: BandReading): Promise<boolean> {
+    const repoPath = this.deps.selfRepoPath;
+    const forge = this.deps.resolveForge(repoPath);
+    if (!forge || forge.isLightweight) {
+      // Fail closed, same as Tier 2: with no PR surface there is nowhere for the fix to go.
+      this.log(`[maintain] ${reading.key}: no forge for ${repoPath} — tier 3 skipped`);
+      return false;
+    }
+    let base: string;
+    try {
+      base = await forge.defaultBranch();
+    } catch {
+      this.log(`[maintain] ${reading.key}: could not resolve the default branch`);
+      return false;
+    }
+    // Freshen origin/<base> so the fix is computed against current main, not a stale local ref.
+    const resolved = await this.deps.worktree.ensureBaseRef(repoPath, base);
+
+    const name = FIX_BRANCH_PREFIX + randomUUID().slice(0, 8);
+    let wt;
+    try {
+      wt = this.deps.worktree.create(repoPath, resolved.baseRef, name);
+    } catch (err) {
+      this.log(`[maintain] ${reading.key}: worktree creation failed: ${String(err)}`);
+      return false;
+    }
+    if (!wt.isolated || !wt.branch) {
+      // A non-isolated result means the repo is not a git checkout — there is nothing to commit to.
+      this.log(`[maintain] ${reading.key}: ${repoPath} is not isolatable — tier 3 skipped`);
+      if (wt.worktreePath !== repoPath) this.deps.worktree.remove(wt.worktreePath);
+      return false;
+    }
+
+    const run: MaintainRun = {
+      id: randomUUID(),
+      bandKey: reading.key,
+      bandId: reading.bandId,
+      tier: reading.tier,
+      value: reading.value,
+      worktreePath: wt.worktreePath,
+      // No agent and no spawn: both ids are empty, and `completeReviewerSpawn` no-ops on an
+      // unknown id so the orphan reaper stays correct without a special case.
+      agentName: "",
+      spawnSessionId: "",
+      spawnedAt: this.now(),
+      completedAt: null,
+      outcome: null,
+      issueNumber: null,
+      issueUrl: null,
+    };
+    // Claim + durable row BEFORE any work, so a crash mid-run leaves an in-flight row for
+    // `reapOrphans` and a cooldown anchor either way.
+    this.fixInflight.set(reading.key, wt.worktreePath);
+    this.deps.store.insertMaintainRun(run);
+
+    let outcome: MaintainOutcome = "error";
+    let pr: { number: number; url: string } | null = null;
+    try {
+      const result = await this.runFix(reading, wt.worktreePath, wt.branch, base, forge);
+      outcome = result.outcome;
+      pr = "pr" in result ? result.pr : null;
+      this.log(`[maintain] ${reading.key} tier 3: ${result.why}`);
+    } catch (err) {
+      this.log(`[maintain] ${reading.key} tier 3 failed: ${String(err)}`);
+    } finally {
+      // Every teardown step is best-effort so the run row below ALWAYS settles. A throw escaping
+      // here would strand the band with an in-flight row until the next boot reconcile.
+      try {
+        this.deps.worktree.remove(wt.worktreePath);
+      } catch (err) {
+        this.log(`[maintain] ${reading.key}: could not remove ${wt.worktreePath}: ${String(err)}`);
+      }
+      // The pushed REMOTE branch backs any opened PR; only the local one is disposable.
+      await this.git(repoPath, ["branch", "-D", wt.branch]).catch(() => {
+        /* best-effort: a never-committed branch may already be gone */
+      });
+      this.deps.store.finishMaintainRun(run.id, {
+        outcome,
+        completedAt: this.now(),
+        issueNumber: pr?.number,
+        issueUrl: pr?.url,
+      });
+      // Dropped LAST: until it is, `inflightWorktrees()` still protects the path.
+      this.fixInflight.delete(reading.key);
+    }
+    return true;
+  }
+
+  /**
+   * The fix itself, in a clean checkout of `origin/<base>`. Three stages, each of which can stand
+   * the run down on its own; only the last one publishes anything.
+   */
+  private async runFix(
+    reading: BandReading,
+    worktreePath: string,
+    branch: string,
+    base: string,
+    forge: GitForge,
+  ): Promise<FixAbort | { outcome: "opened"; why: string; pr: { number: number; url: string } }> {
+    const prepared = await this.prepareFix(worktreePath);
+    if ("outcome" in prepared) return prepared;
+    const failed = await this.verifyFix(worktreePath);
+    if (failed) return failed;
+    return this.publishFix({ reading, worktreePath, branch, base, forge, ...prepared });
+  }
+
+  /**
+   * Install, measure, fix, and inspect the resulting diff. Returns what was removed and which
+   * files moved, or the reason the run stops here.
+   *
+   * Ordered so the cheap disqualifiers run before the expensive checks — measure before fixing,
+   * inspect the diff before typechecking it.
+   */
+  private async prepareFix(
+    worktreePath: string,
+  ): Promise<FixAbort | { before: DeadCodeReading; changed: string[] }> {
+    // Dependencies first — see FIX_INSTALL_DIRS. Without them fallow calls live code dead.
+    try {
+      await this.fixRunner.install(worktreePath);
+    } catch (err) {
+      return { outcome: "error", why: `bun install failed: ${String(err)}` };
+    }
+
+    // Re-measure in the pristine tree. The sweep's reading came from the live checkout, which can
+    // carry uncommitted edits; this is the number the fix is actually accountable to.
+    const before = parseDeadCodeReport(await this.fixRunner.deadCode(worktreePath));
+    if (before === null) return { outcome: "error", why: "could not measure dead code" };
+    if (before.autoFixable === 0) {
+      return { outcome: "skipped", why: "nothing auto-fixable on the base branch" };
+    }
+
+    try {
+      await this.fixRunner.fix(worktreePath);
+    } catch (err) {
+      return { outcome: "error", why: `fallow fix failed: ${String(err)}` };
+    }
+    const changed = await this.changedPaths(worktreePath);
+    if (changed.length === 0) return { outcome: "skipped", why: "fallow fix changed nothing" };
+    // Fail-closed on a manifest edit: `fallow fix` also removes unused DEPENDENCIES, and a
+    // package.json change without a matching lockfile regen lands the PR CI-red. That regen is a
+    // human's call, not a background loop's.
+    const manifests = changed.filter((f) => MANIFEST_RE.test(f));
+    if (manifests.length > 0) {
+      return {
+        outcome: "error",
+        why: `refusing to commit a manifest change without a lockfile regen: ${manifests.join(", ")}`,
+      };
+    }
+    return { before, changed };
+  }
+
+  /** The fail-closed gate, or null when the result is publishable. A red typecheck or a leftover
+   *  finding means the fix is not the clean mechanical removal this tier is licensed for. */
+  private async verifyFix(worktreePath: string): Promise<FixAbort | null> {
+    try {
+      await this.fixRunner.typecheck(worktreePath);
+    } catch (err) {
+      return { outcome: "error", why: `typecheck failed on the result: ${String(err)}` };
+    }
+    const after = parseDeadCodeReport(await this.fixRunner.deadCode(worktreePath));
+    if (after === null) {
+      return { outcome: "error", why: "could not re-measure dead code after the fix" };
+    }
+    if (after.autoFixable !== 0) {
+      return {
+        outcome: "error",
+        why: `${after.autoFixable} auto-fixable finding(s) survived the fix`,
+      };
+    }
+    return null;
+  }
+
+  /** Commit, push and open the PR — or, unarmed, say what that would have been. */
+  private async publishFix(o: {
+    reading: BandReading;
+    worktreePath: string;
+    branch: string;
+    base: string;
+    forge: GitForge;
+    before: DeadCodeReading;
+    changed: string[];
+  }): Promise<FixAbort | { outcome: "opened"; why: string; pr: { number: number; url: string } }> {
+    const { worktreePath, branch, before } = o;
+    if (!this.deps.pr) {
+      return {
+        outcome: "skipped",
+        why: `would open a PR removing ${describeDeadCode(before)} (${o.changed.length} file(s)) — SHEPHERD_MAINTAIN_PR is off`,
+      };
+    }
+    await this.git(worktreePath, ["add", "-A"]);
+    // `--no-verify` for the same reason the doc agent uses it: a server-side commit must not run
+    // this repo's pre-commit hooks against a checkout nobody is sitting in front of. The change is
+    // mechanical and human-reviewed via the PR.
+    await this.git(worktreePath, ["commit", "--no-verify", "-m", DEAD_CODE_COMMIT_MSG]);
+    await this.git(worktreePath, ["push", "-u", "origin", branch]);
+    let created;
+    try {
+      created = await o.forge.openPr({
+        head: branch,
+        base: o.base,
+        title: DEAD_CODE_COMMIT_MSG,
+        body: renderFixPrBody(before, o.reading),
+      });
+    } catch (err) {
+      // The branch is pushed but has no PR. Take it back down rather than leave an orphan on the
+      // remote; `EmptyDiffError` lands here too and is not an error, just nothing to open.
+      await this.git(worktreePath, ["push", "origin", "--delete", branch]).catch(() => {
+        /* best-effort: the remote may already have dropped it */
+      });
+      if (err instanceof EmptyDiffError) {
+        return { outcome: "skipped", why: "no net diff vs the base branch" };
+      }
+      return { outcome: "error", why: `openPr failed: ${String(err)}` };
+    }
+    if (created.number == null || !created.url) {
+      return { outcome: "error", why: "forge opened a PR without a number or url" };
+    }
+    return {
+      outcome: "opened",
+      why: `opened ${created.url} removing ${describeDeadCode(before)}`,
+      pr: { number: created.number, url: created.url },
+    };
+  }
+
+  /** Paths `git status --porcelain` reports as changed, ignoring the status columns. Renames are
+   *  reported as `old -> new`; only the destination matters here. */
+  private async changedPaths(worktreePath: string): Promise<string[]> {
+    const out = await this.git(worktreePath, ["status", "--porcelain"]);
+    return (
+      out
+        .split("\n")
+        .filter((line) => line.trim().length > 0)
+        .map((line) => {
+          const path = line.slice(3).trim();
+          const arrow = path.lastIndexOf(" -> ");
+          return arrow === -1 ? path : path.slice(arrow + 4);
+        })
+        // Porcelain quotes paths containing unusual characters; strip so MANIFEST_RE still matches.
+        .map((path) => (path.startsWith('"') && path.endsWith('"') ? path.slice(1, -1) : path))
+    );
   }
 
   private async launch(reading: BandReading, forge: GitForge): Promise<boolean> {
@@ -658,15 +1118,27 @@ export class MaintainService {
     // `deferredStarts`, before this process has spawned anything.
     await reapTransientByLabel(this.deps.herdr, MAINTAIN_AGENT_LABEL, new Set(), "[maintain]");
     for (const run of this.deps.store.listInflightMaintainRuns()) {
-      if (this.inflight.has(run.bandKey)) continue;
+      if (this.inflight.has(run.bandKey) || this.fixInflight.has(run.bandKey)) continue;
       this.deps.store.finishMaintainRun(run.id, { outcome: "error", completedAt: this.now() });
+      // No-ops for a Tier-3 run, whose spawnSessionId is empty because it never spawned anything.
       this.deps.store.completeReviewerSpawn(run.spawnSessionId, ZEROED_USAGE, this.now());
       try {
         this.deps.worktree.remove(run.worktreePath);
       } catch {
         /* best-effort: already gone */
       }
-      this.log(`[maintain] reaped orphaned diagnosis run for ${run.bandKey}`);
+      // A Tier-3 run also owns a local branch the removed worktree was holding. Left behind it
+      // would collide with nothing (the name is per-run) but would accumulate one dead ref per
+      // interrupted run forever.
+      const fixBranch = fixBranchOf(run.worktreePath);
+      if (fixBranch) {
+        await this.git(this.deps.selfRepoPath, ["branch", "-D", fixBranch]).catch(() => {
+          /* best-effort: a never-committed branch may already be gone */
+        });
+      }
+      this.log(
+        `[maintain] reaped orphaned ${fixBranch ? "fix" : "diagnosis"} run for ${run.bandKey}`,
+      );
     }
   }
 }

--- a/src/maintain.ts
+++ b/src/maintain.ts
@@ -59,6 +59,7 @@ import {
   describeDeadCode,
   describeReading,
   evaluateBands,
+  packagesFor,
   parseDeadCodeReport,
   readMaintainDraft,
   renderFixPrBody,
@@ -67,6 +68,7 @@ import {
   type BandThresholds,
   type DeadCodeReading,
   type EvidenceLine,
+  type FixPackage,
   type MaintainDraft,
 } from "./maintain-core";
 
@@ -116,8 +118,10 @@ export interface FixRunner {
   deadCode(worktreePath: string): Promise<string | null>;
   /** `fallow fix --yes --no-create-config`. Throws on failure. */
   fix(worktreePath: string): Promise<void>;
-  /** `bun run typecheck`. Throws when it does not pass. */
-  typecheck(worktreePath: string): Promise<void>;
+  /** Type-check ONE package: `bun run typecheck` for the server root, `bun run check` for `ui`
+   *  and `extension`. Throws when it does not pass. Per-package because the root tsconfig
+   *  excludes the others — see {@link packagesFor}. */
+  typecheck(worktreePath: string, pkg: FixPackage): Promise<void>;
 }
 
 const execFileP = promisify(execFile);
@@ -176,9 +180,11 @@ const defaultFixRunner: FixRunner = {
       timeout: FIX_SUBPROCESS_TIMEOUT_MS,
     });
   },
-  async typecheck(worktreePath) {
-    await execFileP("bun", ["run", "typecheck"], {
-      cwd: worktreePath,
+  async typecheck(worktreePath, pkg) {
+    // `bun run check` is each sub-package's own svelte-check; `typecheck` is the server's tsc.
+    const [dir, script] = pkg === "root" ? [".", "typecheck"] : [pkg, "check"];
+    await execFileP("bun", ["run", script], {
+      cwd: join(worktreePath, dir),
       timeout: FIX_SUBPROCESS_TIMEOUT_MS,
     });
   },
@@ -694,9 +700,17 @@ export class MaintainService {
   ): Promise<FixAbort | { outcome: "opened"; why: string; pr: { number: number; url: string } }> {
     const prepared = await this.prepareFix(worktreePath);
     if ("outcome" in prepared) return prepared;
-    const failed = await this.verifyFix(worktreePath);
-    if (failed) return failed;
-    return this.publishFix({ reading, worktreePath, branch, base, forge, ...prepared });
+    const verified = await this.verifyFix(worktreePath, prepared.changed);
+    if ("outcome" in verified) return verified;
+    return this.publishFix({
+      reading,
+      worktreePath,
+      branch,
+      base,
+      forge,
+      ...prepared,
+      ...verified,
+    });
   }
 
   /**
@@ -744,13 +758,33 @@ export class MaintainService {
     return { before, changed };
   }
 
-  /** The fail-closed gate, or null when the result is publishable. A red typecheck or a leftover
-   *  finding means the fix is not the clean mechanical removal this tier is licensed for. */
-  private async verifyFix(worktreePath: string): Promise<FixAbort | null> {
-    try {
-      await this.fixRunner.typecheck(worktreePath);
-    } catch (err) {
-      return { outcome: "error", why: `typecheck failed on the result: ${String(err)}` };
+  /**
+   * The fail-closed gate. Returns the packages it actually checked, or the reason the run stops.
+   *
+   * ROUTED BY WHAT CHANGED, not fixed at the root. `bun run typecheck` is `tsc --noEmit` against a
+   * tsconfig that excludes `ui`, `extension`, `site` and `docs-site` — but fallow analyses and
+   * fixes all of them. Running only the root check would pass VACUOUSLY for a fix that deleted a
+   * live export under `ui/src/lib`, and that diff would be committed and opened as a PR.
+   */
+  private async verifyFix(
+    worktreePath: string,
+    changed: string[],
+  ): Promise<FixAbort | { packages: FixPackage[] }> {
+    const { packages, unverifiable } = packagesFor(changed);
+    if (unverifiable.length > 0) {
+      // `site/` and `docs-site/` have no dependencies installed here and no check command wired,
+      // so there is no honest way to verify a fix in them. Refuse rather than commit unverified.
+      return {
+        outcome: "error",
+        why: `refusing to commit changes nothing here can type-check: ${unverifiable.join(", ")}`,
+      };
+    }
+    for (const pkg of packages) {
+      try {
+        await this.fixRunner.typecheck(worktreePath, pkg);
+      } catch (err) {
+        return { outcome: "error", why: `typecheck failed on the result (${pkg}): ${String(err)}` };
+      }
     }
     const after = parseDeadCodeReport(await this.fixRunner.deadCode(worktreePath));
     if (after === null) {
@@ -762,7 +796,7 @@ export class MaintainService {
         why: `${after.autoFixable} auto-fixable finding(s) survived the fix`,
       };
     }
-    return null;
+    return { packages };
   }
 
   /** Commit, push and open the PR — or, unarmed, say what that would have been. */
@@ -774,6 +808,7 @@ export class MaintainService {
     forge: GitForge;
     before: DeadCodeReading;
     changed: string[];
+    packages: FixPackage[];
   }): Promise<FixAbort | { outcome: "opened"; why: string; pr: { number: number; url: string } }> {
     const { worktreePath, branch, before } = o;
     if (!this.deps.pr) {
@@ -794,7 +829,7 @@ export class MaintainService {
         head: branch,
         base: o.base,
         title: DEAD_CODE_COMMIT_MSG,
-        body: renderFixPrBody(before, o.reading),
+        body: renderFixPrBody(before, o.reading, o.packages),
       });
     } catch (err) {
       // The branch is pushed but has no PR. Take it back down rather than leave an orphan on the

--- a/src/server.ts
+++ b/src/server.ts
@@ -4387,6 +4387,7 @@ function handleUsageDelivery({ req, parts, url, deps }: Ctx): Response | null {
   const maintain: MaintainBlock = {
     enabled: config.maintainLoopEnabled,
     act: config.maintainLoopAct,
+    pr: config.maintainLoopPr,
     readings: snap?.readings ?? [],
     recentRuns: snap?.recentRuns ?? [],
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1053,12 +1053,19 @@ export interface DeliveryMetrics {
 
 // ── maintain loop (#2157) ────────────────────────────────────────────────────
 
-/** The three bands v1 evaluates over Shepherd's OWN health data (#2151 R5). */
-export type BandId = "critic_error_rate" | "incident_spike" | "first_pass_collapse";
+/** The bands evaluated over Shepherd's OWN health data (#2151 R5). `dead_code_drift` (#2171) is
+ *  the only one carrying a pre-approved Tier-3 fix class. */
+export type BandId =
+  "critic_error_rate" | "incident_spike" | "first_pass_collapse" | "dead_code_drift";
 
-/** 0 = clear (or below the band's minimum sample), 1 = log, 2 = diagnose. Tier 3 (open a PR for a
- *  pre-approved fix class) is deliberately not implemented — see the follow-up issue. */
-export type MaintainTier = 0 | 1 | 2;
+/** 0 = clear (or below the band's minimum sample), 1 = log, 2 = diagnose, 3 = open a PR for the
+ *  band's pre-approved fix class (#2171).
+ *
+ *  Tier 3 is NOT a fourth threshold: a reading that crosses its band's tier-2 threshold is
+ *  PROMOTED to 3 when — and only when — that band's config declares a `tier3` fix class. A band
+ *  with a mechanical remediation escalates to the PR path instead of the diagnosis path; the
+ *  ladder stays monotonic and no band gains a rung it can never reach. */
+export type MaintainTier = 0 | 1 | 2 | 3;
 
 /** One band evaluated once. `key` is the stable identity a run and a cooldown are keyed by:
  *  `critic_error_rate`, `incident_spike:<signal kind>`, `first_pass_collapse:<repoPath>`. */
@@ -1073,10 +1080,11 @@ export interface BandReading {
   subject: string | null;
   tier: MaintainTier;
   /** The measured quantity. A rate in 0..1 for the two rate bands, an occurrence count for
-   *  `incident_spike`. */
+   *  `incident_spike`, an auto-fixable-finding count for `dead_code_drift`. */
   value: number;
   /** Sample size behind `value` — review spawns, merged tasks, or distinct sessions. A band below
-   *  its minimum sample reports tier 0 and is shown as such rather than as "clear". */
+   *  its minimum sample reports tier 0 and is shown as such rather than as "clear". Count bands
+   *  (`dead_code_drift`) have no separate denominator and report `sampleN === value`. */
   sampleN: number;
   /** True when `sampleN` fell under the band's minimum, i.e. `tier` is 0 for want of data rather
    *  than because the metric is healthy. */
@@ -1084,12 +1092,14 @@ export interface BandReading {
   evaluatedAt: number;
 }
 
-/** Terminal state of a Tier-2 diagnosis run. `skipped` covers a run that produced a draft the
- *  server chose not to file (act off), which is the expected observe-mode outcome. */
-export type MaintainOutcome = "filed" | "skipped" | "error";
+/** Terminal state of a maintain run. `filed` = a Tier-2 diagnosis became an issue; `opened` = a
+ *  Tier-3 fix became a PR (#2171). `skipped` covers a run the server deliberately did not publish
+ *  — act/pr off, or nothing left to fix — which is the expected observe-mode outcome. */
+export type MaintainOutcome = "filed" | "opened" | "skipped" | "error";
 
-/** One Tier-2 diagnosis spawn. Append-only: this is both the audit trail and — critically — the
- *  cooldown anchor, so a row is written for EVERY run including the ones that file nothing. */
+/** One maintain run — a Tier-2 diagnosis spawn or a Tier-3 fix. Append-only: this is both the
+ *  audit trail and — critically — the cooldown anchor, so a row is written for EVERY run including
+ *  the ones that publish nothing. */
 export interface MaintainRun {
   id: string;
   bandKey: string;
@@ -1097,11 +1107,16 @@ export interface MaintainRun {
   tier: MaintainTier;
   value: number;
   worktreePath: string;
+  /** Herdr pane name for a Tier-2 diagnosis. Empty for a Tier-3 fix — it spawns no agent. */
   agentName: string;
+  /** Transient-spawn id for a Tier-2 diagnosis, and its `reviewer_spawns` cost-ledger key. Empty
+   *  for a Tier-3 fix, which has no spawn and therefore no cost row. */
   spawnSessionId: string;
   spawnedAt: number;
   completedAt: number | null;
   outcome: MaintainOutcome | null;
+  /** The published artifact: the issue number for a `filed` run, the PR number for an `opened`
+   *  one. Both live here — a GitHub PR *is* an issue — and `outcome` says which it is. */
   issueNumber: number | null;
   issueUrl: string | null;
 }
@@ -1113,6 +1128,10 @@ export interface MaintainBlock {
   enabled: boolean;
   /** SHEPHERD_MAINTAIN_ACT — a drafted issue is actually filed. Meaningless without `enabled`. */
   act: boolean;
+  /** SHEPHERD_MAINTAIN_PR — a Tier-3 fix actually opens a PR (#2171). Deliberately INDEPENDENT of
+   *  `act`: arming issue-filing must never implicitly arm PR-opening. Meaningless without
+   *  `enabled`. */
+  pr: boolean;
   readings: BandReading[];
   recentRuns: MaintainRun[];
 }

--- a/test/maintain-core.test.ts
+++ b/test/maintain-core.test.ts
@@ -9,6 +9,7 @@ import {
   describeReading,
   evaluateBands,
   mergeThresholds,
+  packagesFor,
   parseDeadCodeReport,
   readMaintainDraft,
   renderFixPrBody,
@@ -661,8 +662,12 @@ describe("describeReading / renderFixPrBody — count band", () => {
     const body = renderFixPrBody(
       { autoFixable: 2, total: 5, byCategory: { unused_exports: 2 } },
       r,
+      ["root", "ui"],
     );
     expect(body).toContain("maintain loop (tier 3)");
+    // The body must name what was ACTUALLY checked — the root tsc alone would be a vacuous claim
+    // for a diff under ui/.
+    expect(body).toContain("`root`, `ui`");
     expect(body).toContain("2 unused exports");
     expect(body).toContain("3 finding(s) are not auto-fixable");
     expect(body).toContain("dead_code_drift");
@@ -672,6 +677,7 @@ describe("describeReading / renderFixPrBody — count band", () => {
     const body = renderFixPrBody(
       { autoFixable: 2, total: 2, byCategory: { unused_exports: 2 } },
       r,
+      ["root"],
     );
     expect(body).not.toContain("Left alone");
   });
@@ -680,5 +686,37 @@ describe("describeReading / renderFixPrBody — count band", () => {
 describe("windowDaysFor", () => {
   it("reports no window for the point-in-time band", () => {
     expect(windowDaysFor("dead_code_drift")).toBe(0);
+  });
+});
+
+describe("packagesFor", () => {
+  it("routes each changed path to the package that can actually check it", () => {
+    // The bug this closes: `bun run typecheck` is tsc against a tsconfig that EXCLUDES ui and
+    // extension, so a root-only gate passes vacuously for a fix under ui/src/lib.
+    expect(packagesFor(["src/usage.ts"]).packages).toEqual(["root"]);
+    expect(packagesFor(["ui/src/lib/x.ts"]).packages).toEqual(["ui"]);
+    expect(packagesFor(["extension/src/background.ts"]).packages).toEqual(["extension"]);
+  });
+
+  it("returns every touched package, cheapest check first", () => {
+    expect(packagesFor(["ui/src/lib/x.ts", "src/usage.ts", "extension/src/y.ts"]).packages).toEqual(
+      ["root", "extension", "ui"],
+    );
+  });
+
+  it("de-duplicates several paths in one package", () => {
+    expect(packagesFor(["ui/a.ts", "ui/b.ts", "ui/c.ts"]).packages).toEqual(["ui"]);
+  });
+
+  it("flags the trees nothing here can verify rather than silently checking the root", () => {
+    // site/ and docs-site/ are in fallow's entry list but have no installed deps and no wired
+    // check in the fix worktree — treating them as "root" would be the same vacuous pass.
+    const out = packagesFor(["src/usage.ts", "site/src/pages/index.astro", "docs-site/x.mjs"]);
+    expect(out.unverifiable).toEqual(["site/src/pages/index.astro", "docs-site/x.mjs"]);
+    expect(out.packages).toEqual(["root"]);
+  });
+
+  it("treats scripts and tests as root", () => {
+    expect(packagesFor(["scripts/x.ts", "test/y.ts"]).packages).toEqual(["root"]);
   });
 });

--- a/test/maintain-core.test.ts
+++ b/test/maintain-core.test.ts
@@ -5,10 +5,13 @@ import {
   bandKey,
   breaches,
   buildDiagnosisPrompt,
+  describeDeadCode,
   describeReading,
   evaluateBands,
   mergeThresholds,
+  parseDeadCodeReport,
   readMaintainDraft,
+  renderFixPrBody,
   renderIssueBody,
   thresholdsFromEnv,
   windowDaysFor,
@@ -22,6 +25,7 @@ const EMPTY_INPUT: BandInput = {
   reviewOutcomes: { verdicts: 0, errors: 0 },
   incidents: [],
   repos: [],
+  deadCode: null,
 };
 
 function input(over: Partial<BandInput>): BandInput {
@@ -215,8 +219,9 @@ describe("evaluateBands", () => {
       reviewOutcomes: { verdicts: 100, errors: 0 },
       incidents: [{ kind: "stall", occurrences: 0, sessions: 0 }],
       repos: [repoRow("/r/a", 1, 20)],
+      deadCode: { autoFixable: 0, total: 0, byCategory: {} },
     });
-    expect(readings).toHaveLength(3);
+    expect(readings).toHaveLength(4);
     expect(readings.every((r) => r.tier === 0)).toBe(true);
   });
 
@@ -453,5 +458,227 @@ describe("renderIssueBody", () => {
     );
     expect(body).not.toContain("## Evidence");
     expect(body).not.toContain("## Open questions");
+  });
+});
+
+// ── dead_code_drift + tier 3 (#2171) ─────────────────────────────────────────
+
+/** A minimal but shape-faithful `fallow dead-code --format json` payload: one auto-fixable unused
+ *  export plus one unused file fallow refuses to touch, which is exactly today's repo state. */
+function fallowReport(over?: {
+  exports?: number;
+  files?: number;
+  extra?: Record<string, unknown>;
+}): string {
+  const exports = over?.exports ?? 1;
+  const files = over?.files ?? 1;
+  return JSON.stringify({
+    kind: "dead-code",
+    schema_version: 7,
+    total_issues: exports + files,
+    unused_files: Array.from({ length: files }, (_, i) => ({
+      path: `ui/src/lib/components/Gone${i}.svelte`,
+      actions: [
+        { type: "delete-file", auto_fixable: false, description: "Delete this file" },
+        { type: "suppress-file", auto_fixable: false, description: "Suppress" },
+      ],
+    })),
+    unused_exports: Array.from({ length: exports }, (_, i) => ({
+      path: "src/usage.ts",
+      export_name: `gone${i}`,
+      actions: [
+        { type: "remove-export", auto_fixable: true, description: "Remove the unused export" },
+        { type: "suppress-line", auto_fixable: false, description: "Suppress" },
+      ],
+    })),
+    // The only other top-level array fallow emits, and the reason the parser keys off `actions`
+    // rather than off "is an array".
+    next_steps: [{ id: "trace-unused-export", command: "fallow dead-code --trace x", reason: "y" }],
+    ...over?.extra,
+  });
+}
+
+describe("parseDeadCodeReport", () => {
+  it("counts only findings fallow can fix itself", () => {
+    const r = parseDeadCodeReport(fallowReport({ exports: 2, files: 3 }));
+    expect(r).not.toBeNull();
+    expect(r!.autoFixable).toBe(2);
+    expect(r!.total).toBe(5);
+    expect(r!.byCategory).toEqual({ unused_exports: 2 });
+  });
+
+  it("ignores top-level arrays that carry no actions", () => {
+    // `next_steps` has three entries in the fixture's shape but no `actions` — counting it would
+    // inflate every reading.
+    const r = parseDeadCodeReport(fallowReport({ exports: 0, files: 0 }));
+    expect(r!.total).toBe(0);
+    expect(r!.autoFixable).toBe(0);
+  });
+
+  it("counts a category fallow adds in a later release without a code change here", () => {
+    const r = parseDeadCodeReport(
+      fallowReport({
+        exports: 0,
+        files: 0,
+        extra: {
+          some_future_category: [
+            { path: "a.ts", actions: [{ type: "x", auto_fixable: true, description: "d" }] },
+          ],
+        },
+      }),
+    );
+    expect(r!.autoFixable).toBe(1);
+    expect(r!.byCategory).toEqual({ some_future_category: 1 });
+  });
+
+  it("returns null rather than a confident zero for anything that is not a dead-code report", () => {
+    // Each of these would otherwise read as "no dead code" — the exact lie that would let the
+    // Tier-3 verify gate pass on a fallow that fell over.
+    expect(parseDeadCodeReport(null)).toBeNull();
+    expect(parseDeadCodeReport("")).toBeNull();
+    expect(parseDeadCodeReport("not json at all {{{")).toBeNull();
+    expect(parseDeadCodeReport(JSON.stringify({ error: "boom" }))).toBeNull();
+    expect(parseDeadCodeReport(JSON.stringify({ kind: "health", total_issues: 0 }))).toBeNull();
+  });
+});
+
+describe("describeDeadCode", () => {
+  it("spells out the per-category breakdown", () => {
+    expect(describeDeadCode(parseDeadCodeReport(fallowReport({ exports: 2 }))!)).toBe(
+      "2 unused exports",
+    );
+  });
+
+  it("says so when there is nothing to fix", () => {
+    expect(describeDeadCode({ autoFixable: 0, total: 3, byCategory: {} })).toBe(
+      "no auto-fixable findings",
+    );
+  });
+});
+
+describe("evaluateBands — dead_code_drift", () => {
+  const reading = (over: Partial<BandInput>) => readingFor(evaluate(over), "dead_code_drift");
+
+  it("is always present, and reads as no-data when fallow could not be run", () => {
+    const r = reading({ deadCode: null });
+    expect(r.tier).toBe(0);
+    expect(r.belowMinSample).toBe(true);
+    expect(r.value).toBe(0);
+  });
+
+  it("is clear at zero auto-fixable findings even with findings a human still owns", () => {
+    const r = reading({ deadCode: { autoFixable: 0, total: 4, byCategory: {} } });
+    expect(r.tier).toBe(0);
+    expect(r.belowMinSample).toBe(false);
+    expect(r.sampleN).toBe(4);
+  });
+
+  it("logs at tier 1 below the tier-2 threshold", () => {
+    const r = reading({ deadCode: { autoFixable: 1, total: 3, byCategory: {} } });
+    expect(r.tier).toBe(1);
+  });
+
+  it("promotes its tier-2 breach to tier 3 — it declares a fix class", () => {
+    const r = reading({ deadCode: { autoFixable: 3, total: 3, byCategory: {} } });
+    expect(r.tier).toBe(3);
+    expect(DEFAULT_BAND_THRESHOLDS.dead_code_drift.tier3).toEqual({ class: "dead_code" });
+  });
+
+  it("reports tier 2, not 3, when the band declares no fix class", () => {
+    // The whole point of the promotion rule: a band without a mechanical remediation keeps the
+    // diagnosis path. Guards against a future edit putting `tier3` on the shared config shape.
+    const noClass = {
+      ...DEFAULT_BAND_THRESHOLDS,
+      dead_code_drift: { tier1: 1, tier2: 3 },
+    };
+    const readings = evaluateBands(
+      input({ deadCode: { autoFixable: 9, total: 9, byCategory: {} } }),
+      noClass,
+      NOW,
+    );
+    expect(readingFor(readings, "dead_code_drift").tier).toBe(2);
+  });
+
+  it("never promotes the three v1 bands — none has a fix class", () => {
+    const readings = evaluateBands(
+      input({
+        reviewOutcomes: { verdicts: 1, errors: 9 },
+        incidents: [{ kind: "stall", occurrences: 100, sessions: 50 }],
+        repos: [repoRow("/r/a", 0.0, 40)],
+        deadCode: { autoFixable: 9, total: 9, byCategory: {} },
+      }),
+      DEFAULT_BAND_THRESHOLDS,
+      NOW,
+    );
+    for (const r of readings) {
+      if (r.bandId === "dead_code_drift") expect(r.tier).toBe(3);
+      else expect(r.tier).toBe(2);
+    }
+  });
+});
+
+describe("mergeThresholds — dead_code_drift", () => {
+  it("retunes the numbers", () => {
+    const t = mergeThresholds({ dead_code_drift: { tier1: 5, tier2: 20 } });
+    expect(t.dead_code_drift.tier1).toBe(5);
+    expect(t.dead_code_drift.tier2).toBe(20);
+  });
+
+  it("keeps the fix class an override cannot reach", () => {
+    // Disarming tier 3 is SHEPHERD_MAINTAIN_PR's job, not the threshold table's — one disarm
+    // switch, not two. An override that drops the class must not silently disarm the tier.
+    const t = mergeThresholds({ dead_code_drift: { tier1: 2, tier2: 4 } });
+    expect(t.dead_code_drift.tier3).toEqual({ class: "dead_code" });
+    const cleared = mergeThresholds({ dead_code_drift: { tier3: null } });
+    expect(cleared.dead_code_drift.tier3).toEqual({ class: "dead_code" });
+  });
+
+  it("falls back field-by-field on garbage", () => {
+    const t = mergeThresholds({ dead_code_drift: { tier1: "lots", tier2: 7 } });
+    expect(t.dead_code_drift.tier1).toBe(DEFAULT_BAND_THRESHOLDS.dead_code_drift.tier1);
+    expect(t.dead_code_drift.tier2).toBe(7);
+  });
+});
+
+describe("describeReading / renderFixPrBody — count band", () => {
+  const r: BandReading = {
+    key: "dead_code_drift",
+    bandId: "dead_code_drift",
+    repoPath: null,
+    subject: null,
+    tier: 3,
+    value: 2,
+    sampleN: 5,
+    belowMinSample: false,
+    evaluatedAt: NOW,
+  };
+
+  it("renders a count, not a percentage", () => {
+    expect(describeReading(r)).toBe("dead_code_drift: 2 auto-fixable of 5 finding(s) → tier 3");
+  });
+
+  it("names what was removed, what was left, and the pinned fallow", () => {
+    const body = renderFixPrBody(
+      { autoFixable: 2, total: 5, byCategory: { unused_exports: 2 } },
+      r,
+    );
+    expect(body).toContain("maintain loop (tier 3)");
+    expect(body).toContain("2 unused exports");
+    expect(body).toContain("3 finding(s) are not auto-fixable");
+    expect(body).toContain("dead_code_drift");
+  });
+
+  it("omits the left-alone section when fallow could fix everything", () => {
+    const body = renderFixPrBody(
+      { autoFixable: 2, total: 2, byCategory: { unused_exports: 2 } },
+      r,
+    );
+    expect(body).not.toContain("Left alone");
+  });
+});
+
+describe("windowDaysFor", () => {
+  it("reports no window for the point-in-time band", () => {
+    expect(windowDaysFor("dead_code_drift")).toBe(0);
   });
 });

--- a/test/maintain.test.ts
+++ b/test/maintain.test.ts
@@ -9,6 +9,7 @@ import {
 import { DEAD_CODE_COMMIT_MSG, DEFAULT_COOLDOWN_MS } from "../src/maintain-core";
 import { UNTRUSTED_CONTENT_DIRECTIVE } from "../src/untrusted";
 import { EmptyDiffError, type GitForge, type Issue } from "../src/forge/types";
+import type { FixPackage } from "../src/maintain-core";
 import type { DeliveryRepoRow, DeliveryStats } from "../src/types";
 
 const SELF = "/repos/shepherd";
@@ -71,8 +72,10 @@ interface Harness {
   /** Dead-code reports: `live` answers the sweep's measurement of the live checkout, `worktree`
    *  is consumed in order by the fix run's before/after measurements. */
   deadCode: { live: string | null; worktree: (string | null)[] };
-  /** Which fix subprocess, if any, should reject. */
-  fixFails: { install: boolean; fix: boolean; typecheck: boolean };
+  /** Which fix subprocess, if any, should reject. `typecheck` may name one package. */
+  fixFails: { install: boolean; fix: boolean; typecheck: boolean | FixPackage };
+  /** Packages the verify gate actually type-checked, in call order. */
+  checked: FixPackage[];
   /** Set to throw from openPr. */
   openPrError: { current: Error | null };
 }
@@ -122,7 +125,8 @@ function harness(over: Partial<MaintainDeps> = {}): Harness {
   const openPrNumbers: number[] = [];
   const statusOut = { current: " M src/usage.ts\n" };
   const deadCode = { live: CLEAN_REPORT as string | null, worktree: [] as (string | null)[] };
-  const fixFails = { install: false, fix: false, typecheck: false };
+  const fixFails = { install: false, fix: false, typecheck: false as boolean | FixPackage };
+  const checked: FixPackage[] = [];
   const openPrError = { current: null as Error | null };
   let nextIssue = 100;
   let nextPr = 500;
@@ -231,8 +235,9 @@ function harness(over: Partial<MaintainDeps> = {}): Harness {
       fix: async () => {
         if (fixFails.fix) throw new Error("fallow fix exploded");
       },
-      typecheck: async () => {
-        if (fixFails.typecheck) throw new Error("TS2322");
+      typecheck: async (_wt: string, pkg: FixPackage) => {
+        checked.push(pkg);
+        if (fixFails.typecheck === true || fixFails.typecheck === pkg) throw new Error("TS2322");
       },
     },
     readDraft: () => draft.current,
@@ -268,6 +273,7 @@ function harness(over: Partial<MaintainDeps> = {}): Harness {
     statusOut,
     deadCode,
     fixFails,
+    checked,
     openPrError,
   };
 }
@@ -913,6 +919,43 @@ describe("tier 3 — fail-closed gates", () => {
     expect((await runWith(h)).outcome).toBe("error");
     expect(h.openedPrs).toHaveLength(0);
     expect(h.logs.join("\n")).toContain("typecheck failed");
+  });
+
+  it("checks every package the diff touches, not just the server root", async () => {
+    // `bun run typecheck` excludes ui/ and extension/, so a root-only gate would pass vacuously
+    // for a fix that deleted a live export under ui/src/lib.
+    const h = drifting();
+    h.statusOut.current = " M src/usage.ts\n M ui/src/lib/x.ts\n M extension/src/y.ts\n";
+    await h.svc.sweep();
+    expect(h.checked).toEqual(["root", "extension", "ui"]);
+    expect(h.openedPrs).toHaveLength(1);
+    expect(h.openedPrs[0]!.body).toContain("`root`, `extension`, `ui`");
+  });
+
+  it("opens nothing when a sub-package check goes red, even with the root green", async () => {
+    const h = drifting();
+    h.statusOut.current = " M ui/src/lib/x.ts\n";
+    h.fixFails.typecheck = "ui";
+    expect((await runWith(h)).outcome).toBe("error");
+    expect(h.openedPrs).toHaveLength(0);
+    expect(h.logs.join("\n")).toContain("typecheck failed on the result (ui)");
+  });
+
+  it("does not run a check for a package the diff never touched", async () => {
+    const h = drifting();
+    h.statusOut.current = " M src/usage.ts\n";
+    await h.svc.sweep();
+    expect(h.checked).toEqual(["root"]);
+  });
+
+  it("refuses to commit a change in a tree nothing here can type-check", async () => {
+    // site/ and docs-site/ are inside fallow's entry list but have no installed deps and no wired
+    // check in the fix worktree.
+    const h = drifting();
+    h.statusOut.current = " M src/usage.ts\n M docs-site/src/x.mjs\n";
+    expect((await runWith(h)).outcome).toBe("error");
+    expect(h.openedPrs).toHaveLength(0);
+    expect(h.logs.join("\n")).toContain("nothing here can type-check");
   });
 
   it("opens nothing when auto-fixable findings survive the fix", async () => {

--- a/test/maintain.test.ts
+++ b/test/maintain.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "bun:test";
 import { SessionStore } from "../src/store";
-import { MAINTAIN_ISSUE_LABEL, MaintainService, type MaintainDeps } from "../src/maintain";
-import { DEFAULT_COOLDOWN_MS } from "../src/maintain-core";
+import {
+  MAINTAIN_ISSUE_LABEL,
+  MaintainService,
+  reportFromFailedExit,
+  type MaintainDeps,
+} from "../src/maintain";
+import { DEAD_CODE_COMMIT_MSG, DEFAULT_COOLDOWN_MS } from "../src/maintain-core";
 import { UNTRUSTED_CONTENT_DIRECTIVE } from "../src/untrusted";
-import type { GitForge, Issue } from "../src/forge/types";
+import { EmptyDiffError, type GitForge, type Issue } from "../src/forge/types";
 import type { DeliveryRepoRow, DeliveryStats } from "../src/types";
 
 const SELF = "/repos/shepherd";
@@ -54,7 +59,43 @@ interface Harness {
   /** Ordered trace of teardown calls, for the close-before-remove guarantee. */
   order: string[];
   detached: { repoPath: string; branch: string; sha: string }[];
+  // ── tier 3 (#2171) ──────────────────────────────────────────────────────────
+  /** Branch worktrees `worktree.create` handed out. */
+  createdWorktrees: { baseBranch: string; name: string; worktreePath: string; branch: string }[];
+  /** Every git invocation, so a test can assert what was (and was not) committed or pushed. */
+  gitCalls: { cwd: string; args: string[] }[];
+  openedPrs: { head: string; base: string; title: string; body: string }[];
+  openPrNumbers: number[];
+  /** What `git status --porcelain` reports after the fake `fallow fix`. */
+  statusOut: { current: string };
+  /** Dead-code reports: `live` answers the sweep's measurement of the live checkout, `worktree`
+   *  is consumed in order by the fix run's before/after measurements. */
+  deadCode: { live: string | null; worktree: (string | null)[] };
+  /** Which fix subprocess, if any, should reject. */
+  fixFails: { install: boolean; fix: boolean; typecheck: boolean };
+  /** Set to throw from openPr. */
+  openPrError: { current: Error | null };
 }
+
+/** A shape-faithful `fallow dead-code --format json` payload: `fixable` auto-fixable unused
+ *  exports plus `files` unused files fallow refuses to touch. */
+function report(fixable: number, files = 0): string {
+  return JSON.stringify({
+    kind: "dead-code",
+    total_issues: fixable + files,
+    unused_exports: Array.from({ length: fixable }, (_, i) => ({
+      path: "src/usage.ts",
+      export_name: `gone${i}`,
+      actions: [{ type: "remove-export", auto_fixable: true, description: "Remove" }],
+    })),
+    unused_files: Array.from({ length: files }, (_, i) => ({
+      path: `ui/src/lib/Gone${i}.svelte`,
+      actions: [{ type: "delete-file", auto_fixable: false, description: "Delete" }],
+    })),
+  });
+}
+
+const CLEAN_REPORT = report(0);
 
 function harness(over: Partial<MaintainDeps> = {}): Harness {
   const store = new SessionStore(":memory:");
@@ -75,12 +116,29 @@ function harness(over: Partial<MaintainDeps> = {}): Harness {
   const tabs: Harness["tabs"] = [];
   const closedTabs: string[] = [];
   const order: string[] = [];
+  const createdWorktrees: Harness["createdWorktrees"] = [];
+  const gitCalls: Harness["gitCalls"] = [];
+  const openedPrs: Harness["openedPrs"] = [];
+  const openPrNumbers: number[] = [];
+  const statusOut = { current: " M src/usage.ts\n" };
+  const deadCode = { live: CLEAN_REPORT as string | null, worktree: [] as (string | null)[] };
+  const fixFails = { install: false, fix: false, typecheck: false };
+  const openPrError = { current: null as Error | null };
   let nextIssue = 100;
+  let nextPr = 500;
 
   const forge = {
     isLightweight: false,
     defaultBranch: async () => "main",
     listIssues: async () => openIssues.map((number) => ({ number }) as Issue),
+    listPullRequests: async () => openPrNumbers.map((number) => ({ number })),
+    openPr: async (o: { head: string; base: string; title: string; body: string }) => {
+      if (openPrError.current) throw openPrError.current;
+      openedPrs.push(o);
+      const number = nextPr++;
+      openPrNumbers.push(number);
+      return { state: "open", number, url: `https://example.test/pull/${number}`, checks: "none" };
+    },
     createIssue: async (o: { title: string; body: string }) => {
       created.push(o);
       const number = nextIssue++;
@@ -130,6 +188,12 @@ function harness(over: Partial<MaintainDeps> = {}): Harness {
         removed.push(p);
         order.push(`remove:${p}`);
       },
+      create: (_repoPath: string, baseBranch: string, name: string) => {
+        const worktreePath = `/wt/shepherd-${name}`;
+        const branch = `shepherd/${name}`;
+        createdWorktrees.push({ baseBranch, name, worktreePath, branch });
+        return { worktreePath, branch, isolated: true };
+      },
       ensureBaseRef: async () => ({ baseRef: "deadbeefcafe" }),
       gitCommonDir: () => "/repos/shepherd/.git",
     } as unknown as MaintainDeps["worktree"],
@@ -147,7 +211,30 @@ function harness(over: Partial<MaintainDeps> = {}): Harness {
       projectsDir: "/tmp/claude/projects",
     }),
     now: () => clock.now,
-    git: async () => `${gitSha.current}\n`,
+    git: async (cwd: string, args: string[]) => {
+      gitCalls.push({ cwd, args });
+      if (args[0] === "rev-parse") return `${gitSha.current}\n`;
+      if (args[0] === "status") return statusOut.current;
+      return "";
+    },
+    fixRunner: {
+      install: async () => {
+        if (fixFails.install) throw new Error("frozen lockfile mismatch");
+      },
+      // The sweep measures the LIVE checkout; the fix run measures its own worktree, twice.
+      deadCode: async (cwd: string) =>
+        cwd === SELF
+          ? deadCode.live
+          : deadCode.worktree.length > 0
+            ? deadCode.worktree.shift()!
+            : CLEAN_REPORT,
+      fix: async () => {
+        if (fixFails.fix) throw new Error("fallow fix exploded");
+      },
+      typecheck: async () => {
+        if (fixFails.typecheck) throw new Error("TS2322");
+      },
+    },
     readDraft: () => draft.current,
     readUsage: async () => null,
     log: (m: string) => logs.push(m),
@@ -174,6 +261,14 @@ function harness(over: Partial<MaintainDeps> = {}): Harness {
     tabs,
     closedTabs,
     order,
+    createdWorktrees,
+    gitCalls,
+    openedPrs,
+    openPrNumbers,
+    statusOut,
+    deadCode,
+    fixFails,
+    openPrError,
   };
 }
 
@@ -705,5 +800,320 @@ describe("restart reconcile", () => {
     // The tab reap is best-effort; the row must still settle so the band is not stuck in flight.
     await fresh.svc.reapOrphans();
     expect(fresh.store.listInflightMaintainRuns()).toHaveLength(0);
+  });
+});
+
+// ── tier 3: the dead-code fix (#2171) ────────────────────────────────────────
+
+/** Enough auto-fixable dead code in the live checkout to put `dead_code_drift` over its tier-2
+ *  threshold — which, because the band declares a fix class, reads as tier 3. */
+function drifting(over: Partial<MaintainDeps> = {}) {
+  const h = harness({ pr: true, ...over });
+  h.deadCode.live = report(4, 2);
+  // The fix worktree sees the same drift, then a clean tree once fallow has fixed it.
+  h.deadCode.worktree = [report(4, 2), CLEAN_REPORT];
+  return h;
+}
+
+describe("tier 3 — routing", () => {
+  it("promotes the band and takes the fix path, not the diagnosis path", async () => {
+    const h = drifting();
+    await h.svc.sweep();
+    expect(h.spawns).toHaveLength(0); // no agent — the whole point of a pre-approved class
+    expect(h.created).toHaveLength(0); // and no issue
+    expect(h.openedPrs).toHaveLength(1);
+    const run = h.store.listMaintainRuns(10).find((r) => r.bandKey === "dead_code_drift")!;
+    expect(run.tier).toBe(3);
+    expect(run.outcome).toBe("opened");
+    expect(run.issueNumber).toBe(500);
+    expect(run.issueUrl).toBe("https://example.test/pull/500");
+    // No spawn happened, so nothing may be charged to the cost ledger.
+    expect(run.spawnSessionId).toBe("");
+    expect(run.agentName).toBe("");
+  });
+
+  it("still diagnoses a tier-2 band that declares no fix class", async () => {
+    const h = harness({ repoDelivery: collapsing });
+    await h.svc.sweep();
+    expect(h.spawns).toHaveLength(1);
+    expect(h.openedPrs).toHaveLength(0);
+  });
+
+  it("spends the per-sweep action cap on the more severe band", async () => {
+    // Tier 3 sorts above tier 2, so the fix runs and the diagnosis waits for tomorrow.
+    const h = drifting({ repoDelivery: collapsing });
+    await h.svc.sweep();
+    expect(h.openedPrs).toHaveLength(1);
+    expect(h.spawns).toHaveLength(0);
+  });
+
+  it("commits, pushes and opens the PR against the default branch", async () => {
+    const h = drifting();
+    await h.svc.sweep();
+    const wt = h.createdWorktrees[0]!;
+    const args = h.gitCalls.filter((c) => c.cwd === wt.worktreePath).map((c) => c.args);
+    expect(args).toContainEqual(["add", "-A"]);
+    expect(args).toContainEqual(["commit", "--no-verify", "-m", DEAD_CODE_COMMIT_MSG]);
+    expect(args).toContainEqual(["push", "-u", "origin", wt.branch]);
+    expect(h.openedPrs[0]!.head).toBe(wt.branch);
+    expect(h.openedPrs[0]!.base).toBe("main");
+    expect(h.openedPrs[0]!.title).toBe(DEAD_CODE_COMMIT_MSG);
+    // The body has to tell the operator what was left behind, or the two unused FILES look fixed.
+    expect(h.openedPrs[0]!.body).toContain("4 unused exports");
+    expect(h.openedPrs[0]!.body).toContain("2 finding(s) are not auto-fixable");
+  });
+
+  it("cleans up the worktree and the local branch on the way out", async () => {
+    const h = drifting();
+    await h.svc.sweep();
+    const wt = h.createdWorktrees[0]!;
+    expect(h.removed).toContain(wt.worktreePath);
+    expect(h.gitCalls.map((c) => c.args)).toContainEqual(["branch", "-D", wt.branch]);
+  });
+});
+
+describe("tier 3 — observe mode", () => {
+  it("does all the work and opens nothing when SHEPHERD_MAINTAIN_PR is off", async () => {
+    const h = drifting({ pr: false });
+    await h.svc.sweep();
+    expect(h.openedPrs).toHaveLength(0);
+    const wtArgs = h.gitCalls.map((c) => c.args.join(" "));
+    expect(wtArgs.some((a) => a.startsWith("commit"))).toBe(false);
+    expect(wtArgs.some((a) => a.startsWith("push"))).toBe(false);
+    // The log must name the real diff, not a guess — that is why observe still installs and fixes.
+    expect(h.logs.join("\n")).toContain("would open a PR removing 4 unused exports");
+    const run = h.store.listMaintainRuns(10).find((r) => r.bandKey === "dead_code_drift")!;
+    expect(run.outcome).toBe("skipped");
+  });
+
+  it("is not armed by SHEPHERD_MAINTAIN_ACT", async () => {
+    // The whole reason tier 3 has its own flag: arming issue-filing must not arm PR-opening.
+    const h = drifting({ pr: false, act: true });
+    await h.svc.sweep();
+    expect(h.openedPrs).toHaveLength(0);
+  });
+});
+
+describe("tier 3 — fail-closed gates", () => {
+  const runWith = async (h: ReturnType<typeof drifting>) => {
+    await h.svc.sweep();
+    return h.store.listMaintainRuns(10).find((r) => r.bandKey === "dead_code_drift")!;
+  };
+
+  it("opens nothing when the install fails", async () => {
+    const h = drifting();
+    h.fixFails.install = true;
+    expect((await runWith(h)).outcome).toBe("error");
+    expect(h.openedPrs).toHaveLength(0);
+  });
+
+  it("opens nothing when typecheck goes red on the result", async () => {
+    const h = drifting();
+    h.fixFails.typecheck = true;
+    expect((await runWith(h)).outcome).toBe("error");
+    expect(h.openedPrs).toHaveLength(0);
+    expect(h.logs.join("\n")).toContain("typecheck failed");
+  });
+
+  it("opens nothing when auto-fixable findings survive the fix", async () => {
+    const h = drifting();
+    h.deadCode.worktree = [report(4, 2), report(2, 2)]; // fallow only got half of them
+    expect((await runWith(h)).outcome).toBe("error");
+    expect(h.openedPrs).toHaveLength(0);
+    expect(h.logs.join("\n")).toContain("2 auto-fixable finding(s) survived");
+  });
+
+  it("refuses to commit a manifest change without a lockfile regen", async () => {
+    // `fallow fix` also removes unused DEPENDENCIES; committing that would land the PR CI-red.
+    const h = drifting();
+    h.statusOut.current = " M src/usage.ts\n M package.json\n";
+    expect((await runWith(h)).outcome).toBe("error");
+    expect(h.openedPrs).toHaveLength(0);
+    expect(h.logs.join("\n")).toContain("package.json");
+  });
+
+  it("catches a lockfile too, in any package", async () => {
+    const h = drifting();
+    h.statusOut.current = " M ui/bun.lock\n";
+    expect((await runWith(h)).outcome).toBe("error");
+    expect(h.openedPrs).toHaveLength(0);
+  });
+
+  it("treats an unreadable post-fix measurement as a failure, never as a clean tree", async () => {
+    const h = drifting();
+    h.deadCode.worktree = [report(4, 2), null];
+    expect((await runWith(h)).outcome).toBe("error");
+    expect(h.openedPrs).toHaveLength(0);
+  });
+
+  it("stands down when the pristine base branch has nothing to fix", async () => {
+    // The sweep measured the LIVE checkout, which can carry uncommitted edits. The clean checkout
+    // of origin/main is what the fix is accountable to.
+    const h = drifting();
+    h.deadCode.worktree = [CLEAN_REPORT];
+    const run = await runWith(h);
+    expect(run.outcome).toBe("skipped");
+    expect(h.openedPrs).toHaveLength(0);
+    expect(h.logs.join("\n")).toContain("nothing auto-fixable on the base branch");
+  });
+
+  it("stands down when fallow fix changes nothing", async () => {
+    const h = drifting();
+    h.statusOut.current = "";
+    const run = await runWith(h);
+    expect(run.outcome).toBe("skipped");
+    expect(h.openedPrs).toHaveLength(0);
+  });
+});
+
+describe("tier 3 — openPr failure", () => {
+  it("takes the pushed branch back down rather than orphaning it on the remote", async () => {
+    const h = drifting();
+    h.openPrError.current = new Error("forge is down");
+    await h.svc.sweep();
+    const wt = h.createdWorktrees[0]!;
+    expect(h.gitCalls.map((c) => c.args)).toContainEqual(["push", "origin", "--delete", wt.branch]);
+    const run = h.store.listMaintainRuns(10).find((r) => r.bandKey === "dead_code_drift")!;
+    expect(run.outcome).toBe("error");
+  });
+
+  it("treats an empty diff as nothing to open, not as an error", async () => {
+    const h = drifting();
+    h.openPrError.current = new EmptyDiffError("shepherd/maintain-fix-aaaaaaaa", "main");
+    await h.svc.sweep();
+    const run = h.store.listMaintainRuns(10).find((r) => r.bandKey === "dead_code_drift")!;
+    expect(run.outcome).toBe("skipped");
+  });
+});
+
+describe("tier 3 — suppression", () => {
+  it("will not open a second PR while the first is still open", async () => {
+    const h = drifting({ cooldownMs: 0 });
+    await h.svc.sweep();
+    expect(h.openedPrs).toHaveLength(1);
+    h.deadCode.worktree = [report(4, 2), CLEAN_REPORT];
+    h.clock.now += 25 * 60 * 60 * 1000;
+    await h.svc.sweep();
+    expect(h.openedPrs).toHaveLength(1);
+    expect(h.logs.join("\n")).toContain("PR #500 is still open");
+  });
+
+  it("opens another once the first PR is gone", async () => {
+    const h = drifting({ cooldownMs: 0 });
+    await h.svc.sweep();
+    h.openPrNumbers.length = 0; // merged or closed
+    h.deadCode.worktree = [report(4, 2), CLEAN_REPORT];
+    h.clock.now += 25 * 60 * 60 * 1000;
+    await h.svc.sweep();
+    expect(h.openedPrs).toHaveLength(2);
+  });
+
+  it("holds the band for the cooldown even when the run published nothing", async () => {
+    const h = drifting({ pr: false });
+    await h.svc.sweep();
+    h.deadCode.worktree = [report(4, 2), CLEAN_REPORT];
+    h.clock.now += 25 * 60 * 60 * 1000;
+    await h.svc.sweep();
+    expect(h.logs.join("\n")).toContain("cooling down");
+  });
+});
+
+describe("tier 3 — restart reconcile", () => {
+  it("settles an interrupted fix run and force-deletes its branch", async () => {
+    const h = harness();
+    h.store.insertMaintainRun({
+      id: "run-1",
+      bandKey: "dead_code_drift",
+      bandId: "dead_code_drift",
+      tier: 3,
+      value: 4,
+      worktreePath: "/wt/shepherd-maintain-fix-abcdef12",
+      agentName: "",
+      spawnSessionId: "",
+      spawnedAt: NOW - 60_000,
+      completedAt: null,
+      outcome: null,
+      issueNumber: null,
+      issueUrl: null,
+    });
+    await h.svc.reapOrphans();
+    expect(h.removed).toContain("/wt/shepherd-maintain-fix-abcdef12");
+    expect(h.gitCalls.map((c) => c.args)).toContainEqual([
+      "branch",
+      "-D",
+      "shepherd/maintain-fix-abcdef12",
+    ]);
+    expect(h.store.listInflightMaintainRuns()).toHaveLength(0);
+  });
+
+  it("does not go looking for a branch behind a tier-2 diagnosis worktree", async () => {
+    const h = harness();
+    h.store.insertMaintainRun({
+      id: "run-2",
+      bandKey: "critic_error_rate",
+      bandId: "critic_error_rate",
+      tier: 2,
+      value: 0.5,
+      worktreePath: "/wt/shepherd-review-sess-abcdef12",
+      agentName: "__maintain__abcdef12",
+      spawnSessionId: "sess",
+      spawnedAt: NOW - 60_000,
+      completedAt: null,
+      outcome: null,
+      issueNumber: null,
+      issueUrl: null,
+    });
+    await h.svc.reapOrphans();
+    expect(h.gitCalls.some((c) => c.args[0] === "branch")).toBe(false);
+  });
+});
+
+describe("tier 3 — worktree protection", () => {
+  it("protects the fix checkout while the run owns it, and releases it after", async () => {
+    // A stale-worktree sweeper reads inflightWorktrees(); if the fix path is missing from it, a
+    // long run has its checkout deleted underneath it.
+    const seen: string[][] = [];
+    // Referenced from the runner closures below, which only run once `drifting` has returned.
+    const h: ReturnType<typeof drifting> = drifting({
+      fixRunner: {
+        install: async () => {
+          seen.push(h.svc.inflightWorktrees());
+        },
+        deadCode: async (cwd: string) =>
+          cwd === SELF ? h.deadCode.live : (h.deadCode.worktree.shift() ?? CLEAN_REPORT),
+        fix: async () => {},
+        typecheck: async () => {
+          seen.push(h.svc.inflightWorktrees());
+        },
+      },
+    });
+    await h.svc.sweep();
+    const wt = h.createdWorktrees[0]!.worktreePath;
+    expect(seen).toHaveLength(2);
+    for (const snapshot of seen) expect(snapshot).toContain(wt);
+    expect(h.svc.inflightWorktrees()).toHaveLength(0);
+  });
+});
+
+describe("reportFromFailedExit", () => {
+  it("keeps the report from a non-zero exit — fallow exits 1 whenever it finds anything", () => {
+    // Verified against fallow 2.100.0: `dead-code` exits 1 both before AND after a fix while
+    // non-auto-fixable findings remain. Discarding that output would leave the band permanently
+    // reading "no data" and tier 3 permanently unreachable.
+    expect(reportFromFailedExit({ code: 1, stdout: '{"kind":"dead-code"}' })).toBe(
+      '{"kind":"dead-code"}',
+    );
+  });
+
+  it("discards output from a KILLED process — it is truncated mid-document", () => {
+    // A timeout or maxBuffer overflow leaves half a JSON document that jsonrepair would happily
+    // close into a shape-valid report with a smaller finding count, which the verify gate could
+    // read as a clean tree.
+    expect(reportFromFailedExit({ killed: true, stdout: '{"kind":"dead-code","unu' })).toBeNull();
+  });
+
+  it("is null when there is no output at all", () => {
+    expect(reportFromFailedExit(new Error("bunx: command not found"))).toBeNull();
+    expect(reportFromFailedExit({ code: 127, stdout: "" })).toBeNull();
   });
 });

--- a/test/server-usage-delivery.test.ts
+++ b/test/server-usage-delivery.test.ts
@@ -122,7 +122,13 @@ test("the delivery payload always carries a maintain block", async () => {
   const { app } = harness();
   const res = await app.fetch(new Request("http://x/api/usage/delivery"));
   const body = await res.json();
-  expect(body.maintain).toEqual({ enabled: false, act: false, readings: [], recentRuns: [] });
+  expect(body.maintain).toEqual({
+    enabled: false,
+    act: false,
+    pr: false,
+    readings: [],
+    recentRuns: [],
+  });
 });
 
 test("a wired maintain service surfaces its readings on the delivery payload", async () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3754,11 +3754,18 @@
   "usage_maintain_state_clear": "unauffällig",
   "usage_maintain_state_log": "Tier 1 · protokolliert",
   "usage_maintain_state_diagnose": "Tier 2 · diagnostiziert",
+  "usage_maintain_band_dead_code": "Toter Code — automatisch behebbar",
+  "usage_maintain_sample_findings": "{n} gefunden",
+  "usage_maintain_state_fix": "Tier 3 · PR eröffnet",
+  "usage_maintain_pr_armed": "Tier 3 aktiv: Eine Überschreitung bei totem Code eröffnet einen Pull Request. Wird nie automatisch gemerged.",
+  "usage_maintain_pr_observe": "Tier 3 nicht aktiv. Mit SHEPHERD_MAINTAIN_PR=1 darf eine Überschreitung bei totem Code einen Pull Request eröffnen.",
   "usage_maintain_state_no_data": "zu wenig Daten",
   "feat_maintain_loop_title": "Der Maintain-Loop eröffnet Arbeit",
   "feat_maintain_loop_body": "Shepherd prüft seine eigenen Health-Signale jetzt täglich gegen drei definierte Bänder. Eine anhaltende Überschreitung startet einen nur lesenden Diagnose-Agenten, der ein Backlog-Issue entwirft — Anomalie, Belege, betroffenes Subsystem, offene Fragen — statt nur zu melden, dass etwas nicht stimmt. Den Bandstatus zeigt Usage → Delivery; aktiv wird das Ganze erst mit SHEPHERD_MAINTAIN_LOOP=1.",
+  "feat_maintain_tier3_title": "Der Maintain-Loop kann einen PR eröffnen",
+  "feat_maintain_tier3_body": "Für eine vorab freigegebene Klasse von Korrekturen — automatisch behebbarer toter Code in Shepherds eigenem Checkout — überspringt der Maintain-Loop jetzt das entworfene Issue und eröffnet direkt einen Pull Request. Diesen Diff schreibt kein Agent: Shepherd führt fallow in einem Wegwerf-Checkout aus, installiert die Abhängigkeiten (ohne sie hält fallow lebenden Code für tot) und committet erst, wenn der Typecheck grün ist und kein automatisch behebbarer Fund übrig bleibt. Berührt die Korrektur eine package.json oder ein Lockfile, bricht sie ab. Automatisch gemerged wird nie, und aktiv ist das Ganze erst mit SHEPHERD_MAINTAIN_PR=1 — bewusst getrennt von SHEPHERD_MAINTAIN_ACT, damit das Anlegen von Issues nie das Eröffnen von PRs mitaktiviert.",
   "gloss_maintain_loop_term": "Maintain-Loop",
-  "gloss_maintain_loop_def": "Eine tägliche Prüfung von Shepherds eigenen Health-Signalen gegen definierte Schwellen. Eine leichte Überschreitung wird protokolliert; eine anhaltende startet einen nur lesenden Agenten, der ein Backlog-Issue zur Sichtung entwirft.",
+  "gloss_maintain_loop_def": "Eine tägliche Prüfung von Shepherds eigenen Health-Signalen gegen definierte Schwellen. Eine leichte Überschreitung wird protokolliert; eine anhaltende startet einen nur lesenden Agenten, der ein Backlog-Issue zur Sichtung entwirft. Für eine vorab freigegebene Klasse mechanischer Korrekturen entfällt das Issue und es wird direkt ein Pull Request eröffnet.",
   "gloss_band_term": "Band",
-  "gloss_band_def": "Ein Health-Signal samt der Schwellen, die festlegen, was beim Überschreiten passiert: Tier 1 protokolliert einen Messwert, Tier 2 startet eine Diagnose. Ein Band unterhalb seiner Mindeststichprobe meldet nichts statt einer irreführenden Zahl."
+  "gloss_band_def": "Ein Health-Signal samt der Schwellen, die festlegen, was beim Überschreiten passiert: Tier 1 protokolliert einen Messwert, Tier 2 startet eine Diagnose. Ein Band, dessen Behebung mechanisch genug für eine Vorab-Freigabe ist, wird stattdessen auf Tier 3 hochgestuft und eröffnet einen Pull Request. Ein Band unterhalb seiner Mindeststichprobe meldet nichts statt einer irreführenden Zahl."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3754,11 +3754,18 @@
   "usage_maintain_state_clear": "clear",
   "usage_maintain_state_log": "tier 1 · logged",
   "usage_maintain_state_diagnose": "tier 2 · diagnosed",
+  "usage_maintain_band_dead_code": "Dead code — auto-fixable",
+  "usage_maintain_sample_findings": "{n} found",
+  "usage_maintain_state_fix": "tier 3 · PR opened",
+  "usage_maintain_pr_armed": "Tier 3 armed: a dead-code breach opens a pull request. Never auto-merged.",
+  "usage_maintain_pr_observe": "Tier 3 not armed. Set SHEPHERD_MAINTAIN_PR=1 to let a dead-code breach open a pull request.",
   "usage_maintain_state_no_data": "too few to judge",
   "feat_maintain_loop_title": "The maintain loop opens work",
   "feat_maintain_loop_body": "Shepherd now watches its own health signals daily against three declared bands. A sustained breach spawns a read-only diagnosis agent that drafts a backlog issue — anomaly, evidence, affected subsystem, open questions — instead of only telling you something looks wrong. Band state lives in Usage → Delivery; it stays off until you set SHEPHERD_MAINTAIN_LOOP=1.",
+  "feat_maintain_tier3_title": "The maintain loop can open a PR",
+  "feat_maintain_tier3_body": "For one pre-approved class of fix — auto-fixable dead code in Shepherd's own checkout — the maintain loop now skips the drafted issue and opens a pull request instead. No agent writes that diff: Shepherd runs fallow in a throwaway checkout, installs dependencies (without them fallow calls live code dead), and only commits once typecheck passes and no auto-fixable finding is left. It refuses outright if the fix touched a package.json or lockfile. Nothing is ever auto-merged, and it stays off until you set SHEPHERD_MAINTAIN_PR=1 — deliberately separate from SHEPHERD_MAINTAIN_ACT, so arming issue-filing never arms PR-opening.",
   "gloss_maintain_loop_term": "Maintain loop",
-  "gloss_maintain_loop_def": "A daily check of Shepherd's own health signals against declared thresholds. A mild breach is logged; a sustained one spawns a read-only agent that drafts a backlog issue for you to triage.",
+  "gloss_maintain_loop_def": "A daily check of Shepherd's own health signals against declared thresholds. A mild breach is logged; a sustained one spawns a read-only agent that drafts a backlog issue for you to triage. For one pre-approved class of mechanical fix it skips the issue and opens a pull request instead.",
   "gloss_band_term": "Band",
-  "gloss_band_def": "One health signal plus the thresholds that decide what happens when it is crossed: tier 1 logs a reading, tier 2 spawns a diagnosis. A band below its minimum sample size reports nothing rather than a misleading number."
+  "gloss_band_def": "One health signal plus the thresholds that decide what happens when it is crossed: tier 1 logs a reading, tier 2 spawns a diagnosis. A band whose remediation is mechanical enough to be pre-approved is promoted to tier 3 instead, which opens a pull request. A band below its minimum sample size reports nothing rather than a misleading number."
 }

--- a/ui/src/lib/components/usage/DeliveryLens.browser.test.ts
+++ b/ui/src/lib/components/usage/DeliveryLens.browser.test.ts
@@ -181,6 +181,7 @@ describe("DeliveryLens — maintain loop band card (#2157)", () => {
   const maintain = (over: Partial<MaintainBlock> = {}): MaintainBlock => ({
     enabled: true,
     act: false,
+    pr: false,
     readings: [reading()],
     recentRuns: [],
     ...over,
@@ -298,5 +299,88 @@ describe("DeliveryLens — maintain loop band card (#2157)", () => {
     render(DeliveryLens, { metrics: metrics({ maintain: maintain({ readings: [] }) }) });
     expect(document.body.textContent).toContain("No bands evaluated yet");
     expect(document.querySelectorAll(".band-row")).toHaveLength(0);
+  });
+});
+
+describe("DeliveryLens — tier 3 dead-code band (#2171)", () => {
+  const deadCode = (over: Partial<BandReading> = {}): BandReading => ({
+    key: "dead_code_drift",
+    bandId: "dead_code_drift",
+    repoPath: null,
+    subject: null,
+    tier: 3,
+    value: 2,
+    sampleN: 5,
+    belowMinSample: false,
+    evaluatedAt: 1_000,
+    ...over,
+  });
+
+  const block = (over: Partial<MaintainBlock> = {}): MaintainBlock => ({
+    enabled: true,
+    act: false,
+    pr: false,
+    readings: [deadCode()],
+    recentRuns: [],
+    ...over,
+  });
+
+  const row = () => document.querySelector(".band-row:not(.row-head)")!;
+
+  it("shows the auto-fixable count as a raw number, not a percentage", async () => {
+    render(DeliveryLens, { metrics: metrics({ maintain: block() }) });
+    const cells = Array.from(row().children).map((c) => c.textContent?.trim());
+    expect(cells[1]).toBe("2");
+    // sampleN is the TOTAL finding count, so it must not read as a denominator like "n=5".
+    expect(cells[2]).toContain("5");
+    expect(cells[2]).not.toContain("n=");
+  });
+
+  it("labels tier 3 distinctly from tier 2 and flags it as bad", async () => {
+    render(DeliveryLens, { metrics: metrics({ maintain: block() }) });
+    const chip = row().querySelector(".chip")!;
+    expect(chip.textContent).toContain("3");
+    expect(chip.className).toContain("chip-bad");
+  });
+
+  it("states tier-3 arming separately from the act flag", async () => {
+    // Reading the act line alone must never suggest PRs are being opened.
+    render(DeliveryLens, { metrics: metrics({ maintain: block({ act: true, pr: false }) }) });
+    expect(document.body.textContent).toContain("SHEPHERD_MAINTAIN_PR=1");
+
+    document.body.innerHTML = "";
+    render(DeliveryLens, { metrics: metrics({ maintain: block({ act: false, pr: true }) }) });
+    expect(document.body.textContent).not.toContain("SHEPHERD_MAINTAIN_PR=1");
+    expect(document.body.textContent).toContain("Never auto-merged");
+  });
+
+  it("links the PR a tier-3 run opened", async () => {
+    render(DeliveryLens, {
+      metrics: metrics({
+        maintain: block({
+          pr: true,
+          recentRuns: [
+            {
+              id: "r1",
+              bandKey: "dead_code_drift",
+              bandId: "dead_code_drift",
+              tier: 3,
+              value: 2,
+              worktreePath: "/wt/x",
+              agentName: "",
+              spawnSessionId: "",
+              spawnedAt: 1,
+              completedAt: 2,
+              outcome: "opened",
+              issueNumber: 512,
+              issueUrl: "https://example.test/pull/512",
+            },
+          ],
+        }),
+      }),
+    });
+    const link = row().querySelector("a.issue-link") as HTMLAnchorElement;
+    expect(link.href).toBe("https://example.test/pull/512");
+    expect(link.textContent).toContain("512");
   });
 });

--- a/ui/src/lib/components/usage/DeliveryLens.svelte
+++ b/ui/src/lib/components/usage/DeliveryLens.svelte
@@ -134,22 +134,34 @@
     if (r.bandId === "critic_error_rate") return m.usage_maintain_band_critic_errors();
     if (r.bandId === "incident_spike")
       return m.usage_maintain_band_incidents({ kind: r.subject ?? "?" });
+    if (r.bandId === "dead_code_drift") return m.usage_maintain_band_dead_code();
     return m.usage_maintain_band_first_pass({ repo: r.subject ?? "?" });
   }
 
-  /** The measured quantity in the band's own units — a rate for the two rate bands, a raw count
-   *  for the incident band. */
-  function bandValue(r: BandReading): string {
-    if (r.belowMinSample) return EMPTY;
-    return r.bandId === "incident_spike" ? String(r.value) : formatPct(r.value);
+  /** Bands whose value is a raw count rather than a rate in 0..1. */
+  function isCountBand(r: BandReading): boolean {
+    return r.bandId === "incident_spike" || r.bandId === "dead_code_drift";
   }
 
+  /** The measured quantity in the band's own units — a rate for the two rate bands, a raw count
+   *  for the incident and dead-code bands. */
+  function bandValue(r: BandReading): string {
+    if (r.belowMinSample) return EMPTY;
+    return isCountBand(r) ? String(r.value) : formatPct(r.value);
+  }
+
+  /** `dead_code_drift`'s sampleN is not a denominator — it is the total finding count, of which
+   *  `value` are the ones fallow can remove itself. Labelled as such so the row does not read as
+   *  "2 out of 3 tries". */
   function bandSample(r: BandReading): string {
-    return m.usage_maintain_sample({ n: r.sampleN });
+    return r.bandId === "dead_code_drift"
+      ? m.usage_maintain_sample_findings({ n: r.sampleN })
+      : m.usage_maintain_sample({ n: r.sampleN });
   }
 
   function bandState(r: BandReading): string {
     if (r.belowMinSample) return m.usage_maintain_state_no_data();
+    if (r.tier === 3) return m.usage_maintain_state_fix();
     if (r.tier === 2) return m.usage_maintain_state_diagnose();
     if (r.tier === 1) return m.usage_maintain_state_log();
     return m.usage_maintain_state_clear();
@@ -157,7 +169,8 @@
 
   function stateClass(r: BandReading): string {
     if (r.belowMinSample) return "chip";
-    return r.tier === 2 ? "chip chip-bad" : r.tier === 1 ? "chip chip-warn" : "chip chip-ok";
+    if (r.tier >= 2) return "chip chip-bad";
+    return r.tier === 1 ? "chip chip-warn" : "chip chip-ok";
   }
 </script>
 
@@ -267,6 +280,11 @@
             {m.usage_maintain_observe()}
           {:else}
             {m.usage_maintain_armed()}
+          {/if}
+          {#if maintain.enabled}
+            <!-- Tier 3 is armed by its own flag, so its state is its own sentence — reading the
+                 act line alone must never suggest PRs are (or are not) being opened. -->
+            {maintain.pr ? m.usage_maintain_pr_armed() : m.usage_maintain_pr_observe()}
           {/if}
         </p>
         {#if maintain.readings.length > 0}

--- a/ui/src/lib/docs-manifest.ts
+++ b/ui/src/lib/docs-manifest.ts
@@ -69,7 +69,7 @@ export const DOCS_PAGES: readonly DocsPage[] = [
     title: "Configuration",
     path: "/reference/configuration/",
     keywords:
-      "every environment variable and the per-agent sandbox profiles. core live preview host tuning (tmpfs inodes) runaway-orphan reaper main agent terminal renderer (research preview) up next quick-start session revival (herdr daemon-restart recovery) push-based hook ingestion tool guard (pretooluse deny) documentation automation (pr-gated doc agent) maintain loop (self-health bands) anonymous usage telemetry per-agent sandbox / permission profiles",
+      "every environment variable and the per-agent sandbox profiles. core live preview host tuning (tmpfs inodes) runaway-orphan reaper main agent terminal renderer (research preview) up next quick-start session revival (herdr daemon-restart recovery) push-based hook ingestion tool guard (pretooluse deny) documentation automation (pr-gated doc agent) maintain loop (self-health bands) tier 3 — the pre-approved fix class anonymous usage telemetry per-agent sandbox / permission profiles",
   },
   {
     title: "External Task API",

--- a/ui/src/lib/feature-announcements/entries/v1.48.0-maintain-tier3.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.48.0-maintain-tier3.ts
@@ -1,0 +1,11 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "maintain-tier3",
+  sinceVersion: "1.48.0",
+  titleKey: "feat_maintain_tier3_title",
+  bodyKey: "feat_maintain_tier3_body",
+  targetId: "usage-delivery-tab",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1512,16 +1512,20 @@ export interface DeliveryMetrics {
 
 // ── maintain loop (#2157) — mirror of the server contract in src/types.ts ────
 
-export type BandId = "critic_error_rate" | "incident_spike" | "first_pass_collapse";
+export type BandId =
+  "critic_error_rate" | "incident_spike" | "first_pass_collapse" | "dead_code_drift";
 
-/** 0 = clear (or below the band's minimum sample), 1 = log, 2 = diagnose. */
-export type MaintainTier = 0 | 1 | 2;
+/** 0 = clear (or below the band's minimum sample), 1 = log, 2 = diagnose, 3 = open a PR for the
+ *  band's pre-approved fix class (#2171). Tier 3 is a promotion of a tier-2 breach on a band that
+ *  declares a fix class, not a fourth threshold. */
+export type MaintainTier = 0 | 1 | 2 | 3;
 
 export interface BandReading {
   key: string;
   bandId: BandId;
   repoPath: string | null;
-  /** Signal kind for `incident_spike`, repo basename for `first_pass_collapse`, else null. */
+  /** Signal kind for `incident_spike`, repo basename for `first_pass_collapse`, else null
+   *  (`critic_error_rate`, `dead_code_drift`). */
   subject: string | null;
   tier: MaintainTier;
   value: number;
@@ -1531,7 +1535,8 @@ export interface BandReading {
   evaluatedAt: number;
 }
 
-export type MaintainOutcome = "filed" | "skipped" | "error";
+/** `filed` = a Tier-2 diagnosis became an issue; `opened` = a Tier-3 fix became a PR (#2171). */
+export type MaintainOutcome = "filed" | "opened" | "skipped" | "error";
 
 export interface MaintainRun {
   id: string;
@@ -1545,6 +1550,7 @@ export interface MaintainRun {
   spawnedAt: number;
   completedAt: number | null;
   outcome: MaintainOutcome | null;
+  /** Issue number for a `filed` run, PR number for an `opened` one — `outcome` says which. */
   issueNumber: number | null;
   issueUrl: string | null;
 }
@@ -1552,6 +1558,8 @@ export interface MaintainRun {
 export interface MaintainBlock {
   enabled: boolean;
   act: boolean;
+  /** SHEPHERD_MAINTAIN_PR — a Tier-3 fix actually opens a PR. Independent of `act`. */
+  pr: boolean;
   readings: BandReading[];
   recentRuns: MaintainRun[];
 }


### PR DESCRIPTION
Closes #2171.

#2157 shipped tiers 1 and 2 and deliberately left tier 3 out: no fix class had been named, and building one speculatively was exactly the surface it declined. This names one.

## The fix class: repo-wide auto-fixable dead code

It meets #2171's three criteria:

- **Unambiguously identifiable** — `fallow dead-code --format json` emits a schema-versioned report with a per-finding `auto_fixable` flag.
- **Mechanical** — `fallow fix` produces the diff deterministically.
- **Fit to arrive as a PR** — CI only runs `fallow audit --base origin/<base>`, a **delta** audit, so residue accumulates on `main` with no gate watching. Three findings are sitting there right now (2 unused `.svelte` files, 1 unused export).

## Three decisions worth reviewing

**Tier 3 is a class marker, not a fourth threshold.** #2171's own shape is `tier3: { class }` — no numbers. So `evaluateBands` *promotes* a tier-2 breach to 3 when its band declares a fix class. A higher threshold would be backwards: you would need *more* dead code to earn the cheap mechanical fix. `tier3` lives on `CountBandConfig` alone — the three v1 bands get no inert `tier3?` field.

**No agent.** `fallow fix` is deterministic, so the run is a plain async routine on the server: no spawn, no tokens, no prompt to inject into, no new write-capable role allowlist, and no `reviewer_spawns` cost row. The band counts only `auto_fixable` findings, so the fix drives it to zero by construction. Unused *files* stay a human's call — fallow itself marks `delete-file` unsafe ("may remove runtime functionality not visible to static analysis").

**`SHEPHERD_MAINTAIN_PR` is independent of `SHEPHERD_MAINTAIN_ACT`**, per the issue. Unarmed, the run still installs, fixes and verifies, then logs the *real* diff it would have opened and throws the branch away — so the observe log is truthful rather than speculative.

## The run

Branch worktree off `origin/<base>` → install → re-measure → `fallow fix` → verify → commit `--no-verify` → push → `openPr`. **Never auto-merges.**

## Two things measured, not assumed

**`bun install` is load-bearing.** In a fresh worktree of `origin/main` *without* `node_modules`, `fallow dead-code` reports **14** findings (6 unused files, 6 unused exports) against **3** with root + `ui/` + `extension/` installed. Skipping it would have deleted live exports. Cost is ~4.3s with `--frozen-lockfile`, which also leaves the tree clean so any post-fix manifest change is unambiguously fallow's.

**`fallow dead-code` exits 1 whenever it finds anything** — verified end-to-end, before *and* after a real fix (the two non-auto-fixable files remain). The first cut of the runner treated that rejection as "could not measure", which would have left the band reading no-data exactly when it matters and tier 3 permanently unreachable. `reportFromFailedExit` keeps stdout from a non-zero exit but discards it from a **killed** process, whose truncated JSON `jsonrepair` would close into a shape-valid report with a smaller count that the verify gate could read as clean.

## Fail-closed gates — each opens nothing and records `error`

Install failure · red `bun run typecheck` · any auto-fixable finding surviving the fix · an unreadable re-measurement · **any `package.json` or lockfile the fix touched** (`fallow fix` also removes unused *dependencies*, and that regen is a human's job, not a background loop's).

If `openPr` throws after the push, the branch is deleted from the remote rather than orphaned. `EmptyDiffError` records `skipped`, not `error`.

## Verification

Root `lint` / `tsc` / 9031 tests · `ui` svelte-check 0 errors / 4773 tests · i18n parity · docs manifest · glossary · `fallow audit --base origin/main --fail-on-issues` clean · full pre-push gate green.

One note: `StatusPip.browser.test.ts` flaked twice on hover timing across ~5 full UI runs and passes in isolation. It is pre-existing and untouched by this diff.
