### PR TITLE
fix(learnings): reject evidence from another repository

### DIFF
--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -2,10 +2,10 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { readRoleResultText, CODEX_LAST_MESSAGE_FILE } from "./codex-last-message";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import type { SessionStore } from "./store";
+import { LearningEvidenceRepoMismatchError, type SessionStore } from "./store";
 import type { HerdrDriver } from "./herdr";
 import { HerdrUnavailableError } from "./herdr";
-import type { Signal, SignalKind } from "./types";
+import type { Learning, Signal, SignalKind } from "./types";
 import { sanitizeScopeGlobs } from "./house-rules";
 import { apiKeyFailClosed, apiKeyPassthroughEnv } from "./spawn-auth";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
@@ -25,12 +25,14 @@ const PROPOSALS_FILE = ".shepherd-learnings.json";
  *  `egress_drop` (a blocked-host name) and `backup_stale` (#1080, a host-global backup-health
  *  alert) are operational, not code-review signals — feeding them to the rule-proposal LLM would
  *  pollute the corpus and count toward the distill threshold. `injection_detected` and
- *  `untrusted_author` are security telemetry for the same reason. */
+ *  `untrusted_author` are security telemetry for the same reason. `evidence_repo_mismatch`
+ *  diagnoses rejected citations and must not feed the distiller's own learning corpus. */
 const NON_LEARNING_SIGNAL_KINDS: ReadonlySet<SignalKind> = new Set<SignalKind>([
   "egress_drop",
   "backup_stale",
   "injection_detected",
   "untrusted_author",
+  "evidence_repo_mismatch",
 ]);
 
 /**
@@ -454,14 +456,18 @@ export class DistillerService {
         );
         continue;
       }
+      const rule = trimRuleToLimit(r.rule);
+      const learning = this.applyEvidenceWrite(() =>
+        this.deps.store.addLearning({
+          repoPath: f.repoPath,
+          rule,
+          rationale: typeof r.rationale === "string" ? r.rationale : "",
+          evidence,
+          scopeGlobs: sanitizeScopeGlobs(r.scopeGlobs),
+        }),
+      );
+      if (!learning) continue;
       have.add(key);
-      this.deps.store.addLearning({
-        repoPath: f.repoPath,
-        rule: trimRuleToLimit(r.rule),
-        rationale: typeof r.rationale === "string" ? r.rationale : "",
-        evidence,
-        scopeGlobs: sanitizeScopeGlobs(r.scopeGlobs),
-      });
       added++;
     }
     return added;
@@ -502,9 +508,23 @@ export class DistillerService {
       const evidence = Array.isArray(e.evidence)
         ? e.evidence.filter((s): s is string => typeof s === "string" && f.signalIds.has(s))
         : [];
-      if (this.deps.store.accrueProposedEvidence(id, evidence) !== null) reaffirmed++;
+      if (
+        this.applyEvidenceWrite(() => this.deps.store.accrueProposedEvidence(id, evidence)) !== null
+      )
+        reaffirmed++;
     }
     return reaffirmed;
+  }
+
+  /** The store records the incident; treat only its provenance rejection as a skipped write. */
+  private applyEvidenceWrite(write: () => Learning | null): Learning | null {
+    try {
+      return write();
+    } catch (error) {
+      if (!(error instanceof LearningEvidenceRepoMismatchError)) throw error;
+      console.warn(`[distill] rejected foreign evidence for ${error.repoPath}`, error);
+      return null;
+    }
   }
 }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -76,6 +76,17 @@ import { normalizeRule } from "./learning-rule";
 import { trimRuleToLimit } from "./learning-shape";
 import type { GitState } from "./forge/types";
 
