### PR TITLE
fix(ui): make issue lists usable on small screens

### DIFF
--- a/ui/src/lib/components/BacklogView.browser.test.ts
+++ b/ui/src/lib/components/BacklogView.browser.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-svelte";
-import { cdp, page } from "vitest/browser";
+import { page } from "vitest/browser";
 import "../../app.css";
 import { overwriteGetLocale } from "$lib/paraglide/runtime";
 import { m } from "$lib/paraglide/messages";
@@ -57,8 +57,8 @@ function props(count: number) {
   };
 }
 
-beforeEach(async () => {
-  await cdp().send("Emulation.setTouchEmulationEnabled", { enabled: true });
+beforeEach(() => {
+  expect(window.matchMedia("(pointer: coarse)").matches).toBe(true);
   overwriteGetLocale(() => "de");
   vi.mocked(listIssues).mockResolvedValue({
     slug: "organization-with-a-long-name/repository-with-a-long-name",
@@ -103,7 +103,6 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  await cdp().send("Emulation.setTouchEmulationEnabled", { enabled: false });
   overwriteGetLocale(() => "en");
   document.body.innerHTML = "";
   await page.viewport(1280, 900);

--- a/ui/src/lib/components/BacklogView.browser.test.ts
+++ b/ui/src/lib/components/BacklogView.browser.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { cdp, page } from "vitest/browser";
+import "../../app.css";
+import { overwriteGetLocale } from "$lib/paraglide/runtime";
+import { m } from "$lib/paraglide/messages";
+import { listIssues, getEpics, getEpic } from "$lib/api";
+import type { BacklogPayload, Issue } from "$lib/types";
+import BacklogView from "./BacklogView.svelte";
+import BacklogOverlay from "./BacklogOverlay.svelte";
+
+vi.mock("$lib/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("$lib/api")>()),
+  listIssues: vi.fn(),
+  getEpics: vi.fn(),
+  getEpic: vi.fn(),
+}));
+
+const noop = () => {};
+const issues: Issue[] = Array.from({ length: 50 }, (_, i) => ({
+  number: i + 1,
+  title: `Issue ${i + 1} with a long title that must not push actions off screen`,
+  body: "A body preview that contributes to the row's natural height.",
+  url: `https://example.com/issues/${i + 1}`,
+  labels: [],
+  assignees: [],
+  createdAt: 0,
+}));
+
+function props(count: number) {
+  const payload: BacklogPayload = {
+    pinnedPath: null,
+    totals: { openIssues: 50, openPRs: 0 },
+    projects: Array.from({ length: count }, (_, i) => ({
+      path: `/repo-${i}`,
+      display: `repo-${i}`,
+      slug: `org/repo-${i}`,
+      kind: "github",
+      openIssues: 50,
+      openPRs: 0,
+      prKinds: null,
+      workflows: null,
+      ciStatus: null,
+      hidden: false,
+    })),
+  };
+  return {
+    payload,
+    mobile: true,
+    onissue: vi.fn(),
+    onpr: noop,
+    onadopt: noop,
+    onlaunchtrain: noop,
+    onaddclone: noop,
+    onaddfork: noop,
+    onaddnewproject: noop,
+  };
+}
+
+beforeEach(async () => {
+  await cdp().send("Emulation.setTouchEmulationEnabled", { enabled: true });
+  overwriteGetLocale(() => "de");
+  vi.mocked(listIssues).mockResolvedValue({
+    slug: "organization-with-a-long-name/repository-with-a-long-name",
+    webUrl: null,
+    issues,
+    viewer: null,
+  });
+  vi.mocked(getEpics).mockResolvedValue({
+    epics: [
+      {
+        parentIssueNumber: 1,
+        parentTitle: "Epic",
+        total: 8,
+        merged: 0,
+        status: "idle",
+        source: "native",
+      },
+    ],
+    subIssues: [],
+  });
+  vi.mocked(getEpic).mockResolvedValue({
+    repoPath: "/repo-0",
+    parentIssueNumber: 1,
+    parentTitle: "Epic",
+    source: "native",
+    children: Array.from({ length: 8 }, (_, i) => ({
+      number: 100 + i,
+      title: `Epic child ${i}`,
+      url: `https://example.com/issues/${100 + i}`,
+      order: i,
+      body: "",
+      blockedBy: [],
+      state: "ready",
+      sessionId: null,
+      prNumber: null,
+      issueClosed: false,
+      claimed: false,
+    })),
+    warnings: [],
+    run: { repoPath: "/repo-0", parentIssueNumber: 1, mode: "auto", status: "idle" },
+  });
+});
+
+afterEach(async () => {
+  await cdp().send("Emulation.setTouchEmulationEnabled", { enabled: false });
+  overwriteGetLocale(() => "en");
+  document.body.innerHTML = "";
+  await page.viewport(1280, 900);
+});
+
+describe("mobile backlog issue scrolling", () => {
+  it.each([
+    ["flow", 1, 320, 568],
+    ["flow", 40, 375, 667],
+    ["overlay", 1, 430, 932],
+    ["overlay", 40, 375, 667],
+    ["flow", 1, 852, 393],
+    ["overlay", 40, 852, 393],
+  ] as const)(
+    "reaches the last issue in %s with %i repositories at %i×%i",
+    async (mode, count, width, height) => {
+      await page.viewport(width, height);
+      const input = props(count);
+      const host = document.createElement("div");
+      // A page-scrolling host with content before the embedded backlog, as on the start page.
+      host.style.paddingTop = "800px";
+      document.body.append(host);
+      if (mode === "flow") {
+        await render(BacklogView, { target: host, props: { ...input, flow: true } });
+        window.scrollTo(0, 300);
+      } else await render(BacklogOverlay, { target: host, props: { ...input, onclose: noop } });
+      const first = page.getByText("repo-0", { exact: true });
+      await first.click();
+      const pageScroll = window.scrollY;
+      if (mode === "flow") expect(pageScroll).toBeGreaterThan(0);
+      await expect.poll(() => document.querySelectorAll(".issue-row").length).toBe(50);
+      await expect.element(page.getByText("Epic child 7", { exact: true })).toBeInTheDocument();
+
+      const detail = document.querySelector<HTMLElement>(".mobile-detail-overlay")!;
+      const list = document.querySelector<HTMLElement>(".issues-list")!;
+      const filter = document.querySelector<HTMLElement>(".issues-list .filter-bar")!;
+      const search = page.getByRole("searchbox", { name: m.issuespanel_filter_placeholder() });
+      await search.fill("Issue 50 ");
+      await expect.poll(() => document.querySelectorAll(".issue-row").length).toBe(1);
+      await search.fill("");
+      await expect.poll(() => document.querySelectorAll(".issue-row").length).toBe(50);
+      const header = document.querySelector<HTMLElement>(".issues-header")!;
+      expect(header.scrollWidth).toBeLessThanOrEqual(header.clientWidth + 1);
+      for (const control of filter.querySelectorAll<HTMLElement>(".issue-filter, .filter-chip")) {
+        expect(control.getBoundingClientRect().height).toBeGreaterThanOrEqual(44);
+      }
+      expect(detail.getBoundingClientRect().top).toBeGreaterThanOrEqual(0);
+      expect(detail.getBoundingClientRect().bottom).toBeLessThanOrEqual(height + 1);
+      expect(list.clientHeight).toBeGreaterThan(44);
+      expect(list.scrollHeight).toBeGreaterThan(list.clientHeight);
+      expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(width);
+      const filterTop = filter.getBoundingClientRect().top;
+      list.scrollTop = list.scrollHeight;
+      await expect.poll(() => list.scrollTop).toBeGreaterThan(0);
+      const last = document.querySelector<HTMLElement>("#epic-issue-row-50")!;
+      expect(last.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+        list.getBoundingClientRect().bottom + 1,
+      );
+      expect(filter.getBoundingClientRect().top).toBeCloseTo(filterTop, 0);
+      const action = last.querySelector<HTMLElement>(".task-btn")!;
+      await page.elementLocator(action).click();
+      expect(input.onissue).toHaveBeenCalledWith(
+        "/repo-0",
+        expect.objectContaining({ number: 50 }),
+      );
+      await page.elementLocator(detail.querySelector<HTMLElement>(".overlay-close")!).click();
+      await expect.poll(() => document.querySelector(".mobile-detail-overlay")).toBeNull();
+      expect(window.scrollY).toBe(pageScroll);
+      host.remove();
+    },
+  );
+});

--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -719,6 +719,14 @@
     overflow: visible;
   }
 
+  /* The start-page repo list grows with content; its detail must fit the screen,
+     independently of that list's height or the document's scroll position. */
+  .backlog-view.mobile.flow .mobile-detail-overlay {
+    position: fixed;
+    padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom)
+      env(safe-area-inset-left);
+  }
+
   .overlay-head {
     display: flex;
     align-items: center;

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -627,6 +627,7 @@
   }
 
   .issues-header {
+    overflow-wrap: anywhere;
     padding: 6px 12px;
     margin-bottom: 8px; /* gap below the border to the flush sticky filter — margin (outside the border), not padding */
     font-size: var(--fs-micro);
@@ -706,7 +707,14 @@
     text-decoration: underline;
   }
 
-  @media (max-width: 768px) {
+  @media (max-width: 768px), (pointer: coarse) {
+    .issue-filter {
+      font-size: var(--fs-lg);
+      min-height: 44px;
+    }
+    .filter-bar :global(.filter-chip) {
+      min-height: 44px;
+    }
     .issues-list {
       -webkit-overflow-scrolling: touch;
     }

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -4032,35 +4032,33 @@ describe("NewTask mobile sources sheet", () => {
 
   it("scrolls on a touch swipe in landscape without selecting or opening the context menu", async () => {
     const session = cdp();
-    await session.send("Emulation.setTouchEmulationEnabled", { enabled: true });
-    try {
-      await page.viewport(852, 393);
-      seedIssues(Array.from({ length: 50 }, (_, i) => mkIssue(i + 1)));
-      render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo" } });
-      await expect.poll(() => srcBtn()).toBeTruthy();
-      await page.elementLocator(srcBtn()!).click();
-      await expect.poll(() => document.querySelectorAll(".sheet .issue-list-row").length).toBe(50);
-      const body = document.querySelector<HTMLElement>(".sheet .ps-body")!;
-      const r = body.getBoundingClientRect();
-      const x = r.left + r.width / 2;
-      const y = r.bottom - 20;
+    // Touch events can be dispatched without changing Chromium's pointer/hover capabilities.
+    mockPointer(true);
+    await page.viewport(852, 393);
+    seedIssues(Array.from({ length: 50 }, (_, i) => mkIssue(i + 1)));
+    render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo" } });
+    await expect.poll(() => srcBtn()).toBeTruthy();
+    await page.elementLocator(srcBtn()!).click();
+    await expect.poll(() => document.querySelectorAll(".sheet .issue-list-row").length).toBe(50);
+    const body = document.querySelector<HTMLElement>(".sheet .ps-body")!;
+    const r = body.getBoundingClientRect();
+    const x = r.left + r.width / 2;
+    const y = r.bottom - 20;
+    await session.send("Input.dispatchTouchEvent", {
+      type: "touchStart",
+      touchPoints: [{ x, y }],
+    });
+    for (const dy of [20, 40, 60, 80]) {
       await session.send("Input.dispatchTouchEvent", {
-        type: "touchStart",
-        touchPoints: [{ x, y }],
+        type: "touchMove",
+        touchPoints: [{ x, y: y - dy }],
       });
-      for (const dy of [20, 40, 60, 80]) {
-        await session.send("Input.dispatchTouchEvent", {
-          type: "touchMove",
-          touchPoints: [{ x, y: y - dy }],
-        });
-      }
-      await session.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
-      await expect.poll(() => body.scrollTop).toBeGreaterThan(0);
-      expect(psWrap()).not.toBeNull();
-      expect(document.querySelector(".issue-ref, [role=menu]")).toBeNull();
-    } finally {
-      await session.send("Emulation.setTouchEmulationEnabled", { enabled: false });
     }
+    await session.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
+    await expect.poll(() => body.scrollTop).toBeGreaterThan(0);
+    expect(psWrap()).not.toBeNull();
+    expect(document.querySelector(".issue-ref, [role=menu]")).toBeNull();
+    expect(window.matchMedia("(hover: hover) and (pointer: fine)").matches).toBe(true);
   });
 
   it("keeps the command search visible while the keyboard-shortened list scrolls", async () => {

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
-import { page } from "vitest/browser";
+import { cdp, page } from "vitest/browser";
 import "../../app.css";
 import { overwriteGetLocale } from "$lib/paraglide/runtime";
 import type {
@@ -4029,6 +4029,109 @@ describe("NewTask mobile sources sheet", () => {
   }
   const srcBtn = () => document.querySelector<HTMLButtonElement>(".sources-btn");
   const psWrap = () => document.querySelector<HTMLElement>(".ps-wrap");
+
+  it("scrolls on a touch swipe in landscape without selecting or opening the context menu", async () => {
+    const session = cdp();
+    await session.send("Emulation.setTouchEmulationEnabled", { enabled: true });
+    try {
+      await page.viewport(852, 393);
+      seedIssues(Array.from({ length: 50 }, (_, i) => mkIssue(i + 1)));
+      render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo" } });
+      await expect.poll(() => srcBtn()).toBeTruthy();
+      await page.elementLocator(srcBtn()!).click();
+      await expect.poll(() => document.querySelectorAll(".sheet .issue-list-row").length).toBe(50);
+      const body = document.querySelector<HTMLElement>(".sheet .ps-body")!;
+      const r = body.getBoundingClientRect();
+      const x = r.left + r.width / 2;
+      const y = r.bottom - 20;
+      await session.send("Input.dispatchTouchEvent", {
+        type: "touchStart",
+        touchPoints: [{ x, y }],
+      });
+      for (const dy of [20, 40, 60, 80]) {
+        await session.send("Input.dispatchTouchEvent", {
+          type: "touchMove",
+          touchPoints: [{ x, y: y - dy }],
+        });
+      }
+      await session.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
+      await expect.poll(() => body.scrollTop).toBeGreaterThan(0);
+      expect(psWrap()).not.toBeNull();
+      expect(document.querySelector(".issue-ref, [role=menu]")).toBeNull();
+    } finally {
+      await session.send("Emulation.setTouchEmulationEnabled", { enabled: false });
+    }
+  });
+
+  it("keeps the command search visible while the keyboard-shortened list scrolls", async () => {
+    const { restore } = installFakeViewport(320);
+    try {
+      await page.viewport(375, 667);
+      seedIssues([mkIssue(1)]);
+      mockGetCommands.mockResolvedValue({
+        commands: Array.from({ length: 50 }, (_, i) => ({
+          name: `command-${i}`,
+          description: "Description",
+          scope: "project",
+        })),
+      });
+      render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo" } });
+      await expect.poll(() => srcBtn()).toBeTruthy();
+      await page.elementLocator(srcBtn()!).click();
+      await page.getByRole("button", { name: m.promptsources_commands_tab(), exact: true }).click();
+      await expect.poll(() => document.querySelectorAll(".sheet .ps-body .row").length).toBe(50);
+      const body = document.querySelector<HTMLElement>(".sheet .ps-body")!;
+      const search = document.querySelector<HTMLElement>(".sheet .ps-filter-bar")!;
+      const top = search.getBoundingClientRect().top;
+      body.scrollTop = body.scrollHeight;
+      await expect.poll(() => body.scrollTop).toBeGreaterThan(0);
+      expect(search.getBoundingClientRect().top).toBeCloseTo(top, 0);
+      expect(body.getBoundingClientRect().bottom).toBeLessThanOrEqual(320);
+      await page
+        .getByRole("textbox", { name: m.promptsources_commands_filter() })
+        .fill("command-49");
+      await expect.poll(() => document.querySelectorAll(".sheet .ps-body .row").length).toBe(1);
+    } finally {
+      restore();
+    }
+  });
+
+  it.each([
+    [320, 568],
+    [375, 667],
+    [430, 932],
+  ])("browses every issue with an unclipped German header at %i×%i", async (width, height) => {
+    overwriteGetLocale(() => "de");
+    await page.viewport(width, height);
+    seedIssues(Array.from({ length: 50 }, (_, i) => mkIssue(i + 1, `scroll-issue-${i + 1}`)));
+    render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo" } });
+    await expect.poll(() => srcBtn()).toBeTruthy();
+    await page.elementLocator(srcBtn()!).click();
+    await expect.poll(() => document.querySelectorAll(".sheet .issue-list-row").length).toBe(50);
+
+    const head = document.querySelector<HTMLElement>(".sheet .ps-head")!;
+    const body = document.querySelector<HTMLElement>(".sheet .ps-body")!;
+    expect(head.scrollWidth).toBeLessThanOrEqual(head.clientWidth + 1);
+    for (const control of head.querySelectorAll<HTMLElement>(".tab, .filter-chip")) {
+      const r = control.getBoundingClientRect();
+      expect(r.left).toBeGreaterThanOrEqual(0);
+      expect(r.right).toBeLessThanOrEqual(width);
+      expectMinPx(r.height, 44, "source control");
+    }
+    expect(body.clientHeight).toBeGreaterThanOrEqual(44);
+    expect(body.scrollHeight).toBeGreaterThan(body.clientHeight);
+    const headTop = head.getBoundingClientRect().top;
+    body.scrollTop = body.scrollHeight;
+    await expect.poll(() => body.scrollTop).toBeGreaterThan(0);
+    const last = body.querySelector<HTMLElement>(".issue-list-row:last-child")!;
+    expect(last.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+      body.getBoundingClientRect().bottom + 1,
+    );
+    expect(head.getBoundingClientRect().top).toBeCloseTo(headTop, 0);
+    await page.elementLocator(last).click();
+    await expect.poll(() => psWrap()).toBeNull();
+    expect(document.querySelector(".issue-ref")?.textContent).toContain("scroll-issue-50");
+  });
 
   it("opens the sheet from the toolbar trigger and lists issues", async () => {
     await page.viewport(390, 844);

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -2621,6 +2621,7 @@
         onclose={() => (activeSheet = null)}
       >
         <PromptSources
+          compactIssues={false}
           {repoPath}
           {issueData}
           {epicParents}
@@ -3986,11 +3987,20 @@
     :global(.sheet:has(.ps-wrap) .ps-wrap) {
       flex: 1;
       min-height: 0;
+      min-width: 0;
       display: flex;
       flex-direction: column;
     }
     :global(.sheet:has(.ps-wrap) .ps-head) {
       flex-shrink: 0;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+    }
+    :global(.sheet:has(.ps-wrap) .open-count) {
+      justify-self: end;
+    }
+    :global(.sheet:has(.ps-wrap) .tabs) {
+      grid-column: 2;
     }
     :global(.sheet:has(.ps-wrap) .ps-body) {
       flex: 1;

--- a/ui/src/lib/components/PromptSources.browser.test.ts
+++ b/ui/src/lib/components/PromptSources.browser.test.ts
@@ -553,6 +553,35 @@ describe("PromptSources label chips (responsive 1↔2 cap)", () => {
 });
 
 describe("PromptSources collapsed rows + show-all expansion", () => {
+  it("keeps all matching issues available across tab and repo changes in browse mode", async () => {
+    mockListIssues.mockResolvedValue({
+      slug: "owner/repo",
+      webUrl: null,
+      issues: Array.from({ length: 50 }, (_, i) => issue(i + 1)),
+      viewer: null,
+    });
+    mockGetCommands.mockResolvedValue({ commands: [command(1)] });
+    const issueData = makeIssueData("/repo");
+    const props = {
+      repoPath: "/repo",
+      issueData,
+      onpick: noop,
+      onpickissue: noop,
+      compactIssues: false,
+    };
+    const view = await render(PromptSources, props);
+    const rowCount = () => document.querySelectorAll(".issue-source-row").length;
+    await expect.poll(rowCount).toBe(50);
+    expect(document.querySelector(".more-row")).toBeNull();
+    await page.getByRole("button", { name: m.promptsources_commands_tab(), exact: true }).click();
+    await page.getByRole("button", { name: m.promptsources_issues_tab(), exact: true }).click();
+    await expect.poll(rowCount).toBe(50);
+    await view.rerender({ ...props, repoPath: "/other" });
+    await issueData.load("/other");
+    await expect.poll(rowCount).toBe(50);
+    expect(document.querySelector(".more-row")).toBeNull();
+  });
+
   it("collapses to 3 rows with an expander; activating it reveals all and collapses back", async () => {
     mockListIssues.mockResolvedValue({
       slug: "owner/repo",

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -42,6 +42,7 @@
     onpickissue,
     onpicksteer = undefined,
     allowIssues = true,
+    compactIssues = true,
     filterKeycap = undefined,
     tabsKeycap = undefined,
     rowKeycap = undefined,
@@ -63,6 +64,8 @@
      *  from the row's right-click / long-press context menu. Never spawns. */
     onpicksteer?: (issue: Issue, steer: Steer) => void;
     allowIssues?: boolean;
+    /** The desktop rail starts with three rows; mobile browsing shows the full list. */
+    compactIssues?: boolean;
     /** Replace the filter chip's mute ▾ (New Task's ⌘F keycap). */
     filterKeycap?: Snippet;
     /** Append after the Issues/Commands switch (⌥T) — the switch itself stays
@@ -351,7 +354,9 @@
   }
 
   const COLLAPSED_ROWS = 3;
-  const shownIssues = $derived(expanded ? visibleIssues : visibleIssues.slice(0, COLLAPSED_ROWS));
+  const shownIssues = $derived(
+    !compactIssues || expanded ? visibleIssues : visibleIssues.slice(0, COLLAPSED_ROWS),
+  );
   /** Issue number of the topmost pickable row — the ↑↓ keycap's anchor. Derived
    *  rather than "index 0" because epic-parent rows are interleaved and not
    *  pickable, so the first RENDERED row is often not the first focusable one. */
@@ -547,7 +552,7 @@
             </button>
           {/if}
         {/each}
-        {#if moreCount > 0 || expanded}
+        {#if compactIssues && (moreCount > 0 || expanded)}
           <button class="more-row" type="button" onclick={() => (expanded = !expanded)}>
             {expanded
               ? m.promptsources_collapse_row()

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -95,6 +95,7 @@ export default defineConfig({
         test: {
           name: "browser",
           include: ["src/**/*.browser.test.ts"],
+          exclude: ["src/lib/components/BacklogView.browser.test.ts"],
           // CI memory headroom (#1261 OOM, exit 137): on a many-core self-hosted
           // runner vitest defaults maxWorkers to nproc, so the browser project
           // spawns ~nproc concurrent chromium pages AND overlaps the full-parallel
@@ -117,6 +118,24 @@ export default defineConfig({
             // process holds the port. strictPort:false lets Vite auto-increment
             // to the next free port; vitest discovers the bound port and hands
             // it to the browser client, so a predictable port isn't needed. (#817)
+            api: { strictPort: false },
+          },
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "browser-touch",
+          include: ["src/lib/components/BacklogView.browser.test.ts"],
+          // Keep native touch capabilities in a separate context: disabling CDP touch
+          // emulation does not restore Chromium's desktop pointer/hover media queries.
+          maxWorkers: 1,
+          sequence: { groupOrder: 2 },
+          browser: {
+            enabled: true,
+            provider: playwright({ contextOptions: { hasTouch: true } }),
+            headless: true,
+            instances: [{ browser: "chromium" }],
             api: { strictPort: false },
           },
         },


### PR DESCRIPTION
## Summary

Make both issue surfaces usable on small screens. The mobile “Issues & Commands” sheet now shows every filtered issue immediately and keeps its header within the screen. The start-page backlog detail fills the viewport instead of inheriting the repository list’s height, which previously left either a tiny issue list or content below the screen. Search and filter controls also remain touch-sized in landscape.

Browser regressions cover reaching and selecting the last of 50 issues, expanded epics, one/many repositories, opening from a scrolled page, German headers at 320–430px, touch swiping in landscape, and command search with a keyboard-shortened viewport. The existing desktop compact picker and filter behavior are preserved.

## Validation

- `bun run lint`
- `cd ui && bun run check`
- `cd ui && bun run check:i18n`
- `cd ui && CI=true bun run test` (4,799 tests)
- Regression assertion verifies desktop hover/fine-pointer capabilities survive the touch gesture. Backlog touch layout tests run in a dedicated Playwright context with `hasTouch: true`, avoiding CDP capability changes that Chromium does not fully reset.
- Full repository pre-push gate passed, including root tests, typecheck, UI/extension checks and builds, and the changed-code audit.
- Visual inspection in light and dark themes; real Chromium touch input exercised. A physical iPhone/Safari test was unavailable.

## Checklist

- [x] Conventional-commit PR title.
- [x] Branch is linear from `origin/main`.
- [x] Relevant lint, check, and test commands pass.
- [x] Existing localized text and design-system tokens reused.
- [x] Existing usability bug fix; no new feature catalog entry required. [no-feature-entry]
- [x] No public API, configuration, or CLI changes requiring documentation.
