### PR TITLE
fix(ui): show runtime model and effort on task cards

### DIFF
--- a/src/activity-signal.ts
+++ b/src/activity-signal.ts
@@ -1,4 +1,5 @@
 import { parseActivity, latestRecordTs, readTranscriptTail, type ActivityEntry } from "./activity";
+import { eachJsonlObject } from "./jsonl";
 import { snapshotFrom, DEFAULT_STALL, type ActivitySnapshot } from "./stall";
 
 /** Per-agent liveness + current-activity signal pushed to UI clients. */
@@ -13,7 +14,13 @@ export interface SessionActivity {
   recentTs: number[];
   /** Subset of `recentTs` whose tool-use errored; the client tints those slices red. */
   recentErrTs: number[];
+  /** Concrete model reported by the provider transcript, when available. */
+  runtimeModel?: string;
+  /** Concrete reasoning-effort tier reported by the provider transcript, when available. */
+  runtimeEffort?: string;
 }
+
+type RuntimeIdentity = Pick<SessionActivity, "runtimeModel" | "runtimeEffort">;
 
 /**
  * Tools that represent internal bookkeeping rather than observable agent work.
@@ -52,6 +59,7 @@ export const STRIP_WINDOW_MS = DEFAULT_STALL.stallMs;
 export function signalFrom(
   entries: ActivityEntry[],
   lastActivityTs: number,
+  identity: RuntimeIdentity = {},
 ): SessionActivity | null {
   const summary = latestMeaningfulSummary(entries);
   // no signal yet — transcript exists but contains no parseable activity
@@ -64,12 +72,25 @@ export function signalFrom(
     recentTs.push(e.ts);
     if (e.status === "error") recentErrTs.push(e.ts);
   }
-  return { lastActivityTs, summary, recentTs, recentErrTs };
+  return { lastActivityTs, summary, recentTs, recentErrTs, ...identity };
+}
+
+/** Newest real model named by a Claude assistant record. Synthetic control records do not
+ * represent an inference model and must not replace the last concrete value. */
+function claudeRuntimeIdentity(text: string): RuntimeIdentity {
+  let runtimeModel: string | undefined;
+  for (const value of eachJsonlObject(text)) {
+    const record = value as { type?: unknown; message?: unknown };
+    if (record.type !== "assistant") continue;
+    const model = (record.message as { model?: unknown } | undefined)?.model;
+    if (typeof model === "string" && model !== "<synthetic>") runtimeModel = model;
+  }
+  return runtimeModel ? { runtimeModel } : {};
 }
 
 /** Pure: derive an activity signal from already-read transcript text. */
 export function signalFromText(text: string): SessionActivity | null {
-  return signalFrom(parseActivity(text), latestRecordTs(text));
+  return signalFrom(parseActivity(text), latestRecordTs(text), claudeRuntimeIdentity(text));
 }
 
 /**
@@ -108,5 +129,8 @@ export function readTranscriptSignals(path: string): {
   }
   const entries = parseActivity(text);
   const lastTs = latestRecordTs(text);
-  return { snapshot: snapshotFrom(entries, lastTs), activity: signalFrom(entries, lastTs) };
+  return {
+    snapshot: snapshotFrom(entries, lastTs),
+    activity: signalFrom(entries, lastTs, claudeRuntimeIdentity(text)),
+  };
 }

--- a/src/codex-activity.ts
+++ b/src/codex-activity.ts
@@ -172,6 +172,33 @@ function latestCodexRecordTs(text: string): number {
   return max;
 }
 
+/** Runtime environment reported by a Codex rollout. Each turn_context repeats the effective
+ * model and effort; session_meta provenance covers the short window before the first turn. */
+function codexRuntimeIdentity(
+  text: string,
+): Pick<SessionActivity, "runtimeModel" | "runtimeEffort"> {
+  let provenanceModel: string | undefined;
+  let runtimeModel: string | undefined;
+  let runtimeEffort: string | undefined;
+  for (const value of eachJsonlObject(text)) {
+    const record = value as { type?: unknown; payload?: unknown };
+    const payload = record.payload as Record<string, unknown> | undefined;
+    if (record.type === "session_meta") {
+      const provenance = payload?.provenance as Record<string, unknown> | undefined;
+      if (typeof provenance?.model === "string") provenanceModel = provenance.model;
+      continue;
+    }
+    if (record.type !== "turn_context") continue;
+    if (typeof payload?.model === "string") runtimeModel = payload.model;
+    if (typeof payload?.effort === "string") runtimeEffort = payload.effort;
+  }
+  const model = runtimeModel ?? provenanceModel;
+  return {
+    ...(model ? { runtimeModel: model } : {}),
+    ...(runtimeEffort ? { runtimeEffort } : {}),
+  };
+}
+
 /** Pure: derive both signals from already-read rollout text (one parse). */
 function codexSignalsFromText(text: string): {
   snapshot: ActivitySnapshot | null;
@@ -179,7 +206,10 @@ function codexSignalsFromText(text: string): {
 } {
   const entries = parseCodexActivity(text);
   const lastTs = latestCodexRecordTs(text);
-  return { snapshot: snapshotFrom(entries, lastTs), activity: signalFrom(entries, lastTs) };
+  return {
+    snapshot: snapshotFrom(entries, lastTs),
+    activity: signalFrom(entries, lastTs, codexRuntimeIdentity(text)),
+  };
 }
 
 /**

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -41,6 +41,7 @@ import { resolveDevPort } from "./preview";
 import { agentTmpDir } from "./tmp-sweep";
 import { config } from "./config";
 import { SessionLiveness, type LivenessOutcome, type TranscriptSignals } from "./session-liveness";
+import { CodexTranscriptLocator, readCodexTranscriptSignals } from "./codex-activity";
 
 const STALL_SIG = "stall"; // fixed signature → a stall fires once per episode
 const AUTH_SIG = "auth"; // fixed signature → a resting MCP-auth block fires once per episode
@@ -417,6 +418,7 @@ export class StatusPoller {
   ) => void;
   /** Usage-limits service for corroboration in classifyHalt. */
   private readonly usageLimitsSvc: { limits(now: number): UsageLimits };
+  private readonly probe: (s: Session) => TranscriptSignals;
 
   constructor(
     private store: SessionStore,
@@ -434,10 +436,7 @@ export class StatusPoller {
      * injectable in tests. One read feeds both the stall decision and the activity
      * emit, so the transcript is no longer parsed twice per running agent per tick.
      */
-    private probe: (s: Session) => TranscriptSignals = (s) =>
-      s.claudeSessionId
-        ? readTranscriptSignals(jsonlPathFor(s.worktreePath, s.claudeSessionId, s.spawnAccountDir))
-        : { snapshot: null, activity: null },
+    probe: ((s: Session) => TranscriptSignals) | undefined = undefined,
     private stallCfg = DEFAULT_STALL,
     private probeCheckMs = 7000,
     /** Pushed when a session's manual readyToMerge flag is auto-cleared on resume. */
@@ -513,7 +512,22 @@ export class StatusPoller {
      * src/index.ts to `service.archive`; undefined (tests that don't care) ⇒ no auto-archive.
      */
     private archiveTerminal?: (id: string) => void,
+    /** Resolves a Codex session's provider-native rollout for the default probe. */
+    codexTranscripts: CodexTranscriptLocator = new CodexTranscriptLocator(),
   ) {
+    this.probe =
+      probe ??
+      ((s) => {
+        if (s.agentProvider === "codex") {
+          const path = codexTranscripts.pathFor(s);
+          return path ? readCodexTranscriptSignals(path) : { snapshot: null, activity: null };
+        }
+        return s.claudeSessionId
+          ? readTranscriptSignals(
+              jsonlPathFor(s.worktreePath, s.claudeSessionId, s.spawnAccountDir),
+            )
+          : { snapshot: null, activity: null };
+      });
     // Merge supplied overrides with real defaults. When preview is omitted entirely
     // we create a no-op wiring so tick() never throws on undefined access.
     this.previewWiring = {
@@ -1236,6 +1250,7 @@ export class StatusPoller {
     // separate error-tick list across calls (the strip is coarse + windowed), so a
     // single push contributes its own `t` to recentErrTs when it's an error.
     const recentErrTs = ev.status === "error" ? [t] : [];
+    const previous = this.lastActivity.get(id);
     this.emitActivity(id, {
       lastActivityTs: t,
       // A real tool name — non-null so it beats the interim `summary:null` heartbeat.
@@ -1243,6 +1258,8 @@ export class StatusPoller {
       summary: ev.toolName ?? null,
       recentTs: windowed,
       recentErrTs,
+      ...(previous?.runtimeModel ? { runtimeModel: previous.runtimeModel } : {}),
+      ...(previous?.runtimeEffort ? { runtimeEffort: previous.runtimeEffort } : {}),
     });
     this.lastHookActivityAt.set(id, t);
   }
@@ -1395,13 +1412,29 @@ export class StatusPoller {
       // heat is NEVER dropped: `PostToolUseFailure` feeds `recentErrTs` via the push path, so
       // suppression is safe — and as a belt-and-suspenders guard, if the probe carries error
       // heat the push hasn't emitted, we still emit it.
-      if (signals.activity && !(hookFresh && signals.activity.recentErrTs.length === 0)) {
-        this.emitActivity(s.id, signals.activity);
-      }
+      if (signals.activity) this.emitProbeActivity(s.id, signals.activity, hookFresh);
       this.applyOutcome(s, step.outcome);
     } else {
       void step.pending.then((o) => this.applyOutcome(s, o));
     }
+  }
+
+  /** Prefer a fresh hook summary while still folding in runtime identity learned by the probe. */
+  private emitProbeActivity(id: string, activity: SessionActivity, hookFresh: boolean): void {
+    if (!hookFresh || activity.recentErrTs.length > 0) {
+      this.emitActivity(id, activity);
+      return;
+    }
+    const previous = this.lastActivity.get(id);
+    if (!previous) return;
+    const runtimeModel = activity.runtimeModel ?? previous.runtimeModel;
+    const runtimeEffort = activity.runtimeEffort ?? previous.runtimeEffort;
+    if (runtimeModel === previous.runtimeModel && runtimeEffort === previous.runtimeEffort) return;
+    this.emitActivity(id, {
+      ...previous,
+      ...(runtimeModel ? { runtimeModel } : {}),
+      ...(runtimeEffort ? { runtimeEffort } : {}),
+    });
   }
 
   /**

--- a/test/activity-signal.test.ts
+++ b/test/activity-signal.test.ts
@@ -44,6 +44,14 @@ function resultLine(id: string, ts: string, is_error = false): string {
   });
 }
 
+function assistantModelLine(model: string, ts: string): string {
+  return JSON.stringify({
+    type: "assistant",
+    timestamp: ts,
+    message: { role: "assistant", model, content: [{ type: "text", text: "done" }] },
+  });
+}
+
 // ── latestMeaningfulSummary ───────────────────────────────────────────────────
 
 test("latestMeaningfulSummary returns null for empty entries", () => {
@@ -190,6 +198,15 @@ test("signalFromText derives heartbeat + meaningful summary from text", () => {
   expect(signal).not.toBeNull();
   expect(signal!.lastActivityTs).toBe(Date.parse("2026-05-31T10:05:00.000Z"));
   expect(signal!.summary).toBe("edited poller.ts");
+});
+
+test("signalFromText reports the newest real Claude model and ignores synthetic records", () => {
+  const text = [
+    assistantModelLine("claude-opus-5-1", "2026-09-07T10:00:00.000Z"),
+    assistantModelLine("<synthetic>", "2026-09-07T10:01:00.000Z"),
+  ].join("\n");
+
+  expect(signalFromText(text)?.runtimeModel).toBe("claude-opus-5-1");
 });
 
 test("readTranscriptSignals: one read yields both snapshot + activity", () => {

--- a/test/codex-activity.test.ts
+++ b/test/codex-activity.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "bun:test";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
 import {
   parseCodexUsage,
   parseCodexActivity,
@@ -130,6 +131,38 @@ describe("readCodexTranscriptSignals", () => {
     const r = readCodexTranscriptSignals(join(import.meta.dir, "fixtures/does-not-exist.jsonl"));
     expect(r.snapshot).toBeNull();
     expect(r.activity).toBeNull();
+  });
+
+  test("reports model and effort from the newest turn context", () => {
+    const dir = mkdtempSync(join(tmpdir(), "codex-runtime-identity-"));
+    const path = join(dir, "rollout.jsonl");
+    try {
+      const records = [
+        {
+          timestamp: "2026-09-07T10:00:00.000Z",
+          type: "session_meta",
+          payload: { provenance: { type: "model", model: "gpt-6-sol" } },
+        },
+        {
+          timestamp: "2026-09-07T10:01:00.000Z",
+          type: "turn_context",
+          payload: { model: "gpt-6-terra", effort: "medium" },
+        },
+        {
+          timestamp: "2026-09-07T10:02:00.000Z",
+          type: "turn_context",
+          payload: { model: "gpt-6-astra", effort: "high" },
+        },
+      ];
+      writeFileSync(path, records.map((record) => JSON.stringify(record)).join("\n"));
+
+      const { activity } = readCodexTranscriptSignals(path);
+
+      expect(activity?.runtimeModel).toBe("gpt-6-astra");
+      expect(activity?.runtimeEffort).toBe("high");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "bun:test";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { SessionStore } from "../src/store";
 import { StatusPoller } from "../src/poller";
 import { makeApp } from "../src/server";
@@ -10,6 +11,7 @@ import { DEFAULT_STALL } from "../src/stall";
 import { maintenance } from "../src/maintenance";
 import { config } from "../src/config";
 import type { ReviewVerdict, PlanGate } from "../src/types";
+import { CodexTranscriptLocator } from "../src/codex-activity";
 
 const baseSession = {
   name: "x",
@@ -28,6 +30,99 @@ const baseSession = {
  *  synchronous tick — so its onActivity/onBlock effects (incl. the resume
  *  block-clear) land on a later microtask. Flush a cycle before asserting them. */
 const flush = () => new Promise((r) => setTimeout(r, 0));
+
+test("default probe emits Codex runtime model and effort via session:activity", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "poller-codex-activity-"));
+  const rolloutPath = join(dir, "rollout.jsonl");
+  try {
+    const store = new SessionStore(":memory:");
+    const session = store.create({ ...baseSession, agentProvider: "codex" });
+    const events: Array<{ event: string; data: { id: string; activity: unknown } }> = [];
+    let clock = Date.parse("2026-09-07T10:10:00.000Z");
+    const records = [
+      {
+        timestamp: "2026-09-07T10:00:00.000Z",
+        type: "turn_context",
+        payload: { model: "gpt-6-astra", effort: "high" },
+      },
+    ];
+    writeFileSync(rolloutPath, records.map((record) => JSON.stringify(record)).join("\n"));
+    const locator = new CodexTranscriptLocator({
+      now: () => clock,
+      find: () => ({ id: "rollout-1", path: rolloutPath }),
+    });
+    const herdr = withListAsync({
+      list: (): HerdrAgent[] => [
+        {
+          agent: "codex",
+          agentStatus: "working",
+          cwd: baseSession.worktreePath,
+          paneId: "p",
+          tabId: "t",
+          name: "",
+          terminalId: baseSession.herdrAgentId,
+          workspaceId: "w",
+        },
+      ],
+      read: () => "working",
+      readAsync: async () => "working",
+    });
+    const poller = new StatusPoller(
+      store,
+      herdr,
+      () => {},
+      () => {},
+      1000,
+      3000,
+      classifyBlocked,
+      () => clock,
+      undefined,
+      DEFAULT_STALL,
+      7000,
+      () => {},
+      (id, activity) => events.push({ event: "session:activity", data: { id, activity } }),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      locator,
+    );
+    poller.captureCodexSessionId = () => false;
+
+    await poller.tick();
+    await flush();
+    records.push({
+      timestamp: "2026-09-07T10:00:10.000Z",
+      type: "turn_context",
+      payload: { model: "gpt-6-astra", effort: "high" },
+    });
+    writeFileSync(rolloutPath, records.map((record) => JSON.stringify(record)).join("\n"));
+    clock += 8000;
+    await poller.tick();
+
+    expect(events).toContainEqual({
+      event: "session:activity",
+      data: {
+        id: session.id,
+        activity: {
+          lastActivityTs: Date.parse("2026-09-07T10:00:10.000Z"),
+          summary: null,
+          recentTs: [],
+          recentErrTs: [],
+          runtimeModel: "gpt-6-astra",
+          runtimeEffort: "high",
+        },
+      },
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 /**
  * tick() (issue #1529) now reads agents over the socket via `listAsync()`, not the
@@ -2429,6 +2524,41 @@ test("hooks: freshness guard suppresses the interim activity emit while push is 
     await flush();
     const interimEmits = h.activities.filter((a) => a.activity.summary === null);
     expect(interimEmits).toHaveLength(0);
+  } finally {
+    config.hooksSignals = orig;
+  }
+});
+
+test("hooks: fresh push activity keeps runtime identity discovered by the transcript probe", async () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = true;
+  try {
+    const h = hookHarness({
+      probe: () => ({
+        snapshot: null,
+        activity: {
+          lastActivityTs: h.now(),
+          summary: "$ bun run test",
+          recentTs: [],
+          recentErrTs: [],
+          runtimeModel: "gpt-6-astra",
+          runtimeEffort: "high",
+        },
+      }),
+    });
+
+    h.poller.ingestActivity(h.id, { toolName: "Read", status: "ok", ts: h.now() });
+    await h.poller.tick(); // prime transcript liveness while the hook signal is fresh
+
+    h.advance(8000);
+    h.poller.ingestActivity(h.id, { toolName: "Read", status: "ok", ts: h.now() });
+    await h.poller.tick();
+
+    expect(h.activities.at(-1)?.activity).toMatchObject({
+      summary: "Read",
+      runtimeModel: "gpt-6-astra",
+      runtimeEffort: "high",
+    });
   } finally {
     config.hooksSignals = orig;
   }

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -146,6 +146,62 @@ function loadPreviewMode(repoPath: string, mode: "ask" | "inline" | "tab" = "ask
   repoConfig.settled = { ...repoConfig.settled, [repoPath]: true };
 }
 
+describe("UnitRow runtime environment", () => {
+  it("shows the concrete Codex runtime model and effort", () => {
+    render(UnitRow, {
+      session: session({ id: "codex-runtime", agentProvider: "codex" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+      activity: {
+        lastActivityTs: Date.now(),
+        summary: null,
+        recentTs: [],
+        recentErrTs: [],
+        runtimeModel: "gpt-6-astra",
+        runtimeEffort: "high",
+      },
+    });
+
+    expect(document.querySelector(".meta-text")?.textContent?.replace(/\s+/g, " ").trim()).toBe(
+      `TASK-01 · GPT-6 Astra · ${m.effort_label_high()}`,
+    );
+  });
+
+  it("shows the concrete Claude model and falls back to the configured effort", () => {
+    render(UnitRow, {
+      session: session({ id: "claude-runtime", model: "opus", effort: "high" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+      activity: {
+        lastActivityTs: Date.now(),
+        summary: null,
+        recentTs: [],
+        recentErrTs: [],
+        runtimeModel: "claude-opus-5-1",
+      },
+    });
+
+    expect(document.querySelector(".meta-text")?.textContent?.replace(/\s+/g, " ").trim()).toBe(
+      `TASK-01 · Opus 5.1 · ${m.effort_label_high()}`,
+    );
+  });
+
+  it("uses the configured model and effort before runtime telemetry arrives", () => {
+    render(UnitRow, {
+      session: session({ id: "configured", model: "opus", effort: "medium" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+    });
+
+    expect(document.querySelector(".meta-text")?.textContent?.replace(/\s+/g, " ").trim()).toBe(
+      `TASK-01 · opus · ${m.effort_label_medium()}`,
+    );
+  });
+});
+
 describe("UnitRow merging badge", () => {
   it("shows MERGING for a merging session, not READY", async () => {
     const now = Date.now();

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -200,6 +200,24 @@ describe("UnitRow runtime environment", () => {
       `TASK-01 · opus · ${m.effort_label_medium()}`,
     );
   });
+
+  it("shows Codex max intent as the effective high effort before runtime telemetry arrives", () => {
+    render(UnitRow, {
+      session: session({
+        id: "codex-clamped-effort",
+        agentProvider: "codex",
+        model: "gpt-6-astra",
+        effort: "max",
+      }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+    });
+
+    expect(document.querySelector(".meta-text")?.textContent?.replace(/\s+/g, " ").trim()).toBe(
+      `TASK-01 · gpt-6-astra · ${m.effort_label_high()}`,
+    );
+  });
 });
 
 describe("UnitRow merging badge", () => {

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -191,8 +191,13 @@
         ? modelLabel(session.model)
         : m.newtask_model_default(),
   );
+  // Mirror src/default-effort.ts → effortForSpawn(): the row describes the effective
+  // environment, while the session keeps the operator's unclamped intent for future relaunches.
+  const configuredEffort = $derived(
+    session.agentProvider === "codex" && session.effort === "max" ? "high" : session.effort,
+  );
   const environmentEffort = $derived(
-    effortLabel(activity?.runtimeEffort ?? session.effort ?? m.effort_default()),
+    effortLabel(activity?.runtimeEffort ?? configuredEffort ?? m.effort_default()),
   );
   function toggleRepoFilter() {
     // Non-additive: a plain click resets the filter to this repo (or clears it when this repo

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -41,7 +41,8 @@
   import { toasts } from "$lib/toasts.svelte";
   import { projectIcons } from "$lib/projectIcons.svelte";
   import { m } from "$lib/paraglide/messages";
-  import { modelLabel } from "$lib/model-label";
+  import { modelLabel, runtimeModelLabel } from "$lib/model-label";
+  import { effortLabel } from "$lib/effort-guidance";
   import { onDestroy } from "svelte";
   import UnitRowRight from "./unit-row/UnitRowRight.svelte";
   import { rowHold } from "$lib/hold-row";
@@ -183,6 +184,16 @@
   const showAckCta = $derived(hasBlockingManualSteps && !isTerminal && !!onackmanualsteps);
   const repoIcon = $derived(projectIcons.iconFor(session.repoPath));
   const repoFiltered = $derived(repoFilter?.has(session.repoPath) ?? false);
+  const environmentModel = $derived(
+    activity?.runtimeModel
+      ? runtimeModelLabel(activity.runtimeModel)
+      : session.model
+        ? modelLabel(session.model)
+        : m.newtask_model_default(),
+  );
+  const environmentEffort = $derived(
+    effortLabel(activity?.runtimeEffort ?? session.effort ?? m.effort_default()),
+  );
   function toggleRepoFilter() {
     // Non-additive: a plain click resets the filter to this repo (or clears it when this repo
     // is already the sole selection — handled by the page's nextRepoFilter).
@@ -924,9 +935,7 @@
 
     <span class="meta">
       <span class="meta-text"
-        ><TaskIdButton {session} /> · {session.model
-          ? modelLabel(session.model)
-          : m.newtask_model_default()}</span
+        ><TaskIdButton {session} /> · {environmentModel} · {environmentEffort}</span
       >
       {#if session.manualSteps.length > 0}
         {#if onshowowed}

--- a/ui/src/lib/model-guidance.test.ts
+++ b/ui/src/lib/model-guidance.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { modelGuidance, modelGuidanceAlias, modelOptionLabel } from "./model-guidance";
-import { configuredModelLabel, modelLabel } from "./model-label";
+import { configuredModelLabel, modelLabel, runtimeModelLabel } from "./model-label";
 import { isFableModel, modelAvailableForProvider } from "./provider-models";
 
 describe("modelGuidance", () => {
@@ -137,5 +137,21 @@ describe("record vs configured labels", () => {
     for (const alias of ["sonnet", "sonnet[1m]", "haiku"]) {
       expect(configuredModelLabel(alias)).toBe(modelLabel(alias));
     }
+  });
+});
+
+describe("runtime model labels", () => {
+  it("formats concrete Codex model slugs", () => {
+    expect(runtimeModelLabel("gpt-6-astra")).toBe("GPT-6 Astra");
+    expect(runtimeModelLabel("gpt-5.6-sol")).toBe("GPT-5.6 Sol");
+  });
+
+  it("formats concrete Claude model slugs", () => {
+    expect(runtimeModelLabel("claude-opus-5-1")).toBe("Opus 5.1");
+    expect(runtimeModelLabel("claude-sonnet-4-8-20260901")).toBe("Sonnet 4.8");
+  });
+
+  it("leaves unknown runtime model ids intact", () => {
+    expect(runtimeModelLabel("future-model-alpha")).toBe("future-model-alpha");
   });
 });

--- a/ui/src/lib/model-label.ts
+++ b/ui/src/lib/model-label.ts
@@ -4,9 +4,9 @@ import { m } from "$lib/paraglide/messages";
  * Friendly display label for a model alias — the RECORD label.
  *
  * Use this wherever the value being rendered was STORED AT SPAWN/SUBMIT TIME: a
- * session card, the status bar, the plan panel, the review-in-flight banner, the
- * viewport, experiment groups. For a run that already happened, the only honest
- * label is what that run was configured with.
+ * session card before runtime telemetry arrives, the status bar, the plan panel,
+ * the review-in-flight banner, the viewport, experiment groups. For a run that
+ * already happened, the only honest label is what that run was configured with.
  *
  * This is why the floating aliases ("opus", "sonnet", …) deliberately render as
  * the bare token here and NOT as "Opus (latest)": `opus` resolves to whatever the
@@ -37,6 +37,28 @@ export function modelLabel(alias: string): string {
     default:
       return alias;
   }
+}
+
+/** Friendly label for a concrete model id reported by a provider's runtime log. */
+export function runtimeModelLabel(model: string): string {
+  const claude = /^claude-(fable|opus|sonnet|haiku)-(\d+)(?:-(\d+))?$/.exec(
+    model.replace(/-\d{8}$/, ""),
+  );
+  if (claude) {
+    const family = claude[1]![0]!.toUpperCase() + claude[1]!.slice(1);
+    return `${family} ${claude[2]}${claude[3] ? `.${claude[3]}` : ""}`;
+  }
+
+  const gpt = /^gpt-(\d+(?:\.\d+)?)(?:-(.+))?$/.exec(model);
+  if (gpt) {
+    const variant = gpt[2]
+      ?.split("-")
+      .map((part) => (part ? part[0]!.toUpperCase() + part.slice(1) : part))
+      .join(" ");
+    return `GPT-${gpt[1]}${variant ? ` ${variant}` : ""}`;
+  }
+
+  return modelLabel(model);
 }
 
 /**

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1047,6 +1047,10 @@ export interface SessionActivity {
   recentTs: number[];
   /** Subset of recentTs whose tool-use errored; the client tints those slices red. */
   recentErrTs: number[];
+  /** Concrete model id reported by the provider's runtime log. */
+  runtimeModel?: string;
+  /** Effective reasoning effort reported by the provider's runtime log. */
+  runtimeEffort?: string;
 }
 
 export interface Session {


### PR DESCRIPTION
## Summary

- expose the concrete runtime model and effort from Claude transcripts and Codex rollouts through `session:activity`
- route the StatusPoller default probe through the provider-native transcript reader while preserving runtime identity across hook activity
- render task-card metadata such as `GPT-6 Astra · High` and `Opus 5.1 · High`, with configured values as the pre-telemetry fallback

[no-feature-entry] This corrects the existing task-card metadata rather than adding a new discoverable capability.

## Testing

- [x] `bun run lint`
- [x] `bun run test` (9,135 passed; 0 failed)
- [x] `cd ui && bun run check` (0 errors; 0 warnings)
- [x] `cd ui && bun run check:i18n` (EN/DE parity)
- [x] `cd ui && bun run test` (4,793 passed; 0 failed)
- [x] pre-push guard (all 7 lanes plus Fallow audit)

## Checklist

- [x] Conventional-commit PR title (`feat`, `fix`, `chore`, `docs`, …) — enforced in CI.
- [x] Branch is rebased onto current `origin/main` and kept linear.
- [x] Root and UI validation commands pass.
- [x] User-facing labels reuse existing i18n messages; no catalog additions are needed.
- [x] No new feature announcement applies; this is an existing metadata display fix.
- [x] No new styling or design tokens were introduced.
- [x] No public API, config, or CLI documentation changed.