### PR TITLE
feat(herdr): support verified herdr 0.9.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,10 @@ exists. It also invokes upstream installers it does not control — specifically
 highest release Shepherd supports — verifies it reports that version, and installs it to
 `~/.local/bin`. That release binary is still third-party code fetched and executed on your machine.
 
-> **Shepherd supports herdr up to 0.8.2.** herdr 0.7.5 (protocol 17) reshaped `agent start`;
-> Shepherd drives it through a CLI external-registration path, and 0.8.2 (protocol 20) keeps that
-> path — 19 → 20 only added methods, parameters, results, and enum values. Shepherd warns at startup and blocks its in-app
+> **Shepherd supports herdr up to 0.9.0.** herdr 0.7.5 (protocol 17) reshaped `agent start`;
+> Shepherd drives it through a CLI external-registration path, and 0.9.0 (protocol 22) keeps that
+> path. Schema, CLI, lifecycle and terminal compatibility are checked against 0.8.2;
+> the sandbox idle-status advisory still applies. Shepherd warns at startup and blocks its in-app
 > herdr updater on any newer, untested version. How a new herdr release gets verified and the
 > ceiling moves is a standing procedure: see
 > [herdr version bumps](https://docs.shepherd.run/reference/rules-herdr-version-bump/)

--- a/docs-site/scripts/gen-cli-reference.ts
+++ b/docs-site/scripts/gen-cli-reference.ts
@@ -27,7 +27,7 @@ import { homedir } from "node:os";
 // changes between versions, so reproducibility is conditional on a single pinned
 // version: the script fails if the installed herdr differs. Bump deliberately (a
 // reviewed change) when upgrading herdr — the regenerated diff is the drift signal.
-const EXPECTED_HERDR_VERSION = "0.8.2";
+const EXPECTED_HERDR_VERSION = "0.9.0";
 
 // Curated allowlist of OPERATOR-facing herdr commands (epic #875 / #880, Option B).
 // Deliberately NOT auto-discovered: the herdr groups Shepherd shells out to

--- a/docs-site/src/content/docs/getting-started.md
+++ b/docs-site/src/content/docs/getting-started.md
@@ -112,12 +112,12 @@ Open <http://localhost:7330>. To expose it (e.g. via Tailscale), set
 - [Bun](https://bun.sh) — backend runtime + package manager
 - `herdr` on `PATH` — [Can Celik](https://github.com/ogulcancelik)'s agent
   multiplexer ([herdr.dev](https://herdr.dev)); manages the interactive `claude`
-  panes (owns the PTYs). **herdr 0.8.2 is the last supported version.** herdr
+  panes (owns the PTYs). **herdr 0.9.0 is the last supported version.** herdr
   0.7.5 (protocol 17) reshaped `agent start`, so Shepherd spawns through a CLI
   external-registration path (`tab create` → `pane run` → `report-agent`) rather
-  than the legacy `agent start`; 0.8.2 (protocol 20) keeps that path, since
-  19 → 20 only added methods, parameters, results, and enum values without removing
-  or reshaping Shepherd's existing surface. Any
+  than the legacy `agent start`; 0.9.0 (protocol 22) keeps that path. Schema, CLI,
+  lifecycle and terminal compatibility are checked against 0.8.2; the sandbox
+  idle-status advisory still applies. Any
   newer, untested version is refused: Shepherd warns at startup, blocks the
   in-app updater, and refuses to spawn on it. New releases are admitted through
   the [herdr version bumps](/reference/rules-herdr-version-bump/) procedure

--- a/docs-site/src/content/docs/reference/cli/channel.md
+++ b/docs-site/src/content/docs/reference/cli/channel.md
@@ -5,7 +5,7 @@ description: "Choose the stable or preview herdr update channel."
 
 Choose the stable or preview herdr update channel.
 
-_Generated from live `herdr --help` — do not edit by hand; run `bun run gen:cli` to regenerate._ _(herdr 0.8.2.)_
+_Generated from live `herdr --help` — do not edit by hand; run `bun run gen:cli` to regenerate._ _(herdr 0.9.0.)_
 
 ```text
 Manage stable and preview update channels

--- a/docs-site/src/content/docs/reference/cli/index.md
+++ b/docs-site/src/content/docs/reference/cli/index.md
@@ -3,7 +3,7 @@ title: "CLI reference"
 description: "Operator-facing herdr CLI commands, generated from live --help."
 ---
 
-Shepherd drives the [`herdr`](https://herdr.dev) interactive-pane manager for you, so most herdr commands are internal plumbing you never run by hand. This reference covers the **operator-facing** commands — the ones you might run directly when managing a Shepherd host. Each page below is the command's own `--help` output (command-level, not every leaf flag), pinned to herdr **0.8.2**.
+Shepherd drives the [`herdr`](https://herdr.dev) interactive-pane manager for you, so most herdr commands are internal plumbing you never run by hand. This reference covers the **operator-facing** commands — the ones you might run directly when managing a Shepherd host. Each page below is the command's own `--help` output (command-level, not every leaf flag), pinned to herdr **0.9.0**.
 
 _Generated from live `herdr --help` — do not edit by hand; run `bun run gen:cli` to regenerate._
 
@@ -17,6 +17,7 @@ Usage: herdr [options]
        herdr completion zsh
        herdr update [--handoff]
        herdr channel set <stable|preview>
+       herdr machine <subcommand> ...
        herdr server stop
        herdr server reload-config
        herdr api <subcommand> ...
@@ -42,6 +43,7 @@ Common commands:
   herdr server reload-config       Reload config.toml in the running server
   herdr config reset-keys          Back up config.toml and remove custom keybindings
   herdr channel <subcommand>       Manage the stable or preview update channel
+  herdr machine <subcommand>       Manage saved SSH machines
   herdr api <subcommand>           Inspect socket API metadata and live runtime state
   herdr workspace <subcommand>     Workspace helpers over the socket API
   herdr worktree <subcommand>      Git worktree helpers over the socket API
@@ -56,7 +58,6 @@ Advanced commands:
   herdr server                     Run as headless server
 
 Options:
-  --no-session        Run monolithically (no server/client, escape hatch)
   --session <name>    Use or create a named persistent session
   --remote <target>   Attach through SSH to a remote Herdr server
   --remote-keybindings <local|server>

--- a/docs-site/src/content/docs/reference/cli/server.md
+++ b/docs-site/src/content/docs/reference/cli/server.md
@@ -5,7 +5,7 @@ description: "Control the herdr server lifecycle (stop, reload config)."
 
 Control the herdr server lifecycle (stop, reload config).
 
-_Generated from live `herdr --help` — do not edit by hand; run `bun run gen:cli` to regenerate._ _(herdr 0.8.2.)_
+_Generated from live `herdr --help` — do not edit by hand; run `bun run gen:cli` to regenerate._ _(herdr 0.9.0.)_
 
 ```text
 Run or control the headless server

--- a/docs-site/src/content/docs/reference/cli/session.md
+++ b/docs-site/src/content/docs/reference/cli/session.md
@@ -5,7 +5,7 @@ description: "Manage named persistent herdr sessions."
 
 Manage named persistent herdr sessions.
 
-_Generated from live `herdr --help` — do not edit by hand; run `bun run gen:cli` to regenerate._ _(herdr 0.8.2.)_
+_Generated from live `herdr --help` — do not edit by hand; run `bun run gen:cli` to regenerate._ _(herdr 0.9.0.)_
 
 ```text
 Manage named persistent sessions

--- a/docs-site/src/content/docs/reference/cli/status.md
+++ b/docs-site/src/content/docs/reference/cli/status.md
@@ -5,7 +5,7 @@ description: "Inspect the local client and the running herdr server."
 
 Inspect the local client and the running herdr server.
 
-_Generated from live `herdr --help` — do not edit by hand; run `bun run gen:cli` to regenerate._ _(herdr 0.8.2.)_
+_Generated from live `herdr --help` — do not edit by hand; run `bun run gen:cli` to regenerate._ _(herdr 0.9.0.)_
 
 ```text
 Show local client and running server status

--- a/docs-site/src/content/docs/reference/cli/update.md
+++ b/docs-site/src/content/docs/reference/cli/update.md
@@ -5,7 +5,7 @@ description: "Download and install the latest herdr version."
 
 Download and install the latest herdr version.
 
-_Generated from live `herdr --help` — do not edit by hand; run `bun run gen:cli` to regenerate._ _(herdr 0.8.2.)_
+_Generated from live `herdr --help` — do not edit by hand; run `bun run gen:cli` to regenerate._ _(herdr 0.9.0.)_
 
 ```text
 Download and install the latest version

--- a/docs/herdr-compat/0.9.0-research-drafts.md
+++ b/docs/herdr-compat/0.9.0-research-drafts.md
@@ -1,0 +1,73 @@
+# herdr 0.9.0 research issue drafts
+
+Drafts only. Publishing these issues requires a separate, explicit operator approval.
+These investigations are follow-ups to [the compatibility report](./0.9.0.md), not
+additional features in the compatibility bump. The open herdr issues were checked
+for overlap; related implementation work is linked below.
+
+## Research: reduce session disruption using herdr's client/server compatibility model
+
+**Question:** Can Shepherd update a client while retaining a compatible running
+server, and how should it distinguish a client update from a daemon transition?
+
+herdr 0.9.0 introduces endpoint-generation compatibility and action-specific feature
+gating. Shepherd's `src/herdr-update.ts` → `HerdrUpdateService` checks the installed
+binary after `buildUpdateScript()` runs `update --handoff`; `src/restart.ts` handles
+the optional daemon handoff on restart. The measured 0.8.2→0.9.0 transition restored
+panes but lost synthetic agent registration, so seamless preservation is not proven.
+
+- Compare client version, daemon version, endpoint generation and private protocol
+  in isolated old/new combinations, with both idle and active synthetic sessions.
+- Identify which operations require a daemon update, how absent capabilities are
+  reported, and what preservation guarantees survive a failed transition.
+- Deliver a measured compatibility/session-retention matrix and a recommendation
+  for update success criteria and operator copy. Do not change the updater yet.
+
+Sources: [v0.9.0 release](https://github.com/herdrdev/herdr/releases/tag/v0.9.0),
+[upstream update logic at v0.9.0](https://github.com/herdrdev/herdr/blob/v0.9.0/src/update.rs).
+Related: [Shepherd's socket integration #1529](https://github.com/erwins-enkel/shepherd/issues/1529).
+
+## Research: evaluate herdr SSH machines for Shepherd sessions
+
+**Question:** Which useful remote-session workflows can herdr's saved SSH machines
+support without breaking Shepherd's local repository and worktree assumptions?
+
+The new herdr UI combines local and remote agents and reconnects machines
+independently. Determine which of those capabilities are actually exposed through
+CLI/API surfaces that Shepherd can use. Inspect `src/herdr.ts` → `HerdrDriver`,
+`src/herdr-session.ts` and `src/worktree.ts` for machine-local identifiers, paths,
+socket selection and process-control assumptions.
+
+- Demonstrate one bounded remote scenario using a disposable SSH host; distinguish
+  viewing remote agents from creating and controlling remote Shepherd sessions.
+- Record authentication, reconnect, machine identity, path mapping and disconnect
+  behaviour, including which operations must execute on the remote host.
+- Deliver concrete use cases, required architectural changes and a go/no-go
+  recommendation. No production remote execution or credential storage changes.
+
+Source: [v0.9.0 release, saved SSH machines](https://github.com/herdrdev/herdr/releases/tag/v0.9.0).
+Related: [Shepherd socket integration #1529](https://github.com/erwins-enkel/shepherd/issues/1529).
+
+## Research: test herdr 0.9 scroll and selection APIs against the socket-terminal blocker
+
+**Question:** Do the new `pane.scroll`, selection/copy methods and improved recent
+reads make off-screen Claude/Codex output accessible through Shepherd's socket
+terminal without regressing its existing node-pty behaviour?
+
+The 0.9.0 schema contains those methods, but method availability alone does not
+prove transcript access. `src/socket-pty-bridge.ts` → `SocketPtyBridge` and
+`scripts/verify-herdr-terminal.ts` are the measurement seams.
+
+- Compare normal and alternate-screen output, scroll up/down, selection/copy,
+  continued output while scrolled, resize and reconnect for both agent CLIs.
+- Separate terminal scrollback from an application's internal transcript and
+  compare against the same sessions through node-pty.
+- Deliver a reproducible capability matrix and a recommendation to the existing
+  blocker. Do not flip transport defaults or remove node-pty in this research.
+
+Sources: [v0.9.0 release](https://github.com/herdrdev/herdr/releases/tag/v0.9.0),
+the vendored `src/generated/herdr-schema.json` captured from the release binary.
+Related implementation work: [scroll blocker #1642](https://github.com/erwins-enkel/shepherd/issues/1642),
+[node-pty removal #1622](https://github.com/erwins-enkel/shepherd/issues/1622),
+[socket driver default #1834](https://github.com/erwins-enkel/shepherd/issues/1834).
+This issue would measure the new 0.9.0 APIs and feed those existing decisions.

--- a/docs/herdr-compat/0.9.0.md
+++ b/docs/herdr-compat/0.9.0.md
@@ -1,0 +1,213 @@
+# herdr 0.9.0 compatibility report
+
+**Overall: PASS** — PASS: 14 · REVIEW: 0 · FAIL: 0
+
+|               |                                                              |
+| ------------- | ------------------------------------------------------------ |
+| Candidate     | herdr 0.9.0 (protocol 22)                                    |
+| Baseline      | herdr 0.8.2 (protocol 20)                                    |
+| Date          | 2026-09-08                                                   |
+| Host          | linux-x86_64                                                 |
+| Invocation    | `bun run herdr:compat -- --candidate 0.9.0 --baseline 0.8.2` |
+| Release notes | https://github.com/herdrdev/herdr/releases/tag/v0.9.0        |
+
+Produced by `bun run herdr:compat`; procedure and verdict semantics:
+[`.claude/rules/herdr-version-bump.md`](../../.claude/rules/herdr-version-bump.md).
+REVIEW items need a written triage in the bump PR; any FAIL blocks the bump until code
+addresses it (or the version is declined, documented in the issue).
+
+## S1 — wire protocol number vs. HERDR_SOCKET_SUPPORTED_PROTOCOLS
+
+**PASS**
+
+Baseline protocol 20, candidate protocol 22; allowlist in src/config.ts: {16, 17, 19, 20, 22}.
+
+## S2 — schema diff (methods, params, results, enums)
+
+**PASS**
+
+- **info** `method` method-added: request method added: product_announcement.dismiss
+- **info** `method` method-added: request method added: release_notes.dismiss
+- **info** `method` method-added: request method added: command.invoke
+- **info** `method` method-added: request method added: client_shell.surface.set
+- **info** `method` method-added: request method added: pane.scroll
+- **info** `method` method-added: request method added: pane.edit_scrollback
+- **info** `method` method-added: request method added: pane.selection.read
+- **info** `method` method-added: request method added: pane.copy_motion
+- **info** `method` method-added: request method added: pane.copy_search
+- **info** `method` method-added: request method added: pane.link.activate
+- **info** `method` method-added: request method added: integration.list
+- **info** `params:workspace.create` param-added: param property added: source_workspace_id
+- **info** `params:workspace.close` param-added: param property added: close_group
+- **info** `params:worktree.list` param-added: param property added: trust_repository
+- **info** `params:worktree.create` param-added: param property added: trust_repository
+- **info** `params:worktree.open` param-added: param property added: trust_repository
+- **info** `params:worktree.remove` param-added: param property added: trust_repository
+- **info** `result:pane_selection` result-variant-added: result variant added: pane_selection
+- **info** `result:pane_copy_motion` result-variant-added: result variant added: pane_copy_motion
+- **info** `result:pane_copy_search` result-variant-added: result variant added: pane_copy_search
+- **info** `result:integration_list` result-variant-added: result variant added: integration_list
+- **info** `result:pane_link_activated` result-variant-added: result variant added: pane_link_activated
+- **info** `result:client_shell_surface_set` result-variant-added: result variant added: client_shell_surface_set
+
+## S3 — record-shape gate: TabInfo / PaneInfo / AgentInfo (#2032)
+
+**PASS**
+
+No drift.
+
+## S4 — CLI surface of the subcommands Shepherd invokes
+
+**PASS**
+
+No drift.
+
+## L1 — tab.list labels non-null (reaper keying, #2029)
+
+**PASS**
+
+| Probe               | baseline | candidate |
+| ------------------- | -------- | --------- |
+| all labels non-null | true     | true      |
+
+## L2 — agentless tab reports agent_status "unknown"
+
+**PASS**
+
+| Probe        | baseline | candidate |
+| ------------ | -------- | --------- |
+| agent_status | unknown  | unknown   |
+
+## L3 — pane process-info returns foreground procs for a shell pane
+
+**PASS**
+
+| Probe            | baseline | candidate |
+| ---------------- | -------- | --------- |
+| foreground procs | 1        | 1         |
+
+## L4 — tab_ids not reused across a close (#569)
+
+**PASS**
+
+| Probe     | baseline | candidate |
+| --------- | -------- | --------- |
+| id reused | false    | false     |
+
+## L5 — last-tab close behaviour (#1760)
+
+**PASS**
+
+| Probe     | baseline                   | candidate                  |
+| --------- | -------------------------- | -------------------------- |
+| behaviour | closed-workspace-destroyed | closed-workspace-destroyed |
+
+Shepherd handles both refusal and workspace teardown since #2056 (last-tab guard + ensureWorkspace rebuild); a THIRD behaviour, or a flip, needs a human look.
+
+## L6 — external-registration spawn replay (#1890)
+
+**PASS**
+
+| Probe                        | baseline | candidate |
+| ---------------------------- | -------- | --------- |
+| agent record keys            | 13       | 13        |
+| status after --state working | working  | working   |
+
+## L7 — report-agent --state idle lands on… (herdr #1716 / sandbox-status floor)
+
+**PASS**
+
+| Probe                     | baseline | candidate |
+| ------------------------- | -------- | --------- |
+| status after --state idle | done     | done      |
+
+#1716 unchanged: `HERDR_LAST_FULL_SANDBOX_STATUS_VERSION` stays 0.7.4 and the two-path sandbox downgrade advisory keeps working.
+
+## L8 — `status server` stays parseable (running + version line)
+
+**PASS**
+
+| Probe     | baseline | candidate |
+| --------- | -------- | --------- |
+| parseable | true     | true      |
+
+## L9 — terminal session control contract (scripts/verify-herdr-terminal.ts)
+
+**PASS**
+
+Exit code 0 against the candidate's isolated server.
+
+## L10 — duplicate --agent registration collides (squatter eviction, #2033)
+
+**PASS**
+
+| Probe              | baseline     | candidate    |
+| ------------------ | ------------ | ------------ |
+| duplicate rejected | false        | false        |
+| error code         | undetermined | undetermined |
+
+This herdr ACCEPTS a duplicate registration, so the register-path collision retry is defensive only — harmless, and it guards a herdr that starts refusing. A flip either way is a behaviour change worth a look.
+
+## Next steps
+
+1. Triage every REVIEW above; fix or consciously accept every FAIL (document either way).
+2. Regenerate the vendored protocol against the candidate binary:
+   `HERDR_BIN=<candidate> bun run gen:herdr-schema && bun run gen:herdr-types`
+   (then `bun run gen:herdr-fixtures` against a live candidate server).
+3. Walk the bump-PR checklist in `.claude/rules/herdr-version-bump.md` and extend its
+   bump-history table with what this version taught us.
+
+## Supplemental verification and triage
+
+Verified on Linux x86_64 with the official release binaries. The static and live
+checks above used the explicit 0.8.2 baseline, including after the ceiling changed.
+S1 initially required REVIEW because protocol 22 was absent from the allowlist;
+the additive schema diff and live probes justify admitting **22 only**. Protocols
+18 and 21 remain excluded. All 14 automated checks now pass.
+
+The fixture manifest was recaptured from an isolated 0.9.0 server: all four methods
+(`ping`, `agent.list`, `pane.process_info`, `workspace.list`) returned the same
+result types and top-level field lists as the committed manifest. Historical
+v0.7.5 response fixtures remain unchanged.
+
+### Standard terminal and upgrade transition
+
+In addition to L9, the actual `src/pty-attach.mjs` Node helper was exercised against
+an isolated server with synthetic, externally registered shell agents. Input
+produced a unique output marker; the helper's NUL-prefixed resize frame changed
+`stty size` to 27 rows × 91 columns. Reattaching and starting a fresh registered
+pane on 0.9.0 passed the same checks.
+
+The isolated 0.8.2 server was handed to a **copy** of the 0.9.0 release binary with
+`server live-handoff --import-exe <candidate> --expected-protocol 22 --expected-version 0.9.0`.
+The resulting server reported `status: running`, `version: 0.9.0`,
+`endpoint_compatible: yes`, `private_protocol: 22`, and
+`private_protocol_compatible: yes`; API calls succeeded.
+
+**This transition did not preserve the synthetic agent session.** Workspace, tab
+and pane IDs were restored, but terminal IDs changed and `agent list` was empty.
+Re-registering the restored pane, attaching, reattaching, sending input, resizing
+and creating a new agent pane all succeeded. This is compatible with Shepherd's
+existing update warning that running sessions end; it is not evidence of a
+seamless live upgrade. The existing session revival path remains necessary.
+
+This probe verifies the explicit daemon transition, not the network downloader,
+systemd restart behaviour, or preservation of real Claude/Codex processes. Neither
+the operator's installed binary nor their running daemon was changed. Isolated
+servers and helper processes were stopped after verification.
+
+### Release changes outside Shepherd's driven surface
+
+The [0.9.0 release notes](https://github.com/herdrdev/herdr/releases/tag/v0.9.0)
+change workspace-group closure, lifecycle event replay, and remove `--no-session`.
+Shepherd manages Git worktrees itself and does not invoke `workspace.close` or
+`--no-session`; its drivers poll snapshots instead of subscribing to herdr's
+lifecycle stream. No adaptation of those surfaces is required for this bump.
+
+The external-registration path still maps a reported `idle` to `done` (L7), so
+`HERDR_LAST_FULL_SANDBOX_STATUS_VERSION` stays 0.7.4 and the advisory remains.
+The spawn and pane-control floors and socket feature-flag defaults are unchanged.
+
+New client/server update negotiation, SSH machines and pane scroll/selection APIs
+are research candidates, not features adopted by this compatibility change.
+No macOS or Windows runtime verification is claimed.

--- a/src/config.ts
+++ b/src/config.ts
@@ -86,7 +86,9 @@ export const HERDR_MIN_VERSION = "0.7.0";
 // in a stable release and is deliberately NOT admitted: this is an allowlist, not a floor.
 // 20 = herdr 0.8.2: purely additive over 19 (`pane.input.set`, graphics-layer params/results,
 // right-click pane splits, and enum values) — the existing drive surface carries over (#2096).
-export const HERDR_SOCKET_SUPPORTED_PROTOCOLS = new Set([16, 17, 19, 20]);
+// 22 = herdr 0.9.0: additive schema changes; driven records, CLI and terminal contract verified
+// against 0.8.2 (docs/herdr-compat/0.9.0.md). Unverified protocol 21 remains excluded.
+export const HERDR_SOCKET_SUPPORTED_PROTOCOLS = new Set([16, 17, 19, 20, 22]);
 // TTL backing DiagnosticsService.current() — a request without ?refresh=1 reads
 // this cache. Matches the existing CountsService/backlog 60s TTL.
 export const DIAGNOSTICS_TTL_MS = 60_000;

--- a/src/generated/herdr-protocol.ts
+++ b/src/generated/herdr-protocol.ts
@@ -420,6 +420,26 @@ export type RequestNotificationShowSound = "none" | "done" | "request";
 export type RequestPaneAgentState = "idle" | "working" | "blocked" | "unknown";
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestPaneCopyMotion".
+ */
+export type RequestPaneCopyMotion =
+  | "line_end"
+  | "first_non_blank"
+  | "next_word_start"
+  | "previous_word_start"
+  | "next_word_end"
+  | "next_big_word_start"
+  | "previous_big_word_start"
+  | "next_big_word_end"
+  | "previous_paragraph"
+  | "next_paragraph";
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestPaneCopySearchDirection".
+ */
+export type RequestPaneCopySearchDirection = "forward" | "backward";
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
  * via the `definition` "RequestPaneDirection".
  */
 export type RequestPaneDirection = "left" | "right" | "up" | "down";
@@ -735,6 +755,11 @@ export type SuccessResponsePluginPlatform = "linux" | "macos" | "windows";
 export type SuccessResponsePopupSize = number | string;
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "SuccessResponseIntegrationState".
+ */
+export type SuccessResponseIntegrationState = "not_installed" | "current" | "outdated";
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
  * via the `definition` "SuccessResponseIntegrationTarget".
  */
 export type SuccessResponseIntegrationTarget =
@@ -1029,6 +1054,29 @@ export type SuccessResponseResponseResult =
       [k: string]: unknown;
     }
   | {
+      pane_id: string;
+      text: string;
+      type: "pane_selection";
+      [k: string]: unknown;
+    }
+  | {
+      content_revision: number;
+      cursor: SuccessResponsePaneTextPoint;
+      pane_id: string;
+      type: "pane_copy_motion";
+      [k: string]: unknown;
+    }
+  | {
+      content_revision: number;
+      current?: number | null;
+      current_global?: number | null;
+      matches: SuccessResponsePaneTextRange[];
+      pane_id: string;
+      total: number;
+      type: "pane_copy_search";
+      [k: string]: unknown;
+    }
+  | {
       revision: number;
       sequence: number;
       type: "pane_graphics_frame_ack";
@@ -1087,6 +1135,11 @@ export type SuccessResponseResponseResult =
       changed: boolean;
       reason: SuccessResponseClientWindowTitleReason;
       type: "client_window_title";
+      [k: string]: unknown;
+    }
+  | {
+      integrations: SuccessResponseIntegrationInfo[];
+      type: "integration_list";
       [k: string]: unknown;
     }
   | {
@@ -1152,6 +1205,12 @@ export type SuccessResponseResponseResult =
       [k: string]: unknown;
     }
   | {
+      handled: boolean;
+      type: "pane_link_activated";
+      url?: string | null;
+      [k: string]: unknown;
+    }
+  | {
       logs: SuccessResponsePluginCommandLogInfo[];
       type: "plugin_log_list";
       [k: string]: unknown;
@@ -1175,6 +1234,12 @@ export type SuccessResponseResponseResult =
       diagnostics: string[];
       status: SuccessResponseConfigReloadStatus;
       type: "config_reload";
+      [k: string]: unknown;
+    }
+  | {
+      active: boolean;
+      projection_revision: number;
+      type: "client_shell_surface_set";
       [k: string]: unknown;
     }
   | {
@@ -1538,11 +1603,55 @@ export interface RequestAgentWaitParams {
   until?: RequestAgentStatus[];
 }
 /**
+ * Updates whether the requesting client shell receives and controls pane presentation.
+ *
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestClientShellSurfaceSetParams".
+ */
+export interface RequestClientShellSurfaceSetParams {
+  active: boolean;
+}
+/**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
  * via the `definition` "RequestClientWindowTitleSetParams".
  */
 export interface RequestClientWindowTitleSetParams {
   title: string;
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestCommandInvokeParams".
+ */
+export interface RequestCommandInvokeParams {
+  /**
+   * Opaque endpoint-issued command identifier from the client-shell projection.
+   */
+  command_id: string;
+  pane_id?: string | null;
+  /**
+   * Client-owned selection coordinates, validated against the pane's content revision.
+   */
+  selection?: RequestPaneSelectionReadParams | null;
+  tab_id?: string | null;
+  workspace_id?: string | null;
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestPaneSelectionReadParams".
+ */
+export interface RequestPaneSelectionReadParams {
+  anchor: RequestPaneTextPoint;
+  content_revision?: number | null;
+  cursor: RequestPaneTextPoint;
+  pane_id: string;
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestPaneTextPoint".
+ */
+export interface RequestPaneTextPoint {
+  col: number;
+  row: number;
 }
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
@@ -1628,6 +1737,36 @@ export interface RequestPaneClearAgentAuthorityParams {
 }
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestPaneCopyMotionParams".
+ */
+export interface RequestPaneCopyMotionParams {
+  content_revision?: number | null;
+  cursor: RequestPaneTextPoint;
+  motion: RequestPaneCopyMotion;
+  pane_id: string;
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestPaneCopySearchParams".
+ */
+export interface RequestPaneCopySearchParams {
+  content_revision: number;
+  cursor: RequestPaneTextPoint;
+  direction: RequestPaneCopySearchDirection;
+  pane_id: string;
+  previous?: RequestPaneTextRange | null;
+  query: string;
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestPaneTextRange".
+ */
+export interface RequestPaneTextRange {
+  end: RequestPaneTextPoint;
+  start: RequestPaneTextPoint;
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
  * via the `definition` "RequestPaneCurrentParams".
  */
 export interface RequestPaneCurrentParams {
@@ -1700,6 +1839,17 @@ export interface RequestPaneInputSetParams {
  */
 export interface RequestPaneLayoutParams {
   pane_id?: string | null;
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestPaneLinkActivateParams".
+ */
+export interface RequestPaneLinkActivateParams {
+  col: number;
+  content_revision?: number | null;
+  offset_from_bottom?: number | null;
+  pane_id: string;
+  viewport_row: number;
 }
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
@@ -1819,6 +1969,14 @@ export interface RequestPaneResizeParams {
   amount?: number | null;
   direction: RequestPaneDirection;
   pane_id?: string | null;
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestPaneScrollParams".
+ */
+export interface RequestPaneScrollParams {
+  offset_from_bottom: number;
+  pane_id: string;
 }
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
@@ -2038,6 +2196,21 @@ export interface RequestPluginUnlinkParams {
 }
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestProductAnnouncementDismissParams".
+ */
+export interface RequestProductAnnouncementDismissParams {
+  id: string;
+  version: string;
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestReleaseNotesDismissParams".
+ */
+export interface RequestReleaseNotesDismissParams {
+  version: string;
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
  * via the `definition` "RequestServerLiveHandoffParams".
  */
 export interface RequestServerLiveHandoffParams {
@@ -2090,6 +2263,14 @@ export interface RequestTabTarget {
 }
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestWorkspaceCloseParams".
+ */
+export interface RequestWorkspaceCloseParams {
+  close_group?: boolean;
+  workspace_id: string;
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
  * via the `definition` "RequestWorkspaceCreateParams".
  */
 export interface RequestWorkspaceCreateParams {
@@ -2099,6 +2280,10 @@ export interface RequestWorkspaceCreateParams {
   };
   focus?: boolean;
   label?: string | null;
+  /**
+   * Workspace whose focused pane supplies the `follow` cwd policy.
+   */
+  source_workspace_id?: string | null;
 }
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
@@ -2155,6 +2340,7 @@ export interface RequestWorktreeCreateParams {
   focus?: boolean;
   label?: string | null;
   path?: string | null;
+  trust_repository?: boolean;
   workspace_id?: string | null;
 }
 /**
@@ -2163,6 +2349,7 @@ export interface RequestWorktreeCreateParams {
  */
 export interface RequestWorktreeListParams {
   cwd?: string | null;
+  trust_repository?: boolean;
   workspace_id?: string | null;
 }
 /**
@@ -2175,6 +2362,7 @@ export interface RequestWorktreeOpenParams {
   focus?: boolean;
   label?: string | null;
   path?: string | null;
+  trust_repository?: boolean;
   workspace_id?: string | null;
 }
 /**
@@ -2183,6 +2371,7 @@ export interface RequestWorktreeOpenParams {
  */
 export interface RequestWorktreeRemoveParams {
   force?: boolean;
+  trust_repository?: boolean;
   workspace_id: string;
 }
 /**
@@ -2510,6 +2699,18 @@ export interface SuccessResponsePluginManifestStartup {
 }
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "SuccessResponseIntegrationInfo".
+ */
+export interface SuccessResponseIntegrationInfo {
+  available: boolean;
+  command: string;
+  label: string;
+  state: SuccessResponseIntegrationState;
+  target: SuccessResponseIntegrationTarget;
+  [k: string]: unknown;
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
  * via the `definition` "SuccessResponseIntegrationInstallResult".
  */
 export interface SuccessResponseIntegrationInstallResult {
@@ -2659,6 +2860,24 @@ export interface SuccessResponsePaneSwapResult {
 }
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "SuccessResponsePaneTextPoint".
+ */
+export interface SuccessResponsePaneTextPoint {
+  col: number;
+  row: number;
+  [k: string]: unknown;
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "SuccessResponsePaneTextRange".
+ */
+export interface SuccessResponsePaneTextRange {
+  end: SuccessResponsePaneTextPoint;
+  start: SuccessResponsePaneTextPoint;
+  [k: string]: unknown;
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
  * via the `definition` "SuccessResponsePaneZoomResult".
  */
 export interface SuccessResponsePaneZoomResult {
@@ -2758,7 +2977,19 @@ export interface SuccessResponsePluginSourceInfo1 {
  */
 export interface SuccessResponseServerCapabilities {
   detached_server_daemon?: boolean;
+  /**
+   * Stable client-owned endpoint generation supported by this server.
+   */
+  endpoint_protocol_generation?: number | null;
+  /**
+   * Whether this server supports endpoint health probes.
+   */
+  health_check?: boolean;
   live_handoff: boolean;
+  /**
+   * Whether this server supports explicit client-shell surface interest.
+   */
+  surface_interest?: boolean;
   [k: string]: unknown;
 }
 /**
@@ -3018,7 +3249,7 @@ export interface ErrorResponseErrorBody {
   [k: string]: unknown;
 }
 
-export const HERDR_PROTOCOL = 20 as const;
+export const HERDR_PROTOCOL = 22 as const;
 
 export interface HerdrParams {
   ping: RequestPingParams;
@@ -3028,8 +3259,12 @@ export interface HerdrParams {
   "server.agent_manifests": RequestEmptyParams;
   "server.reload_agent_manifests": RequestEmptyParams;
   "notification.show": RequestNotificationShowParams;
+  "product_announcement.dismiss": RequestProductAnnouncementDismissParams;
+  "release_notes.dismiss": RequestReleaseNotesDismissParams;
+  "command.invoke": RequestCommandInvokeParams;
   "client.window_title.set": RequestClientWindowTitleSetParams;
   "client.window_title.clear": RequestEmptyParams;
+  "client_shell.surface.set": RequestClientShellSurfaceSetParams;
   "session.snapshot": RequestEmptyParams;
   "workspace.create": RequestWorkspaceCreateParams;
   "workspace.list": RequestEmptyParams;
@@ -3039,7 +3274,7 @@ export interface HerdrParams {
   "workspace.move": RequestWorkspaceMoveParams;
   "workspace.move_block": RequestWorkspaceMoveBlockParams;
   "workspace.report_metadata": RequestWorkspaceReportMetadataParams;
-  "workspace.close": RequestWorkspaceTarget;
+  "workspace.close": RequestWorkspaceCloseParams;
   "worktree.list": RequestWorktreeListParams;
   "worktree.create": RequestWorktreeCreateParams;
   "worktree.open": RequestWorktreeOpenParams;
@@ -3076,11 +3311,17 @@ export interface HerdrParams {
   "pane.edges": RequestPaneEdgesParams;
   "pane.focus_direction": RequestPaneFocusDirectionParams;
   "pane.resize": RequestPaneResizeParams;
+  "pane.scroll": RequestPaneScrollParams;
+  "pane.edit_scrollback": RequestPaneTarget;
+  "pane.selection.read": RequestPaneSelectionReadParams;
+  "pane.copy_motion": RequestPaneCopyMotionParams;
+  "pane.copy_search": RequestPaneCopySearchParams;
   "pane.list": RequestPaneListParams;
   "pane.current": RequestPaneCurrentParams;
   "pane.get": RequestPaneTarget;
   "pane.focus": RequestPaneTarget;
   "pane.input.set": RequestPaneInputSetParams;
+  "pane.link.activate": RequestPaneLinkActivateParams;
   "pane.rename": RequestPaneRenameParams;
   "pane.send_text": RequestPaneSendTextParams;
   "pane.send_keys": RequestPaneSendKeysParams;
@@ -3099,6 +3340,7 @@ export interface HerdrParams {
   "events.subscribe": RequestEventsSubscribeParams;
   "events.wait": RequestEventsWaitParams;
   "pane.wait_for_output": RequestPaneWaitForOutputParams;
+  "integration.list": RequestEmptyParams;
   "integration.install": RequestIntegrationInstallParams;
   "integration.uninstall": RequestIntegrationUninstallParams;
   "plugin.link": RequestPluginLinkParams;

--- a/src/generated/herdr-schema.json
+++ b/src/generated/herdr-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "protocol": 20,
+  "protocol": 22,
   "schema_version": 1,
   "schemas": {
     "error_response": {
@@ -1689,6 +1689,18 @@
           ],
           "type": "object"
         },
+        "ClientShellSurfaceSetParams": {
+          "description": "Updates whether the requesting client shell receives and controls pane presentation.",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "active"
+          ],
+          "type": "object"
+        },
         "ClientWindowTitleSetParams": {
           "properties": {
             "title": {
@@ -1697,6 +1709,47 @@
           },
           "required": [
             "title"
+          ],
+          "type": "object"
+        },
+        "CommandInvokeParams": {
+          "properties": {
+            "command_id": {
+              "description": "Opaque endpoint-issued command identifier from the client-shell projection.",
+              "type": "string"
+            },
+            "pane_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "selection": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/request/$defs/PaneSelectionReadParams"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Client-owned selection coordinates, validated against the pane's content revision."
+            },
+            "tab_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "workspace_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "command_id"
           ],
           "type": "object"
         },
@@ -2403,6 +2456,94 @@
           ],
           "type": "object"
         },
+        "PaneCopyMotion": {
+          "enum": [
+            "line_end",
+            "first_non_blank",
+            "next_word_start",
+            "previous_word_start",
+            "next_word_end",
+            "next_big_word_start",
+            "previous_big_word_start",
+            "next_big_word_end",
+            "previous_paragraph",
+            "next_paragraph"
+          ],
+          "type": "string"
+        },
+        "PaneCopyMotionParams": {
+          "properties": {
+            "content_revision": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "cursor": {
+              "$ref": "#/schemas/request/$defs/PaneTextPoint"
+            },
+            "motion": {
+              "$ref": "#/schemas/request/$defs/PaneCopyMotion"
+            },
+            "pane_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id",
+            "cursor",
+            "motion"
+          ],
+          "type": "object"
+        },
+        "PaneCopySearchDirection": {
+          "enum": [
+            "forward",
+            "backward"
+          ],
+          "type": "string"
+        },
+        "PaneCopySearchParams": {
+          "properties": {
+            "content_revision": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "cursor": {
+              "$ref": "#/schemas/request/$defs/PaneTextPoint"
+            },
+            "direction": {
+              "$ref": "#/schemas/request/$defs/PaneCopySearchDirection"
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "previous": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/request/$defs/PaneTextRange"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "query": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id",
+            "query",
+            "direction",
+            "cursor",
+            "content_revision"
+          ],
+          "type": "object"
+        },
         "PaneCurrentParams": {
           "properties": {
             "caller_pane_id": {
@@ -2579,6 +2720,47 @@
               ]
             }
           },
+          "type": "object"
+        },
+        "PaneLinkActivateParams": {
+          "properties": {
+            "col": {
+              "format": "uint16",
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "content_revision": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "offset_from_bottom": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "viewport_row": {
+              "format": "uint16",
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "pane_id",
+            "viewport_row",
+            "col"
+          ],
           "type": "object"
         },
         "PaneListParams": {
@@ -3011,6 +3193,50 @@
           ],
           "type": "string"
         },
+        "PaneScrollParams": {
+          "properties": {
+            "offset_from_bottom": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "pane_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id",
+            "offset_from_bottom"
+          ],
+          "type": "object"
+        },
+        "PaneSelectionReadParams": {
+          "properties": {
+            "anchor": {
+              "$ref": "#/schemas/request/$defs/PaneTextPoint"
+            },
+            "content_revision": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "cursor": {
+              "$ref": "#/schemas/request/$defs/PaneTextPoint"
+            },
+            "pane_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id",
+            "anchor",
+            "cursor"
+          ],
+          "type": "object"
+        },
         "PaneSendInputParams": {
           "properties": {
             "keys": {
@@ -3155,6 +3381,41 @@
           },
           "required": [
             "pane_id"
+          ],
+          "type": "object"
+        },
+        "PaneTextPoint": {
+          "properties": {
+            "col": {
+              "format": "uint16",
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "row": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "row",
+            "col"
+          ],
+          "type": "object"
+        },
+        "PaneTextRange": {
+          "properties": {
+            "end": {
+              "$ref": "#/schemas/request/$defs/PaneTextPoint"
+            },
+            "start": {
+              "$ref": "#/schemas/request/$defs/PaneTextPoint"
+            }
+          },
+          "required": [
+            "start",
+            "end"
           ],
           "type": "object"
         },
@@ -3631,6 +3892,21 @@
             }
           ]
         },
+        "ProductAnnouncementDismissParams": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "version",
+            "id"
+          ],
+          "type": "object"
+        },
         "ReadFormat": {
           "enum": [
             "text",
@@ -3646,6 +3922,17 @@
             "detection"
           ],
           "type": "string"
+        },
+        "ReleaseNotesDismissParams": {
+          "properties": {
+            "version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "version"
+          ],
+          "type": "object"
         },
         "ServerLiveHandoffParams": {
           "properties": {
@@ -4145,6 +4432,20 @@
           ],
           "type": "string"
         },
+        "WorkspaceCloseParams": {
+          "properties": {
+            "close_group": {
+              "type": "boolean"
+            },
+            "workspace_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "workspace_id"
+          ],
+          "type": "object"
+        },
         "WorkspaceCreateParams": {
           "properties": {
             "cwd": {
@@ -4164,6 +4465,13 @@
               "type": "boolean"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source_workspace_id": {
+              "description": "Workspace whose focused pane supplies the `follow` cwd policy.",
               "type": [
                 "string",
                 "null"
@@ -4344,6 +4652,9 @@
                 "null"
               ]
             },
+            "trust_repository": {
+              "type": "boolean"
+            },
             "workspace_id": {
               "type": [
                 "string",
@@ -4360,6 +4671,9 @@
                 "string",
                 "null"
               ]
+            },
+            "trust_repository": {
+              "type": "boolean"
             },
             "workspace_id": {
               "type": [
@@ -4400,6 +4714,9 @@
                 "null"
               ]
             },
+            "trust_repository": {
+              "type": "boolean"
+            },
             "workspace_id": {
               "type": [
                 "string",
@@ -4413,6 +4730,9 @@
           "properties": {
             "force": {
               "default": false,
+              "type": "boolean"
+            },
+            "trust_repository": {
               "type": "boolean"
             },
             "workspace_id": {
@@ -4542,6 +4862,54 @@
         {
           "properties": {
             "method": {
+              "const": "product_announcement.dismiss",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/ProductAnnouncementDismissParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "release_notes.dismiss",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/ReleaseNotesDismissParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "command.invoke",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/CommandInvokeParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
               "const": "client.window_title.set",
               "type": "string"
             },
@@ -4563,6 +4931,22 @@
             },
             "params": {
               "$ref": "#/schemas/request/$defs/EmptyParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "client_shell.surface.set",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/ClientShellSurfaceSetParams"
             }
           },
           "required": [
@@ -4722,7 +5106,7 @@
               "type": "string"
             },
             "params": {
-              "$ref": "#/schemas/request/$defs/WorkspaceTarget"
+              "$ref": "#/schemas/request/$defs/WorkspaceCloseParams"
             }
           },
           "required": [
@@ -5310,6 +5694,86 @@
         {
           "properties": {
             "method": {
+              "const": "pane.scroll",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneScrollParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.edit_scrollback",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneTarget"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.selection.read",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneSelectionReadParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.copy_motion",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneCopyMotionParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.copy_search",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneCopySearchParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
               "const": "pane.list",
               "type": "string"
             },
@@ -5379,6 +5843,22 @@
             },
             "params": {
               "$ref": "#/schemas/request/$defs/PaneInputSetParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.link.activate",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneLinkActivateParams"
             }
           },
           "required": [
@@ -5667,6 +6147,22 @@
             },
             "params": {
               "$ref": "#/schemas/request/$defs/PaneWaitForOutputParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "integration.list",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/EmptyParams"
             }
           },
           "required": [
@@ -7145,6 +7641,33 @@
           ],
           "type": "object"
         },
+        "IntegrationInfo": {
+          "properties": {
+            "available": {
+              "type": "boolean"
+            },
+            "command": {
+              "type": "string"
+            },
+            "label": {
+              "type": "string"
+            },
+            "state": {
+              "$ref": "#/schemas/success_response/$defs/IntegrationState"
+            },
+            "target": {
+              "$ref": "#/schemas/success_response/$defs/IntegrationTarget"
+            }
+          },
+          "required": [
+            "target",
+            "label",
+            "command",
+            "available",
+            "state"
+          ],
+          "type": "object"
+        },
         "IntegrationInstallResult": {
           "properties": {
             "messages": {
@@ -7158,6 +7681,14 @@
             "messages"
           ],
           "type": "object"
+        },
+        "IntegrationState": {
+          "enum": [
+            "not_installed",
+            "current",
+            "outdated"
+          ],
+          "type": "string"
         },
         "IntegrationTarget": {
           "enum": [
@@ -7983,6 +8514,41 @@
             "source_pane_id",
             "focused_pane_id",
             "layout"
+          ],
+          "type": "object"
+        },
+        "PaneTextPoint": {
+          "properties": {
+            "col": {
+              "format": "uint16",
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "row": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "row",
+            "col"
+          ],
+          "type": "object"
+        },
+        "PaneTextRange": {
+          "properties": {
+            "end": {
+              "$ref": "#/schemas/success_response/$defs/PaneTextPoint"
+            },
+            "start": {
+              "$ref": "#/schemas/success_response/$defs/PaneTextPoint"
+            }
+          },
+          "required": [
+            "start",
+            "end"
           ],
           "type": "object"
         },
@@ -9256,6 +9822,103 @@
             },
             {
               "properties": {
+                "pane_id": {
+                  "type": "string"
+                },
+                "text": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "pane_selection",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane_id",
+                "text"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "content_revision": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "cursor": {
+                  "$ref": "#/schemas/success_response/$defs/PaneTextPoint"
+                },
+                "pane_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "pane_copy_motion",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane_id",
+                "cursor",
+                "content_revision"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "content_revision": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "current": {
+                  "format": "uint32",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "current_global": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "matches": {
+                  "items": {
+                    "$ref": "#/schemas/success_response/$defs/PaneTextRange"
+                  },
+                  "type": "array"
+                },
+                "pane_id": {
+                  "type": "string"
+                },
+                "total": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": {
+                  "const": "pane_copy_search",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane_id",
+                "content_revision",
+                "matches",
+                "total"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
                 "revision": {
                   "format": "uint64",
                   "minimum": 0,
@@ -9467,6 +10130,25 @@
                 "type",
                 "changed",
                 "reason"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "integrations": {
+                  "items": {
+                    "$ref": "#/schemas/success_response/$defs/IntegrationInfo"
+                  },
+                  "type": "array"
+                },
+                "type": {
+                  "const": "integration_list",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "integrations"
               ],
               "type": "object"
             },
@@ -9694,6 +10376,28 @@
             },
             {
               "properties": {
+                "handled": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "const": "pane_link_activated",
+                  "type": "string"
+                },
+                "url": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "type",
+                "handled"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
                 "logs": {
                   "items": {
                     "$ref": "#/schemas/success_response/$defs/PluginCommandLogInfo"
@@ -9783,6 +10487,29 @@
               "type": "object"
             },
             {
+              "description": "Acknowledgement for the client-shell surface interest lease. This method is new on the\nendpoint protocol, so its revision-bearing result can establish an activation floor.",
+              "properties": {
+                "active": {
+                  "type": "boolean"
+                },
+                "projection_revision": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": {
+                  "const": "client_shell_surface_set",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "active",
+                "projection_revision"
+              ],
+              "type": "object"
+            },
+            {
               "properties": {
                 "type": {
                   "const": "ok",
@@ -9802,7 +10529,26 @@
               "default": false,
               "type": "boolean"
             },
+            "endpoint_protocol_generation": {
+              "description": "Stable client-owned endpoint generation supported by this server.",
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "health_check": {
+              "default": false,
+              "description": "Whether this server supports endpoint health probes.",
+              "type": "boolean"
+            },
             "live_handoff": {
+              "type": "boolean"
+            },
+            "surface_interest": {
+              "default": false,
+              "description": "Whether this server supports explicit client-shell surface interest.",
               "type": "boolean"
             }
           },

--- a/src/herdr-capabilities.ts
+++ b/src/herdr-capabilities.ts
@@ -5,8 +5,8 @@
 // Shepherd's legacy spawn command — an `env …` shim (always) wrapped, when a bwrap backend is
 // present, in `bwrap … -- env … claude …`. Shepherd now spawns on 0.7.5 through the CLI
 // external-registration path (`tab create` → `pane run` → `report-agent`, #1890), so 0.7.5 is fully
-// supported — and 0.8.2 (protocol 20) with it, since 19 → 20 added methods/params/results/enums
-// without removing or reshaping any (#2096). This module is the single source of truth for the version ceilings; callers warn
+// supported through 0.9.0 (protocol 22): the driven CLI, records and lifecycle were verified
+// against 0.8.2 (see docs/herdr-compat/0.9.0.md). This module owns the version ceilings; callers warn
 // (preflight/diagnostics), fail spawns loudly (the driver), and block the in-app herdr-update for a
 // herdr newer than Shepherd can drive.
 import { compareSemver } from "./semver";
@@ -15,14 +15,12 @@ import { compareSemver } from "./semver";
  *  in-app updater block, and the diagnostics ceiling display. Equal to
  *  {@link HERDR_LAST_SPAWNABLE_VERSION} since #1893; a herdr newer than this is
  *  warned/blocked/refused across the capability layer AND the driver. */
-export const HERDR_LAST_SUPPORTED_VERSION = "0.8.2";
+export const HERDR_LAST_SUPPORTED_VERSION = "0.9.0";
 
-/** The newest herdr version the CLI driver can SPAWN on. 0.8.2 (protocol 20) still spawns via the
- *  external-registration path introduced for 0.7.5 (`tab create` → `pane run` → `report-agent`,
- *  #1890): protocol 19 → 20 is purely additive (`pane.input.set`, graphics-layer params/results,
- *  right-click pane splits, and enum values), with no method, param or result shape removed or
- *  reshaped, so the 0.7.5 spawn surface carries over unchanged (#2096). */
-export const HERDR_LAST_SPAWNABLE_VERSION = "0.8.2";
+/** The newest herdr version the CLI driver can SPAWN on. 0.9.0 (protocol 22) still spawns via
+ *  the external-registration path introduced for 0.7.5 (`tab create` → `pane run` → `report-agent`,
+ *  #1890). Schema, CLI and isolated lifecycle/terminal probes: docs/herdr-compat/0.9.0.md. */
+export const HERDR_LAST_SPAWNABLE_VERSION = "0.9.0";
 
 /** First herdr version that requires the external-registration spawn path instead of `agent start`
  *  (protocol 17 reshaped `agent start` so the wrapped `env …`/`bwrap …` argv can no longer be
@@ -69,7 +67,7 @@ export function detectedHerdrVersion(): string | null {
 }
 
 /** Whether the installed herdr is one Shepherd can spawn agents on: the CLI driver spawns up to
- *  {@link HERDR_LAST_SPAWNABLE_VERSION} (0.8.2) via the external-registration path (#1890). Now
+ *  {@link HERDR_LAST_SPAWNABLE_VERSION} (0.9.0) via the external-registration path (#1890). Now
  *  equal to the general support ceiling {@link isHerdrVersionSupported} (#1893).
  *  null/unparseable → true (never false-alarm on an unreadable version). */
 export function herdrSpawnSupported(): boolean {

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -301,10 +301,10 @@ describe("DiagnosticsService probes", () => {
       expect(c.hintKey).toBe("diagnostics_hint_herdr_ok");
     });
 
-    it("error/unsupported on a herdr past the ceiling (0.8.3) — outranks liveness", async () => {
+    it("error/unsupported on a herdr past the ceiling (0.9.1) — outranks liveness", async () => {
       const svc = new DiagnosticsService({
         ...healthyDeps(),
-        runVersion: versionRunner({ ...HEALTHY_VERSIONS, herdr: "herdr 0.8.3" }),
+        runVersion: versionRunner({ ...HEALTHY_VERSIONS, herdr: "herdr 0.9.1" }),
         runHerdrLiveness: async () => {}, // even a healthy daemon can't rescue an unsupported version
       });
       const c = byId((await svc.check(0)).checks, "herdr");

--- a/test/gen-cli-reference.test.ts
+++ b/test/gen-cli-reference.test.ts
@@ -29,7 +29,7 @@ test("gen-cli-reference omits the upstream LLM-directed footer from every snapsh
       `#!/usr/bin/env bun
 const args = Bun.argv.slice(2);
 if (args[0] === "--version") {
-  console.log("herdr 0.8.2");
+  console.log("herdr 0.9.0");
 } else {
   console.log(\`Operator help stays.
 

--- a/test/herdr-capabilities.test.ts
+++ b/test/herdr-capabilities.test.ts
@@ -22,16 +22,17 @@ test("parseHerdrVersion: null when no version present", () => {
   expect(parseHerdrVersion("garbage")).toBeNull();
 });
 
-// ── isHerdrVersionSupported (the 0.8.2 ceiling) ──────────────────────────────
+// ── isHerdrVersionSupported (the 0.9.0 ceiling) ──────────────────────────────
 
-test("isHerdrVersionSupported: <=0.8.2 supported, 0.8.3+ not", () => {
+test("isHerdrVersionSupported: <=0.9.0 supported, 0.9.1+ not", () => {
   expect(isHerdrVersionSupported("0.8.2")).toBe(true);
   expect(isHerdrVersionSupported("0.8.0")).toBe(true);
   expect(isHerdrVersionSupported("0.7.5")).toBe(true);
   expect(isHerdrVersionSupported("0.7.4")).toBe(true);
   expect(isHerdrVersionSupported("0.6.9")).toBe(true);
-  expect(isHerdrVersionSupported("0.8.3")).toBe(false);
-  expect(isHerdrVersionSupported("0.9.0")).toBe(false);
+  expect(isHerdrVersionSupported("0.9.0")).toBe(true);
+  expect(isHerdrVersionSupported("0.9.1")).toBe(false);
+  expect(isHerdrVersionSupported("0.10.0")).toBe(false);
   expect(isHerdrVersionSupported("1.0.0")).toBe(false);
 });
 
@@ -39,8 +40,8 @@ test("isHerdrVersionSupported: null/unparseable → true (never false-alarm)", (
   expect(isHerdrVersionSupported(null)).toBe(true);
 });
 
-test("HERDR_LAST_SUPPORTED_VERSION is 0.8.2 and is itself supported", () => {
-  expect(HERDR_LAST_SUPPORTED_VERSION).toBe("0.8.2");
+test("HERDR_LAST_SUPPORTED_VERSION is 0.9.0 and is itself supported", () => {
+  expect(HERDR_LAST_SUPPORTED_VERSION).toBe("0.9.0");
   expect(isHerdrVersionSupported(HERDR_LAST_SUPPORTED_VERSION)).toBe(true);
 });
 
@@ -70,25 +71,28 @@ test("setDetectedHerdrVersion drives detectedHerdrVersion + herdrSpawnSupported"
   expect(detectedHerdrVersion()).toBe("0.8.2");
   expect(herdrSpawnSupported()).toBe(true);
 
-  // Beyond the spawnable ceiling → still refused.
-  setDetectedHerdrVersion("0.8.3");
-  expect(herdrSpawnSupported()).toBe(false);
   setDetectedHerdrVersion("0.9.0");
+  expect(herdrSpawnSupported()).toBe(true);
+
+  // Beyond the spawnable ceiling → still refused.
+  setDetectedHerdrVersion("0.9.1");
+  expect(herdrSpawnSupported()).toBe(false);
+  setDetectedHerdrVersion("0.10.0");
   expect(herdrSpawnSupported()).toBe(false);
 });
 
 // ── external-registration spawn path (0.7.5+) ────────────────────────────────
 
-test("HERDR_LAST_SPAWNABLE_VERSION is 0.8.2 and matches the support ceiling", () => {
-  expect(HERDR_LAST_SPAWNABLE_VERSION).toBe("0.8.2");
+test("HERDR_LAST_SPAWNABLE_VERSION is 0.9.0 and matches the support ceiling", () => {
+  expect(HERDR_LAST_SPAWNABLE_VERSION).toBe("0.9.0");
   // Converged with the support ceiling (#1893): the ceiling is both spawnable AND supported.
   expect(HERDR_LAST_SPAWNABLE_VERSION).toBe(HERDR_LAST_SUPPORTED_VERSION);
   expect(isHerdrVersionSupported("0.8.2")).toBe(true);
 });
 
-test("the sandbox-status floor stays at 0.7.4 — herdr #1716 is unfixed on 0.8.2", async () => {
-  // Measured on live 0.7.5, 0.8.0, AND 0.8.2 daemons: a reported `idle` for an externally-registered
-  // agent lands on `done` on both. Moving this with the ceiling would silently retire the
+test("the sandbox-status floor stays at 0.7.4 — herdr #1716 is unfixed on 0.9.0", async () => {
+  // Measured on live 0.7.5, 0.8.0, 0.8.2, and 0.9.0 daemons: a reported `idle` for an externally-registered
+  // agent lands on `done` on all four. Moving this with the ceiling would silently retire the
   // two-path sandbox downgrade advisory (#2039).
   const { HERDR_LAST_FULL_SANDBOX_STATUS_VERSION } = await import("../src/herdr-capabilities");
   expect(HERDR_LAST_FULL_SANDBOX_STATUS_VERSION).toBe("0.7.4");
@@ -103,6 +107,6 @@ test("herdrUsesExternalRegistrationSpawn: true from 0.7.5 up, false below and pr
 
   setDetectedHerdrVersion("0.7.5");
   expect(herdrUsesExternalRegistrationSpawn()).toBe(true);
-  setDetectedHerdrVersion("0.8.2");
+  setDetectedHerdrVersion("0.9.0");
   expect(herdrUsesExternalRegistrationSpawn()).toBe(true);
 });

--- a/test/herdr-downgrade.test.ts
+++ b/test/herdr-downgrade.test.ts
@@ -15,7 +15,7 @@ import {
 
 // The service under test refreshes the PROCESS-WIDE spawn-guard version (#1887) as a side
 // effect of check()/downgrade(). bun runs every test file in one process, so a leftover
-// unsupported version (0.8.3) from a failure-path test here would make any later file that
+// unsupported version (0.9.1) from a failure-path test here would make any later file that
 // spawns via the drivers throw HerdrSpawnUnsupportedError (seen as an order-dependent CI
 // break in herdr-socket-driver.test.ts). Reset to the un-probed default after every test.
 afterEach(() => setDetectedHerdrVersion(null));
@@ -127,11 +127,11 @@ test("buildDowngradeScript: missing versions degrade to 'unknown'", () => {
 const KEY = herdrAssetKey()!; // the test host is always a supported platform
 const TARGET_URL = herdrReleaseUrl(HERDR_LAST_SUPPORTED_VERSION, KEY);
 
-/** Service primed for a stranded install (current 0.8.3 — above the ceiling), with every seam injected
+/** Service primed for a stranded install (current 0.9.1 — above the ceiling), with every seam injected
  *  so no real process spawns and no network is touched. */
 function primedDowngrade(
   opts: {
-    current?: string; // installed BEFORE the downgrade; default 0.8.3 (stranded)
+    current?: string; // installed BEFORE the downgrade; default 0.9.1 (stranded)
     installedAfter?: string; // what --version reports AFTER; default = the ceiling (success)
     manifestUrl?: string | null; // releases[<ceiling>].assets[KEY]; null = entry missing
     fetchLatest?: () => Promise<never>; // override to make the manifest fetch throw
@@ -146,7 +146,7 @@ function primedDowngrade(
   const scripts: string[] = [];
   const dones: HerdrUpdateResult[] = [];
   const begun: boolean[] = [];
-  const current = opts.current ?? "0.8.3";
+  const current = opts.current ?? "0.9.1";
   let versionCalls = 0;
   const releases: Record<string, { assets?: Record<string, string> }> = {};
   if (opts.manifestUrl !== null) {
@@ -179,12 +179,12 @@ const settle = () => new Promise((r) => setTimeout(r, 10));
 
 test("downgrade(): happy path — runs the script, reports ok, refreshes the spawn guard", async () => {
   const { svc, scripts, dones, begun } = primedDowngrade();
-  await svc.check(1); // seeds current=0.8.3 → currentUnsupported
+  await svc.check(1); // seeds current=0.9.1 → currentUnsupported
   expect(svc.downgrade()).toEqual({ started: true });
   await settle();
   expect(scripts).toHaveLength(1);
   expect(scripts[0]).toContain(TARGET_URL); // the cross-checked template URL drives the script
-  expect(dones[0]).toMatchObject({ ok: true, from: "0.8.3", to: HERDR_LAST_SUPPORTED_VERSION });
+  expect(dones[0]).toMatchObject({ ok: true, from: "0.9.1", to: HERDR_LAST_SUPPORTED_VERSION });
   expect(begun).toEqual([true, false]); // maintenance begin/end
   expect(detectedHerdrVersion()).toBe(HERDR_LAST_SUPPORTED_VERSION); // spawn-guard ceiling refreshed, no restart
   expect(svc.current()).toMatchObject({
@@ -202,7 +202,7 @@ test("downgrade(): refuses when the installed herdr is already supported", async
 });
 
 test("downgrade(): re-reads the installed version at gate time — a stale cached status does not skip a live re-check", async () => {
-  // check() sees 0.8.3 (stranded) and caches it; before downgrade() is called, the
+  // check() sees 0.9.1 (stranded) and caches it; before downgrade() is called, the
   // operator manually pins herdr back to the ceiling out-of-band (e.g. a shell `herdr
   // update` or a hand rollback). The gate must catch that on its OWN re-read rather
   // than trusting the up-to-6h-stale `this.last.current` — otherwise it would still
@@ -212,15 +212,15 @@ test("downgrade(): re-reads the installed version at gate time — a stale cache
   const svc = new HerdrUpdateService({
     versionRunner: () => {
       versionCalls++;
-      // call 1 = check() (stale 0.8.3); call 2 = downgrade()'s gate re-read (live ceiling)
-      return `herdr ${versionCalls === 1 ? "0.8.3" : HERDR_LAST_SUPPORTED_VERSION}`;
+      // call 1 = check() (stale 0.9.1); call 2 = downgrade()'s gate re-read (live ceiling)
+      return `herdr ${versionCalls === 1 ? "0.9.1" : HERDR_LAST_SUPPORTED_VERSION}`;
     },
-    fetchLatest: async () => ({ version: "0.8.3", releases: {} }),
+    fetchLatest: async () => ({ version: "0.9.1", releases: {} }),
     runDowngrade: async (script) => {
       scripts.push(script);
     },
   });
-  await svc.check(1); // seeds last.current = "0.8.3" — now stale
+  await svc.check(1); // seeds last.current = "0.9.1" — now stale
   expect(svc.downgrade()).toEqual({ started: false });
   expect(scripts).toHaveLength(0); // never reached the script — no needless restart
 });
@@ -243,13 +243,13 @@ test("downgrade(): double-launch guarded while one is in flight", async () => {
 test("downgrade(): missing manifest entry → fails BEFORE running anything", async () => {
   const { svc, scripts, dones, begun, logs } = primedDowngrade({
     manifestUrl: null,
-    installedAfter: "0.8.3", // binary untouched
+    installedAfter: "0.9.1", // binary untouched
   });
   await svc.check(1);
   svc.downgrade();
   await settle();
   expect(scripts).toHaveLength(0); // never reached the script
-  expect(dones[0]).toMatchObject({ ok: false, to: "0.8.3" });
+  expect(dones[0]).toMatchObject({ ok: false, to: "0.9.1" });
   expect(dones[0]!.error).toContain(`no ${HERDR_LAST_SUPPORTED_VERSION} asset`);
   expect(begun).toEqual([true, false]); // maintenance still cleared
   // A pre-flight refusal never runs the script, so it leaves no audit-log trace —
@@ -260,7 +260,7 @@ test("downgrade(): missing manifest entry → fails BEFORE running anything", as
 test("downgrade(): manifest URL divergence from the template → refuses", async () => {
   const { svc, scripts, dones } = primedDowngrade({
     manifestUrl: "https://evil.example.com/herdr",
-    installedAfter: "0.8.3",
+    installedAfter: "0.9.1",
   });
   await svc.check(1);
   svc.downgrade();
@@ -273,12 +273,12 @@ test("downgrade(): manifest URL divergence from the template → refuses", async
 test("downgrade(): manifest fetch throws → fails cleanly, binary untouched", async () => {
   let checked = false;
   const { svc, dones, begun } = primedDowngrade({
-    installedAfter: "0.8.3",
+    installedAfter: "0.9.1",
     fetchLatest: async () => {
       if (!checked) {
         checked = true;
         // first call (check) succeeds so the service knows it is stranded
-        return { version: "0.8.3", releases: {} } as never;
+        return { version: "0.9.1", releases: {} } as never;
       }
       throw new Error("herdr.dev unreachable");
     },
@@ -286,23 +286,23 @@ test("downgrade(): manifest fetch throws → fails cleanly, binary untouched", a
   await svc.check(1);
   svc.downgrade();
   await settle();
-  expect(dones[0]).toMatchObject({ ok: false, to: "0.8.3" });
+  expect(dones[0]).toMatchObject({ ok: false, to: "0.9.1" });
   expect(dones[0]!.error).toContain("unreachable");
   expect(begun).toEqual([true, false]);
 });
 
 test("downgrade(): version unchanged after the script → reports failure, not the target", async () => {
-  const { svc, dones } = primedDowngrade({ installedAfter: "0.8.3" });
+  const { svc, dones } = primedDowngrade({ installedAfter: "0.9.1" });
   await svc.check(1);
   svc.downgrade();
   await settle();
-  expect(dones[0]).toMatchObject({ ok: false, to: "0.8.3" });
+  expect(dones[0]).toMatchObject({ ok: false, to: "0.9.1" });
   expect(dones[0]!.error).toContain("not downgraded");
 });
 
 test("downgrade(): watchdog timeout kills a hung script and reports the actual version", async () => {
   const { svc, dones } = primedDowngrade({
-    installedAfter: "0.8.3",
+    installedAfter: "0.9.1",
     watchdogMs: 20,
     runDowngrade: (_script, _onLine, signal) =>
       new Promise<void>((resolve) => {
@@ -312,6 +312,6 @@ test("downgrade(): watchdog timeout kills a hung script and reports the actual v
   await svc.check(1);
   svc.downgrade();
   await new Promise((r) => setTimeout(r, 60));
-  expect(dones[0]).toMatchObject({ ok: false, to: "0.8.3" });
+  expect(dones[0]).toMatchObject({ ok: false, to: "0.9.1" });
   expect(dones[0]!.error).toContain("timed out");
 });

--- a/test/herdr-socket-driver.test.ts
+++ b/test/herdr-socket-driver.test.ts
@@ -576,6 +576,29 @@ describe("selectHerdrDriver", () => {
     expect(client.close).not.toHaveBeenCalled();
   });
 
+  it.each([16, 17, 19, 20, 22])("default allowlist admits protocol %i", async (protocol) => {
+    const client = fakePingClient(() => Promise.resolve({ protocol }));
+    const driver = await selectHerdrDriver({
+      enabled: true,
+      makeCli: () => fakeCli() as unknown as HerdrDriver,
+      makeClient: () => client as unknown as HerdrSocketClient,
+    });
+    expect(driver).toBeInstanceOf(SocketHerdrDriver);
+    expect(client.close).not.toHaveBeenCalled();
+  });
+
+  it.each([18, 21, 23])("default allowlist rejects unverified protocol %i", async (protocol) => {
+    const cli = fakeCli() as unknown as HerdrDriver;
+    const client = fakePingClient(() => Promise.resolve({ protocol }));
+    const driver = await selectHerdrDriver({
+      enabled: true,
+      makeCli: () => cli,
+      makeClient: () => client as unknown as HerdrSocketClient,
+    });
+    expect(driver).toBe(cli);
+    expect(client.close).toHaveBeenCalledTimes(1);
+  });
+
   it("enabled:true, unsupported protocol returns the cli; client.close called once", async () => {
     const cliInstance = fakeCli() as unknown as HerdrDriver;
     const client = fakePingClient(() => Promise.resolve({ protocol: 99 }));

--- a/test/herdr-update.test.ts
+++ b/test/herdr-update.test.ts
@@ -139,28 +139,28 @@ test("current == latest → updateAvailable false", async () => {
 test("check(): a newer-but-unsupported latest (past the ceiling) sets latestUnsupported", async () => {
   const svc = new HerdrUpdateService({
     versionRunner: () => "herdr 0.8.2",
-    fetchLatest: async () => ({ version: "0.8.3", notes: "### Breaking" }),
+    fetchLatest: async () => ({ version: "0.9.1", notes: "### Breaking" }),
   });
   const s = await svc.check(1000);
   expect(s.updateAvailable).toBe(true); // a newer version does exist
   expect(s.latestUnsupported).toBe(true); // …but Shepherd can't run it
 });
 
-test("check(): a supported latest (0.7.5 → 0.8.2) is NOT flagged unsupported", async () => {
+test("check(): a supported latest (0.8.2 → 0.9.0) is NOT flagged unsupported", async () => {
   const svc = new HerdrUpdateService({
-    versionRunner: () => "herdr 0.7.5",
-    fetchLatest: async () => ({ version: "0.8.2" }),
+    versionRunner: () => "herdr 0.8.2",
+    fetchLatest: async () => ({ version: "0.9.0" }),
   });
   const s = await svc.check(1000);
   expect(s.updateAvailable).toBe(true);
-  expect(s.latestUnsupported).toBe(false); // 0.8.2 is now supported — the updater offers it
+  expect(s.latestUnsupported).toBe(false); // 0.9.0 is now supported — the updater offers it
 });
 
 test("apply(): refuses to upgrade into an unsupported latest (never started)", async () => {
   let ran = false;
   const svc = new HerdrUpdateService({
     versionRunner: () => "herdr 0.8.2",
-    fetchLatest: async () => ({ version: "0.8.3" }),
+    fetchLatest: async () => ({ version: "0.9.1" }),
     runUpdate: async () => {
       ran = true;
     },
@@ -226,6 +226,26 @@ test("apply(): success when re-read version equals target; maintenance begins th
   expect(begun).toEqual([true, false]); // begin, then end
   expect(dones).toHaveLength(1);
   expect(dones[0]).toMatchObject({ ok: true, to: "0.6.8" });
+});
+
+test("apply(): 0.8.2 → 0.9.0 succeeds and clears unsupported/downgrade flags", async () => {
+  const { svc, begun, dones } = primed({
+    current: "0.8.2",
+    latest: "0.9.0",
+    installedAfter: "0.9.0",
+  });
+  await svc.check(1);
+  expect(svc.apply()).toEqual({ started: true });
+  await settle();
+  expect(begun).toEqual([true, false]);
+  expect(dones).toEqual([{ ok: true, from: "0.8.2", to: "0.9.0" }]);
+  expect(svc.current()).toMatchObject({
+    current: "0.9.0",
+    updateAvailable: false,
+    latestUnsupported: false,
+    currentUnsupported: false,
+    downgradeTarget: null,
+  });
 });
 
 test("apply(): failure when version unchanged even though the child exits 0 (rc lies)", async () => {
@@ -315,11 +335,11 @@ test("apply(): streams runUpdate lines to onLog", async () => {
 });
 
 // ── check(): stranded install (unsupported INSTALLED herdr, #1898) ───────────
-test("check(): an unsupported INSTALLED herdr (0.8.3) sets currentUnsupported + downgradeTarget", async () => {
-  // 0.8.2 is now the supported ceiling (#2096), so the stranded case is 0.8.3+.
+test("check(): an unsupported INSTALLED herdr (0.9.1) sets currentUnsupported + downgradeTarget", async () => {
+  // 0.9.0 is now the supported ceiling, so the stranded case is 0.9.1+.
   const svc = new HerdrUpdateService({
-    versionRunner: () => "herdr 0.8.3",
-    fetchLatest: async () => ({ version: "0.8.3" }),
+    versionRunner: () => "herdr 0.9.1",
+    fetchLatest: async () => ({ version: "0.9.1" }),
   });
   const s = await svc.check(1000);
   expect(s.currentUnsupported).toBe(true);
@@ -341,14 +361,14 @@ test("check(): a supported installed herdr (0.7.4) is not stranded; no downgrade
 test("check(): a failed fetch carries the prior current into the stranded flags", async () => {
   let calls = 0;
   const svc = new HerdrUpdateService({
-    versionRunner: () => "herdr 0.8.3", // 0.8.3 is unsupported (ceiling is now 0.8.2, #2096)
+    versionRunner: () => "herdr 0.9.1", // 0.9.1 is unsupported (ceiling is now 0.9.0)
     fetchLatest: async () => {
       calls++;
       if (calls > 1) throw new Error("herdr.dev down");
-      return { version: "0.8.3" };
+      return { version: "0.9.1" };
     },
   });
-  await svc.check(1000); // seeds current=0.8.3
+  await svc.check(1000); // seeds current=0.9.1
   const s = await svc.check(2000); // fetch fails; current carried from last
   expect(s.error).toContain("down");
   expect(s.currentUnsupported).toBe(true);

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -141,8 +141,8 @@ function reply(args: string[], workspaceList: string): string {
   return FIXTURE;
 }
 
-test("start REFUSES on a herdr above the spawnable ceiling (>0.8.2), spawning nothing", async () => {
-  setDetectedHerdrVersion("0.8.3");
+test("start REFUSES on a herdr above the spawnable ceiling (>0.9.0), spawning nothing", async () => {
+  setDetectedHerdrVersion("0.9.1");
   try {
     const calls: string[][] = [];
     const d = mkDriver((args) => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3788,5 +3788,7 @@
   "feat_spawn_progress_body": "Neue Aufgabe nennt jetzt den Schritt, an dem der Start gerade steht — Basis-Branch aktualisieren, Worktree anlegen, auf den Agent warten — und sagt bei langer Wartezeit, warum, samt Abbrechen.",
   "usage_delivery_evidence_repo_mismatch": "Fremde Repo-Evidenz abgewiesen",
   "feat_learnings_evidence_repo_title": "Learnings prüfen die Herkunft ihrer Evidenz",
-  "feat_learnings_evidence_repo_body": "Neue Regelvorschläge mit nachweislich fremder Repo-Evidenz werden vollständig abgewiesen. Die Vorfälle erscheinen in der Signalstatistik. Unbekannte oder abgelaufene Signal-IDs gelten nicht als Herkunftskonflikt; bestehende Regeln bleiben unverändert."
+  "feat_learnings_evidence_repo_body": "Neue Regelvorschläge mit nachweislich fremder Repo-Evidenz werden vollständig abgewiesen. Die Vorfälle erscheinen in der Signalstatistik. Unbekannte oder abgelaufene Signal-IDs gelten nicht als Herkunftskonflikt; bestehende Regeln bleiben unverändert.",
+  "feat_herdr_090_title": "herdr 0.9.0 wird unterstützt",
+  "feat_herdr_090_body": "Du kannst herdr jetzt in Shepherd auf 0.9.0 aktualisieren. Agentstart, Terminalsteuerung und Aufräumen wurden gegen isolierte Server mit 0.8.2 und 0.9.0 geprüft. Der bestehende Hinweis zum Sandbox-Status gilt weiterhin."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3788,5 +3788,7 @@
   "feat_spawn_progress_body": "New Task now names the step it is on while a task starts — updating the base branch, creating the worktree, waiting for the agent — and if it drags on, it says why and offers to cancel.",
   "usage_delivery_evidence_repo_mismatch": "Foreign repo evidence rejected",
   "feat_learnings_evidence_repo_title": "Learnings check evidence provenance",
-  "feat_learnings_evidence_repo_body": "New rule proposals citing evidence known to belong to another repo are rejected in full. Incidents appear in signal statistics. Unknown or expired signal IDs are not treated as provenance conflicts; existing rules remain unchanged."
+  "feat_learnings_evidence_repo_body": "New rule proposals citing evidence known to belong to another repo are rejected in full. Incidents appear in signal statistics. Unknown or expired signal IDs are not treated as provenance conflicts; existing rules remain unchanged.",
+  "feat_herdr_090_title": "herdr 0.9.0 is supported",
+  "feat_herdr_090_body": "You can now update herdr to 0.9.0 from Shepherd. Agent startup, terminal controls and cleanup were checked against isolated 0.8.2 and 0.9.0 servers. The existing sandbox status advisory still applies."
 }

--- a/ui/src/lib/feature-announcements/entries/v1.48.0-herdr-090.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.48.0-herdr-090.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "herdr-090",
+  sinceVersion: "1.48.0",
+  titleKey: "feat_herdr_090_title",
+  bodyKey: "feat_herdr_090_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
## Summary

Shepherd currently blocks herdr 0.9.0 as unsupported. Raise the support and spawn ceilings to 0.9.0 and explicitly admit socket protocol 22 after checking the official release against 0.8.2. Versions above 0.9.0 and unverified protocols remain blocked.

Regenerate the protocol schema/types and CLI reference, update boundary/updater/downgrade tests and support documentation, and add an EN/DE What's-New entry. The four recaptured fixture contracts are unchanged. The [compatibility report](https://github.com/erwins-enkel/shepherd/blob/66572094ca45be654f7ca8ddde39151dd1fcbdc3/docs/herdr-compat/0.9.0.md) contains 14 passing checks and supplemental node-pty/upgrade evidence.

The isolated daemon transition restored panes with new terminal IDs and lost the synthetic agent registration. Re-registration, attach/reconnect, resize and new starts worked afterward. This does **not** promise seamless session preservation; the existing update warning and sandbox idle-status advisory remain applicable. Runtime verification was on Linux x86_64, not macOS/Windows.

Three [research issue drafts](https://github.com/erwins-enkel/shepherd/blob/66572094ca45be654f7ca8ddde39151dd1fcbdc3/docs/herdr-compat/0.9.0-research-drafts.md) cover session-preserving updates, SSH machines and scroll/selection APIs. They remain drafts pending separate publication approval; no new features or issues were created.

## Validation

- `bun run herdr:compat -- --candidate 0.9.0 --baseline 0.8.2`: 14 PASS, 0 REVIEW, 0 FAIL.
- Root: `bun run lint`, `bun run typecheck`, `bun run test` (9,158 passed; 16 skipped).
- UI: `bun run check`, `bun run test` (4,791 passed), `bun run check:i18n`, `bun run check:docs-manifest`.
- Docs: `bun run check`, `bun run build`; CLI generation is byte-identical on repeat.
- `bun run check:herdr-types`, `bun run check:announcement-versions`; self-reviewed the final diff.
- All seven pre-push lanes passed on the rebased commit, including UI/extension builds and tests; fallow found no issues in the 25 changed files.

## Checklist

- [x] Conventional-commit title; branch rebased onto `origin/main`, with no merge commits.
- [x] Relevant local lint/check/test commands pass.
- [x] EN/DE catalogs and What's-New entry updated.
- [x] Documentation and generated artifacts updated.
