### PR TITLE
refactor(skills): prompt-audit pass on the shipped skills

### DIFF
--- a/.claude/skills/merge-train/SKILL.md
+++ b/.claude/skills/merge-train/SKILL.md
@@ -15,7 +15,7 @@ not the exception.
 
 ## Stages
 
-Work the stages in order. Create a TodoWrite item per stage.
+Work the stages in order.
 
 ### 1. Gather
 
@@ -111,16 +111,15 @@ re-synthesize and re-present.
 
 ### 6. Merge on approval
 
-> **NEVER move the home base's checked-out branch.** The primary working
-> directory (where the Shepherd server runs and the New Task form reads its
-> default base branch) is the **home base**. Shepherd cuts every new task branch
-> from the home base's checked-out `HEAD`, so a `git checkout` / `git switch` /
-> `git checkout -B` there silently re-bases any task spawned **mid-train** onto a
-> throwaway branch (`mt-…`) instead of `main`/`dev`. That task then loses its
-> autopilot/critic/plan-gate wiring because its base ref vanishes when the train
-> finishes and the branch is deleted — and the New Task form is opaque, so the
-> operator won't notice. Do **all** rebasing in an **isolated scratch worktree**;
-> the home base stays on its original branch for the entire train.
+> **Don't move the home base's checked-out branch.** The primary working
+> directory — where the Shepherd server runs — is the **home base**, and it is a
+> live checkout the operator and any non-isolated session share. Do all rebasing
+> in an **isolated scratch worktree**; the home base stays on its original branch
+> for the entire train. New tasks base off the repo default branch
+> (`origin/HEAD`), so a stray checkout usually won't re-base them — but where
+> `origin/HEAD` is unset the checked-out branch is the fallback, and a task
+> spawned mid-train would then cut from a throwaway `mt-…` branch that vanishes
+> when the train finishes.
 
 **Set up once, before the loop** — capture the home-base branch and add a
 scratch worktree (never reused by Shepherd sessions):
@@ -170,7 +169,7 @@ Report a final summary: what merged, what was held, and any follow-ups.
   off main, zero merge commits relative to `origin/main`.
 - **i18n parity** — `cd ui && bun run check:i18n`: any new user-facing string
   needs matching keys in **both** `ui/messages/en.json` and `de.json`.
-- **Tests/lint** — root: `bun install && bun run lint && bun test`; UI:
+- **Tests/lint** — root: `bun install && bun run lint && bun run test`; UI:
   `cd ui && bun install && bun run check && bun run test` (vitest, not `bun test`).
   Run only when a verdict is uncertain and the diff warrants local verification;
   otherwise trust CI rollup.
@@ -183,4 +182,4 @@ Report a final summary: what merged, what was held, and any follow-ups.
 - Re-evaluate after every merge; concurrent agents make a stale plan dangerous.
 - A red gate removes a PR from the train; it never gets bypassed.
 - Never move the home base's checked-out branch — rebase in an isolated scratch
-  worktree so tasks spawned mid-train still cut from the correct base.
+  worktree.

--- a/.claude/skills/shepherd-onboarding/SKILL.md
+++ b/.claude/skills/shepherd-onboarding/SKILL.md
@@ -19,14 +19,13 @@ Two paths share one spine. **Greenfield** = a near-empty repo with a PRD/spec.
 only at intake (Stage 0–1) and at the CLAUDE.md content (Stage 2); Stages 3–6 are
 identical.
 
-This skill is **self-contained**: it ships in the Shepherd repo and runs in _other_
-operators' repos, so it never references any operator-specific command or external
-planning skill. Everything it needs is in this file and its `references/`.
+Work only from this file and its `references/` — this skill runs in **other operators'
+repos**, where no operator-specific command or external planning skill exists.
 
 ## Stages
 
-Work the stages in order. Create a TodoWrite item per stage. **Nothing outward
-(issue creation, body edits) happens before the Stage 4 approval gate.**
+Work the stages in order. **Nothing outward (issue creation, body edits) happens
+before the Stage 4 approval gate.**
 
 | Stage                  | What happens                                                              | Detail                             |
 | ---------------------- | ------------------------------------------------------------------------- | ---------------------------------- |
