### PR TITLE
fix(ui): stop the StatusPip close test racing a real stray cursor (#2180)

### DIFF
--- a/ui/src/lib/components/StatusPip.browser.test.ts
+++ b/ui/src/lib/components/StatusPip.browser.test.ts
@@ -53,15 +53,23 @@ describe("StatusPip tip mode (statusTip action)", () => {
     expect(document.querySelector(".status-tip")?.getAttribute("role")).toBe("tooltip");
     // Most specs in this suite drive *real* clicks, and the cursor they leave behind
     // persists across files sharing a worker's page — so a real pointer can be resting
-    // on this chip. As the panel settles into its anchored position the browser
-    // re-hit-tests and fires a **trusted** pointerenter, which reopens the tooltip and
-    // cancels the pending close: right for a pointer that genuinely is there, but it
-    // strands the synthetic leave below forever (no real pointer ever leaves again).
-    // Re-issue the leave on those so the assertion measures the close path rather than
-    // the harness's stray cursor. Synthetic events cannot trigger this handler.
-    pipEl().addEventListener("pointerenter", (e) => {
-      if (e.isTrusted) leave();
-    });
+    // over this component. The panel is body-appended and only positioned after show()
+    // (floating-anchor's computePosition is async, and .status-tip is inset:auto), so as
+    // it settles the browser re-hit-tests and delivers a **trusted** pointerenter — to
+    // the chip (show() → cancelClose) or to the panel, its own larger target (a bare
+    // cancelClose). Either cancels the pending close with nothing left to re-schedule
+    // it, which is right for a pointer that genuinely is there but strands the synthetic
+    // leave below forever, since no real pointer ever leaves again.
+    //
+    // Release both by re-issuing the leave, so the assertion measures the close path
+    // rather than the harness's stray cursor. Synthetic events never re-enter this.
+    const releaseTrusted = (el: Element) =>
+      el.addEventListener("pointerenter", (e) => {
+        if (!e.isTrusted) return;
+        el.dispatchEvent(new PointerEvent("pointerleave", { pointerType: "mouse", bubbles: true }));
+      });
+    releaseTrusted(pipEl());
+    releaseTrusted(document.querySelector(".status-tip")!);
     leave();
     await vi.waitFor(() => expect(tooltipOpen()).toBe(false));
   });

--- a/ui/src/lib/components/StatusPip.browser.test.ts
+++ b/ui/src/lib/components/StatusPip.browser.test.ts
@@ -51,6 +51,17 @@ describe("StatusPip tip mode (statusTip action)", () => {
     enter();
     await vi.waitFor(() => expect(tooltipOpen()).toBe(true));
     expect(document.querySelector(".status-tip")?.getAttribute("role")).toBe("tooltip");
+    // Most specs in this suite drive *real* clicks, and the cursor they leave behind
+    // persists across files sharing a worker's page — so a real pointer can be resting
+    // on this chip. As the panel settles into its anchored position the browser
+    // re-hit-tests and fires a **trusted** pointerenter, which reopens the tooltip and
+    // cancels the pending close: right for a pointer that genuinely is there, but it
+    // strands the synthetic leave below forever (no real pointer ever leaves again).
+    // Re-issue the leave on those so the assertion measures the close path rather than
+    // the harness's stray cursor. Synthetic events cannot trigger this handler.
+    pipEl().addEventListener("pointerenter", (e) => {
+      if (e.isTrusted) leave();
+    });
     leave();
     await vi.waitFor(() => expect(tooltipOpen()).toBe(false));
   });


### PR DESCRIPTION
Closes #2180.

## The diagnosis in the issue is wrong, and so was mine

Both said "timing budget": the close is deferred behind a real 140 ms grace timer, `vi.waitFor`'s default 1000 ms budget is only ~5x that, and under parallel load it runs out. I shipped that fix first — an explicit budget derived from the grace period — and **it did not work**: the flake reproduced with the larger budget in place, burning the *entire* 3140 ms while the file's other four tests took ~46 ms combined.

That asymmetry is the tell. A throttled timer would be *late*; this one never fires at all.

## What is actually happening

I instrumented the failing test to record close latency and every pointer event reaching the chip and the panel, flagging which were browser-generated. A stuck run under full parallel load:

```
elapsed=-1  rescue=panel-leave
pipEvs=[pointerleave@0  pointerover!@2  pointerenter!@2]
```

`!` marks `isTrusted`. Two milliseconds after the test's synthetic `pointerleave`, the browser dispatches a **real** `pointerover`/`pointerenter` to the chip. That runs `statusTip.svelte.ts` → `onPointerEnter()` → `show()` → `cancelClose()`, cancelling the pending close. Nothing is left to reopen the question: the cursor is stationary, so no further real `pointerleave` arrives, no outside pointerdown, no Esc. The tooltip stays open for 20 s in the instrumented run, and only a `pointerleave` dispatched on the *panel* rescued it.

Why a real cursor is on the chip at all: most specs in this suite drive real clicks through CDP, and that cursor position persists across files sharing a worker's page. In isolation nothing ever moves it — which is exactly why the file is 5/5 green alone and only fails in the full run.

So **the action is behaving correctly**. A pointer really is resting on the chip, and keeping the tooltip open is the documented affordance. The test is the thing that lies: it dispatches "the pointer left" while the pointer demonstrably has not. **No timeout value could ever have fixed this.**

## The fix

Re-issue the leave when a *trusted* re-entry arrives, so the assertion measures the close path rather than the harness's stray cursor. One file, most of it the explanation.

Applied to **both** elements that can absorb that re-entry: the chip (`show()` → `cancelClose()`) and the panel, whose own `pointerenter` handler is a bare `cancelClose()` with nothing to re-schedule the close. The panel is body-appended, `inset:auto`, and only positioned after `show()` by `floating-anchor`'s async `computePosition`, so it is both a valid target for the post-`leave()` re-hit-test and the larger one. The captured stuck run happened to land on the chip, but it was *rescued* by a `pointerleave` on the panel — direct evidence that the panel path strands the assertion identically.

The action is untouched. The 140 ms grace period is unchanged and still exercised for real — no fake timers, no injected override, no lengthened budget.

## What I reverted, and why

The earlier budget change is gone. Its premise was that load stretches the grace timer; across 49 instrumented runs under exactly that load, the close took **151 ms in 48 of them**. The timer never stretched once, so the change addressed a problem that does not exist.

## Verification

- **75/75 green** full `ui/` suite runs with the chip guard, then **40/40 green** after extending it to the panel (300 files, 4775 tests each).
- Baseline for comparison: 17/17 green on unmodified `main` (the flake did not fire), then **2 failures in 50 runs** (~4%) once the instrumentation made it observable, including one *with* the larger budget applied.
- `bun run check` (0 errors, 6054 files), root `eslint`, `prettier --check`, and `fallow audit --base origin/main` — all clean.

One honest note on method: I first tried to verify deterministically by parking the real cursor on the chip with `hover()`. The test passed — but so did the control with the fix removed, so that experiment does not reproduce the bug and proves nothing. The 75-run sweep is the actual evidence.

## Not addressed

#2028 (EpicPanel leaks a rejection under parallel load) is a sibling in the "only in the full run" class but a different mechanism, and is untouched here.
