### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs/external-task-api.md
+++ b/docs/external-task-api.md
@@ -145,7 +145,26 @@ Shepherd also archives the session on its own once the shell has exited.
 | `403`  | Origin header present and not in `SHEPHERD_ALLOWED_HOSTS`. Also `{ "error": "insufficient_scope" }` when the bearer is a valid minted token whose scope doesn't reach this route — the credential is fine, so retrying won't help; mint one with a wider scope                            |
 | `409`  | First-run gate pending — a fresh install whose repo root hasn't been picked yet; body `{ error: "first_run_pending" }`. Pick a workspace folder in the HUD (or start the server with `SHEPHERD_REPO_ROOT` set) and retry                                                                  |
 | `409`  | Clean-terminal conflict — `{ error: "terminal_exists", existingId }` (that repo already has a terminal), `{ error: "terminal_unsupported" }` (the installed herdr has no `terminal session control`), or `{ error: "terminal_session" }` (an agent-only verb aimed at a terminal session) |
+| `409`  | The spawn was cancelled while in flight — `{ error: "spawn canceled", code: "spawn_canceled" }`. Reachable only for a caller that supplied `X-Shepherd-Spawn-Id` and then called the cancel route below; the worktree is already rolled back, so this is a cancellation, not a failure    |
 | `415`  | Missing/incorrect `Content-Type`                                                                                                                                                                                                                                                          |
+
+### Watching and cancelling a slow start
+
+`POST /api/sessions` only answers once the agent is running, and most of that wait
+is herdr auto-detecting a trusted agent. A caller can name its own spawn with an
+`X-Shepherd-Spawn-Id` **header** (a client-chosen id matching
+`^[A-Za-z0-9-]{8,64}$` — the HUD sends a `crypto.randomUUID()`). It is a header,
+not a body field, because the create body is what a usage hold persists as a held
+task and a replayed id would be stale; an unknown key in the body is a `400`.
+
+With that header the server broadcasts a `spawn:progress` event per create phase
+on the existing `/events` stream, and `POST /api/spawns/:spawnId/cancel` aborts
+the create — it answers `200 { "canceled": true }` when the signal landed and
+`{ "canceled": false }` when the agent came up first (the spawn then runs to
+completion). A cancelled create unwinds the worktree and answers the `409`
+`spawn_canceled` above. Without the header the spawn is still measured and still
+logs its phase line; it just can't be watched or cancelled
+(`src/spawn-progress.ts`, `src/server.ts`).
 
 ## Usage-aware hold gate
 