@@ -39,7 +38,7 @@ Work the stages in order. Create a TodoWrite item per stage. **Nothing outward
 | 6. Point to first task | Below — name the DAG roots and the first slice                            | this file                          |
 
 **Read `references/claude-md-contract.md` before Stage 2** — it lists what the
-CLAUDE.md must _not_ contain, which is where this stage usually goes wrong.
+CLAUDE.md must _not_ contain.
 
 ### 4. Approve (hard gate)
 

--- a/agent-skills/.claude/skills/shepherd-preview/SKILL.md
+++ b/agent-skills/.claude/skills/shepherd-preview/SKILL.md
@@ -13,9 +13,9 @@ enabled, onto the tailnet). It finds the server by port.
 Start it **from this worktree**. That is the case the preview is built around, and it keeps the
 server next to the code you are changing.
 
-Prototyping from your scratchpad works too — Shepherd recognises a server you started there by the
-session marker every process you spawn inherits, so it is no longer invisible. It is still the
-second-best option: nothing in the scratchpad ends up in the PR.
+Prototyping from your scratchpad works too: Shepherd finds a server you start there by the session
+marker every process you spawn inherits. It is still the second-best option — nothing in the
+scratchpad ends up in the PR.
 
 ## Pointing the preview at a specific port
 

--- a/agent-skills/.claude/skills/shepherd-pull-requests/SKILL.md
+++ b/agent-skills/.claude/skills/shepherd-pull-requests/SKILL.md
@@ -64,10 +64,9 @@ Declare them in the PR body with EITHER carrier:
 
 Prefix a step with `POST-MERGE:` when it must happen AFTER the PR merges.
 
-**DEFAULT TO DECLARING NOTHING.** Most PRs need NO manual steps. Add a step ONLY for a real
-out-of-band action a human must take; if merging fully completes the change, OMIT the carrier
-entirely. NEVER invent steps to fill the block — a spurious step is worse than none. When in doubt,
-declare nothing.
+Most PRs need no manual steps: if merging fully completes the change, omit the carrier entirely.
+Declare a step only for a real out-of-band action a human must take — an un-acked non-`POST-MERGE`
+step blocks the PR's auto-merge, so a spurious one strands a PR that was otherwise ready to land.
 
 If you have already opened the PR when you realize a step is owed, add it with
 `gh pr edit --body` rather than opening a second PR.


