### PR TITLE
fix(settings): label unknown token scopes as no access

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3594,6 +3594,7 @@
   "settings_access_scope_read": "Lesen",
   "settings_access_scope_submit": "Einreichen",
   "settings_access_scope_full": "Vollzugriff",
+  "settings_access_scope_unknown": "Unbekannt — kein Zugriff",
   "settings_access_scope_read_hint": "Darf die Herde lesen — Sitzungen, Wartepunkte, Git-Status — und live mitverfolgen. Kann keine Arbeit starten und kein Terminal erreichen.",
   "settings_access_scope_submit_hint": "Alles wie bei „Lesen“, dazu Arbeit einreichen: eine Sitzung starten, eine wartende Aufgabe einstellen oder freigeben, einen Screenshot anhängen, ein Issue anlegen. Kann eine laufende Sitzung nicht steuern und kein Terminal erreichen.",
   "settings_access_scope_full_hint": "Derselbe Zugriff wie du, das laufende Terminal eingeschlossen — damit lässt sich in jeden laufenden Agenten tippen. Wähle das nur für einen Client, der Arbeit wirklich steuern muss.",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3594,6 +3594,7 @@
   "settings_access_scope_read": "Read",
   "settings_access_scope_submit": "Submit",
   "settings_access_scope_full": "Full",
+  "settings_access_scope_unknown": "Unknown — no access",
   "settings_access_scope_read_hint": "Can read the herd — sessions, holds, git status — and follow live updates. Cannot start work, and cannot reach a terminal.",
   "settings_access_scope_submit_hint": "Everything Read can do, plus handing work in: start a session, queue or release a held task, attach a screenshot, file an issue. Cannot steer a running session or reach a terminal.",
   "settings_access_scope_full_hint": "The same access you have, the live terminal included — it can type into any running agent. Pick this only for a client that genuinely needs to drive work.",

--- a/ui/src/lib/components/settings/SettingsAccessPanel.browser.test.ts
+++ b/ui/src/lib/components/settings/SettingsAccessPanel.browser.test.ts
@@ -228,6 +228,18 @@ describe("SettingsAccessPanel", () => {
     expect(document.querySelectorAll(".tokens .scope-badge")).toHaveLength(3);
   });
 
+  it("labels an unrecognized stored scope as unknown with no access", async () => {
+    // SQLite can carry a scope outside the declared union; the API preserves it.
+    stubApi({ tokens: [token({ scope: "wat" as unknown as AccessToken["scope"] })] });
+    render(SettingsAccessPanel, { payload: payload(false) });
+
+    await expect.element(page.getByText("Asyar extension", { exact: true })).toBeVisible();
+    const badge = document.querySelector(".tokens .scope-badge");
+    expect(badge).not.toBeNull();
+    expect(badge!.textContent).not.toBe("Full");
+    expect(badge!.textContent).toBe("Unknown — no access");
+  });
+
   it("colours a full-scope badge apart from a narrower one", async () => {
     // Regression lock for a CSS-ordering trap: `.badge` and `.scope-badge` are both single-class
     // selectors, so only source order separates them. With `.scope-badge` above `.badge`, every

--- a/ui/src/lib/components/settings/SettingsAccessPanel.svelte
+++ b/ui/src/lib/components/settings/SettingsAccessPanel.svelte
@@ -32,12 +32,14 @@
 
   /** One line per level, describing what the token will and will not reach. Shown for the
    *  SELECTED scope so the operator reads the consequence before minting, not after. */
-  const scopeLabel = (s: TokenScope) =>
+  const scopeLabel = (s: string) =>
     s === "read"
       ? m.settings_access_scope_read()
       : s === "submit"
         ? m.settings_access_scope_submit()
-        : m.settings_access_scope_full();
+        : s === "full"
+          ? m.settings_access_scope_full()
+          : m.settings_access_scope_unknown();
   const scopeHint = (s: TokenScope) =>
     s === "read"
       ? m.settings_access_scope_read_hint()


### PR DESCRIPTION
## Summary

A stored scope such as `wat` currently appears as **Full** in Settings → Access even though the server grants it no access. Give `scopeLabel()` a `string` boundary, an explicit `full` branch, and the localized fallback **Unknown — no access** / **Unbekannt — kein Zugriff**.

Add a browser regression test that checks the token's actual badge. Scope hints, badge styling, and server enforcement remain unchanged.

Closes #2090

## Validation

- Regression reproduced before the fix (`Full` badge); all 18 panel tests pass after it.
- `bun run lint`, UI `bun run check`, `bun run check:i18n`, and full UI tests pass (300 files, 4,790 tests).
- Full pre-push gate passes after rebasing onto `origin/main`, including root tests (9,149 passed, 16 skipped), typechecks, UI/extension tests and builds, and the delta audit.
- Self-reviewed the four-file diff for correctness, security, and scope; no additional findings.

## Checklist

- [x] Conventional-commit title and linear branch rebased onto `main`.
- [x] Relevant local checks and tests pass.
- [x] User-facing text is translated in both UI catalogs.
- [x] Existing badge design is preserved.
- [x] Bug fix only; no new feature announcement, public API/config change, or documentation update needed.
