### PR TITLE
feat(gates): gate the fallow version pin across every site (#2182)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,9 @@ jobs:
     # The local pre-push hook no longer shares this job's shell body — it runs the
     # same gate set in parallel lanes via scripts/pre-push.ts. When you add/remove/
     # reorder a step here, mirror it there (and vice-versa). Deliberate differences:
-    # the hook scopes prettier/eslint to the push delta and pins fallow to 2.100.0;
-    # CI keeps the whole-repo checks. Keep the fallow version in sync across both.
+    # the hook scopes prettier/eslint to the push delta and pins fallow@2.100.0;
+    # CI keeps the whole-repo checks. The pin is gated: scripts/check-fallow-pin.mjs
+    # fails when any site names a different version.
     # Don't run the full suite on release-please's generated PR: it only bumps the
     # version + CHANGELOG, so verify is wasted minutes. That PR DOES trigger this
     # workflow — see release-please.yml. Skip ONLY when BOTH the head branch carries
@@ -164,8 +165,8 @@ jobs:
         # (#851) — a Svelte-appropriate bar so new components aren't churned against the
         # library-default 20/15. The #756 line-shift mis-attribution that forced the old
         # 2.97 pin was re-tested against 2.100 and does NOT reproduce (inherited template
-        # findings now attribute correctly across line shifts). Keep this version in sync
-        # with .husky/pre-push and CONTRIBUTING.md.
+        # findings now attribute correctly across line shifts). Every site naming this
+        # version is gated by scripts/check-fallow-pin.mjs — bump them together.
         if: github.event_name == 'pull_request'
         run: bunx fallow@2.100.0 audit --base origin/${{ github.base_ref }} --fail-on-issues
 

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -57,3 +57,5 @@ jobs:
         run: node scripts/check-announcement-versions.mjs
       - name: Model-list mirror (src/types.ts ↔ ui/src/lib/types.ts)
         run: node scripts/check-model-mirror.mjs
+      - name: Fallow version pin (identical at every site)
+        run: node scripts/check-fallow-pin.mjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ and failed pushes. Independent work runs in parallel (bounded by your core count
 lane teeing to its own `.test-logs/` file, with a per-lane wall-clock **timeout backstop**
 so a hung child can never wedge the push. The checks (per lane) are:
 
-- **gates:** branch-hygiene · feature-catalog · generated-docs · glossary · announcement-versions · model-mirror · herdr-types
+- **gates:** branch-hygiene · feature-catalog · generated-docs · glossary · announcement-versions · model-mirror · fallow-pin · herdr-types
 - **prettier:** `prettier --check` over the push **delta** (see note)
 - **eslint:** root + extension eslint over the push **delta** (see note)
 - **tsc:** `bun run typecheck` (root `tsc --noEmit`)
@@ -95,8 +95,8 @@ so a hung child can never wedge the push. The checks (per lane) are:
 >   offline? The hook falls back to whole-repo lint and skips fallow.)
 > - **Same checks, different scoping.** Because the hook no longer shares `ci.yml`'s shell
 >   body, the two gate definitions can drift — when you change a CI step, mirror it in
->   `scripts/pre-push.ts` (there's a sync banner in both files). Keep the `fallow@2.100.0`
->   pin in sync across the hook, `ci.yml`, and this file.
+>   `scripts/pre-push.ts` (there's a sync banner in both files). The `fallow@2.100.0` pin is
+>   gated across every site by `bun run check:fallow-pin` — bump them together.
 >
 > **Concurrency is core-aware.** Lane fan-out and per-tool worker counts are bounded so
 > `laneCap × workers ≤ cores` — no oversubscription on a modest box. Override the lane cap
@@ -114,7 +114,7 @@ so a hung child can never wedge the push. The checks (per lane) are:
 > type errors. Bun runs `.ts` by stripping types, so it never type-checks — only
 > `tsc` does.
 
-> **fallow is pinned to `2.100.0`** (not `@latest`) so analyzer changes are adopted
+> **the fallow pin is `fallow@2.100.0`** (not `@latest`) so analyzer changes are adopted
 > deliberately, not on a random run. The synthetic Svelte `<template>` complexity metric
 > (fallow 2.98+) is adopted via `health.thresholdOverrides` in `.fallowrc.jsonc`
 > ([#851](https://github.com/erwins-enkel/shepherd/issues/851)) — a Tier-1 global bar
@@ -129,8 +129,8 @@ so a hung child can never wedge the push. The checks (per lane) are:
 > reproduce** — fallow attributes inherited template findings correctly across line
 > shifts and complexity changes; the audit's new-only gate fires only when a template is
 > a finding in HEAD that was not one in the base. A genuinely new oversized template will
-> still trip as _introduced_ (the gate working) — fix or grandfather it. Keep the version
-> in sync with `.github/workflows/ci.yml` and `.husky/pre-push`.
+> still trip as _introduced_ (the gate working) — fix or grandfather it. Every site naming
+> the pin is gated by `bun run check:fallow-pin`, so a one-sided bump fails the build.
 
 Run any of these manually at any time:
 
@@ -140,6 +140,7 @@ bun run typecheck            # root tsc --noEmit (src + test)
 bun run format               # prettier --write across the repo
 bun test ./test              # core test suite
 bun run check:model-mirror   # model/effort lists identical in src/types.ts ↔ ui/src/lib/types.ts
+bun run check:fallow-pin     # the pinned fallow version identical at every site
 cd ui && bun run check       # svelte-check (ui types)
 cd ui && bun run check:i18n  # locale-catalog parity (en ↔ de)
 cd ui && bun run test        # ui test suite (vitest)

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "check:glossary": "node scripts/check-glossary.mjs",
     "check:announcement-versions": "node scripts/check-announcement-versions.mjs",
     "check:model-mirror": "node scripts/check-model-mirror.mjs",
+    "check:fallow-pin": "node scripts/check-fallow-pin.mjs",
     "next-version": "node scripts/next-version.mjs",
     "gen:herdr-schema": "bun run scripts/gen-herdr-schema.ts",
     "gen:herdr-types": "bun run scripts/gen-herdr-types.ts",

--- a/scripts/check-fallow-pin.d.mts
+++ b/scripts/check-fallow-pin.d.mts
@@ -1,0 +1,54 @@
+// Types for the node-run fallow-pin gate (scripts/check-fallow-pin.mjs). The gate stays
+// plain .mjs so `node scripts/check-fallow-pin.mjs` works as a CLI in any context (the
+// package script, the pre-push gates lane, PR hygiene); this declaration only exists so
+// its TypeScript importer — test/check-fallow-pin.test.ts — gets real types instead of
+// `any`. Mirrors scripts/check-model-mirror.d.mts's role.
+
+/** How a site names the pin: a `fallow@<semver>` invocation, or the TS constant. */
+export type PinKind = "invocation" | "declaration";
+
+/** One place the pinned version is written out. */
+export interface PinRef {
+  kind: PinKind;
+  /** The semver as written, prerelease/build tails included. */
+  version: string;
+  /** 1-based line within the file. */
+  line: number;
+  /** Repo-relative path. Set by `scanTree`; absent from `extractPinRefs` output. */
+  file?: string;
+}
+
+/** Why a comparison failed, or null when it did not. */
+export type PinFailure = "no-canonical" | "no-invocations" | "drift";
+
+export interface PinResult {
+  /** True when every reference names `canonical`. */
+  ok: boolean;
+  reason: PinFailure | null;
+  /** The version parsed from `FALLOW_VERSION`, or null when it could not be parsed. */
+  canonical: string | null;
+  /** References whose version differs from `canonical`. Empty unless `reason` is "drift". */
+  mismatches: PinRef[];
+  invocations: number;
+  declarations: number;
+  /** Distinct files contributing at least one reference. */
+  files: number;
+}
+
+/** The file holding `FALLOW_VERSION` — the canonical every other site is compared to. */
+export const CANONICAL_REL: string;
+
+/** Every pin reference in one file's text, sorted by line. */
+export function extractPinRefs(source: string): PinRef[];
+
+/** The version `FALLOW_VERSION` is declared as, or null when it cannot be parsed. */
+export function extractCanonicalVersion(source: string): string | null;
+
+/** Compare every reference against the canonical, as structured data. */
+export function comparePins(canonical: string | null, refs: PinRef[]): PinResult;
+
+/** `process.env` minus git's repo-local variables (GIT_DIR, GIT_INDEX_FILE, …). */
+export function gitEnv(): NodeJS.ProcessEnv;
+
+/** Scan every file git tracks under `root`; each ref carries its repo-relative `file`. */
+export function scanTree(root: string, env?: NodeJS.ProcessEnv): PinRef[];

--- a/scripts/check-fallow-pin.mjs
+++ b/scripts/check-fallow-pin.mjs
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+// Fallow version-pin gate (#2182): every place the repo names the pinned fallow
+// release must name the SAME release.
+//
+// THE HAZARD this closes: the pin is deliberately NOT `@latest`, and it is written out
+// twelve times across six files — a CI step, a pre-push argv, a `.fallowrc.jsonc`
+// baseline recipe, four spots in CONTRIBUTING.md, a test comment, and `FALLOW_VERSION`
+// in src/maintain-core.ts. Every site carried a "keep in sync" comment and nothing
+// enforced it. Since #2179 that is no longer merely untidy: the `dead_code_drift`
+// maintain band uses `FALLOW_VERSION` to MEASURE and to run `fallow fix`, unattended.
+// A one-sided edit is silent in both directions:
+//   • bump ci.yml only        → the band keeps scoring on the old analyser, and a
+//                               Tier-3 PR can land CI-red on findings it never saw.
+//   • bump FALLOW_VERSION only → the loop opens PRs for a finding class CI does not
+//                               enforce.
+//
+// WHY TEXTUAL rather than one exported constant every site reads: `.github/workflows/
+// ci.yml`, `CONTRIBUTING.md` and `.fallowrc.jsonc` cannot import TypeScript, so the
+// duplication is STRUCTURAL — a gate is the only thing that can close it. Same argument,
+// and same shape, as scripts/check-model-mirror.mjs (#1936); all three wiring points
+// (the `check:fallow-pin` package script, the pre-push `gates` lane, the PR-hygiene
+// workflow) invoke a gate as a bare command, which a `bun test` assertion cannot fill.
+//
+// WHY REPO-WIDE rather than a declared file list (which is what check-model-mirror.mjs
+// does, and what #2182 proposed): a `bunx fallow@…` invocation can appear in ANY new
+// file, unlike a `const` in a known module. A fixed list reproduces the very hole this
+// gate exists to close, one level up — a pin added in a seventh file would be invisible.
+// Enumerating tracked files costs a few milliseconds and covers new sites for free.
+//
+// WHY ONE TOKEN: five of the twelve sites used to name the version in PROSE ("pins
+// fallow to X", "Verified against fallow X"). No safe pattern can match those, because
+// the SAME comment blocks legitimately name other releases — `(fallow 2.98+)`, the
+// release that introduced the synthetic Svelte <template> metric, and "the old 2.97
+// pin". #2182 reworded all five to carry the `fallow@<semver>` token instead, so the
+// legitimate prose stays unmatched BY CONSTRUCTION (no `@`) rather than by an exclusion
+// list. Keep it that way: write a new pin site as `fallow@<version>`, and keep prose
+// about some OTHER release in the un-`@`-ed form.
+//
+// It fails CLOSED, in both directions: an unparseable canonical is an error, and so is
+// finding ZERO pinned invocations (which means the pattern rotted, not that the repo is
+// clean — the exact vacuous pass a gate must never produce).
+//
+// Plain ESM — no dependencies, no transpile. Importable (extractPinRefs /
+// extractCanonicalVersion / comparePins / scanTree) by test/check-fallow-pin.test.ts.
+
+import { spawnSync } from "node:child_process";
+import { readFileSync, realpathSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Resolved from this file, never process.cwd(), so the CLI works from any directory.
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** The file holding `FALLOW_VERSION` — the canonical every other site is compared to. */
+export const CANONICAL_REL = "src/maintain-core.ts";
+
+/**
+ * A full semver, prerelease and build metadata included.
+ *
+ * The tails are not decoration: with a bare `\d+\.\d+\.\d+` a site pinned to
+ * `<x.y.z>-beta.1` would capture only `<x.y.z>` and compare EQUAL to a plain `<x.y.z>`
+ * elsewhere — drift the gate would wave through.
+ */
+const SEMVER = String.raw`\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?`;
+
+/**
+ * A pinned invocation: `fallow@<semver>`, the form every non-TypeScript site uses
+ * (`bunx fallow@<version> audit …`, the pre-push argv, the CONTRIBUTING snippets).
+ *
+ * Deliberately narrow. `fallow@…` and `fallow@<pinned>` — the two intentionally
+ * version-free placeholders in the tree (scripts/pre-push.ts, src/maintain.ts and the
+ * docs-site configuration reference) — do not match, and neither does prose naming a
+ * different release without the `@`.
+ */
+const invocationRe = () => new RegExp(String.raw`fallow@(` + SEMVER + `)`, "g");
+
+/**
+ * The `FALLOW_VERSION` declaration. Scanned repo-wide, not just in {@link CANONICAL_REL},
+ * so a SECOND declaration (a hand-copied UI mirror, say) is caught rather than assumed
+ * absent.
+ *
+ * Anchored on the `const` keyword rather than the loose `<NAME>[^=]*=` idiom used
+ * elsewhere in scripts/ — check-model-mirror.mjs learned that one the hard way: these
+ * names appear in PROSE right next to their declarations (maintain-core.ts's own doc
+ * comment argues about keeping `FALLOW_VERSION` in sync), and an import statement names
+ * it too. `\b` rejects a longer name sharing the prefix.
+ */
+const declarationRe = () =>
+  new RegExp(
+    String.raw`(?:export\s+)?const\s+FALLOW_VERSION\b\s*(?::[^=]*)?=\s*["'](` + SEMVER + `)["']`,
+    "g",
+  );
+
+/** 1-based line number of `index` in `source`. */
+function lineOf(source, index) {
+  let line = 1;
+  for (let i = 0; i < index; i += 1) if (source[i] === "\n") line += 1;
+  return line;
+}
+
+/**
+ * Every pin reference in one file's text, sorted by line. Returns `[]` for a file that
+ * names no pinned version — the overwhelmingly common case.
+ */
+export function extractPinRefs(source) {
+  const refs = [];
+  for (const [kind, re] of [
+    ["invocation", invocationRe()],
+    ["declaration", declarationRe()],
+  ]) {
+    let m;
+    while ((m = re.exec(source)) !== null) {
+      refs.push({ kind, version: m[1], line: lineOf(source, m.index) });
+    }
+  }
+  return refs.sort((a, b) => a.line - b.line);
+}
+
+/** The version `FALLOW_VERSION` is declared as, or null when it cannot be parsed. */
+export function extractCanonicalVersion(source) {
+  const m = declarationRe().exec(source);
+  return m ? m[1] : null;
+}
+
+/**
+ * Compare every reference against the canonical. Returns STRUCTURED data — prose
+ * formatting lives only in the CLI below, so tests assert on facts rather than
+ * substring-matching a message that is free to be reworded.
+ *
+ * `reason` is one of "no-canonical" (nothing to compare against), "no-invocations" (the
+ * pattern found nothing, so the comparison would be vacuous), "drift", or null when ok.
+ */
+export function comparePins(canonical, refs) {
+  const invocations = refs.filter((r) => r.kind === "invocation").length;
+  const base = {
+    canonical,
+    invocations,
+    declarations: refs.length - invocations,
+    files: new Set(refs.map((r) => r.file)).size,
+    mismatches: [],
+  };
+
+  if (!canonical) return { ...base, ok: false, reason: "no-canonical" };
+  if (invocations === 0) return { ...base, ok: false, reason: "no-invocations" };
+
+  const mismatches = refs.filter((r) => r.version !== canonical);
+  return {
+    ...base,
+    mismatches,
+    ok: mismatches.length === 0,
+    reason: mismatches.length ? "drift" : null,
+  };
+}
+
+// ── the tree ─────────────────────────────────────────────────────────────────
+
+/**
+ * `process.env` minus git's repo-local variables.
+ *
+ * Git exports GIT_DIR / GIT_INDEX_FILE / GIT_WORK_TREE / … into hooks, and this gate
+ * runs from one. Inherited, they would point `git ls-files` at the hook's repository no
+ * matter which `cwd` it is given — so a run from a fixture tree would enumerate the REAL
+ * repo instead. `.husky/pre-push` scrubs the same set for the same reason. The list is
+ * asked of git rather than hardcoded so it stays right as git adds variables; the
+ * fallback covers a `git` that cannot answer.
+ */
+export function gitEnv() {
+  const env = { ...process.env };
+  const r = spawnSync("git", ["rev-parse", "--local-env-vars"], { encoding: "utf8" });
+  const names =
+    r.status === 0
+      ? r.stdout.split("\n").map((s) => s.trim())
+      : ["GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR", "GIT_OBJECT_DIRECTORY"];
+  for (const name of names) if (name) delete env[name];
+  return env;
+}
+
+/** Every file git tracks under `root`, as repo-relative paths. */
+function trackedFiles(root, env) {
+  const r = spawnSync("git", ["ls-files", "-z"], { cwd: root, env, maxBuffer: 64 * 1024 * 1024 });
+  if (r.status !== 0) {
+    const why = r.stderr?.toString().trim() || r.error?.message || `exit ${r.status}`;
+    throw new Error(`\`git ls-files\` failed in ${root}: ${why}`);
+  }
+  return r.stdout.toString("utf8").split("\0").filter(Boolean);
+}
+
+/**
+ * Scan every tracked file for pin references. Each ref carries its repo-relative `file`.
+ *
+ * Two files are skipped rather than parsed: one that is gone from the working tree (a
+ * staged deletion, or a broken symlink) and one that looks binary. The `fallow` prefilter
+ * is what keeps this cheap — it rejects ~99% of the tree on a substring test, before any
+ * UTF-8 decode. Both spellings are checked because the two patterns need exactly those:
+ * lowercase for `fallow@`, uppercase for `FALLOW_VERSION`.
+ */
+export function scanTree(root, env = gitEnv()) {
+  const refs = [];
+  for (const rel of trackedFiles(root, env)) {
+    let buf;
+    try {
+      buf = readFileSync(join(root, rel));
+    } catch {
+      continue;
+    }
+    if (!buf.includes("fallow") && !buf.includes("FALLOW")) continue;
+    if (buf.subarray(0, 8000).includes(0)) continue;
+    for (const ref of extractPinRefs(buf.toString("utf8"))) refs.push({ file: rel, ...ref });
+  }
+  return refs;
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Is this module the process entry point (i.e. run as the CLI, not imported)?
+ *
+ * Both normalizations matter, and getting either wrong silently skips the CLI block — so
+ * `node scripts/check-fallow-pin.mjs` exits 0 having compared NOTHING, the exact vacuous
+ * pass this gate exists to prevent. See the long-form derivation in
+ * scripts/check-model-mirror.mjs: `fileURLToPath` because import.meta.url is
+ * percent-encoded, and `realpathSync(argv[1])` because Node realpath-resolves the entry
+ * module but leaves argv[1] merely resolved. Both are covered by regression tests in
+ * test/check-fallow-pin.test.ts.
+ */
+function isMainModule() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return realpathSync(entry) === fileURLToPath(import.meta.url);
+  } catch {
+    // argv[1] isn't a resolvable path (eval/bundler harness) → not the CLI entry.
+    return false;
+  }
+}
+
+/** Human-readable failure text for a non-ok result. Wording is intentionally untested. */
+function formatFailure(result) {
+  const fix =
+    `Fix: make every site name the same version. \`FALLOW_VERSION\` in ${CANONICAL_REL} is the` +
+    ` canonical — it drives the unattended maintain loop, so a site disagreeing with it means the` +
+    ` loop measures against one analyser while CI gates with another.`;
+
+  if (result.reason === "no-canonical") {
+    return (
+      `fallow pin: could not parse \`FALLOW_VERSION\` in ${CANONICAL_REL} —` +
+      ` expected \`export const FALLOW_VERSION = "<semver>";\`.\n` +
+      `There is nothing to compare the other ${result.invocations} pin site(s) against, so this is` +
+      ` an error rather than a skipped comparison.`
+    );
+  }
+
+  if (result.reason === "no-invocations") {
+    return (
+      `fallow pin: found ZERO pinned \`fallow@<semver>\` invocations in the tree.\n` +
+      `Either every pinned invocation is gone, or this gate's pattern has rotted — both are` +
+      ` errors, never a silent pass. Pin sites are written as \`fallow@<version>\`; prose about a` +
+      ` DIFFERENT release stays in the un-\`@\`-ed form on purpose.`
+    );
+  }
+
+  const lines = result.mismatches.map(
+    (m) =>
+      `  ${m.file}:${m.line} — ${m.kind === "declaration" ? "FALLOW_VERSION" : "pinned invocation"}` +
+      ` names ${m.version}, canonical is ${result.canonical}`,
+  );
+  return `fallow pin: ${result.mismatches.length} site(s) disagree with the canonical:\n${lines.join("\n")}\n\n${fix}`;
+}
+
+if (isMainModule()) {
+  let result;
+  try {
+    const refs = scanTree(ROOT);
+    const canonical = extractCanonicalVersion(readFileSync(join(ROOT, CANONICAL_REL), "utf8"));
+    result = comparePins(canonical, refs);
+  } catch (err) {
+    console.error(`fallow pin: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+
+  if (!result.ok) {
+    console.error(formatFailure(result));
+    process.exit(1);
+  }
+
+  console.log(
+    `✓ fallow pin: ${result.canonical} everywhere — ${result.invocations} pinned invocation(s)` +
+      ` + ${result.declarations} FALLOW_VERSION declaration(s) across ${result.files} file(s).`,
+  );
+}

--- a/scripts/pre-push.ts
+++ b/scripts/pre-push.ts
@@ -13,7 +13,7 @@
  * │ (and vice-versa). Two DELIBERATE local-only differences from CI:              │
  * │  • prettier/eslint are scoped to the push DELTA (vs origin/main) — CI keeps   │
  * │    the whole-repo check, so tree-wide drift is still caught before merge.     │
- * │  • fallow stays pinned to 2.100.0 (keep in sync w/ ci.yml + CONTRIBUTING.md). │
+ * │  • fallow@2.100.0 pin — same as CI, gated by check-fallow-pin.mjs.            │
  * └──────────────────────────────────────────────────────────────────────────────┘
  *
  * The hook (`.husky/pre-push`) scrubs git's local-env-vars and execs this script,
@@ -403,6 +403,12 @@ function buildLanes(
         args: ["scripts/check-model-mirror.mjs"],
         cwd: repoRoot,
       },
+      {
+        label: "fallow pin",
+        cmd: "node",
+        args: ["scripts/check-fallow-pin.mjs"],
+        cwd: repoRoot,
+      },
       { label: "herdr types", cmd: "bun", args: ["run", "check:herdr-types"], cwd: repoRoot },
     ],
   });
@@ -667,8 +673,8 @@ async function main(): Promise<void> {
   }
 
   // fallow runs only after every lane passes (delta vs origin/main). Skipped when
-  // origin/main is unavailable (offline) so a push isn't wedged. Pinned 2.100.0 —
-  // keep in sync with .github/workflows/ci.yml + CONTRIBUTING.md.
+  // origin/main is unavailable (offline) so a push isn't wedged. Pinned fallow@2.100.0,
+  // gated against every other pin site by scripts/check-fallow-pin.mjs.
   if (delta) {
     console.log("  → fallow audit (delta vs origin/main)");
     // Bounded so a cold `bunx fallow@…` download that hangs can't wedge the push —

--- a/test/check-fallow-pin.test.ts
+++ b/test/check-fallow-pin.test.ts
@@ -1,0 +1,339 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  CANONICAL_REL,
+  comparePins,
+  extractCanonicalVersion,
+  extractPinRefs,
+  gitEnv,
+  scanTree,
+} from "../scripts/check-fallow-pin.mjs";
+
+// Resolved from this file, never process.cwd(), so the live-tree cases below behave
+// identically under `bun test ./test` and a single-file invocation.
+const ROOT = join(import.meta.dir, "..");
+
+/**
+ * Every fixture pin is BUILT, never written literally.
+ *
+ * This file is scanned by the very gate it tests, so a literal `fallow` + `@` + digits
+ * here would fail the gate ON ITS OWN TEST FILE. Interpolation leaves `fallow@${…}` in
+ * the source — no digit after the `@`, so the pattern cannot match — which keeps the
+ * repo-wide scan free of exclusion lists. An exclusion would be a cheap escape hatch in
+ * the one file most likely to need real coverage. `decl` interpolates for the same
+ * reason: the declaration pattern needs a digit straight after the opening quote.
+ */
+const pin = (v: string) => `fallow@${v}`;
+const decl = (v: string) => `export const FALLOW_VERSION = "${v}";\n`;
+
+// ── extractPinRefs ───────────────────────────────────────────────────────────
+
+describe("extractPinRefs", () => {
+  test("finds a pinned invocation with its line", () => {
+    const source = `first line\nrun: bunx ${pin("2.100.0")} audit --base origin/main\n`;
+    expect(extractPinRefs(source)).toEqual([{ kind: "invocation", version: "2.100.0", line: 2 }]);
+  });
+
+  test("finds the FALLOW_VERSION declaration", () => {
+    expect(extractPinRefs(`// a comment\n${decl("2.100.0")}`)).toEqual([
+      { kind: "declaration", version: "2.100.0", line: 2 },
+    ]);
+  });
+
+  test("captures a prerelease tail instead of truncating to the release", () => {
+    // A bare \d+\.\d+\.\d+ would capture "2.100.0" here and compare EQUAL to a plain
+    // 2.100.0 at another site — drift the gate would wave through.
+    expect(extractPinRefs(`bunx ${pin("2.100.0-beta.1")} audit`).map((r) => r.version)).toEqual([
+      "2.100.0-beta.1",
+    ]);
+  });
+
+  test("ignores prose naming a DIFFERENT release beside a real pin", () => {
+    // Shapes lifted from ci.yml / CONTRIBUTING.md. These are correct as written, and
+    // they are why #2182 normalized the prose PIN sites to carry `@` rather than
+    // widening the pattern to "fallow near a semver" — which would flag all three.
+    const source =
+      "# The synthetic Svelte <template> complexity metric (fallow 2.98+) is adopted\n" +
+      "# via health.thresholdOverrides. The line-shift mis-attribution that forced the\n" +
+      "# old 2.97 pin was re-tested against 2.100 and does NOT reproduce.\n";
+    expect(extractPinRefs(source)).toEqual([]);
+  });
+
+  test("ignores the deliberately version-free placeholders", () => {
+    // scripts/pre-push.ts and src/maintain.ts write `fallow@…`; the docs-site
+    // configuration reference writes `fallow@<pinned>`. Both must stay unmatched.
+    const source = "a cold `bunx fallow@…` download\nruns `bunx fallow@<pinned> fix --yes`\n";
+    expect(extractPinRefs(source)).toEqual([]);
+  });
+
+  test("finds every site in a file, ordered by line", () => {
+    const source = `${decl("2.100.0")}// then: bunx ${pin("2.100.0")} dupes\n`;
+    expect(extractPinRefs(source).map((r) => [r.line, r.kind])).toEqual([
+      [1, "declaration"],
+      [2, "invocation"],
+    ]);
+  });
+});
+
+// ── extractCanonicalVersion ──────────────────────────────────────────────────
+
+describe("extractCanonicalVersion", () => {
+  test("reads the declaration", () => {
+    expect(extractCanonicalVersion(decl("2.100.0"))).toBe("2.100.0");
+  });
+
+  test("is null when the constant is only IMPORTED or named in prose", () => {
+    // src/maintain.ts imports FALLOW_VERSION, and maintain-core.ts's own doc comment
+    // argues about keeping it in sync — a loose `<NAME>[^=]*=` anchor lands on prose.
+    const source =
+      `import { FALLOW_VERSION } from "./maintain-core";\n` +
+      `// KEEP IN SYNC with the other pin sites — FALLOW_VERSION is the canonical.\n`;
+    expect(extractCanonicalVersion(source)).toBeNull();
+  });
+
+  test("is null when the value is not a version literal", () => {
+    // A reshape (env lookup, imported constant) must fail closed, not read as "0 sites".
+    expect(
+      extractCanonicalVersion(`const FALLOW_VERSION = process.env.FALLOW ?? "";\n`),
+    ).toBeNull();
+  });
+});
+
+// ── comparePins ──────────────────────────────────────────────────────────────
+
+describe("comparePins", () => {
+  const ref = (
+    file: string,
+    version: string,
+    kind: "invocation" | "declaration" = "invocation",
+    line = 1,
+  ) => ({ file, kind, version, line });
+
+  test("ok when every site names the canonical", () => {
+    const result = comparePins("2.100.0", [
+      ref(".github/workflows/ci.yml", "2.100.0"),
+      ref("src/maintain-core.ts", "2.100.0", "declaration"),
+    ]);
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBeNull();
+    expect([result.invocations, result.declarations, result.files]).toEqual([1, 1, 2]);
+  });
+
+  test("names the odd site out", () => {
+    const odd = ref("CONTRIBUTING.md", "2.99.0", "invocation", 147);
+    const result = comparePins("2.100.0", [ref(".github/workflows/ci.yml", "2.100.0"), odd]);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("drift");
+    expect(result.mismatches).toEqual([odd]);
+  });
+
+  test("reports a drifted SECOND declaration like any other site", () => {
+    // The canonical comes from src/maintain-core.ts, so its own declaration can never
+    // mismatch — but a hand-copied mirror elsewhere can, which is why the declaration
+    // pattern is scanned repo-wide rather than only in the canonical file.
+    const mirror = ref("ui/src/lib/maintain.ts", "2.99.0", "declaration", 12);
+    const result = comparePins("2.100.0", [
+      ref("src/maintain-core.ts", "2.100.0", "declaration"),
+      ref(".github/workflows/ci.yml", "2.100.0"),
+      mirror,
+    ]);
+    expect(result.mismatches).toEqual([mirror]);
+  });
+
+  test("fails closed when the canonical cannot be parsed", () => {
+    const result = comparePins(null, [ref(".github/workflows/ci.yml", "2.100.0")]);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("no-canonical");
+  });
+
+  test("fails closed on ZERO invocations — a rotted pattern, not a clean tree", () => {
+    // Two empty sides comparing as "equal" is the vacuous pass a gate must never
+    // produce: it reads as green precisely when it has stopped checking anything.
+    const result = comparePins("2.100.0", [ref("src/maintain-core.ts", "2.100.0", "declaration")]);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("no-invocations");
+  });
+});
+
+// ── the CLI, against throwaway checkouts ─────────────────────────────────────
+
+function withFixture(prefix: string, fn: (dir: string) => void): void {
+  // realpathSync keeps the temp root free of symlink components, so each case isolates
+  // the one thing it names (macOS `os.tmpdir()` is `/var/folders/…` → `/private/var/…`,
+  // which would otherwise make the spaced-path case fail for the *symlink* reason).
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+  try {
+    fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/** Build a throwaway git checkout at `dir` holding a copy of the gate; returns its path. */
+function fakeCheckout(dir: string, files: Record<string, string>): string {
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = join(dir, rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, content);
+  }
+  const script = join(dir, "scripts", "check-fallow-pin.mjs");
+  mkdirSync(dirname(script), { recursive: true });
+  copyFileSync(join(ROOT, "scripts", "check-fallow-pin.mjs"), script);
+
+  // The gate enumerates through `git ls-files`, so the fixture must be a real repo with
+  // a populated index. EVERY git call here runs with git's repo-local variables scrubbed
+  // (`gitEnv`): the root suite honours an ambient GIT_DIR, so an inherited one would
+  // point `git init`/`git add` at the REAL repository regardless of `cwd` — the exact
+  // trap `.husky/pre-push` unsets those variables to avoid.
+  const env = gitEnv();
+  for (const args of [
+    ["init", "-q"],
+    ["add", "-A"],
+  ]) {
+    const r = spawnSync("git", args, { cwd: dir, env, encoding: "utf8" });
+    // A non-zero status here would leave the fixture repo-less, and `git ls-files` would
+    // walk UP to whatever repo contains tmpdir — so assert rather than assume.
+    expect(r.status).toBe(0);
+  }
+  return script;
+}
+
+function runGate(script: string) {
+  return spawnSync("node", [script], { encoding: "utf8", env: gitEnv() });
+}
+
+/** A checkout whose one pinned invocation disagrees with FALLOW_VERSION. */
+function driftedCheckout(dir: string): string {
+  return fakeCheckout(dir, {
+    "src/maintain-core.ts": decl("2.100.0"),
+    "docs/notes.md": `first line\nrun \`bunx ${pin("2.99.0")} audit\`\n`,
+  });
+}
+
+test("CLI exits 0 when every site agrees", () => {
+  withFixture("shepherd-fallow-pin-ok-", (dir) => {
+    const script = fakeCheckout(dir, {
+      "src/maintain-core.ts": decl("2.100.0"),
+      "docs/notes.md": `run \`bunx ${pin("2.100.0")} audit\`\n`,
+      ".fallowrc.jsonc": `// bunx ${pin("2.100.0")} dupes --save-baseline\n{}\n`,
+    });
+    const r = runGate(script);
+    expect(`${r.stdout}${r.stderr}`).toContain("2.100.0");
+    expect(r.status).toBe(0);
+  });
+});
+
+test("CLI exits 1 and names the drifted file:line and both versions", () => {
+  withFixture("shepherd-fallow-pin-drift-", (dir) => {
+    const r = runGate(driftedCheckout(dir));
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("docs/notes.md:2");
+    expect(r.stderr).toContain("2.99.0");
+    expect(r.stderr).toContain("2.100.0");
+  });
+});
+
+test("CLI exits 1 when FALLOW_VERSION cannot be parsed", () => {
+  withFixture("shepherd-fallow-pin-nocanon-", (dir) => {
+    const script = fakeCheckout(dir, {
+      "src/maintain-core.ts": "export const MAX_ACTIONS_PER_SWEEP = 1;\n",
+      "docs/notes.md": `run \`bunx ${pin("2.100.0")} audit\`\n`,
+    });
+    const r = runGate(script);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("FALLOW_VERSION");
+  });
+});
+
+test("CLI exits 1 when ZERO pinned invocations are found", () => {
+  withFixture("shepherd-fallow-pin-empty-", (dir) => {
+    const script = fakeCheckout(dir, { "src/maintain-core.ts": decl("2.100.0") });
+    const r = runGate(script);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("ZERO");
+  });
+});
+
+// Both cases below exercise the `isMainModule` guard, whose failure modes are
+// indistinguishable from success by exit code alone: if the guard is wrong the CLI block
+// never runs and the process exits 0 having compared NOTHING. So each plants a DRIFTED
+// checkout and asserts exit 1 — only a CLI that genuinely ran can produce that.
+
+test("the CLI runs (and fails) from a checkout path containing a space", () => {
+  // Guards the percent-encoding trap: import.meta.url encodes the space as %20, so a
+  // `file://` + argv[1] concat comparison is false and the CLI is skipped.
+  withFixture("shepherd fallow pin ", (dir) => {
+    expect(dir).toContain(" "); // the whole point of the case
+    const r = runGate(driftedCheckout(dir));
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("2.99.0");
+  });
+});
+
+test("the CLI runs (and fails) when reached through a SYMLINKED path component", () => {
+  // Guards the realpath trap: Node realpath-resolves the entry module behind
+  // import.meta.url but leaves argv[1] merely path.resolve'd, so without
+  // realpathSync(argv[1]) the comparison is false and the CLI is skipped.
+  withFixture("shepherd-fallow-pin-symlink-", (root) => {
+    const real = join(root, "real");
+    mkdirSync(real, { recursive: true });
+    const script = driftedCheckout(real);
+    const link = join(root, "link");
+    symlinkSync(real, link);
+    const viaLink = join(link, "scripts", "check-fallow-pin.mjs");
+    // Same file, reached via the symlink — argv[1] keeps "link", import.meta.url "real".
+    expect(realpathSync(viaLink)).toBe(script);
+    const r = runGate(viaLink);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("2.99.0");
+  });
+});
+
+// ── the live tree ────────────────────────────────────────────────────────────
+
+describe("the live tree", () => {
+  test("every pin site agrees with FALLOW_VERSION", () => {
+    const canonical = extractCanonicalVersion(readFileSync(join(ROOT, CANONICAL_REL), "utf8"));
+    const result = comparePins(canonical, scanTree(ROOT));
+    expect(result.mismatches).toEqual([]);
+    expect(result.ok).toBe(true);
+  });
+
+  test("still covers every file #2182 normalized", () => {
+    // Guards the OTHER half of #2182. Five of the twelve sites named the version in
+    // prose, which no safe pattern can match; they were reworded to carry the
+    // `fallow@<semver>` token. Reverting any of them shrinks the gate's coverage
+    // silently — the gate itself would still pass, having stopped watching that site.
+    // Counts are a FLOOR, so adding a pin site is free; removing one is deliberate.
+    const perFile = new Map<string, number>();
+    for (const r of scanTree(ROOT)) perFile.set(r.file!, (perFile.get(r.file!) ?? 0) + 1);
+
+    const expected: Record<string, number> = {
+      ".fallowrc.jsonc": 1,
+      ".github/workflows/ci.yml": 2,
+      "CONTRIBUTING.md": 4,
+      "scripts/pre-push.ts": 3,
+      "src/maintain-core.ts": 1,
+      "test/maintain.test.ts": 1,
+    };
+    const shortfalls = Object.entries(expected)
+      .filter(([file, atLeast]) => (perFile.get(file) ?? 0) < atLeast)
+      .map(
+        ([file, atLeast]) =>
+          `${file}: ${perFile.get(file) ?? 0} gated site(s), expected ≥ ${atLeast}`,
+      );
+    expect(shortfalls).toEqual([]);
+  });
+});

--- a/test/maintain.test.ts
+++ b/test/maintain.test.ts
@@ -1140,7 +1140,7 @@ describe("tier 3 — worktree protection", () => {
 
 describe("reportFromFailedExit", () => {
   it("keeps the report from a non-zero exit — fallow exits 1 whenever it finds anything", () => {
-    // Verified against fallow 2.100.0: `dead-code` exits 1 both before AND after a fix while
+    // Verified against fallow@2.100.0: `dead-code` exits 1 both before AND after a fix while
     // non-auto-fixable findings remain. Discarding that output would leave the band permanently
     // reading "no data" and tier 3 permanently unreachable.
     expect(reportFromFailedExit({ code: 1, stdout: '{"kind":"dead-code"}' })).toBe(


### PR DESCRIPTION
Closes #2182.

The fallow pin is deliberately not `@latest`, and nothing enforced that its copies agree. Since #2179 that stopped being cosmetic: the `dead_code_drift` band uses `FALLOW_VERSION` to measure and to run `fallow fix`, unattended. A one-sided edit is silent in both directions — bump `ci.yml` only and the band keeps scoring on the old analyser; bump `FALLOW_VERSION` only and the loop opens PRs for a class CI does not enforce.

### The issue undercounts the problem

It says 8 sites across 4 files. The tree has **12 across 6**. Also missed: `.fallowrc.jsonc` (a runnable `bunx fallow@2.100.0 dupes --save-baseline` recipe), a fourth `CONTRIBUTING.md` mention, and a `test/maintain.test.ts` provenance note.

### Two halves

**1. Normalize the prose.** Five of the twelve sites named the version in prose ("pins fallow to 2.100.0", "Verified against fallow 2.100.0"). No safe pattern can match those, because the *same comment blocks* legitimately name other releases — `(fallow 2.98+)`, the release that introduced the synthetic Svelte `<template>` metric, and "the old 2.97 pin". A loose "fallow near a semver" regex flags both as drift. So all five were reworded to carry the `fallow@<semver>` token, and the legitimate prose stays unmatched **by construction** (no `@`) rather than by an exclusion list. Coverage 7/12 → 12/12.

**2. `scripts/check-fallow-pin.mjs`**, in the mould of `check-model-mirror.mjs` (#1936) — textual for the same reason: two of the sites are a YAML workflow and a Markdown doc that no test can import, and all three wiring points invoke a gate as a bare command.

`FALLOW_VERSION` in `src/maintain-core.ts` is the canonical (it drives the unattended loop); every `fallow@<semver>` in a tracked file must equal it. Fails closed on an unparseable canonical **and** on finding zero invocations — a rotted pattern must be an error, never the vacuous pass a gate exists to prevent.

### One deliberate departure from the issue's shape

It proposes a fixed 4-file list, mirroring `check-model-mirror`. This scans **repo-wide** over `git ls-files` instead: a `bunx fallow@…` invocation can land in any new file, unlike a `const` in a known module, so a fixed list reproduces the same silent-drift hole one level up — a pin in a seventh file would be invisible. The scan costs a few milliseconds behind a `fallow` substring prefilter.

Also updated: four sentences instructing humans to hand-sync the pin now point at the gate instead.

### Notable in review

- **The test file is scanned by the gate it tests.** A literal `fallow@2.99.0` fixture would fail the gate on its own test file. Every fixture pin is built by interpolation, so the source holds only `fallow@${…}` — no digit after the `@`. That keeps the repo-wide scan free of exclusion lists; a self-exemption would be a cheap escape hatch in the one file most needing coverage.
- **Ambient `GIT_DIR`.** The fixture CLI tests build throwaway git repos. Root tests honour an ambient `GIT_DIR`, so every git call — in the gate and the tests — runs with git's repo-local vars scrubbed (the same set `.husky/pre-push` unsets). Without it, `git init`/`git add` would operate on the real repository.
- **Prerelease tails are captured.** A bare `\d+\.\d+\.\d+` would read `2.100.0-beta.1` as `2.100.0` and compare it equal to a plain `2.100.0` elsewhere.

### Verification

- Gate reports 11 pinned invocations + 1 `FALLOW_VERSION` declaration across 6 files — the full inventory.
- Drifting **each** of the six files individually exits 1 and names the `file:line`; bumping `FALLOW_VERSION` alone flags all 11 others.
- Removing the canonical, and separately every invocation, each exit 1.
- `bun run test` 9062 pass / 0 fail · `bun run lint` · `bun run typecheck` · prettier clean.
- `bunx fallow@2.100.0 audit --base origin/main --fail-on-issues` clean; pre-push green with the new gate in the `gates` lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