+/** A rejected evidence write; its diagnostic signal is persisted before this is thrown. */
+export class LearningEvidenceRepoMismatchError extends Error {
+  constructor(
+    readonly repoPath: string,
+    readonly foreignEvidence: { id: string; repoPath: string }[],
+  ) {
+    super(`Learning evidence belongs to another repository: ${repoPath}`);
+    this.name = "LearningEvidenceRepoMismatchError";
+  }
+}
+
 /** Tolerantly parse a persisted JSON column, falling back to `fallback` on any error. */
 function safeJsonParse<T>(raw: string | null | undefined, fallback: T): T {
   if (typeof raw !== "string" || raw === "") return fallback;
@@ -4923,6 +4934,27 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     };
   }
 
+  /** Reject the whole write on proven foreign evidence. Missing/pruned ids are unknown,
+   *  not proof of a repo mismatch. Keep the diagnostic outside a rolled-back learning write. */
+  private assertLearningEvidenceRepo(
+    repoPath: string,
+    rule: string,
+    evidence: string[],
+    operation: "add" | "accrue",
+  ): void {
+    const foreignEvidence = this.getSignalsByIds(evidence)
+      .filter((signal) => signal.repoPath !== repoPath)
+      .map((signal) => ({ id: signal.id, repoPath: signal.repoPath }));
+    if (foreignEvidence.length === 0) return;
+    this.addSignal({
+      repoPath,
+      sessionId: null,
+      kind: "evidence_repo_mismatch",
+      payload: JSON.stringify({ operation, rule, foreignEvidence, citedCount: evidence.length }),
+    });
+    throw new LearningEvidenceRepoMismatchError(repoPath, foreignEvidence);
+  }
+
   /** Resolve signal ids to their distinct kind + session sets for durable diversity tracking.
    *  kinds = distinct signal.kind values; sessions = distinct non-null/non-empty sessionIds,
    *  capped at 50 to bound row growth. Used by addLearning and accrueProposedEvidence. */
