### PR TITLE
feat(codex): add GPT-6 Astra and default to GPT-5.6 Sol

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -895,10 +895,10 @@ export const config = {
   // value applies to both the New Task picker and drain/autopilot auto-spawns. Env seeds
   // a fresh DB; absent/invalid → "auto".
   defaultModel: normalizeDefaultModelSetting(process.env.SHEPHERD_DEFAULT_MODEL) ?? "auto",
-  // Provider-specific Codex default. Existing installs seed to the picker's historical first
-  // choice; "default" means no --model flag and lets Codex choose.
+  // Provider-specific Codex default. Persisted operator choices override this seed;
+  // "default" means no --model flag and lets Codex choose.
   defaultCodexModel:
-    normalizeDefaultCodexModelSetting(process.env.SHEPHERD_DEFAULT_CODEX_MODEL) ?? "gpt-5.5",
+    normalizeDefaultCodexModelSetting(process.env.SHEPHERD_DEFAULT_CODEX_MODEL) ?? "gpt-5.6-sol",
   // Global default reasoning-effort setting ("default" | <tier>). "default" = emit no effort flag.
   // Applies to the New Task picker and drain/autopilot auto-spawns. Env seeds a fresh DB;
   // absent/invalid → "default". Persisted + UI-configurable. No "auto" tier (effort has no promo).

--- a/src/default-model.ts
+++ b/src/default-model.ts
@@ -48,6 +48,11 @@ export function normalizeDefaultCodexModelSetting(value: unknown): string | null
   return CODEX_SETTING_VALUES.has(value) ? value : null;
 }
 
+/** A persisted choice overrides the config seed; invalid stored data uses the provider default. */
+export function resolvePersistedDefaultCodexModel(saved: string | null, seed: string): string {
+  return saved === null ? seed : (normalizeDefaultCodexModelSetting(saved) ?? "default");
+}
+
 /**
  * Map a SETTING string to the spawn-ready model value passed to service.create().
  * "auto" and "default" both resolve to null (no --model flag).

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,7 @@ import { resolveNodeHost, TailscaleServeService } from "./tailscale";
 import {
   drainSpawnModel,
   modelForProviderOrDefault,
-  normalizeDefaultCodexModelSetting,
+  resolvePersistedDefaultCodexModel,
   normalizeDefaultModelSetting,
   normalizeFableAvailable,
   normalizeRoleCli,
@@ -329,9 +329,7 @@ if (savedDm !== null) {
   if (v !== null) config.defaultModel = v;
 }
 const savedDcm = store.getSetting("defaultCodexModel");
-if (savedDcm !== null) {
-  config.defaultCodexModel = normalizeDefaultCodexModelSetting(savedDcm) ?? "default";
-}
+config.defaultCodexModel = resolvePersistedDefaultCodexModel(savedDcm, config.defaultCodexModel);
 const savedDe = store.getSetting("defaultEffort");
 if (savedDe !== null) {
   const v = normalizeDefaultEffortSetting(savedDe);

--- a/src/types.ts
+++ b/src/types.ts
@@ -380,10 +380,11 @@ export const EFFORTS = ["low", "medium", "high", "xhigh", "max"] as const;
 /** Curated Codex CLI model aliases shown in the task dialog. The server accepts any safe Codex
  *  model alias because the installed Codex CLI may learn new names before Shepherd does. */
 export const CODEX_MODELS = [
-  "gpt-5.5",
   "gpt-5.6-sol",
+  "gpt-6-astra",
   "gpt-5.6-terra",
   "gpt-5.6-luna",
+  "gpt-5.5",
   "gpt-5.4",
   "gpt-5.3-codex",
   "gpt-5.1-codex",

--- a/test/config-defaults.test.ts
+++ b/test/config-defaults.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+
+describe("Codex model config seed", () => {
+  test.each([
+    [undefined, "gpt-5.6-sol"],
+    ["not-a-curated-model", "gpt-5.6-sol"],
+    ["gpt-5.5", "gpt-5.5"],
+    ["default", "default"],
+  ])("environment %s resolves to %s", (value, expected) => {
+    const env = { ...process.env };
+    delete env.SHEPHERD_DEFAULT_CODEX_MODEL;
+    if (value !== undefined) env.SHEPHERD_DEFAULT_CODEX_MODEL = value;
+    const result = Bun.spawnSync({
+      cmd: [
+        process.execPath,
+        "--eval",
+        'import { config } from "./src/config.ts"; console.log(config.defaultCodexModel);',
+      ],
+      cwd: fileURLToPath(new URL("..", import.meta.url)),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString().trim()).toBe(expected);
+  });
+});

--- a/test/default-model.test.ts
+++ b/test/default-model.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, test, expect, describe } from "bun:test";
 import {
   normalizeDefaultCodexModelSetting,
+  resolvePersistedDefaultCodexModel,
   normalizeDefaultModelSetting,
   normalizeRepoDefaultModelSetting,
   resolveDefaultModelSetting,
@@ -77,6 +78,17 @@ describe("normalizeDefaultCodexModelSetting", () => {
     expect(normalizeDefaultCodexModelSetting("auto")).toBeNull();
     expect(normalizeDefaultCodexModelSetting("gpt-6-unknown")).toBeNull();
     expect(normalizeDefaultCodexModelSetting(null)).toBeNull();
+  });
+});
+
+describe("resolvePersistedDefaultCodexModel", () => {
+  test.each([
+    [null, "gpt-5.6-sol"],
+    ["gpt-5.5", "gpt-5.5"],
+    ["default", "default"],
+    ["invalid-model", "default"],
+  ])("stored %s resolves to %s", (saved, expected) => {
+    expect(resolvePersistedDefaultCodexModel(saved, "gpt-5.6-sol")).toBe(expected);
   });
 });
 

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "feat_codex_astra_title": "GPT-6 Astra ist auswählbar",
+  "feat_codex_astra_body": "Wähle GPT-6 Astra in der Codex-Modellauswahl. GPT-5.6 Sol ist jetzt Shepherds eingebauter Codex-Standard; deine gespeicherte Modellwahl bleibt erhalten.",
   "app_shell_heading": "Shepherd Missionskontrolle",
   "common_loading": "lädt…",
   "common_close": "schließen",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "feat_codex_astra_title": "GPT-6 Astra is selectable",
