### PR TITLE
fix(herdr): key the agent_name_taken squatter eviction on the tab label (#2033)

### DIFF
--- a/.claude/rules/herdr-version-bump.md
+++ b/.claude/rules/herdr-version-bump.md
@@ -52,10 +52,11 @@ shipped stable).
 2. **Run the check:** `bun run herdr:compat -- --candidate <version>`. Static half: schema diff,
    the #2032 record-shape gate (`TabInfo`/`PaneInfo`/`AgentInfo` required/nullable drift = FAIL),
    and a `--help` diff over every subcommand Shepherd invokes. Live half: candidate vs. baseline
-   (= current ceiling) as isolated servers, probes L1–L9 (reaper assumptions from #2029/#2032,
+   (= current ceiling) as isolated servers, probes L1–L10 (reaper assumptions from #2029/#2032,
    tab-id reuse #569, last-tab behaviour #1760, the external-registration spawn replay #1890,
-   the #1716 idle probe, the status surface, and the terminal contract via
-   `scripts/verify-herdr-terminal.ts`). Report: `docs/herdr-compat/<version>.md`, exit 1 on FAIL.
+   the #1716 idle probe, the status surface, the terminal contract via
+   `scripts/verify-herdr-terminal.ts`, and whether a duplicate `--agent` registration collides
+   #2033). Report: `docs/herdr-compat/<version>.md`, exit 1 on FAIL.
 3. **Triage every REVIEW, fix or consciously accept every FAIL.** Behavioural changes get code
    (as #2056's last-tab guard did) and a test pinning the new behaviour.
 4. **Regenerate the vendored protocol** against the candidate:

--- a/scripts/herdr-compat.ts
+++ b/scripts/herdr-compat.ts
@@ -9,7 +9,7 @@
  * Static half (no server): schema diff + #2032 record-shape gate from `api schema --json`,
  * plus a `--help` surface diff over every subcommand Shepherd drives. Live half: candidate and
  * baseline each run as an ISOLATED headless server (own HOME/XDG/socket — the operator's
- * daemon is never touched) and the L1–L9 probes are measured A/B. Output: a markdown report
+ * daemon is never touched) and the L1–L10 probes are measured A/B. Output: a markdown report
  * at docs/herdr-compat/<candidate>.md (committed by the eventual bump PR) and exit 1 iff any
  * check FAILs (REVIEW items are triage work, not machine verdicts).
  */

--- a/scripts/herdr-compat.ts
+++ b/scripts/herdr-compat.ts
@@ -228,6 +228,28 @@ function liveChecks({ base, cand }: AB, l9: { ran: boolean; exit: number | null 
       : "Did not run (no workspace or earlier failure) — run it by hand against a candidate server.",
   });
 
+  checks.push({
+    id: "L10",
+    title: "duplicate --agent registration collides (squatter eviction, #2033)",
+    verdict:
+      cand.duplicateNameRejected === null
+        ? "REVIEW"
+        : cand.duplicateNameRejected === base.duplicateNameRejected &&
+            cand.duplicateNameErrorCode === base.duplicateNameErrorCode
+          ? "PASS"
+          : "REVIEW",
+    details:
+      abTable([
+        ["duplicate rejected", show(base.duplicateNameRejected), show(cand.duplicateNameRejected)],
+        ["error code", show(base.duplicateNameErrorCode), show(cand.duplicateNameErrorCode)],
+      ]) +
+      (cand.duplicateNameRejected === true
+        ? "\n\nThe register-path `agent_name_taken` retry is LIVE: its squatter eviction (#2033, keyed on the tab label) is what keeps a colliding spawn self-healing."
+        : cand.duplicateNameRejected === false
+          ? "\n\nThis herdr ACCEPTS a duplicate registration, so the register-path collision retry is defensive only — harmless, and it guards a herdr that starts refusing. A flip either way is a behaviour change worth a look."
+          : "\n\nNot measured — re-run, or exercise it by hand before trusting the register-path collision retry."),
+  });
+
   const notes = [
     ...base.notes.map((n) => `baseline: ${n}`),
     ...cand.notes.map((n) => `candidate: ${n}`),

--- a/scripts/herdr-compat/probes.ts
+++ b/scripts/herdr-compat/probes.ts
@@ -248,20 +248,28 @@ export async function runProbes(
     for (const argv of register(heldPane)) await runOk(server, argv);
 
     // The colliding spawn. The refusal can surface on either half of the register pair.
+    //
+    // The verdict is accumulated LOCALLY and published only once the pair has actually been run
+    // through: writing `false` up front would let a throw part-way (a dead server, a failed run)
+    // land in the report as "this herdr ACCEPTS duplicates" — a measurement nobody made. An abort
+    // must leave the field null, which the report renders as "not measured".
     const dupPane = await livePane(`${squatName}-dup`);
-    o.duplicateNameRejected = false;
+    let rejected = false;
+    let rejectionCode: string | null = null;
     for (const argv of register(dupPane)) {
       const res = await server.run(argv);
       const code = errorCode(res.stdout) ?? errorCode(res.stderr);
       if (res.exitCode !== 0 || code !== null) {
-        o.duplicateNameRejected = true;
-        o.duplicateNameErrorCode = code;
+        rejected = true;
+        rejectionCode = code;
         break;
       }
     }
+    o.duplicateNameRejected = rejected;
+    o.duplicateNameErrorCode = rejectionCode;
   } catch (err) {
-    // `duplicateNameRejected` is assigned only after the squatter is bound and holding, so an abort
-    // here leaves it null — "not measured", which is exactly what the report must show.
+    // `duplicateNameRejected` is published only after the duplicate registration has been run
+    // through, so an abort here leaves it null — "not measured", which is what the report shows.
     o.notes.push(
       `duplicate-name probe failed: ${err instanceof Error ? err.message : String(err)}`,
     );

--- a/scripts/herdr-compat/probes.ts
+++ b/scripts/herdr-compat/probes.ts
@@ -6,7 +6,7 @@
  * them into verdicts. Observations are facts ("what did this herdr do"), never judgements —
  * when a step can't be measured the field stays null/"undetermined" rather than guessing.
  *
- * The catalog (ids L1–L8 here; L9 = scripts/verify-herdr-terminal.ts, run by the caller):
+ * The catalog (ids L1–L8 and L10 here; L9 = scripts/verify-herdr-terminal.ts, run by the caller):
  *  L1  tab.list returns a non-null label for every tab            (reaper keying, #2029)
  *  L2  an agentless tab reports agent_status "unknown"            (husk detection, #2029)
  *  L3  pane process-info returns foreground procs for a shell     (fail-closed spare, #2029)
@@ -16,6 +16,7 @@
  *  L7  report-agent --state idle: does it land on idle or done?   (herdr #1716 / sandbox floor)
  *  L8  `status server` stays parseable (status: running + version line) — the surface this
  *      SOP's isolated servers, the downgrade script and operator diagnostics read
+ *  L10 a DUPLICATE `--agent` registration: does herdr reject it, and with which code? (#2033)
  */
 
 import type { IsolatedServer } from "./isolated-server";
@@ -42,6 +43,12 @@ export interface LiveObservations {
   statusAfterIdle: string | null;
   /** L8: `status server` exits 0, says "status: running" and carries a parseable version. */
   statusParseable: boolean | null;
+  /** L10: did re-binding an already-registered `--agent` name on a second pane get refused?
+   *  null = the probe could not run it. */
+  duplicateNameRejected: boolean | null;
+  /** L10: the `error.code` of that refusal (`agent_name_taken` is what the retries assume);
+   *  null when nothing was refused, or the refusal carried no JSON error envelope. */
+  duplicateNameErrorCode: string | null;
   /** Anything worth carrying into the report verbatim. */
   notes: string[];
 }
@@ -52,6 +59,16 @@ interface JsonObject {
 const obj = (v: unknown): JsonObject =>
   typeof v === "object" && v !== null ? (v as JsonObject) : {};
 const arr = (v: unknown): unknown[] => (Array.isArray(v) ? v : []);
+
+/** The `error.code` of a herdr CLI JSON error envelope, or null when the text is not one. */
+function errorCode(raw: string): string | null {
+  try {
+    const code = obj(obj(JSON.parse(raw)).error).code;
+    return typeof code === "string" ? code : null;
+  } catch {
+    return null;
+  }
+}
 
 /** run() and throw on non-zero exit — for herdr commands that print nothing on success. */
 async function runOk(server: IsolatedServer, argv: string[]): Promise<void> {
@@ -88,6 +105,8 @@ export async function runProbes(
     statusAfterWorking: null,
     statusAfterIdle: null,
     statusParseable: null,
+    duplicateNameRejected: null,
+    duplicateNameErrorCode: null,
     notes: [],
   };
 
@@ -163,6 +182,89 @@ export async function runProbes(
     if (afterIdle) o.statusAfterIdle = String(afterIdle.agent_status ?? "");
   } catch (err) {
     o.notes.push(`spawn replay failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // L10: does a DUPLICATE `--agent` registration actually collide? (#2033)
+  //
+  // Both drivers carry an `agent_name_taken` retry at the REGISTER step that evicts the squatter
+  // holding the name — on the assumption that herdr refuses a second registration under a name in
+  // use, which the code itself records as unverified. Either answer is fine for Shepherd (a herdr
+  // that accepts the duplicate simply makes the retry defensive); a CHANGE between versions is what
+  // needs a human.
+  //
+  // SELF-CONTAINED on purpose: it registers its OWN name on a fresh pane and holds it at `working`,
+  // rather than reusing L6's agent. L7 has already pushed that one to `idle` by now, and a herdr
+  // that releases a finished agent's name would make this probe answer "no collision" for the wrong
+  // reason — as it also would whenever L6's registration failed and the name was never bound.
+  try {
+    const squatName = "shepherd-compat-squat";
+    /** Fresh tab + pane running something long-lived, ready to be registered against. */
+    const livePane = async (label: string): Promise<string> => {
+      const tab = obj(
+        obj(
+          await server.runJson([
+            "tab",
+            "create",
+            "--cwd",
+            server.workDir,
+            "--label",
+            label,
+            "--no-focus",
+          ]),
+        ).result,
+      );
+      const paneId = String(obj(tab.root_pane).pane_id);
+      await runOk(server, ["pane", "run", paneId, "sleep 300"]);
+      return paneId;
+    };
+    const register = (paneId: string): string[][] => [
+      [
+        "pane",
+        "report-agent-session",
+        paneId,
+        "--source",
+        "shepherd",
+        "--agent",
+        squatName,
+        "--agent-session-id",
+        `shepherd-${paneId}`,
+      ],
+      [
+        "pane",
+        "report-agent",
+        paneId,
+        "--source",
+        "shepherd",
+        "--agent",
+        squatName,
+        "--state",
+        "working",
+      ],
+    ];
+
+    // The squatter: bound to `squatName` and left WORKING, exactly the state a stale Shepherd agent
+    // is in when the next spawn collides with it.
+    const heldPane = await livePane(squatName);
+    for (const argv of register(heldPane)) await runOk(server, argv);
+
+    // The colliding spawn. The refusal can surface on either half of the register pair.
+    const dupPane = await livePane(`${squatName}-dup`);
+    o.duplicateNameRejected = false;
+    for (const argv of register(dupPane)) {
+      const res = await server.run(argv);
+      const code = errorCode(res.stdout) ?? errorCode(res.stderr);
+      if (res.exitCode !== 0 || code !== null) {
+        o.duplicateNameRejected = true;
+        o.duplicateNameErrorCode = code;
+        break;
+      }
+    }
+  } catch (err) {
+    // `duplicateNameRejected` is assigned only after the squatter is bound and holding, so an abort
+    // here leaves it null — "not measured", which is exactly what the report must show.
+    o.notes.push(
+      `duplicate-name probe failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 
   // L2 + L3 + L4 on a fresh agentless tab.

--- a/src/herdr-socket-driver.ts
+++ b/src/herdr-socket-driver.ts
@@ -4,6 +4,7 @@ import {
   HerdrDriver,
   HerdrSpawnUnsupportedError,
   TabLedger,
+  agentsHoldingName,
   buildWrappedArgv,
   classifyPaneWrite,
   createSerializer,
@@ -15,6 +16,7 @@ import {
   parseProcs,
   parseReadText,
   parseTabs,
+  readTabLabels,
   resolvePaneId,
   sanitizeHerdrAgentName,
   stopViaRecordedTab,
@@ -241,7 +243,7 @@ export class SocketHerdrDriver implements IHerdrDriver {
       // `HerdrDriver.startImpl075`.
       const sandboxed = argv.includes("bwrap");
       const agent = sandboxed
-        ? await this.resolveByRegistration(rootPaneId, sanitizeHerdrAgentName(name))
+        ? await this.resolveByRegistration(rootPaneId, name)
         : await this.resolveByAutoDetect(rootPaneId, name, opts?.signal);
       // Retain the authoritative spawn handle (#1852) — the tab is ours even if the process inside
       // dies before it next appears in `agent.list`.
@@ -254,14 +256,13 @@ export class SocketHerdrDriver implements IHerdrDriver {
   }
 
   /** Sandboxed resolve: externally register (surfaces the bwrap'd agent + establishes Shepherd's
-   *  lifecycle authority) then resolve from the live list. Socket sibling of the CLI driver's. */
-  private async resolveByRegistration(paneId: string, agentName: string): Promise<HerdrAgent> {
-    await this.registerAgentWithCollisionRetry(paneId, agentName);
+   *  lifecycle authority) then resolve from the live list. Socket sibling of the CLI driver's —
+   *  including its RAW-name contract: the sanitize happens at the RPC boundary below (#2033). */
+  private async resolveByRegistration(paneId: string, rawName: string): Promise<HerdrAgent> {
+    await this.registerAgentWithCollisionRetry(paneId, rawName);
     const agent = (await this.listAsync()).find((a) => a.paneId === paneId);
     if (!agent || !agent.terminalId) {
-      throw new Error(
-        `herdr: agent list has no registered agent for pane ${paneId} (${agentName})`,
-      );
+      throw new Error(`herdr: agent list has no registered agent for pane ${paneId} (${rawName})`);
     }
     return agent;
   }
@@ -335,7 +336,10 @@ export class SocketHerdrDriver implements IHerdrDriver {
    * tab-create/pane-run). The opaque per-pane `agent_session_id` (`shepherd-<paneId>`) is stable +
    * unique per spawn (one pane per spawn).
    */
-  private async registerAgentWithCollisionRetry(paneId: string, agentName: string): Promise<void> {
+  private async registerAgentWithCollisionRetry(paneId: string, rawName: string): Promise<void> {
+    // The name grammar is bound HERE, so this is the sanitize boundary; the raw name is kept for
+    // the TAB-label collision lookup below (#2033). Mirrors the CLI driver.
+    const agentName = sanitizeHerdrAgentName(rawName);
     const agentSessionId = `shepherd-${paneId}`;
     const MAX_ATTEMPTS = 3;
     for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
@@ -356,8 +360,13 @@ export class SocketHerdrDriver implements IHerdrDriver {
       } catch (err) {
         if (!isNameTakenError(err) || attempt === MAX_ATTEMPTS - 1) throw err;
         // Evict squatter(s) by name — never by regex-parsing the error string — then re-run the
-        // register pair against our existing pane.
-        const squatters = (await this.listAsync()).filter((a) => a.name === agentName);
+        // register pair against our existing pane. Keyed on the RAW name through
+        // `agentsHoldingName`, so a 0.7.5 `agent.list` without `name` still resolves them by TAB
+        // label (#2033). OUR OWN pane is excluded — its tab carries the same label.
+        const labels = await readTabLabels(this);
+        const squatters = agentsHoldingName(await this.listAsync(), rawName, () => labels).filter(
+          (a) => a.paneId !== paneId,
+        );
         for (const sq of squatters) await this.closeTab(sq.tabId, { allowLastTab: true });
       }
     }
@@ -445,8 +454,13 @@ export class SocketHerdrDriver implements IHerdrDriver {
         return res?.agent;
       } catch (err) {
         if (!isNameTakenError(err) || attempt === MAX_ATTEMPTS - 1) throw err;
-        // Evict squatter(s) by name — never by regex-parsing the error string
-        const squatters = (await this.listAsync()).filter((a) => a.name === name);
+        // Evict squatter(s) by name — never by regex-parsing the error string. Via
+        // `agentsHoldingName` so an `agent.list` without `name` still identifies them by TAB label
+        // (#2033); OUR just-created tab is excluded — it carries the same label.
+        const labels = await readTabLabels(this);
+        const squatters = agentsHoldingName(await this.listAsync(), name, () => labels).filter(
+          (a) => a.tabId !== tabId,
+        );
         for (const sq of squatters) await this.closeTab(sq.tabId, { allowLastTab: true });
       }
     }

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -526,21 +526,24 @@ export function sanitizeHerdrAgentName(raw: string): string {
  * it verbatim through `agent start`, and the 0.7.5+ register path binds
  * {@link sanitizeHerdrAgentName}(rawName).
  *
- * Two branches, in order:
- *  1. `name` matches → those agents, and the labels are never read. Wherever herdr still populates
- *     `name` AND something holds it, the result is exactly what the pre-#2033 filter returned.
- *  2. NO `name` matched → the TAB label, compared in herdr's own 0.7.5 name space (`sanitize` on
- *     both sides): 0.7.5 emits no `agent.name` at all, and `tab create --label` carries the RAW
- *     name while the register call binds the SANITIZED one — sanitized-space equality is what makes
- *     the two surfaces comparable. Deliberately NOT keyed on `agent`: that field holds the bare
- *     agent KIND (`"claude"`) for trusted auto-detected agents, so matching it would both alias the
- *     kind and miss an auto-detected squatter, which reports the kind rather than its name.
+ * A VERSION SWITCH, not a fall-through: which surface herdr populates decides which one is read.
+ *  1. ANY record carries `name` → this herdr populates the field, so its name space is
+ *     authoritative and is used EXCLUSIVELY — strict equality, labels never read. A record without
+ *     `name` in such a list genuinely holds no name. ≤0.7.4 always lands here, so its eviction is
+ *     byte-identical to before.
+ *  2. NO record carries `name` (0.7.5+, which emits it for nobody) → the TAB label, compared in
+ *     herdr's own name space (`sanitize` on both sides): `tab create --label` carries the RAW name
+ *     while the register call binds the SANITIZED one, so sanitized equality is what makes the two
+ *     surfaces comparable. Deliberately NOT keyed on `agent`: that field holds the bare agent KIND
+ *     (`"claude"`) for trusted auto-detected agents, so matching it would both alias the kind and
+ *     miss an auto-detected squatter, which reports the kind rather than its name.
  *
- * Note branch 2 is a FALL-THROUGH, not a version switch, so on a herdr that does send `name` this
- * is a SUPERSET of the old behaviour: a collision whose holder is absent from `agent list` (herdr's
- * own error calls such a candidate `status=Unknown`) now evicts the tab carrying that label, where
- * before it evicted nothing and the spawn was guaranteed to fail. That is the intent — the label
- * space searched is Shepherd's own — but it IS a behaviour change on ≤0.7.4, not a no-op.
+ * The switch is load-bearing, and an earlier revision of this function got it wrong. Branch 2's
+ * comparison is necessarily COARSER than herdr's ≤0.7.4 space: `sanitize` is lossy, so two
+ * genuinely different live sessions (`fix login`, `fix-login`) share one sanitized label. Letting
+ * branch 2 run as a mere fallback wherever branch 1 found nothing would let a raw-name collision
+ * evict the unrelated live session that merely sanitizes alike. Where herdr tells us the names, we
+ * believe it and evict nothing rather than guess from a coarser surface.
  *
  * No labels available (a herdr read failed, or the caller has no source) → empty set, never a
  * broader match: a failed read must not widen what gets closed.
@@ -554,8 +557,8 @@ export function agentsHoldingName(
   rawName: string,
   labels: TabLabelSource,
 ): HerdrAgent[] {
-  const byName = agents.filter((a) => a.name === rawName);
-  if (byName.length > 0) return byName;
+  // One record carrying the field is proof this herdr populates it — see the version switch above.
+  if (agents.some((a) => a.name !== undefined)) return agents.filter((a) => a.name === rawName);
   const map = labels();
   if (!map) return [];
   const wanted = sanitizeHerdrAgentName(rawName);

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -521,6 +521,64 @@ export function sanitizeHerdrAgentName(raw: string): string {
 }
 
 /**
+ * The agents that HOLD herdr agent name `rawName` — the squatters an `agent_name_taken` retry has
+ * to evict before it can re-attempt (#2033). `rawName` is the raw, human-facing name: ≤0.7.4 binds
+ * it verbatim through `agent start`, and the 0.7.5+ register path binds
+ * {@link sanitizeHerdrAgentName}(rawName).
+ *
+ * Two branches, in order:
+ *  1. `name` matches → those agents, and the labels are never read. Wherever herdr still populates
+ *     `name` AND something holds it, the result is exactly what the pre-#2033 filter returned.
+ *  2. NO `name` matched → the TAB label, compared in herdr's own 0.7.5 name space (`sanitize` on
+ *     both sides): 0.7.5 emits no `agent.name` at all, and `tab create --label` carries the RAW
+ *     name while the register call binds the SANITIZED one — sanitized-space equality is what makes
+ *     the two surfaces comparable. Deliberately NOT keyed on `agent`: that field holds the bare
+ *     agent KIND (`"claude"`) for trusted auto-detected agents, so matching it would both alias the
+ *     kind and miss an auto-detected squatter, which reports the kind rather than its name.
+ *
+ * Note branch 2 is a FALL-THROUGH, not a version switch, so on a herdr that does send `name` this
+ * is a SUPERSET of the old behaviour: a collision whose holder is absent from `agent list` (herdr's
+ * own error calls such a candidate `status=Unknown`) now evicts the tab carrying that label, where
+ * before it evicted nothing and the spawn was guaranteed to fail. That is the intent — the label
+ * space searched is Shepherd's own — but it IS a behaviour change on ≤0.7.4, not a no-op.
+ *
+ * No labels available (a herdr read failed, or the caller has no source) → empty set, never a
+ * broader match: a failed read must not widen what gets closed.
+ *
+ * `labels` is read AT MOST ONCE, and only on the collision path — a successful spawn pays nothing.
+ * Callers must exclude their OWN freshly-created handle from the result: the tab was created with
+ * `label: name` moments earlier, so it matches branch 2 by construction.
+ */
+export function agentsHoldingName(
+  agents: HerdrAgent[],
+  rawName: string,
+  labels: TabLabelSource,
+): HerdrAgent[] {
+  const byName = agents.filter((a) => a.name === rawName);
+  if (byName.length > 0) return byName;
+  const map = labels();
+  if (!map) return [];
+  const wanted = sanitizeHerdrAgentName(rawName);
+  return agents.filter((a) => {
+    const label = map.get(a.tabId);
+    return label !== undefined && sanitizeHerdrAgentName(label) === wanted;
+  });
+}
+
+/** Read `tab_id` → label for an {@link agentsHoldingName} lookup, best-effort: a failed `tab list`
+ *  yields `undefined`, which NARROWS the match to the `name` branch rather than widening it.
+ *  Shared by both drivers' collision retries, and only ever called from inside one (#2033). */
+export async function readTabLabels(
+  driver: Pick<IHerdrDriver, "tabsAsync">,
+): Promise<ReadonlyMap<string, string> | undefined> {
+  try {
+    return tabLabelMap(await driver.tabsAsync());
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Resolve a herdr `terminal_id` to its `pane_id` from an `agent list` snapshot. On herdr 0.7.5 the
  * driver's read/send/relabel must target `pane_id` — `terminal_id` and label are rejected as
  * `agent_not_found` — but Shepherd keys sessions on `terminal_id`, so this lookup is load-bearing.
@@ -1061,8 +1119,14 @@ export class HerdrDriver implements IHerdrDriver {
           // Non-name-taken error → propagate immediately; or attempts exhausted → propagate
           throw err;
         }
-        // Evict squatter(s) by name — never by regex-parsing the error string
-        const squatters = (await this.listAsync()).filter((a) => a.name === name);
+        // Evict squatter(s) by name — never by regex-parsing the error string. Resolved through
+        // `agentsHoldingName`, so an `agent list` that carries no `name` still identifies them by
+        // TAB label (#2033). OUR just-created tab is excluded: it was labelled with the same name
+        // moments ago, so it matches the label branch by construction.
+        const labels = await readTabLabels(this);
+        const squatters = agentsHoldingName(await this.listAsync(), name, () => labels).filter(
+          (a) => a.tabId !== tabId,
+        );
         for (const sq of squatters) await this.closeTab(sq.tabId, { allowLastTab: true });
       }
     }
@@ -1199,7 +1263,7 @@ export class HerdrDriver implements IHerdrDriver {
       // exactly as it did on ≤0.7.4 — resolving the spawn by waiting for auto-detection instead.
       const sandboxed = argv.includes("bwrap");
       const agent = sandboxed
-        ? await this.resolveByRegistration(paneId, sanitizeHerdrAgentName(name))
+        ? await this.resolveByRegistration(paneId, name)
         : await this.resolveByAutoDetect(paneId, name, opts?.signal);
       // Retain the authoritative spawn handle (#1852): the tab is ours even if the process inside
       // dies before it next appears in `agent list`.
@@ -1216,14 +1280,14 @@ export class HerdrDriver implements IHerdrDriver {
    * --state working`), which both surfaces it in `agent list` immediately AND establishes Shepherd's
    * lifecycle authority (herdr can't detect the bwrap'd agent, so Shepherd owns its state — #1891).
    * Resolve from the live list, joining on the pane_id we ran in; its terminal_id is Shepherd's key.
+   * Takes the RAW name and sanitizes at the RPC boundary below, so the collision retry keeps the
+   * raw form its TAB-label lookup needs (#2033).
    */
-  private async resolveByRegistration(paneId: string, agentName: string): Promise<HerdrAgent> {
-    await this.registerAgentWithCollisionRetry(paneId, agentName);
+  private async resolveByRegistration(paneId: string, rawName: string): Promise<HerdrAgent> {
+    await this.registerAgentWithCollisionRetry(paneId, rawName);
     const agent = (await this.listAsync()).find((a) => a.paneId === paneId);
     if (!agent || !agent.terminalId) {
-      throw new Error(
-        `herdr: agent list has no registered agent for pane ${paneId} (${agentName})`,
-      );
+      throw new Error(`herdr: agent list has no registered agent for pane ${paneId} (${rawName})`);
     }
     return agent;
   }
@@ -1296,11 +1360,15 @@ export class HerdrDriver implements IHerdrDriver {
    * ≤0.7.4 name-collision breaker but at the REGISTER step — on 0.7.5 the `--agent` name is bound
    * here, not at spawn, and our tab/pane/`claude` are already live — so a collision re-runs ONLY the
    * register pair (never tab-create/pane-run) after evicting same-named squatters. Whether
-   * `report-agent(-session)` even emits `agent_name_taken` is unverified; because `agentName` is
-   * sanitized AND de-duped upstream (`uniqueName`) and each spawn registers a freshly-created pane, a
-   * real collision is expected to be rare/absent, and the retry collapses to a single pass otherwise.
+   * `report-agent(-session)` even emits `agent_name_taken` is unverified — measured by the
+   * `herdr:compat` L10 probe since #2033; because the name is sanitized below AND de-duped upstream
+   * (`uniqueName`) and each spawn registers a freshly-created pane, a real collision is expected to
+   * be rare/absent, and the retry collapses to a single pass otherwise.
    */
-  private async registerAgentWithCollisionRetry(paneId: string, agentName: string): Promise<void> {
+  private async registerAgentWithCollisionRetry(paneId: string, rawName: string): Promise<void> {
+    // herdr's name grammar is bound HERE, not at spawn — so this is the sanitize boundary. The raw
+    // name is kept for the collision lookup below, which reads TAB labels (raw) (#2033).
+    const agentName = sanitizeHerdrAgentName(rawName);
     // Opaque per-pane associator: claude's own session id is unknown at spawn, and herdr only echoes
     // this back on the agent record — keeping agent_status fresh via a real session id is a separate
     // child (#1889). Stable + unique per spawn (one pane per spawn).
@@ -1334,8 +1402,14 @@ export class HerdrDriver implements IHerdrDriver {
       } catch (err) {
         if (!isNameTakenError(err) || attempt === MAX_ATTEMPTS - 1) throw err;
         // Evict squatter(s) by name — never by regex-parsing the error string — then re-run the
-        // register pair against our existing pane.
-        const squatters = (await this.listAsync()).filter((a) => a.name === agentName);
+        // register pair against our existing pane. Keyed through `agentsHoldingName` on the RAW
+        // name: 0.7.5 sends no `agent.name`, so the squatter is identified by its TAB label (which
+        // carries the raw name) compared in the sanitized space the registration binds (#2033).
+        // OUR OWN pane is excluded — its tab carries the same label.
+        const labels = await readTabLabels(this);
+        const squatters = agentsHoldingName(await this.listAsync(), rawName, () => labels).filter(
+          (a) => a.paneId !== paneId,
+        );
         for (const sq of squatters) await this.closeTab(sq.tabId, { allowLastTab: true });
       }
     }

--- a/src/review.ts
+++ b/src/review.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import type { SessionStore } from "./store";
-import type { HerdrDriver, HerdrAgent } from "./herdr";
+import { agentsHoldingName, tabLabelMap, type HerdrDriver, type HerdrAgent } from "./herdr";
 import type { WorktreeMgr } from "./worktree";
 import type { GitForge, GitState, PrStatus } from "./forge/types";
 import { CRITIC_REVIEW_MARKER, AUTHOR_RESPONSE_MARKER } from "./forge/types";
@@ -289,7 +289,7 @@ export interface ReviewServiceDeps extends MembraneSeams {
   // wait-for-the-deadline behavior. Tests exercising that layer MUST provide it.
   herdr: Pick<
     HerdrDriver,
-    "start" | "stop" | "list" | "closeTab" | "paneForegroundProcs" | "readAsync"
+    "start" | "stop" | "list" | "tabs" | "closeTab" | "paneForegroundProcs" | "readAsync"
   >;
   worktree: Pick<WorktreeMgr, "createDetached" | "remove" | "gitCommonDir">;
   resolveForge: (repoPath: string) => GitForge | null;
@@ -1882,13 +1882,23 @@ export class ReviewService {
   }
 
   /** Find a live herdr agent that was spawned for a review run, resolved by NAME first
-   *  ("review TASK-<n>"), falling back to the worktree cwd. ONE `list()` call per
-   *  invocation. An empty/falsy `label` (session gone) skips the name match entirely —
-   *  an unnamed agent (name="") would otherwise match every gone-session lookup and
-   *  close an unrelated agent. Returns undefined when no live agent matches. */
+   *  ("review TASK-<n>"), falling back to the worktree cwd. An empty/falsy `label` (session gone)
+   *  skips the name match entirely — it would otherwise match every gone-session lookup and close
+   *  an unrelated agent. The name match runs through `agentsHoldingName`, so on a herdr that sends
+   *  no `agent.name` the reviewer is still found by its TAB label instead of silently degrading to
+   *  the cwd fallback (#2033). Tab labels are read best-effort and only when there is a label to
+   *  match. Returns undefined when no live agent matches. */
   private findSquatter(label: string, cwd: string): HerdrAgent | undefined {
     const agents = this.deps.herdr.list();
-    const byName = label ? agents.find((a) => a.name === label) : undefined;
+    const byName = label
+      ? agentsHoldingName(agents, label, () => {
+          try {
+            return tabLabelMap(this.deps.herdr.tabs());
+          } catch {
+            return undefined;
+          }
+        })[0]
+      : undefined;
     return byName ?? agents.find((a) => a.cwd === cwd);
   }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -16,7 +16,12 @@ import {
 } from "./agent-control";
 import type { WorktreeMgr } from "./worktree";
 import type { HerdrAgent, HerdrDriver } from "./herdr";
-import { createSerializer, matchAgents, needsAccountRedrive } from "./herdr";
+import {
+  createSerializer,
+  matchAgents,
+  needsAccountRedrive,
+  sanitizeHerdrAgentName,
+} from "./herdr";
 import { config } from "./config";
 import {
   operatorLanguageBlock,
@@ -4350,7 +4355,8 @@ export class SessionService {
   }
 
   /**
-   * Every name a live herdr already answers to — the set {@link uniqueName} suffixes around.
+   * Every name a live herdr already answers to, in SANITIZED form — the set {@link uniqueName}
+   * suffixes around.
    *
    * The UNION of two surfaces, because no single one covers every herdr: ≤0.7.4 puts the name on
    * the agent record, while 0.7.5+ sends no `agent.name` at all and the name survives only as the
@@ -4358,23 +4364,30 @@ export class SessionService {
    * which is what let two live sessions share a name and turned the repaired `agent_name_taken`
    * eviction into a hazard for the live sibling.
    *
+   * Compared in SANITIZED space because that is the space herdr 0.7.5+ actually binds: the register
+   * call passes `sanitizeHerdrAgentName(name)`, so `fix login` and `fix-login` are ONE name to
+   * herdr even though they are two distinct raw labels. De-duping raw let both go live, and the
+   * second one's spawn then collided and evicted the first — the very hazard this function exists
+   * to prevent. Sanitized comparison is a superset of the raw one (equal raw implies equal
+   * sanitized), so it never de-dupes less than before; at worst it suffixes a punctuation twin that
+   * ≤0.7.4 would have tolerated, which is cheap and safe.
+   *
    * Best-effort by contract: a failed `tab list` degrades the naming to the agent-name half, it
    * never fails session creation. Tab labels also cover Shepherd's helper tabs, which only makes
    * the set more conservative.
    */
   private takenHerdrNames(): Set<string> {
-    const names = new Set(
-      this.deps.herdr
-        .list()
-        .map((a) => a.name)
-        .filter((n): n is string => !!n),
-    );
+    const taken = new Set<string>();
+    const add = (raw: string | undefined): void => {
+      if (raw) taken.add(sanitizeHerdrAgentName(raw));
+    };
+    for (const a of this.deps.herdr.list()) add(a.name);
     try {
-      for (const t of this.deps.herdr.tabs()) if (t.label) names.add(t.label);
+      for (const t of this.deps.herdr.tabs()) add(t.label);
     } catch {
       /* best-effort: the agent-name half alone */
     }
-    return names;
+    return taken;
   }
 
   /**
@@ -4407,7 +4420,7 @@ export class SessionService {
     // A candidate is taken if a live agent owns the name OR (when repoPath is given) the
     // matching branch already exists. Both are cheap; branchExists is a bounded `git rev-parse`.
     const isTaken = (candidate: string): boolean =>
-      liveNames.has(candidate) ||
+      liveNames.has(sanitizeHerdrAgentName(candidate)) ||
       (!!repoPath && this.deps.worktree.branchExists(repoPath, `shepherd/${candidate}`));
 
     if (!isTaken(base)) return base;

--- a/src/service.ts
+++ b/src/service.ts
@@ -220,6 +220,7 @@ export interface ServiceDeps {
     HerdrDriver,
     | "start"
     | "list"
+    | "tabs"
     | "stop"
     | "send"
     | "relabel"
@@ -4349,6 +4350,34 @@ export class SessionService {
   }
 
   /**
+   * Every name a live herdr already answers to — the set {@link uniqueName} suffixes around.
+   *
+   * The UNION of two surfaces, because no single one covers every herdr: ≤0.7.4 puts the name on
+   * the agent record, while 0.7.5+ sends no `agent.name` at all and the name survives only as the
+   * TAB label (#2033). Reading agent names alone made this de-duper a no-op on every 0.7.5 host —
+   * which is what let two live sessions share a name and turned the repaired `agent_name_taken`
+   * eviction into a hazard for the live sibling.
+   *
+   * Best-effort by contract: a failed `tab list` degrades the naming to the agent-name half, it
+   * never fails session creation. Tab labels also cover Shepherd's helper tabs, which only makes
+   * the set more conservative.
+   */
+  private takenHerdrNames(): Set<string> {
+    const names = new Set(
+      this.deps.herdr
+        .list()
+        .map((a) => a.name)
+        .filter((n): n is string => !!n),
+    );
+    try {
+      for (const t of this.deps.herdr.tabs()) if (t.label) names.add(t.label);
+    } catch {
+      /* best-effort: the agent-name half alone */
+    }
+    return names;
+  }
+
+  /**
    * Derive a herdr-unique agent name from `base`. The namer maps a prompt to a name
    * deterministically, so resubmitting a similar prompt yields the same base — and herdr
    * rejects a second agent with a name already in use (`agent_name_taken`), which would
@@ -4374,12 +4403,7 @@ export class SessionService {
    * agent name, branch, and worktree path all in sync on the suffixed value.
    */
   private uniqueName(base: string, herd?: string, repoPath?: string): string {
-    const liveNames = new Set(
-      this.deps.herdr
-        .list()
-        .map((a) => a.name)
-        .filter(Boolean),
-    );
+    const liveNames = this.takenHerdrNames();
     // A candidate is taken if a live agent owns the name OR (when repoPath is given) the
     // matching branch already exists. Both are cheap; branchExists is a bounded `git rev-parse`.
     const isTaken = (candidate: string): boolean =>

--- a/test/herdr-075.test.ts
+++ b/test/herdr-075.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test, expect, beforeEach, afterEach } from "bun:test";
 import {
+  agentsHoldingName,
   classifyPaneWrite,
   HerdrDriver,
   matchAgent,
@@ -427,6 +428,177 @@ test("the label source is memoized: one read arbitrates a whole contended pass",
   ];
   matchAgents(sessions, UNNAMED_AGENTS, src);
   expect(calls).toBe(1);
+});
+
+// ── agent_name_taken squatter eviction keys on the TAB label too (#2033) ──────
+//
+// 0.7.5 sends no `agent.name`, so `agents.filter((a) => a.name === name)` selected the empty set:
+// nothing was evicted, all three attempts re-collided, and the spawn failed with `agent_name_taken`
+// instead of self-healing. The name survives on the TAB label, which `tab create --label` was given
+// raw — compared in the sanitized space the registration actually binds.
+
+/** The squatter (`t_sq`) plus OUR OWN freshly-created pane (`p_075`/`t_075`). Both tabs carry the
+ *  same label, so the self-eviction guard is what keeps the spawn from closing its own tab. */
+const COLLIDING_AGENTS = JSON.stringify({
+  result: {
+    type: "agent_list",
+    agents: [
+      {
+        agent: "review-task-09",
+        agent_status: "working",
+        cwd: "/wt/a",
+        pane_id: "p_sq",
+        tab_id: "t_sq",
+        terminal_id: "term_sq",
+        workspace_id: "w1",
+      },
+      {
+        agent: "review-task-09",
+        agent_status: "working",
+        cwd: "/wt/a",
+        pane_id: "p_075",
+        tab_id: "t_075",
+        terminal_id: "term_075",
+        workspace_id: "w1",
+      },
+    ],
+  },
+});
+
+const COLLIDING_TABS = JSON.stringify({
+  result: {
+    type: "tab_list",
+    tabs: [
+      { tab_id: "t_sq", label: "review TASK-09", agent_status: "working", workspace_id: "w1" },
+      { tab_id: "t_075", label: "review TASK-09", agent_status: "working", workspace_id: "w1" },
+    ],
+  },
+});
+
+function nameTaken(): Error {
+  return Object.assign(new Error("herdr CLI error"), {
+    stderr: JSON.stringify({ error: { code: "agent_name_taken", message: "name in use" } }),
+  });
+}
+
+/** A 0.7.5 sandboxed spawn whose first registration collides; `attempts` counts the register calls. */
+function collidingDriver(collisions: number) {
+  let attempts = 0;
+  const { d, calls } = mkDriver((args) => {
+    if (args[0] === "pane" && args[1] === "report-agent-session") {
+      attempts++;
+      if (attempts <= collisions) throw nameTaken();
+      return REPORT_SESSION;
+    }
+    if (args[0] === "agent" && args[1] === "list") return COLLIDING_AGENTS;
+    if (args[0] === "tab" && args[1] === "list") return COLLIDING_TABS;
+    return route(args);
+  });
+  return { d, calls, attempts: () => attempts };
+}
+
+/** The ≤0.7.4 shape: herdr populates `name` on every record. */
+const NAMED_AGENTS: HerdrAgent[] = [
+  { ...UNNAMED_AGENTS[0]!, name: "review TASK-09" },
+  { ...UNNAMED_AGENTS[1]!, name: "review TASK-10" },
+];
+
+test("agentsHoldingName: a `name` hit wins outright and never reads the labels", () => {
+  const labels = () => {
+    throw new Error("labels must not be read when `name` already matched");
+  };
+  expect(agentsHoldingName(NAMED_AGENTS, "review TASK-09", labels).map((a) => a.tabId)).toEqual([
+    "tA",
+  ]);
+});
+
+test("agentsHoldingName: the label branch is a FALL-THROUGH, not a version switch", () => {
+  // Deliberate, and a real behaviour change on a herdr that still sends `name`: when NOTHING holds
+  // the name, the label is consulted anyway. herdr's own `agent_name_taken` names candidates with
+  // `status=Unknown` — a holder absent from `agent list` — and before #2033 that spawn was
+  // guaranteed to fail with nothing evicted. The label space searched is Shepherd's own.
+  const orphaned: HerdrAgent[] = [{ ...NAMED_AGENTS[0]!, name: "renamed-out-of-band" }];
+  expect(
+    agentsHoldingName(orphaned, "review TASK-09", () => TAB_LABELS).map((a) => a.tabId),
+  ).toEqual(["tA"]);
+  // …but a name nobody holds on ANY surface still evicts nothing.
+  expect(agentsHoldingName(NAMED_AGENTS, "nobody", () => TAB_LABELS)).toEqual([]);
+});
+
+test("agentsHoldingName: falls back to the TAB label in herdr's sanitized name space", () => {
+  // The raw label is what `tab create` was given; the registration bound `review-task-09`.
+  expect(agentsHoldingName(UNNAMED_AGENTS, "review TASK-09", () => TAB_LABELS)).toHaveLength(1);
+  expect(agentsHoldingName(UNNAMED_AGENTS, "review TASK-09", () => TAB_LABELS)[0]!.tabId).toBe(
+    "tA",
+  );
+  // Sanitized-space equality: the caller may hold either form of the same name.
+  expect(agentsHoldingName(UNNAMED_AGENTS, "review-task-10", () => TAB_LABELS)[0]!.tabId).toBe(
+    "tB",
+  );
+});
+
+test("agentsHoldingName: no labels → empty set, never a broader match", () => {
+  // A failed `tab list` must NARROW the match. Widening it would close an unrelated agent's tab.
+  expect(agentsHoldingName(UNNAMED_AGENTS, "review TASK-09", () => undefined)).toEqual([]);
+});
+
+test("agentsHoldingName: never keys on `agent` — the bare KIND must not alias a name", () => {
+  // Both UNNAMED_AGENTS report `agent: "claude"` (trusted auto-detection). A session that sanitizes
+  // to `claude` must not sweep up every claude in the fleet.
+  expect(agentsHoldingName(UNNAMED_AGENTS, "claude", () => TAB_LABELS)).toEqual([]);
+});
+
+test("start (0.7.5, SANDBOXED): a register collision evicts the squatter by TAB label, then retries", async () => {
+  const { d, calls, attempts } = collidingDriver(1);
+  const agent = await d.start("review TASK-09", "/wt/a", ["bwrap", "--", "claude", "go"]);
+
+  // The squatter — resolvable ONLY via its tab label — was evicted, and the retry made progress.
+  expect(calls).toContainEqual(["tab", "close", "t_sq"]);
+  expect(attempts()).toBe(2);
+  expect(agent.terminalId).toBe("term_075");
+});
+
+test("start (0.7.5, SANDBOXED): the eviction never closes the tab the spawn just created", async () => {
+  // Our own tab was labelled with the same name moments earlier, so it matches the label branch by
+  // construction. Without the self-eviction guard the retry would close the pane it is spawning into.
+  const { d, calls } = collidingDriver(1);
+  await d.start("review TASK-09", "/wt/a", ["bwrap", "--", "claude", "go"]);
+
+  const closed = calls.filter((c) => c[0] === "tab" && c[1] === "close").map((c) => c[2]);
+  expect(closed).toContain("t_sq");
+  expect(closed).not.toContain("t_075");
+});
+
+test("start (0.7.5, SANDBOXED): a persistent collision still rolls the tab back and throws", async () => {
+  // Eviction is bounded — three attempts, then the spawn fails loudly and leaves no husk behind.
+  const { d, calls, attempts } = collidingDriver(99);
+  await expect(
+    d.start("review TASK-09", "/wt/a", ["bwrap", "--", "claude", "go"]),
+  ).rejects.toThrow();
+  expect(attempts()).toBe(3);
+  expect(calls).toContainEqual(["tab", "close", "t_075"]); // OUR tab, rolled back on the failure path
+});
+
+test("start (0.7.5, SANDBOXED): a failing tab list narrows the eviction instead of widening it", async () => {
+  // No labels and no `agent.name` → nothing is identifiable, so nothing is closed. The spawn fails
+  // exactly as it does today; it must never fall back to closing whatever else is in the list.
+  let attempts = 0;
+  const { d, calls } = mkDriver((args) => {
+    if (args[0] === "pane" && args[1] === "report-agent-session") {
+      attempts++;
+      throw nameTaken();
+    }
+    if (args[0] === "agent" && args[1] === "list") return COLLIDING_AGENTS;
+    if (args[0] === "tab" && args[1] === "list") throw new Error("herdr: tab list unavailable");
+    return route(args);
+  });
+  await expect(
+    d.start("review TASK-09", "/wt/a", ["bwrap", "--", "claude", "go"]),
+  ).rejects.toThrow();
+  expect(attempts).toBe(3);
+  expect(calls.filter((c) => c[0] === "tab" && c[1] === "close").map((c) => c[2])).not.toContain(
+    "t_sq",
+  );
 });
 
 test("stop (0.7.5): closes the recorded tab of a started agent", async () => {

--- a/test/herdr-075.test.ts
+++ b/test/herdr-075.test.ts
@@ -512,17 +512,35 @@ test("agentsHoldingName: a `name` hit wins outright and never reads the labels",
   ]);
 });
 
-test("agentsHoldingName: the label branch is a FALL-THROUGH, not a version switch", () => {
-  // Deliberate, and a real behaviour change on a herdr that still sends `name`: when NOTHING holds
-  // the name, the label is consulted anyway. herdr's own `agent_name_taken` names candidates with
-  // `status=Unknown` — a holder absent from `agent list` — and before #2033 that spawn was
-  // guaranteed to fail with nothing evicted. The label space searched is Shepherd's own.
+test("agentsHoldingName: where herdr populates `name`, a miss evicts NOTHING (version switch)", () => {
+  // Not a fall-through. The label comparison is necessarily coarser than herdr's ≤0.7.4 raw name
+  // space — `sanitize` is lossy, so two genuinely different live sessions (`fix login` vs
+  // `fix-login`) share one sanitized label. If a raw-name miss fell through to labels, a collision
+  // on one would evict the OTHER live session's tab. Where herdr tells us the names, believe it.
   const orphaned: HerdrAgent[] = [{ ...NAMED_AGENTS[0]!, name: "renamed-out-of-band" }];
-  expect(
-    agentsHoldingName(orphaned, "review TASK-09", () => TAB_LABELS).map((a) => a.tabId),
-  ).toEqual(["tA"]);
-  // …but a name nobody holds on ANY surface still evicts nothing.
+  expect(agentsHoldingName(orphaned, "review TASK-09", () => TAB_LABELS)).toEqual([]);
   expect(agentsHoldingName(NAMED_AGENTS, "nobody", () => TAB_LABELS)).toEqual([]);
+});
+
+test("agentsHoldingName: a punctuation twin is never evicted for its sibling's collision", () => {
+  // The concrete hazard behind the version switch: `uniqueName` now de-dupes in sanitized space so
+  // these two cannot both go live, but the eviction must not depend on that holding.
+  const twins: HerdrAgent[] = [
+    { ...UNNAMED_AGENTS[0]!, name: "fix login" },
+    { ...UNNAMED_AGENTS[1]!, name: "fix-login" },
+  ];
+  const labels = new Map([
+    ["tA", "fix login"],
+    ["tB", "fix-login"],
+  ]);
+  expect(agentsHoldingName(twins, "fix login", () => labels).map((a) => a.tabId)).toEqual(["tA"]);
+  expect(agentsHoldingName(twins, "fix-login", () => labels).map((a) => a.tabId)).toEqual(["tB"]);
+});
+
+test("agentsHoldingName: an empty agent list still reaches the label branch (husk-only tabs)", () => {
+  // `some()` over no records is false, so a collision whose holder left no agent record at all is
+  // still resolvable by label — and no live agent can be harmed, because there are none.
+  expect(agentsHoldingName([], "review TASK-09", () => TAB_LABELS)).toEqual([]);
 });
 
 test("agentsHoldingName: falls back to the TAB label in herdr's sanitized name space", () => {

--- a/test/herdr-socket-075.test.ts
+++ b/test/herdr-socket-075.test.ts
@@ -206,6 +206,78 @@ describe("SocketHerdrDriver — 0.7.5 (protocol 17) external-registration spawn"
     expect(rec).toContainEqual({ method: "tab.close", params: { tab_id: "t_075" } });
   });
 
+  // ── agent_name_taken squatter eviction keys on the TAB label too (#2033) ──────
+  //
+  // Socket sibling of the CLI driver's coverage. 0.7.5 sends no `agent.name`, so the old
+  // `a.name === agentName` filter selected the empty set: nothing evicted, all three attempts
+  // re-collided, and the spawn failed with `agent_name_taken` instead of self-healing.
+
+  /** The squatter (`t_sq`), plus OUR OWN freshly-created pane — both tabs carry the same label. */
+  const collidingAgents = () => [
+    {
+      agent: "review-task-09",
+      agent_status: "working",
+      cwd: "/wt/a",
+      pane_id: "p_sq",
+      tab_id: "t_sq",
+      terminal_id: "term_sq",
+      workspace_id: "w1",
+    },
+    {
+      agent: "review-task-09",
+      agent_status: "working",
+      cwd: "/wt/a",
+      pane_id: "p_075",
+      tab_id: "t_075",
+      terminal_id: "term_075",
+      workspace_id: "w1",
+    },
+  ];
+  const collidingTabs = () => [
+    { tab_id: "t_sq", label: "review TASK-09", workspace_id: "w1" },
+    { tab_id: "t_075", label: "review TASK-09", workspace_id: "w1" },
+  ];
+
+  it("start() SANDBOXED: a register collision evicts the squatter by TAB label, then retries", async () => {
+    let reports = 0;
+    const { rec, client } = mkClient({
+      agents: collidingAgents,
+      tabs: collidingTabs,
+      onReport: () => {
+        if (++reports === 1) throw new HerdrSocketError("agent_name_taken", "name in use");
+      },
+    });
+    const driver = new SocketHerdrDriver(client, noCli, async () => {});
+
+    const agent = await driver.start("review TASK-09", "/wt/a", ["bwrap", "--", "claude", "go"]);
+
+    // The squatter is resolvable ONLY via its tab label — `agent.name` is absent on every record.
+    expect(rec).toContainEqual({ method: "tab.close", params: { tab_id: "t_sq" } });
+    expect(reports).toBe(2); // the retry actually made progress
+    expect(agent.terminalId).toBe("term_075");
+  });
+
+  it("start() SANDBOXED: the eviction never closes the tab the spawn just created", async () => {
+    // Our own tab was labelled with the same name moments earlier, so it matches by construction.
+    let reports = 0;
+    const { rec, client } = mkClient({
+      agents: collidingAgents,
+      tabs: collidingTabs,
+      onReport: () => {
+        if (++reports === 1) throw new HerdrSocketError("agent_name_taken", "name in use");
+      },
+    });
+    const driver = new SocketHerdrDriver(client, noCli, async () => {});
+
+    await driver.start("review TASK-09", "/wt/a", ["bwrap", "--", "claude", "go"]);
+
+    const closed = rec
+      .filter((r) => r.method === "tab.close")
+      .map((r) => (r.params as { tab_id: string }).tab_id);
+    expect(closed).toContain("t_sq");
+    expect(closed).not.toContain("t_075");
+  });
+
   it("start() records the spawn handle: a later stop() closes the recorded tab (agent-list-free)", async () => {
     // tab.list label matches the start name so the recorded-tab-first close fires without agent.list
     const { rec, client } = mkClient({

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -3419,6 +3419,7 @@ function makeOrphanDeps(
     sessions?: Record<string, any>;
     reviews?: Record<string, any>;
     agents?: any[];
+    tabs?: any[];
     worktreeExists?: (p: string) => boolean;
     readUsage?: (wt: string, id: string) => Promise<any>;
   } = {},
@@ -3428,6 +3429,7 @@ function makeOrphanDeps(
   const closedTabs: string[] = [];
   const removedWorktrees: string[] = [];
   const agents = opts.agents ?? [];
+  const tabs = opts.tabs ?? [];
 
   const deps = {
     store: {
@@ -3449,6 +3451,7 @@ function makeOrphanDeps(
       start: async () => ({ terminalId: "rt" }) as any,
       stop: async () => {},
       list: () => agents,
+      tabs: () => tabs,
       closeTab: async (tabId: string) => closedTabs.push(tabId),
     },
     worktree: {
@@ -3517,6 +3520,52 @@ test("reapOrphans: true orphan (worktree present), error verdict — reaps, drop
   expect(droppedReviews).toEqual(["s1"]);
   // taskId in re-kick set
   expect(result).toContain("s1");
+});
+
+test("reapOrphans: resolves the squatter by TAB label when herdr sends no agent.name (#2033)", async () => {
+  // The 0.7.5 record shape: no `name` at all. Its cwd is deliberately NOT the orphan worktree, so
+  // only the tab label can resolve it — the cwd fallback would find nothing and the still-alive
+  // critic would keep holding the name "review TASK-01".
+  const row = {
+    reviewerSessionId: "rev-2033",
+    taskSessionId: "s1",
+    kind: "review",
+    worktreePath: "/orphan-wt",
+    completedAt: null,
+    spawnedAt: 0,
+  };
+  const { deps, closedTabs } = makeOrphanDeps([row], {
+    sessions: { s1: session({ id: "s1", desig: "TASK-01" }) },
+    agents: [{ agent: "review-task-01", tabId: "tab-99", terminalId: "rt-99", cwd: "/other-wt" }],
+    tabs: [{ tabId: "tab-99", label: "review TASK-01", agentStatus: "working", workspaceId: "w1" }],
+    worktreeExists: (p) => p === "/orphan-wt",
+  });
+  const svc = new ReviewService(deps as any);
+  await svc.reapOrphans();
+
+  expect(closedTabs).toEqual(["tab-99"]);
+});
+
+test("reapOrphans: a tab label for a DIFFERENT reviewer is never mistaken for the squatter", async () => {
+  // Eviction must stay precise: an unrelated reviewer's tab keeps running.
+  const row = {
+    reviewerSessionId: "rev-2033b",
+    taskSessionId: "s1",
+    kind: "review",
+    worktreePath: "/orphan-wt",
+    completedAt: null,
+    spawnedAt: 0,
+  };
+  const { deps, closedTabs } = makeOrphanDeps([row], {
+    sessions: { s1: session({ id: "s1", desig: "TASK-01" }) },
+    agents: [{ agent: "review-task-77", tabId: "tab-77", terminalId: "rt-77", cwd: "/other-wt" }],
+    tabs: [{ tabId: "tab-77", label: "review TASK-77", agentStatus: "working", workspaceId: "w1" }],
+    worktreeExists: (p) => p === "/orphan-wt",
+  });
+  const svc = new ReviewService(deps as any);
+  await svc.reapOrphans();
+
+  expect(closedTabs).toEqual([]);
 });
 
 test("reapOrphans: readUsage returns null → NULL usage booked (unknown, not 0), full reap for error-verdict orphan", async () => {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -978,6 +978,38 @@ test("syncWorktreeBranch de-dupes against a TAB label when herdr sends no agent.
   expect(store.get(s.id)!.name).toBe("refresh-on-wake-2"); // suffixed off the tab label alone
 });
 
+test("syncWorktreeBranch de-dupes in SANITIZED space — a punctuation twin is already taken", () => {
+  // herdr 0.7.5+ binds `sanitizeHerdrAgentName(name)`, so `Refresh On Wake` and `refresh-on-wake`
+  // are ONE name to herdr. De-duping raw let both go live; the second one's spawn then collided
+  // and its eviction closed the first — the hazard this de-dupe exists to prevent.
+  const store = new SessionStore(":memory:");
+  const s = store.create({
+    name: "view-refresh",
+    prompt: "x",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/view-refresh",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_a",
+  });
+  const service = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: { currentBranch: () => "shepherd/refresh-on-wake" } as any,
+    herdr: {
+      relabel: async () => {},
+      list: () => [],
+      // Differs from the adopted slug only by case and punctuation — same herdr name.
+      tabs: () => [{ tabId: "t1", label: "Refresh On Wake" }],
+    } as any,
+  });
+
+  expect(service.syncWorktreeBranch(s.id)).toBe("shepherd/refresh-on-wake");
+  expect(store.get(s.id)!.name).toBe("refresh-on-wake-2");
+});
+
 test("syncWorktreeBranch: a failing tab read degrades the de-dupe, it never fails the rename", () => {
   // Best-effort by contract: a herdr hiccup must not take session naming down with it.
   const store = new SessionStore(":memory:");

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -946,6 +946,69 @@ test("syncWorktreeBranch de-dupes the adopted name against live tab labels", () 
   expect(row.name).toBe("refresh-on-wake-2"); // display name de-duped
 });
 
+test("syncWorktreeBranch de-dupes against a TAB label when herdr sends no agent.name (#2033)", () => {
+  // The 0.7.5 shape: the sibling's record carries only the bare KIND under `agent` and no `name`,
+  // so the agent-name half of the taken set is empty. Reading it alone made this de-duper a no-op
+  // on every 0.7.5 host — two live sessions could then share a name, which is exactly the state the
+  // repaired `agent_name_taken` eviction must never be handed.
+  const store = new SessionStore(":memory:");
+  const s = store.create({
+    name: "view-refresh",
+    prompt: "x",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/view-refresh",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_a",
+  });
+  const service = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: { currentBranch: () => "shepherd/refresh-on-wake" } as any,
+    herdr: {
+      relabel: async () => {},
+      list: () => [{ agent: "claude", tabId: "t1" }],
+      tabs: () => [{ tabId: "t1", label: "refresh-on-wake" }],
+    } as any,
+  });
+
+  expect(service.syncWorktreeBranch(s.id)).toBe("shepherd/refresh-on-wake");
+  expect(store.get(s.id)!.name).toBe("refresh-on-wake-2"); // suffixed off the tab label alone
+});
+
+test("syncWorktreeBranch: a failing tab read degrades the de-dupe, it never fails the rename", () => {
+  // Best-effort by contract: a herdr hiccup must not take session naming down with it.
+  const store = new SessionStore(":memory:");
+  const s = store.create({
+    name: "view-refresh",
+    prompt: "x",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/view-refresh",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_a",
+  });
+  const service = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: { currentBranch: () => "shepherd/refresh-on-wake" } as any,
+    herdr: {
+      relabel: async () => {},
+      list: () => [],
+      tabs: () => {
+        throw new Error("herdr: tab list unavailable");
+      },
+    } as any,
+  });
+
+  expect(service.syncWorktreeBranch(s.id)).toBe("shepherd/refresh-on-wake");
+  expect(store.get(s.id)!.name).toBe("refresh-on-wake"); // nothing taken → the bare slug stands
+});
+
 test("syncWorktreeBranch is a no-op when the live branch matches the stored one", () => {
   const store = new SessionStore(":memory:");
   const s = store.create({


### PR DESCRIPTION
Closes #2033.

Follow-up to #2029, which fixed every `agent.name` consumer whose failure leaked a tab. This takes the ones that were deliberately left behind, plus one that #2029 missed.

## The bug

herdr 0.7.5 sends no `name` on agent records, so `(await this.listAsync()).filter((a) => a.name === name)` selected the empty set on every 0.7.5+ host. Nothing was evicted, all three retry attempts re-collided, and a sandboxed spawn failed with `agent_name_taken` instead of self-healing.

Two of the four collision sites are actually live-broken. Both `startAgentWithCollisionRetry` implementations sit behind `!herdrUsesExternalRegistrationSpawn()`, so they are unreachable on 0.7.5 and correct on ≤0.7.4 where `name` is present. The **register** pair is what fails in the field.

## The fix

One shared `agentsHoldingName(agents, rawName, labels)` in `src/herdr.ts`: a `name` hit wins outright and the labels are never read; otherwise the **tab label** decides, compared in herdr's own name space (`sanitize` on both sides), since `tab create --label` carries the raw name while the register call binds the sanitized one. No labels available narrows the match to nothing rather than widening it — a failed `tab list` must never broaden what gets closed.

The captured fixtures already prove the join, so no new ones were needed:

| surface | value |
| --- | --- |
| `agent-list-registered.json` | `{ agent: "review-task-09", tab_id: "t_075" }` — no `name` key |
| `tab-list-helpers.json` | `{ tab_id: "t_075", label: "review TASK-09" }` |
| `sanitizeHerdrAgentName("review TASK-09")` | `"review-task-09"` — the name the register call bound |

**Not keyed on `agent`**, where the issue notes the label also surfaces. That field holds the bare agent KIND (`"claude"`) for trusted auto-detected agents, so matching it would both alias the kind *and* miss an auto-detected squatter, which reports the kind rather than its name. The tab label has neither problem, so the caveat that kept this out of #2029 dissolves rather than being worked around. The error string still goes unparsed, per the standing comment at all four sites.

### Two consequences worth reviewing

**The label branch is a VERSION SWITCH, not a fall-through.** *(Revised after review — an earlier revision of this PR had it as a fall-through and defended that; the critic was right.)* Any record carrying `name` proves this herdr populates the field, so its name space is used exclusively and a miss evicts nothing. Only a list where nobody carries `name` (0.7.5+) reaches the label branch, which makes ≤0.7.4 genuinely byte-identical.

This matters because the label comparison is necessarily *coarser* than herdr's ≤0.7.4 raw name space: `sanitize` is lossy, so `fix login` and `fix-login` are two distinct live sessions sharing one sanitized label. As a fall-through, a raw-name collision on one could have evicted the other. Where herdr tells us the names, believe it.

The same raw/sanitized mismatch is why `uniqueName` now de-dupes in sanitized space — that is the space herdr 0.7.5+ actually binds, and de-duping raw let both twins go live in the first place. Sanitized comparison is a superset of the raw one (equal raw implies equal sanitized), so it never de-dupes less.

**Each site excludes its own freshly-created handle** (register on `paneId`, `agent start` on `tabId`). Tab-label matching newly makes our own tab a candidate, since it was labelled with the same name moments earlier; without the guard a repaired eviction could close the pane it is spawning into.

## `uniqueName` — the third consumer, not named in the issue

`service.ts` → `uniqueName()` built its taken set from `agent.name` alone, so on 0.7.5 the live-agent half of the de-dupe was dead and only the `shepherd/<candidate>` branch check remained. That is the state a *repaired* eviction must never be handed: with duplicates getting through, a colliding spawn would evict a **live sibling's** tab. It now takes the union of both surfaces, extracted into `takenHerdrNames()` (which also brings `uniqueName` back under the fallow complexity gate).

`review.ts` → `findSquatter()` rides the same helper, so a restart-orphaned critic is found by its tab label instead of silently degrading to the cwd fallback.

## Verification

`bun run lint`, `bun run typecheck`, `bun run test` green — **9131 pass, 0 fail**.

Every new behaviour test was confirmed **red** against the original source before the fix, not assumed:

| test | proven red against |
| --- | --- |
| CLI register collision (2) | the exact old predicate `a.name === agentName`, surgically restored |
| socket register collision (2) | original source |
| `findSquatter` by tab label (1) | original source |
| `uniqueName` de-dupe by label (1) | original source |
| version switch: a `name` miss evicts nothing (1) | the fall-through revision |
| `uniqueName` sanitized-space de-dupe (1) | the raw-comparison revision |

The pre-existing ≤0.7.4 collision tests in `test/herdr.test.ts` pass **untouched**.

The issue notes that verifying this means forcing a real name collision, which no test did. `herdr:compat` gains **L10**: it registers its own name on a fresh pane, holds it at `working`, then attempts the same name on a second pane — answering the question the code itself records as unverified (*"Whether `report-agent(-session)` even emits `agent_name_taken` is unverified"*). It is deliberately self-contained rather than reusing L6's agent, because L7 has already flipped that one to `idle` by then and a herdr that releases a finished agent's name would make the probe answer "no collision" for the wrong reason. Either answer is fine for Shepherd — one that accepts the duplicate just makes the retry defensive — so the verdict is PASS on agreement with the baseline and REVIEW on a flip, mirroring how L5 treats last-tab behaviour.

## Out of scope

- Re-checking against 0.8.x — that is #2032. This fix is version-agnostic by construction: it prefers `name` wherever herdr sends it, so a herdr that restores the field needs no follow-up.
- Regenerating `docs/herdr-compat/0.8.2.md` with the L10 row: that report is a captured artefact of a real A/B run against downloaded binaries, regenerated by the next version-bump PR.

One plan item was dropped: a unit test asserting the L10 row renders. `scripts/herdr-compat.ts` is a top-level script that `process.exit()`s at import and exports nothing, so `liveChecks` cannot be imported by a test, and no existing L1–L9 row has one. Making it testable would mean restructuring the script's entrypoint, which does not trace to this issue.