--- a/ui/src/lib/docs-manifest.ts
+++ b/ui/src/lib/docs-manifest.ts
@@ -75,7 +75,7 @@ export const DOCS_PAGES: readonly DocsPage[] = [
     title: "External Task API",
     path: "/reference/external-task-api/",
     keywords:
-      "submit tasks to shepherd from external agents over plain http. tl;dr why no new endpoint is needed cors / csrf does not block programmatic clients what actually gates access recommended setup for a remote agent request schema responses usage-aware hold gate steering and ending a task exporting a whole session by task-id gaps are marked, never silent",
+      "submit tasks to shepherd from external agents over plain http. tl;dr why no new endpoint is needed cors / csrf does not block programmatic clients what actually gates access recommended setup for a remote agent request schema responses watching and cancelling a slow start usage-aware hold gate steering and ending a task exporting a whole session by task-id gaps are marked, never silent",
   },
   {
     title: "Concepts & glossary",


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc sync — 2026-09-08

Scope checked: every commit since the last doc sync (`b8cfef986`, 2026-09-03), plus a
defaults audit of `docs-site/src/content/docs/reference/configuration.md` against
`src/config.ts` and `src/maintain-core.ts`.

## Changes

- **`docs/external-task-api.md`** — the `POST /api/sessions` **Responses** table did not
  list the `409 { error: "spawn canceled", code: "spawn_canceled" }` answer added in
  `f992a2a18` (`feat(newtask): name the phase a slow start is stuck in, and allow
  cancelling it`, #2189 — `createErrorResponse` in `src/server.ts`). Added that row plus
  a short **Watching and cancelling a slow start** subsection covering the optional
  `X-Shepherd-Spawn-Id` header (id shape `^[A-Za-z0-9-]{8,64}$` from `SPAWN_ID_RE` in
  `src/spawn-progress.ts`; a header rather than a body field because the create body is
  what a usage hold persists), the `spawn:progress` events it enables, and
  `POST /api/spawns/:spawnId/cancel` with its `{ canceled: true | false }` outcomes
  (`cancelSpawn`, `src/spawn-progress.ts`; route in `src/server.ts`).

## Verified current — no change needed

- `docs-site/src/content/docs/reference/configuration.md` — every documented default
  still matches `src/config.ts` (preview ports/sweep/kill-age/idle-stop, reaper CPU/age,
  usage hold `80` / downgrade `70` + `haiku`, review timeout 10 min and its clamps,
  tmpfs knobs, doc-agent `low` / nightly hour `3`, maintain hour `4` / effort `default`,
  Aptabase key), and the maintain band thresholds match `DEFAULT_BAND_THRESHOLDS` in
  `src/maintain-core.ts` (incl. the `dead_code_drift` tier-3 `dead_code` class).
- `docs-site/src/content/docs/getting-started.md` — "herdr 0.8.2 is the last supported
  version" still matches `HERDR_LAST_SUPPORTED_VERSION` / `HERDR_LAST_SPAWNABLE_VERSION`
  in `src/herdr-capabilities.ts` and the protocol-20 note in `src/config.ts`.
- `docs/external-task-api.md` effort row and `docs-site/.../glossary.md` "Reasoning
  effort" — still match `effortForSpawn` / `effortsForProvider` after `14cbac972`
  (Codex passes `xhigh` through, clamps `max` to `high`).
- `docs/sandbox-security.md`, `docs-site/.../operating.md`, `.../glossary.md`,
  `.../index.md` — no claim contradicted by any commit in the window. The Herd Rundown
  removal (`eda3c8375`) and the critic-severity work (`334d3be48`) had already been
  reflected in the in-scope pages by their own commits; no stale "Rundown" reference
  remains in the in-scope set.
- `docs/token-usage-analysis.md` — a dated report of a specific historical sample, with
  its own "since this report" annotations. Nothing in the window invalidates it, and its
  figures are not meant to track current source.

## Uncertain / needs human judgment

- **New env vars are absent from `configuration.md`, but the page is not exhaustive.**
  `SHEPHERD_DEFAULT_MODEL`, `SHEPHERD_DEFAULT_CODEX_MODEL`, `SHEPHERD_DEFAULT_EFFORT`,
  `SHEPHERD_DEFAULT_AGENT_PROVIDER`, the per-role `*_CLI/_MODEL/_EFFORT` vars for
  critic/planner/recap/autopilot/namer/distiller/optimizer/merge-suggest, and others have
  never been listed there. That is a pre-existing gap rather than staleness from a recent
  commit, and the page's intro ("every environment variable") is arguably already
  overstated — adding rows would be new documentation, so I left it alone.
- **Codex model roster / default changed (`df99a06ee`).** `CODEX_MODELS` now leads with
  `gpt-5.6-sol` and adds `gpt-6-astra`; the `defaultCodexModel` seed moved from `gpt-5.5`
  to `gpt-5.6-sol`. No in-scope page names a Codex model id, so nothing is stale — but if
  the roster is meant to be operator-visible somewhere in these pages, that call is yours.
- **Product framing says "fleets of Claude Code agents"** (`index.md` hero and
  `getting-started.md` opener) while Codex is a first-class provider. This reads as
  deliberate branding rather than a factual error, so I did not touch it.
- **The New Task shaping round (`5d37eb29a`) and spawn-phase UI (`f992a2a18`)** are
  operator-facing but have no existing home in the in-scope pages; documenting them would
  mean new sections in `getting-started.md` or `operating.md`, which I judged outside
  "fix what is stale". Only the HTTP-surface half landed, in `external-task-api.md`.