+  "feat_codex_astra_body": "Choose GPT-6 Astra in the Codex model pickers. GPT-5.6 Sol is now Shepherd's built-in Codex default; your saved model choices stay as they are.",
   "app_shell_heading": "Shepherd mission control",
   "common_loading": "loading…",
   "common_close": "close",

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -1815,8 +1815,8 @@ describe("NewTask Codex model picker", () => {
     expect(options).toContain("gpt-5.5");
     expect(options.slice(0, 5)).toEqual([
       "default",
-      "gpt-5.5",
       "gpt-5.6-sol",
+      "gpt-6-astra",
       "gpt-5.6-terra",
       "gpt-5.6-luna",
     ]);
@@ -1864,8 +1864,8 @@ describe("NewTask Codex model picker", () => {
 
     await expect
       .poll(() => Array.from(modelSelect().options).map((o) => o.value))
-      .toContain("gpt-5.4");
-    modelSelect().value = "gpt-5.4";
+      .toContain("gpt-6-astra");
+    modelSelect().value = "gpt-6-astra";
     modelSelect().dispatchEvent(new Event("change", { bubbles: true }));
 
     await fillPromptAndClickRun();
@@ -1873,7 +1873,7 @@ describe("NewTask Codex model picker", () => {
     await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
     expect(onsubmit.mock.calls[0]?.[0]).toMatchObject({
       agentProvider: "codex",
-      model: "gpt-5.4",
+      model: "gpt-6-astra",
     });
   });
 
@@ -3052,7 +3052,7 @@ describe("NewTask manual provider change (preserved reset semantics)", () => {
     // Manual provider change: unconditional reset to the new provider's default.
     providerSel().value = "codex";
     providerSel().dispatchEvent(new Event("change", { bubbles: true }));
-    await expect.poll(() => modelSel().value).toBe("gpt-5.5");
+    await expect.poll(() => modelSel().value).toBe("gpt-5.6-sol");
   });
 });
 

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -224,7 +224,7 @@
   let model = $state(
     safeInitial ??
       preselectModel(
-        agentProvider === "codex" ? (defaultCodexModel ?? "gpt-5.5") : defaultModel,
+        agentProvider === "codex" ? (defaultCodexModel ?? "gpt-5.6-sol") : defaultModel,
         agentProvider,
         fableAvailable,
       ),
@@ -681,7 +681,7 @@
   function modelSettingFor(provider: AgentProvider): string {
     const override = repoPath ? repoConfig.defaultModelFor(repoPath) : "inherit";
     const setting =
-      provider === "codex" ? (defaultCodexModel ?? "gpt-5.5") : (defaultModel ?? "auto");
+      provider === "codex" ? (defaultCodexModel ?? "gpt-5.6-sol") : (defaultModel ?? "auto");
     return override !== "inherit" &&
       (override === "auto" ||
         override === "default" ||

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -180,8 +180,8 @@
   let defaultModel = $state("auto"); // raw default-model setting (auto|default|<alias>)
   let defaultModelSaved = "auto";
   let defaultModelBusy = $state(false);
-  let defaultCodexModel = $state("gpt-5.5");
-  let defaultCodexModelSaved = "gpt-5.5";
+  let defaultCodexModel = $state("gpt-5.6-sol");
+  let defaultCodexModelSaved = "gpt-5.6-sol";
   let defaultCodexModelBusy = $state(false);
   let defaultAgentProvider = $state<AgentProvider>("claude");
   let defaultAgentProviderSaved: AgentProvider = "claude";
@@ -293,7 +293,7 @@
       payload = s; // the section panels seed their own state from this
       defaultModel = s.defaultModel ?? "auto";
       defaultModelSaved = defaultModel;
-      defaultCodexModel = s.defaultCodexModel ?? "gpt-5.5";
+      defaultCodexModel = s.defaultCodexModel ?? "gpt-5.6-sol";
       defaultCodexModelSaved = defaultCodexModel;
       defaultAgentProvider = s.defaultAgentProvider ?? "claude";
       defaultAgentProviderSaved = s.defaultAgentProvider ?? "claude";

--- a/ui/src/lib/components/UpNextPanel.browser.test.ts
+++ b/ui/src/lib/components/UpNextPanel.browser.test.ts
@@ -537,7 +537,7 @@ describe("UpNextPanel provider picker", () => {
           .map((o) => o.value)
           .slice(0, 5),
       )
-      .toEqual(["default", "gpt-5.5", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]);
+      .toEqual(["default", "gpt-5.6-sol", "gpt-6-astra", "gpt-5.6-terra", "gpt-5.6-luna"]);
     await expect.poll(() => Array.from(model.options).map((o) => o.value)).toContain("gpt-5.4");
     model.value = "gpt-5.4";
     model.dispatchEvent(new Event("change", { bubbles: true }));

--- a/ui/src/lib/demo/seed.ts
+++ b/ui/src/lib/demo/seed.ts
@@ -987,7 +987,7 @@ function buildSettings(): Settings {
     autoReviveEnabled: false,
     sessionHousekeepingEnabled: true,
     defaultModel: "auto",
-    defaultCodexModel: "gpt-5.5",
+    defaultCodexModel: "gpt-5.6-sol",
     defaultEffort: "default",
     operatorLanguage: "en",
     criticCli: "inherit",

--- a/ui/src/lib/feature-announcements/entries/v1.48.0-codex-astra.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.48.0-codex-astra.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "codex-astra",
+  sinceVersion: "1.48.0",
+  titleKey: "feat_codex_astra_title",
+  bodyKey: "feat_codex_astra_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -2285,10 +2285,11 @@ export const EFFORTS = ["low", "medium", "high", "xhigh", "max"] as const;
 
 /** Curated Codex CLI model aliases shown in the task dialog. */
 export const CODEX_MODELS = [
-  "gpt-5.5",
   "gpt-5.6-sol",
+  "gpt-6-astra",
   "gpt-5.6-terra",
   "gpt-5.6-luna",
+  "gpt-5.5",
   "gpt-5.4",
   "gpt-5.3-codex",
   "gpt-5.1-codex",


### PR DESCRIPTION
## Summary

Adds GPT-6 Astra to the shared Codex model pickers and changes Shepherd's built-in Codex default from GPT-5.5 to GPT-5.6 Sol. Explicitly saved model choices, including GPT-5.5, remain unchanged. Includes an English/German What's-New entry.

Regression coverage checks Astra selection and submission, the default for absent/invalid environment settings, and preservation of persisted choices.

## Validation

- Root: `bun run lint`; `bun run test` — 9,081 passed, 16 skipped.
- UI: `bun run check`; `bun run test` — 4,777 passed.
- Model-mirror, i18n parity, glossary, and changed-file formatting checks passed.

## Checklist

- [x] Conventional-commit PR title.
- [x] Branch cut from `main`, with linear history.
- [x] Root lint/tests and UI check/tests pass.
- [x] User-facing text uses both locale catalogs.
- [x] Feature-announcement entry included.
- [x] Existing picker design retained.
- [x] User-facing behavior documented in What's New.