### PR DESCRIPTION
Audited the six shipped skill files with the `prompt-audit` procedure from [anthropics/skills](https://github.com/anthropics/skills/blob/main/skills/claude-api/shared/prompt-audit.md), then applied the high- and medium-confidence findings.

The procedure's frame is **"every token earns its place"**, explicitly *not* "make it short" — so this is a correctness pass. Net −3 lines. Reasoned constraints, fragile-operation scripts and working redundancy all stay.

## Provenance — why this is concentrated in one file

Five of the six files went through #2016 (doctor pass) and/or #2018 (Claude 5 context-engineering rules) and are largely clean. `merge-train/SKILL.md` was authored **2026-06-16** and has **never been edited since** — neither pass touched it. Both high-confidence findings are in it, and both are the same failure mode: skill text contradicting code.

The two `shepherd-onboarding/references/*.md` files yielded nothing and are untouched.

## Findings applied

| # | Finding | prompt-audit pattern | Confidence | Action |
| --- | --- | --- | --- | --- |
| F1 | merge-train's home-base rule rests on a mechanism #828 removed | 1d Fossils + 2 Volatile specifics | High | rewrite ×2 |
| F2 | Five capped emphases stacking one manual-steps instruction | 1a Pressure language + 1c Padding | High | rewrite |
| F3 | Gate rules prescribe a bare `bun test` that CLAUDE.md forbids | 2 Volatile specifics | High | rewrite |
| F4 | "Create a TodoWrite item per stage" | 1b plan-before-acting + 3 tool names in prose | Medium | remove ×2 |
| F5 | "so it is no longer invisible" | 1d Migration-relative phrasing | Medium | rewrite |
| F6 | "This skill is self-contained" — maintainer note, not agent instruction | 2 Verbose SKILL.md | Medium | rewrite |
| F7 | "…which is where this stage usually goes wrong" | 1c Strategy coaching | Medium | remove clause |

### F1 — the home-base fossil

The skill claimed Shepherd cuts every new task branch from the home base's checked-out `HEAD`, and warned in caps against a `git checkout` there. PR #828 — *"fix(task): base new tasks off the repo default branch, not the current checkout"* — **merged 2026-06-19, three days after this skill landed**:

- `ui/src/lib/api.ts` → `pickBaseBranch()`, by its own comment the "single source for every New Task / quick-launch / merge-train spawn site", resolves `origin/HEAD` **first**
- `src/branches.ts` → `listBranches()` reads the `origin/HEAD` symref (same PR)
- `src/drain.ts` resolves `forge.defaultBranch()` or a pinned epic branch — it never reads the home base's `HEAD`

**Kept, because it is still true:** `listBranches()` leaves `default` null when `origin/HEAD` is unset, and `pickBaseBranch()` then falls back to `current`; the home base is also a live checkout the operator and non-isolated sessions share. So the scratch-worktree procedure stays — only the falsified justification is replaced, in both places it appeared (the §6 blockquote and the Principles bullet, whose trailing clause repeated the same dead mechanism).

### F3 — a root test command the repo forbids

§Gate rules told reviewers to run root `bun install && bun run lint && bun test`. `CLAUDE.md` §Verify forbids the bare form by name, because `package.json` scopes the root script to `bun test ./test`; bare `bun test` picks up `ui/`'s vitest rune tests and fails spuriously — on the one path where the skill says to trust local verification over the CI rollup.

Commit `850449fbc` introduced **both** `"test": "bun test ./test"` and this skill, so it shipped contradicting its own commit. The same bullet gets the UI half right ("vitest, not `bun test`"); only the root half changes.

### F2 — the manual-steps emphasis stack

Five capped emphases stated one instruction five ways, and never gave the reason. Replaced with the concrete consequence from `src/automerge-core.ts`: an un-acked non-`POST-MERGE` step blocks the PR's auto-merge, so a spurious one strands a PR that was otherwise ready to land.

## Considered and deliberately kept

prompt-audit's keep list binds as hard as its pattern tables, and *"an audit that finds nothing should change nothing."*

- The duplicated import hand-off in `shepherd-onboarding` — keep-list #8 (working redundancy) and #10 (one end-of-prompt recap is a known good pattern); the two copies agree.
- merge-train's fixed verdict block — #7, format-pinning on a genuinely format-sensitive output the main agent parses.
- "On **any** failure, stop the train" and the read-only reviewer allowlist — #3 and #5.
- The "never hunt for the operator password" line — 1e: a real security boundary with its reason attached.
- **Low-confidence flag, not edited:** merge-train's frontmatter enumerates three near-synonymous trigger phrases. Group 2 documents *growth*; this description has one commit and has never grown. Group 3 protects routing text, skills currently under-trigger, and there is no trigger eval to check a cut against.
- **Group 4 checks run, both clean:** merge-train's model-call sites are genuine judgment (not a deterministic plan the model is executing); token accounting already exists (`docs/research/standing-prompt-trim-2026-08-03.md`, `scripts/measure-spawn-prefix.sh`).

## Verification

Every factual claim in all six files was checked against current code — ports, routes, fence grammars, script names, hint-file precedence, excluded debugger ports. Twelve claims, ten hold; the two that did not are F1 and F3.

`bun run test` 9074 pass / 0 fail, `bun run lint` clean, prettier clean. `test/agent-skills.test.ts` runs the **real** `parseEpicBody()` over `shepherd-pull-requests/SKILL.md` — the ` ```epic-dag ` example block is byte-identical, so that pin still passes. Pre-push gates (tsc, extension, root tests, ui, fallow delta) all green.

## Follow-up

Tracked as #2206 — the manual-steps guidance also ships from `MANUAL_STEPS_NOTICE` and the tool guard's `PR_CREATE_CONTEXT`, both still in the pre-audit register. In-code prompt constants were explicitly scoped out of this audit, so they are not touched here. Note that the guard copy co-occurs with the skill (it fires at `gh pr create` rather than replacing the skill), so that one is the half worth fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