@@ -4943,6 +4975,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     evidence: string[];
     scopeGlobs?: string[];
   }): Learning {
+    this.assertLearningEvidenceRepo(input.repoPath, input.rule, input.evidence, "add");
     const now = Date.now();
     const { kinds, sessions } = this.resolveDiversity(input.evidence);
     const l: Learning = {
@@ -5536,6 +5569,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     const existingSet = new Set(cur.evidence);
     const fresh = signalIds.filter((s) => typeof s === "string" && s && !existingSet.has(s));
     if (fresh.length === 0) return null;
+    this.assertLearningEvidenceRepo(cur.repoPath, cur.rule, fresh, "accrue");
     const newEvidence = [...cur.evidence, ...fresh];
     const { kinds: freshKinds, sessions: freshSessions } = this.resolveDiversity(fresh);
     // Read existing diversity sets from the raw row to avoid double-parsing via hydrate.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1302,7 +1302,8 @@ export type SignalKind =
   | "egress_drop"
   | "backup_stale"
   | "injection_detected"
-  | "untrusted_author";
+  | "untrusted_author"
+  | "evidence_repo_mismatch";
 
 export interface Signal {
   id: string;

--- a/test/delivery-metrics.test.ts
+++ b/test/delivery-metrics.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { SessionStore } from "../src/store";
+import { LearningEvidenceRepoMismatchError, SessionStore } from "../src/store";
 import { buildDeliveryMetrics } from "../src/delivery-metrics";
 import type { CiConclusion, PlanDrift, ReviewerSpawnOutcome } from "../src/types";
 
@@ -260,6 +260,33 @@ test("repeat incidents group signals by kind with distinct sessions", () => {
   expect(stall.occurrences).toBe(3);
   expect(stall.sessions).toBe(2);
   expect(m.incidents.find((i) => i.kind === "critic")!.sessions).toBe(0);
+});
+
+test("repo evidence: repeated rejected writes appear as incidents without attributing foreign sessions", () => {
+  const store = mk();
+  const foreign = store.addSignal({
+    repoPath: "/other",
+    sessionId: "foreign-session",
+    kind: "critic",
+    payload: "a",
+  });
+  for (let i = 0; i < 2; i++) {
+    expect(() =>
+      store.addLearning({
+        repoPath: "/r",
+        rule: `rule ${i}`,
+        rationale: "",
+        evidence: [foreign.id],
+      }),
+    ).toThrow(LearningEvidenceRepoMismatchError);
+  }
+  const metrics = buildDeliveryMetrics({ store, range: "all", now: Date.now() });
+  expect(metrics.incidents).toContainEqual({
+    kind: "evidence_repo_mismatch",
+    occurrences: 2,
+    sessions: 0,
+  });
+  expect(metrics.incidents).toContainEqual({ kind: "critic", occurrences: 1, sessions: 1 });
 });
 
 test("only this task's spawns count toward its rounds", () => {

--- a/test/distiller.test.ts
+++ b/test/distiller.test.ts
@@ -10,7 +10,7 @@ import {
   LEARNING_FACT_SHAPE,
   LEARNING_RULE_MAX_CHARS,
 } from "../src/learning-shape";
-import { SessionStore } from "../src/store";
+import { LearningEvidenceRepoMismatchError, SessionStore } from "../src/store";
 import { config } from "../src/config";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
 import { HerdrUnavailableError } from "../src/herdr";
@@ -92,6 +92,191 @@ test("consider does nothing below the signal threshold", async () => {
   await d.consider("/r");
   expect(started.length).toBe(0);
 });
+
+test("repo evidence: distiller skips foreign citations, records one incident and cleans up", async () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r", 3);
+  const foreign = store.addSignal({
+    repoPath: "/other",
+    sessionId: "s2",
+    kind: "critic",
+    payload: "b",
+  });
+  let changes = 0;
+  const { deps, started } = mkDeps(
+    store,
+    {
+      rules: [{ rule: "bad", evidence: [store.listSignals("/r")[0]!.id, foreign.id] }],
+    },
+    () => {
+      changes++;
+    },
+  );
+  const stopped: string[] = [];
+  const removed: string[] = [];
+  deps.herdr.stop = async (id) => {
+    stopped.push(id);
+  };
+  deps.scratch.remove = (dir) => {
+    removed.push(dir);
+  };
+  const warn = spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    const d = new DistillerService(deps);
+    await d.consider("/r");
+    await d.tick();
+    await d.tick(); // finalization must not repeat the rejection or its cleanup
+    expect(store.listLearnings("/r")).toEqual([]);
+    expect(
+      store.listSignals("/r").filter((sig) => sig.kind === "evidence_repo_mismatch"),
+    ).toHaveLength(1);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]![0]).toContain("/r");
+    expect(changes).toBe(0);
+    expect(stopped).toEqual(["dist1"]);
+    expect(removed).toEqual([started[0]!.dir]);
+  } finally {
+    warn.mockRestore();
+  }
+});
+
+test("repo evidence: rejected adds do not consume the success limit or poison dedup", async () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r", 3);
+  const own = store.listSignals("/r")[0]!;
+  const foreign = store.addSignal({
+    repoPath: "/other",
+    sessionId: null,
+    kind: "critic",
+    payload: "b",
+  });
+  let changes = 0;
+  const { deps } = mkDeps(
+    store,
+    {
+      rules: [
+        ...Array.from({ length: 6 }, (_, i) => ({ rule: `RULE ${i}`, evidence: [foreign.id] })),
+        ...Array.from({ length: 6 }, (_, i) => ({ rule: `rule ${i}`, evidence: [own.id] })),
+      ],
+    },
+    () => {
+      changes++;
+    },
+  );
+  const warn = spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    const d = new DistillerService(deps);
+    await d.consider("/r");
+    await d.tick();
+    const saved = store.listLearnings("/r");
+    expect(saved.map((l) => l.rule).sort()).toEqual([
+      "rule 0",
+      "rule 1",
+      "rule 2",
+      "rule 3",
+      "rule 4",
+    ]);
+    expect(saved.every((l) => l.evidence.length === 1 && l.evidence[0] === own.id)).toBe(true);
+    expect(
+      store.listSignals("/r").filter((sig) => sig.kind === "evidence_repo_mismatch"),
+    ).toHaveLength(6);
+    expect(changes).toBe(1);
+  } finally {
+    warn.mockRestore();
+  }
+});
+
+test("repo evidence: mismatch telemetry affects neither threshold nor written corpus", async () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r", 2);
+  for (let i = 0; i < 10; i++) {
+    store.addSignal({
+      repoPath: "/r",
+      sessionId: null,
+      kind: "evidence_repo_mismatch",
+      payload: "incident",
+    });
+  }
+  const { deps, started } = mkDeps(store, { rules: [] });
+  const corpusIds: string[] = [];
+  deps.writeSignals = (_dir, signals) => {
+    corpusIds.push(...signals.map((sig) => sig.id));
+  };
+  const d = new DistillerService(deps);
+  await d.consider("/r");
+  expect(started).toHaveLength(0);
+  seedSignals(store, "/r", 1);
+  await d.consider("/r");
+  expect(started).toHaveLength(1);
+  expect(corpusIds.sort()).toEqual(
+    store
+      .listSignals("/r")
+      .filter((sig) => sig.kind === "reply")
+      .map((sig) => sig.id)
+      .sort(),
+  );
+  await d.tick();
+});
+
+test("repo evidence: reaffirm continues after a typed store rejection", async () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r", 3);
+  const sig = store.listSignals("/r")[0]!;
+  const first = store.addLearning({ repoPath: "/r", rule: "first", rationale: "", evidence: [] });
+  const second = store.addLearning({ repoPath: "/r", rule: "second", rationale: "", evidence: [] });
+  const { deps } = mkDeps(store, {
+    reaffirm: [
+      { id: first.id, evidence: [sig.id] },
+      { id: second.id, evidence: [sig.id] },
+    ],
+  });
+  // The run filter normally prevents this; simulate the store rejecting the first write.
+  const accrue = spyOn(store, "accrueProposedEvidence").mockImplementationOnce(() => {
+    throw new LearningEvidenceRepoMismatchError("/r", [{ id: sig.id, repoPath: "/other" }]);
+  });
+  const warn = spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    const d = new DistillerService(deps);
+    await d.consider("/r");
+    await d.tick();
+    expect(store.getLearning(first.id)!.evidence).toEqual([]);
+    expect(store.getLearning(second.id)!.evidence).toEqual([sig.id]);
+    expect(warn).toHaveBeenCalledTimes(1);
+  } finally {
+    accrue.mockRestore();
+    warn.mockRestore();
+  }
+});
+
+for (const method of ["addLearning", "accrueProposedEvidence"] as const) {
+  test(`repo evidence: distiller does not swallow unrelated ${method} failures`, async () => {
+    const store = new SessionStore(":memory:");
+    seedSignals(store, "/r", 3);
+    const sig = store.listSignals("/r")[0]!;
+    const existing = store.addLearning({
+      repoPath: "/r",
+      rule: "existing",
+      rationale: "",
+      evidence: [],
+    });
+    const { deps } = mkDeps(
+      store,
+      method === "addLearning"
+        ? { rules: [{ rule: "new", evidence: [sig.id] }] }
+        : { reaffirm: [{ id: existing.id, evidence: [sig.id] }] },
+    );
+    const write = spyOn(store, method).mockImplementation(() => {
+      throw new Error("database unavailable");
+    });
+    try {
+      const d = new DistillerService(deps);
+      await d.consider("/r");
+      await expect(d.tick()).rejects.toThrow("database unavailable");
+    } finally {
+      write.mockRestore();
+    }
+  });
+}
 
 test("automatic consideration respects the persisted per-repository interval", async () => {
   const store = new SessionStore(":memory:");

--- a/test/store-learnings.test.ts
+++ b/test/store-learnings.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
-import { SessionStore } from "../src/store";
+import { LearningEvidenceRepoMismatchError, SessionStore } from "../src/store";
 import { runAutoTrial } from "../src/learnings-lifecycle";
 
 test("addSignal stores and lists newest-first within a repo", () => {
@@ -70,6 +70,131 @@ test("setLearningStatus transitions and can edit rule text; getLearning round-tr
   expect(up.rule).toBe("new wording");
   expect(s.getLearning(l.id)?.status).toBe("active");
   expect(s.setLearningStatus("missing", "dismissed")).toBeNull();
+});
+
+for (const mixed of [false, true]) {
+  test(`repo evidence: addLearning rejects ${mixed ? "mixed" : "entirely foreign"} citations without inserting a rule`, () => {
+    const s = new SessionStore(":memory:");
+    const own = s.addSignal({ repoPath: "/r", sessionId: "s1", kind: "reply", payload: "a" });
+    const foreign = s.addSignal({
+      repoPath: "/other",
+      sessionId: "s2",
+      kind: "critic",
+      payload: "foreign payload must not be copied",
+    });
+    const evidence = mixed ? [own.id, foreign.id, "unknown"] : [foreign.id];
+
+    expect(() => s.addLearning({ repoPath: "/r", rule: "rule", rationale: "", evidence })).toThrow(
+      LearningEvidenceRepoMismatchError,
+    );
+    expect(s.listLearnings("/r")).toEqual([]);
+    expect(s.listLearnings("/other")).toEqual([]);
+    expect(s.pendingLearningCount()).toBe(0);
+    const incidents = s.listSignals("/r").filter((sig) => sig.kind === "evidence_repo_mismatch");
+    expect(incidents).toHaveLength(1);
+    expect(incidents[0]!.sessionId).toBeNull();
+    expect(JSON.parse(incidents[0]!.payload)).toEqual({
+      operation: "add",
+      rule: "rule",
+      foreignEvidence: [{ id: foreign.id, repoPath: "/other" }],
+      citedCount: evidence.length,
+    });
+  });
+}
+
+test("repo evidence: accepted citations retain counts, duplicates, unknown IDs and diversity", () => {
+  const s = new SessionStore(":memory:");
+  const reply = s.addSignal({ repoPath: "/r", sessionId: "s1", kind: "reply", payload: "a" });
+  const block = s.addSignal({ repoPath: "/r", sessionId: "s2", kind: "block", payload: "b" });
+  const critic = s.addSignal({ repoPath: "/r", sessionId: null, kind: "critic", payload: "c" });
+  const evidence = [reply.id, reply.id, block.id, critic.id, "unknown"];
+  const l = s.addLearning({ repoPath: "/r", rule: "rule", rationale: "why", evidence });
+
+  for (const saved of [l, s.getLearning(l.id)!]) {
+    expect(saved.evidence).toEqual(evidence);
+    expect(saved.evidenceCount).toBe(5);
+    expect(saved.distinctKinds).toBe(3);
+    expect(saved.distinctSessions).toBe(2);
+    expect(saved.lastEvidenceAt).toBe(l.createdAt);
+  }
+  expect(s.listSignals("/r")).toHaveLength(3);
+});
+
+test("repo evidence: pruned foreign citations are unknown, not proof of a mismatch", () => {
+  const s = new SessionStore(":memory:");
+  const foreign = s.addSignal({ repoPath: "/other", sessionId: "s1", kind: "reply", payload: "a" });
+  s.pruneSignals(foreign.ts + 1);
+  const evidence = [foreign.id, "unknown"];
+  const l = s.addLearning({ repoPath: "/r", rule: "rule", rationale: "", evidence });
+  expect(s.getLearning(l.id)).toMatchObject({
+    evidence,
+    evidenceCount: 2,
+    distinctKinds: 0,
+    distinctSessions: 0,
+  });
+  expect(s.listSignals("/r")).toEqual([]);
+});
+
+test("repo evidence: pruning signals does not alter a stored learning or its diversity", () => {
+  const s = new SessionStore(":memory:");
+  const sig = s.addSignal({ repoPath: "/r", sessionId: "s1", kind: "reply", payload: "a" });
+  const l = s.addLearning({ repoPath: "/r", rule: "rule", rationale: "", evidence: [sig.id] });
+  const before = s.getLearning(l.id);
+  s.pruneSignals(sig.ts + 1);
+  expect(s.getLearning(l.id)).toEqual(before);
+  expect(s.getSignalsByIds([sig.id])).toEqual([]);
+});
+
+test("repo evidence: a foreign fresh citation rejects the whole accrual and preserves trial state", () => {
+  const s = new SessionStore(":memory:");
+  const own = s.addSignal({ repoPath: "/r", sessionId: "s1", kind: "reply", payload: "a" });
+  const foreign = s.addSignal({
+    repoPath: "/other",
+    sessionId: "s2",
+    kind: "critic",
+    payload: "b",
+  });
+  const l = s.addLearning({ repoPath: "/r", rule: "rule", rationale: "", evidence: [] });
+  s.trialLearning(l.id);
+  s.revertTrial(l.id, "proposed");
+  const before = s.getLearning(l.id)!;
+  expect(before.reTrialBlockedAt).not.toBeNull();
+
+  expect(() => s.accrueProposedEvidence(l.id, [own.id, foreign.id, "unknown"])).toThrow(
+    LearningEvidenceRepoMismatchError,
+  );
+  expect(s.getLearning(l.id)).toEqual(before);
+  const incidents = s.listSignals("/r").filter((sig) => sig.kind === "evidence_repo_mismatch");
+  expect(incidents).toHaveLength(1);
+  expect(JSON.parse(incidents[0]!.payload)).toEqual({
+    operation: "accrue",
+    rule: "rule",
+    foreignEvidence: [{ id: foreign.id, repoPath: "/other" }],
+    citedCount: 3,
+  });
+});
+
+test("repo evidence: accrual preserves unknown IDs and no-op semantics", () => {
+  const s = new SessionStore(":memory:");
+  const own = s.addSignal({ repoPath: "/r", sessionId: "s1", kind: "reply", payload: "a" });
+  const foreign = s.addSignal({
+    repoPath: "/other",
+    sessionId: "s2",
+    kind: "critic",
+    payload: "b",
+  });
+  const l = s.addLearning({ repoPath: "/r", rule: "rule", rationale: "", evidence: [own.id] });
+  expect(s.accrueProposedEvidence(l.id, [own.id, "unknown"])).toMatchObject({
+    evidence: [own.id, "unknown"],
+    evidenceCount: 2,
+    distinctKinds: 1,
+    distinctSessions: 1,
+  });
+  expect(s.accrueProposedEvidence(l.id, [own.id, "unknown"])).toBeNull();
+  s.setLearningStatus(l.id, "active");
+  expect(s.accrueProposedEvidence(l.id, [foreign.id])).toBeNull();
+  expect(s.accrueProposedEvidence("missing", [foreign.id])).toBeNull();
+  expect(s.listSignals("/r")).toHaveLength(1);
 });
 
 test("pendingLearningCount counts proposed across all repos", () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3785,5 +3785,8 @@
   "newtask_spawn_seconds": "{seconds} s",
   "newtask_spawn_progress_aria": "Fortschritt beim Start der Aufgabe",
   "feat_spawn_progress_title": "Sehen, warum ein Start dauert",
-  "feat_spawn_progress_body": "Neue Aufgabe nennt jetzt den Schritt, an dem der Start gerade steht — Basis-Branch aktualisieren, Worktree anlegen, auf den Agent warten — und sagt bei langer Wartezeit, warum, samt Abbrechen."
+  "feat_spawn_progress_body": "Neue Aufgabe nennt jetzt den Schritt, an dem der Start gerade steht — Basis-Branch aktualisieren, Worktree anlegen, auf den Agent warten — und sagt bei langer Wartezeit, warum, samt Abbrechen.",
+  "usage_delivery_evidence_repo_mismatch": "Fremde Repo-Evidenz abgewiesen",
+  "feat_learnings_evidence_repo_title": "Learnings prüfen die Herkunft ihrer Evidenz",
+  "feat_learnings_evidence_repo_body": "Neue Regelvorschläge mit nachweislich fremder Repo-Evidenz werden vollständig abgewiesen. Die Vorfälle erscheinen in der Signalstatistik. Unbekannte oder abgelaufene Signal-IDs gelten nicht als Herkunftskonflikt; bestehende Regeln bleiben unverändert."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3785,5 +3785,8 @@
   "newtask_spawn_seconds": "{seconds} s",
   "newtask_spawn_progress_aria": "Task start progress",
   "feat_spawn_progress_title": "See why a start is taking long",
-  "feat_spawn_progress_body": "New Task now names the step it is on while a task starts — updating the base branch, creating the worktree, waiting for the agent — and if it drags on, it says why and offers to cancel."
+  "feat_spawn_progress_body": "New Task now names the step it is on while a task starts — updating the base branch, creating the worktree, waiting for the agent — and if it drags on, it says why and offers to cancel.",
+  "usage_delivery_evidence_repo_mismatch": "Foreign repo evidence rejected",
+  "feat_learnings_evidence_repo_title": "Learnings check evidence provenance",
+  "feat_learnings_evidence_repo_body": "New rule proposals citing evidence known to belong to another repo are rejected in full. Incidents appear in signal statistics. Unknown or expired signal IDs are not treated as provenance conflicts; existing rules remain unchanged."
 }

--- a/ui/src/lib/components/usage/DeliveryLens.svelte
+++ b/ui/src/lib/components/usage/DeliveryLens.svelte
@@ -256,7 +256,11 @@
         <div class="rows">
           {#each metrics.incidents as incident (incident.kind)}
             <div class="row incident-row">
-              <span class="repo-name">{incident.kind}</span>
+              <span class="repo-name"
+                >{incident.kind === "evidence_repo_mismatch"
+                  ? m.usage_delivery_evidence_repo_mismatch()
+                  : incident.kind}</span
+              >
               <span class="numeric"
                 >{m.usage_delivery_incident_count({
                   occurrences: incident.occurrences,

--- a/ui/src/lib/feature-announcements/entries/v1.48.0-learnings-evidence-repo.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.48.0-learnings-evidence-repo.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "learnings-evidence-repo",
+  sinceVersion: "1.48.0",
+  titleKey: "feat_learnings_evidence_repo_title",
+  bodyKey: "feat_learnings_evidence_repo_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
## Summary

A new learning for repo A could cite signals from repo B and later be injected or promoted into repo A. The store now rejects the entire new rule or fresh evidence batch when any resolved citation belongs to another repository. The distiller logs the rejection and continues, without consuming its successful-add limit or blocking a later valid proposal with the same text.

Each rejected write records one `evidence_repo_mismatch` signal, shown with a DE/EN label in the existing Delivery statistics and excluded from the distiller's corpus and threshold. Unknown or pruned IDs retain their existing evidence-count/diversity semantics. Existing learning rows and cross-repo merge suggestions remain unchanged. Includes a feature announcement.

Closes #2145

## Validation

- Reproduced the bad inserts and evidence accrual with failing tests before implementing the guard; added 14 regression tests covering strict rejection, diagnostics, counts, retention, continuation, deduplication, and corpus exclusion.
- Root: `bun run lint`, `bun run typecheck`, `bun run test` — 9,145 passed, 15 skipped.
- UI: `bun run check` (zero errors/warnings), `bun run check:i18n`, `bun run test` — 4,789 passed.
- `bun run check:announcement-versions`, Prettier, and `git diff --check` passed.
- Self-reviewed the changed production code and tests for partial writes, duplicate diagnostics, counter drift, and changes to historical data.

## Checklist

- [x] Conventional-commit PR title.
- [x] Branch rebased on `origin/main`; no merge commits.
- [x] Relevant root and UI lint/check/test commands passed.
- [x] User-facing text uses both i18n catalogs.
- [x] Feature-announcement entry targets the next release.
- [x] Existing design-system panel and statistic row reused.
- [x] User-facing behavior documented in the announcement; no public API/config/CLI changes.
