### PR TITLE
feat(buildqueue): keep approval and start actions visible

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -3744,6 +3744,8 @@ function handleRelaunchUploads({ req, parts, deps }: Ctx): Response | null {
 // one steer reaches both — so it names the action, not the transport.
 const APPROVE_STEER =
   "✅ Build queue approved by the operator. Begin now: work the steps in order, marking each step active then done as you go. If you find a better approach, revise only the remaining pending steps — never rewrite completed ones.";
+const APPROVE_PLANNING_STEER =
+  "✅ Build queue approved by the operator for planning only. Create or continue the plan, then stop for review. If the plan is already awaiting review, wait. Never implement until the plan is approved and execution is explicitly authorized.";
 
 /** Render an applier outcome (src/agent-control.ts) as an HTTP response. The REST routes and the
  *  MCP tools are two renderings of the SAME applier, so validation, events and status semantics
@@ -3780,7 +3782,9 @@ async function approveBuildQueue(deps: AppDeps, id: string): Promise<Response> {
   // Awaited so the "Begin now" steer has landed before the operator sees the approved queue, and
   // so a failed send still surfaces as a 500 (exactly as the sync throw did pre-#1567). The
   // boolean is still ignored: a dead pane must not un-approve the queue.
-  await deps.service.reply(id, APPROVE_STEER);
+  const steer =
+    deps.store.get(id)?.planPhase === "planning" ? APPROVE_PLANNING_STEER : APPROVE_STEER;
+  await deps.service.reply(id, steer);
   return json(q);
 }
 

--- a/test/build-queue-api.test.ts
+++ b/test/build-queue-api.test.ts
@@ -419,6 +419,68 @@ test("POST queue/approve calls service.reply with APPROVE_STEER text", async () 
   expect(replies.at(0)!.text).toContain("work the steps in order");
 });
 
+test("POST queue/approve during planning approves the queue without authorizing execution", async () => {
+  const { app, store, emitted, replies } = harness();
+  const session = makeSession(store, repoDir);
+  store.setPlanPhase(session.id, "planning");
+  store.replaceBuildQueue(session.id, [{ id: "planned-step", title: "Implement the plan" }]);
+  store.putPlanGate({
+    sessionId: session.id,
+    planHash: "plan-hash",
+    decision: "changes_requested",
+    summary: "Awaiting revision",
+    body: "Revise the plan before execution.",
+    findings: ["Clarify the rollout."],
+    round: 1,
+    cap: 3,
+    approved: false,
+    plan: "Draft plan",
+    updatedAt: 1,
+  });
+  const planBefore = store.getPlanGate(session.id);
+  const stepsBefore = store.getBuildQueue(session.id).steps;
+
+  const res = await app.fetch(
+    new Request(`http://x/api/sessions/${session.id}/queue/approve`, {
+      method: "POST",
+    }),
+  );
+
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.approved).toBe(true);
+  expect(body.approvalKind).toBe("operator");
+  expect(store.getBuildQueue(session.id).approved).toBe(true);
+  expect(store.getBuildQueue(session.id).approvalKind).toBe("operator");
+  expect(emitted.filter((event) => event.event === "queue:update")).toEqual([
+    { event: "queue:update", data: body },
+  ]);
+  expect(replies).toEqual([
+    {
+      id: session.id,
+      text: "✅ Build queue approved by the operator for planning only. Create or continue the plan, then stop for review. If the plan is already awaiting review, wait. Never implement until the plan is approved and execution is explicitly authorized.",
+    },
+  ]);
+  expect(store.getBuildQueue(session.id).steps).toEqual(stepsBefore);
+  expect(store.getPlanGate(session.id)).toEqual(planBefore);
+  expect(store.get(session.id)?.planPhase).toBe("planning");
+});
+
+test("POST queue/approve during execution retains the execution steer", async () => {
+  const { app, store, replies } = harness();
+  const session = makeSession(store, repoDir);
+  store.setPlanPhase(session.id, "executing");
+
+  await app.fetch(
+    new Request(`http://x/api/sessions/${session.id}/queue/approve`, {
+      method: "POST",
+    }),
+  );
+
+  expect(replies).toHaveLength(1);
+  expect(replies.at(0)!.text).toContain("Begin now: work the steps in order");
+});
+
 test("POST queue/approve for unknown session → 404", async () => {
   const { app } = harness();
   const res = await app.fetch(

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2211,7 +2211,7 @@
   "feat_operator_auth_body": "Shepherd ist jetzt durch ein Einzelbetreiber-Passwort geschützt. Jede Seite, das Live-Terminal und der Aktivitätsstrom erfordern eine Sitzung — setze SHEPHERD_PASSWORD oder hol dir das automatisch generierte Passwort beim ersten Start aus dem Server-Log. Abmelden jederzeit über Einstellungen → Sitzung.",
   "buildqueue_approval_auto": "auto-freigegeben",
   "buildqueue_approval_operator": "freigegeben",
-  "buildqueue_run_queued": "wartet",
+  "buildqueue_run_queued": "noch nicht gestartet",
   "buildqueue_run_running": "läuft",
   "buildqueue_run_done": "erledigt",
   "newtask_agent_provider_label": "Coding CLI",
@@ -3791,5 +3791,18 @@
   "feat_learnings_evidence_repo_title": "Learnings prüfen die Herkunft ihrer Evidenz",
   "feat_learnings_evidence_repo_body": "Neue Regelvorschläge mit nachweislich fremder Repo-Evidenz werden vollständig abgewiesen. Die Vorfälle erscheinen in der Signalstatistik. Unbekannte oder abgelaufene Signal-IDs gelten nicht als Herkunftskonflikt; bestehende Regeln bleiben unverändert.",
   "feat_herdr_090_title": "herdr 0.9.0 wird unterstützt",
-  "feat_herdr_090_body": "Du kannst herdr jetzt in Shepherd auf 0.9.0 aktualisieren. Agentstart, Terminalsteuerung und Aufräumen wurden gegen isolierte Server mit 0.8.2 und 0.9.0 geprüft. Der bestehende Hinweis zum Sandbox-Status gilt weiterhin."
+  "feat_herdr_090_body": "Du kannst herdr jetzt in Shepherd auf 0.9.0 aktualisieren. Agentstart, Terminalsteuerung und Aufräumen wurden gegen isolierte Server mit 0.8.2 und 0.9.0 geprüft. Der bestehende Hinweis zum Sandbox-Status gilt weiterhin.",
+  "buildqueue_approve_plan": "Freigeben & planen",
+  "buildqueue_approve_plan_hint": "Gib die Queue frei, um die Planung fortzusetzen. Die Umsetzung wartet auf die Planfreigabe.",
+  "buildqueue_start": "Jetzt starten",
+  "buildqueue_start_hint": "Die Queue ist freigegeben, aber noch nicht gestartet. Sende dem Agenten ein Startsignal.",
+  "buildqueue_start_plan_hint": "Startet die Planung. Die Umsetzung wartet auf die Planfreigabe.",
+  "buildqueue_plan_reviewing": "Planprüfung läuft.",
+  "buildqueue_plan_review_hint": "Die Queue-Freigabe gibt den Plan nicht frei. Prüfe den Plan im Plan-Dialog und fahre dort fort.",
+  "buildqueue_sending": "Signal wird gesendet…",
+  "buildqueue_action_sent": "Startsignal gesendet.",
+  "buildqueue_action_failed": "Das Signal konnte nicht gesendet werden. Versuche es erneut.",
+  "buildqueue_start_steer": "Die Build-Queue ist bereits freigegeben. Fahre mit dem nächsten zulässigen Schritt fort und halte den Queue-Fortschritt aktuell. Bei aktivem Plan-Gate darfst du nur den Plan erstellen oder fortsetzen und musst anschließend zur Prüfung anhalten. Beginne keine Umsetzung, bevor der Plan freigegeben und die Ausführung ausdrücklich erlaubt wurde. Liegt der Plan bereits zur Prüfung vor, warte auf diese Freigabe.",
+  "feat_build_queue_start_title": "Wartende Build-Queue starten",
+  "feat_build_queue_start_body": "Freigegebene, noch nicht gestartete Queues bieten jetzt „Jetzt starten“. Freigabe und Start bleiben auch bei eingeklappter Queue oder mobilem Header sichtbar. Während der Planung setzt eine Freigabe nur die Planung fort; die Umsetzung wartet weiterhin auf die Planfreigabe."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2211,7 +2211,7 @@
   "feat_operator_auth_body": "Shepherd now sits behind a single-operator password. Every page, the live terminal, and the activity stream require a session — set SHEPHERD_PASSWORD, or grab the auto-generated one from the server log on first boot. Sign out anytime from Settings → Session.",
   "buildqueue_approval_auto": "auto-approved",
   "buildqueue_approval_operator": "approved",
-  "buildqueue_run_queued": "queued",
+  "buildqueue_run_queued": "not started",
   "buildqueue_run_running": "running",
   "buildqueue_run_done": "done",
   "newtask_agent_provider_label": "Coding CLI",
@@ -3791,5 +3791,18 @@
   "feat_learnings_evidence_repo_title": "Learnings check evidence provenance",
   "feat_learnings_evidence_repo_body": "New rule proposals citing evidence known to belong to another repo are rejected in full. Incidents appear in signal statistics. Unknown or expired signal IDs are not treated as provenance conflicts; existing rules remain unchanged.",
   "feat_herdr_090_title": "herdr 0.9.0 is supported",
-  "feat_herdr_090_body": "You can now update herdr to 0.9.0 from Shepherd. Agent startup, terminal controls and cleanup were checked against isolated 0.8.2 and 0.9.0 servers. The existing sandbox status advisory still applies."
+  "feat_herdr_090_body": "You can now update herdr to 0.9.0 from Shepherd. Agent startup, terminal controls and cleanup were checked against isolated 0.8.2 and 0.9.0 servers. The existing sandbox status advisory still applies.",
+  "buildqueue_approve_plan": "Approve & plan",
+  "buildqueue_approve_plan_hint": "Approve the queue to continue planning. Implementation waits for plan approval.",
+  "buildqueue_start": "Start now",
+  "buildqueue_start_hint": "The queue is approved but has not started. Send the agent a start signal.",
+  "buildqueue_start_plan_hint": "Starts planning. Implementation waits for plan approval.",
+  "buildqueue_plan_reviewing": "Plan review in progress.",
+  "buildqueue_plan_review_hint": "Queue approval does not release the plan. Use the plan dialog to review it and continue.",
+  "buildqueue_sending": "Sending signal…",
+  "buildqueue_action_sent": "Start signal sent.",
+  "buildqueue_action_failed": "Could not send the signal. Try again.",
+  "buildqueue_start_steer": "The build queue is already approved. Continue with the next permitted step and keep queue progress updated. If the plan gate is active, only create or continue the plan, then stop for review. Do not implement until the plan is approved and execution is explicitly authorized. If the plan is already awaiting review, wait for that approval.",
+  "feat_build_queue_start_title": "Start a waiting build queue",
+  "feat_build_queue_start_body": "Approved queues that have not started now offer Start now. Approval and start actions stay visible when the queue or mobile header is collapsed. During planning, approval only continues planning; implementation still waits for plan approval."
 }

--- a/ui/src/lib/components/BuildQueuePanel.browser.test.ts
+++ b/ui/src/lib/components/BuildQueuePanel.browser.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
-import { page } from "vitest/browser";
+import { tick, type ComponentProps } from "svelte";
+import { page, userEvent } from "vitest/browser";
 import "../../app.css";
 import type { BuildQueue } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
-import { putBuildQueue } from "$lib/api";
+import { getLocale, setLocale } from "$lib/paraglide/runtime";
+import { putBuildQueue, approveBuildQueue, replySession } from "$lib/api";
 import { buildQueueCollapse } from "$lib/build-queue-collapse.svelte";
 
 // Mock the API so no real network calls are made.
@@ -12,6 +14,7 @@ vi.mock("$lib/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("$lib/api")>();
   return {
     ...actual,
+    replySession: vi.fn(async () => {}),
     getBuildQueue: vi.fn(async (): Promise<BuildQueue> => ({
       sessionId: "s1",
       steps: [],
@@ -32,38 +35,287 @@ vi.mock("$lib/api", async (importOriginal) => {
 
 const { default: BuildQueuePanel } = await import("./BuildQueuePanel.svelte");
 
-let fontStyle: HTMLStyleElement;
 beforeEach(() => {
   buildQueueCollapse.set(false);
-  fontStyle = document.createElement("style");
-  fontStyle.textContent = `:root {
-    --font-mono: ui-monospace, monospace;
-    --color-bg: #0a0d0c;
-    --color-panel: #1a1a1a;
-    --color-line: #333;
-    --color-inset: #111;
-    --color-ink: #ccc;
-    --color-ink-bright: #fff;
-    --color-muted: #666;
-    --color-faint: #444;
-    --color-amber: #f5a623;
-    --color-green: #4caf50;
-    --color-red: #f44336;
-    --color-slate: #708090;
-    --status-done: var(--color-slate);
-    --fs-meta: 12px;
-    --fs-micro: 10px;
-  }
-  *, *::before, *::after { box-sizing: border-box; }
-  body { margin: 0; }`;
-  document.head.appendChild(fontStyle);
+  vi.mocked(replySession).mockReset().mockResolvedValue(undefined);
+  vi.mocked(approveBuildQueue).mockClear();
 });
 afterEach(() => {
-  fontStyle.remove();
   document.body.innerHTML = "";
 });
 
 const noop = () => {};
+
+describe("BuildQueuePanel — approved queue start", () => {
+  it("starts an auto-approved waiting queue without re-approving or bypassing planning", async () => {
+    vi.mocked(replySession).mockClear();
+    vi.mocked(approveBuildQueue).mockClear();
+    const queue: BuildQueue = {
+      sessionId: "s1",
+      approved: true,
+      approvalKind: "auto",
+      steps: [{ id: "a", title: "Prepare plan", status: "pending", position: 0 }],
+    };
+    render(BuildQueuePanel, {
+      sessionId: "s1",
+      enabled: true,
+      queue,
+      onbootstrap: noop,
+      sessionStatus: "blocked",
+      planPhase: "planning",
+    });
+    const start = page.getByRole("button", { name: "Start now", exact: true });
+    await expect.element(start).toBeVisible();
+    await start.click();
+    expect(replySession).toHaveBeenCalledOnce();
+    expect(vi.mocked(replySession).mock.calls[0][0]).toBe("s1");
+    expect(vi.mocked(replySession).mock.calls[0][1]).toContain("Do not implement");
+    expect(approveBuildQueue).not.toHaveBeenCalled();
+    expect(queue.approvalKind).toBe("auto");
+  });
+});
+
+describe("BuildQueuePanel — action lifecycle", () => {
+  const waiting: BuildQueue = {
+    sessionId: "s1",
+    approved: true,
+    approvalKind: "auto",
+    steps: [{ id: "a", title: "Prepare plan", status: "pending", position: 0 }],
+  };
+  const props: ComponentProps<typeof BuildQueuePanel> = {
+    sessionId: "s1",
+    enabled: true,
+    queue: waiting,
+    onbootstrap: noop,
+    sessionStatus: "blocked",
+    planPhase: "planning",
+  };
+
+  it("labels planning approval honestly and keeps it outside the collapsed list", async () => {
+    buildQueueCollapse.set(true);
+    const { rerender } = await render(BuildQueuePanel, {
+      ...props,
+      queue: { ...waiting, approved: false },
+    });
+    const approve = page.getByRole("button", { name: m.buildqueue_approve_plan() });
+    await expect.element(approve).toBeVisible();
+    await expect.element(page.getByText(m.buildqueue_awaiting_hint())).not.toBeInTheDocument();
+    await expect
+      .element(page.getByRole("button", { name: m.buildqueue_approve(), exact: true }))
+      .not.toBeInTheDocument();
+    await approve.click();
+    expect(approveBuildQueue).toHaveBeenCalledExactlyOnceWith("s1");
+    expect(replySession).not.toHaveBeenCalled();
+    expect(buildQueueCollapse.collapsed).toBe(true);
+    await rerender({ planPhase: "executing" });
+    await expect
+      .element(page.getByRole("button", { name: m.buildqueue_approve(), exact: true }))
+      .toBeVisible();
+  });
+
+  for (const approved of [false, true]) {
+    for (const planReview of ["reviewing", "available"] as const) {
+      it(`keeps ${planReview} in the plan flow (queue approved=${approved})`, async () => {
+        render(BuildQueuePanel, { ...props, queue: { ...waiting, approved }, planReview });
+        const hint =
+          planReview === "reviewing"
+            ? m.buildqueue_plan_reviewing()
+            : m.buildqueue_plan_review_hint();
+        await expect.element(page.getByText(hint)).toBeVisible();
+        expect(document.querySelector(".bqp-action-row")).toBeNull();
+        expect(replySession).not.toHaveBeenCalled();
+        expect(approveBuildQueue).not.toHaveBeenCalled();
+      });
+    }
+  }
+
+  const inactiveCases: [string, Partial<ComponentProps<typeof BuildQueuePanel>>][] = [
+    ["running session", { sessionStatus: "running" }],
+    ["archived session", { sessionStatus: "archived" }],
+    ["ended terminal", { terminalEnded: true }],
+    ["active step", { queue: { ...waiting, steps: [{ ...waiting.steps[0], status: "active" }] } }],
+    ["done step", { queue: { ...waiting, steps: [{ ...waiting.steps[0], status: "done" }] } }],
+    ["all skipped", { queue: { ...waiting, steps: [{ ...waiting.steps[0], status: "skipped" }] } }],
+    ["empty queue", { queue: { ...waiting, steps: [] } }],
+  ];
+  for (const [name, overrides] of inactiveCases) {
+    it(`does not offer a start for ${name}`, async () => {
+      render(BuildQueuePanel, { ...props, ...overrides, folded: true });
+      expect(document.querySelector(".bqp")).toBeNull();
+      expect(replySession).not.toHaveBeenCalled();
+    });
+  }
+
+  for (const kind of ["start", "approve"] as const) {
+    it(`keeps ${kind} failures visible and retries without parallel sends`, async () => {
+      const pending = Promise.withResolvers<never>();
+      const api = kind === "start" ? vi.mocked(replySession) : vi.mocked(approveBuildQueue);
+      api.mockImplementationOnce(() => pending.promise);
+      render(BuildQueuePanel, {
+        ...props,
+        queue: { ...waiting, approved: kind === "start" },
+        folded: true,
+      });
+      const button = document.querySelector<HTMLButtonElement>(".bqp-approve")!;
+      button.click();
+      button.click();
+      await tick();
+      expect(api).toHaveBeenCalledTimes(1);
+      expect(button.disabled).toBe(true);
+      pending.reject(new Error("offline"));
+      await expect.element(page.getByRole("alert")).toHaveTextContent(m.buildqueue_action_failed());
+      expect(button.disabled).toBe(false);
+      await page
+        .getByRole("button", {
+          name: kind === "start" ? m.buildqueue_start() : m.buildqueue_approve_plan(),
+        })
+        .click();
+      expect(api).toHaveBeenCalledTimes(2);
+      await expect.element(page.getByRole("status")).toHaveTextContent(m.buildqueue_action_sent());
+    });
+  }
+
+  it("retains request feedback across progress updates but drops it on session change", async () => {
+    const pending = Promise.withResolvers<void>();
+    vi.mocked(replySession).mockReturnValueOnce(pending.promise);
+    const { rerender } = await render(BuildQueuePanel, { ...props, folded: true });
+    await page.getByRole("button", { name: m.buildqueue_start() }).click();
+    await rerender({ sessionStatus: "running", enabled: false, queue: { ...waiting, steps: [] } });
+    await expect.element(page.getByRole("status")).toHaveTextContent(m.buildqueue_sending());
+    pending.resolve();
+    await expect.element(page.getByRole("status")).toHaveTextContent(m.buildqueue_action_sent());
+    await rerender({ sessionId: "s2", queue: { ...waiting, sessionId: "s2" } });
+    expect(document.querySelector(".bqp")).toBeNull();
+  });
+
+  it("does not seed a different session with an old approval response", async () => {
+    const pending = Promise.withResolvers<BuildQueue>();
+    vi.mocked(approveBuildQueue).mockReturnValueOnce(pending.promise);
+    const onbootstrap = vi.fn();
+    const { rerender } = await render(BuildQueuePanel, {
+      ...props,
+      queue: { ...waiting, approved: false },
+      onbootstrap,
+    });
+    await page.getByRole("button", { name: m.buildqueue_approve_plan() }).click();
+    await rerender({ sessionId: "s2", queue: { ...waiting, sessionId: "s2" } });
+    pending.resolve(waiting);
+    await tick();
+    expect(onbootstrap).not.toHaveBeenCalledWith(waiting);
+    await expect.element(page.getByText(m.buildqueue_action_sent())).not.toBeInTheDocument();
+  });
+});
+
+// Sample actual CSS colors, compositing translucent ancestor backgrounds in the browser.
+function contrast(element: HTMLElement, foreground = getComputedStyle(element).color): number {
+  const ctx = document.createElement("canvas").getContext("2d")!;
+  ctx.canvas.width = ctx.canvas.height = 1;
+  ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue("--bg");
+  ctx.fillRect(0, 0, 1, 1);
+  const ancestors: HTMLElement[] = [];
+  for (let node: HTMLElement | null = element; node; node = node.parentElement)
+    ancestors.unshift(node);
+  for (const node of ancestors) {
+    ctx.fillStyle = getComputedStyle(node).backgroundColor;
+    ctx.fillRect(0, 0, 1, 1);
+  }
+  function luminance() {
+    const rgb = [...ctx.getImageData(0, 0, 1, 1).data].slice(0, 3).map((v) => {
+      const n = v / 255;
+      return n <= 0.04045 ? n / 12.92 : ((n + 0.055) / 1.055) ** 2.4;
+    });
+    return rgb[0] * 0.2126 + rgb[1] * 0.7152 + rgb[2] * 0.0722;
+  }
+  const bg = luminance();
+  ctx.fillStyle = foreground;
+  ctx.fillRect(0, 0, 1, 1);
+  const fg = luminance();
+  return (Math.max(bg, fg) + 0.05) / (Math.min(bg, fg) + 0.05);
+}
+
+describe("BuildQueuePanel — real themes and mobile layout", () => {
+  const locale = getLocale();
+  afterEach(async () => {
+    document.documentElement.removeAttribute("data-theme");
+    document.documentElement.removeAttribute("data-contrast");
+    document.documentElement.style.removeProperty("--ui-scale");
+    setLocale(locale, { reload: false });
+    await page.viewport(1280, 900);
+  });
+  for (const theme of ["light", "dark"]) {
+    for (const highContrast of [false, true]) {
+      for (const width of [390, 1280]) {
+        it(`keeps actions readable and reachable: ${theme}, high=${highContrast}, width=${width}`, async () => {
+          await page.viewport(width, width === 390 ? 844 : 900);
+          document.documentElement.dataset.theme = theme;
+          document.documentElement.dataset.contrast = highContrast ? "high" : "normal";
+          document.documentElement.style.setProperty("--ui-scale", "1.5");
+          setLocale("de", { reload: false });
+          const queue: BuildQueue = {
+            sessionId: "s1",
+            approved: false,
+            steps: Array.from({ length: 20 }, (_, i) => ({
+              id: String(i),
+              title: `Schritt ${i + 1}: Planung anhand der Anforderungen prüfen`,
+              detail: "Die Änderungen vorbereiten und prüfen.",
+              status: "pending",
+              position: i,
+            })),
+          };
+          const { rerender } = await render(BuildQueuePanel, {
+            sessionId: "s1",
+            enabled: true,
+            queue,
+            sessionStatus: "blocked",
+            planPhase: "planning",
+            onbootstrap: noop,
+            folded: true,
+          });
+          const button = document.querySelector<HTMLButtonElement>(".bqp-approve")!;
+          const panel = document.querySelector<HTMLElement>(".bqp")!;
+          for (const selector of [
+            ".bqp-approve",
+            ".bqp-hint",
+            ".bqp-awaiting-chip",
+            ".badge-pending",
+          ]) {
+            expect(
+              contrast(document.querySelector<HTMLElement>(selector)!),
+              selector,
+            ).toBeGreaterThanOrEqual(4.5);
+          }
+          expect(
+            contrast(button, getComputedStyle(button).borderColor),
+            "button border",
+          ).toBeGreaterThanOrEqual(3);
+          expect(panel.scrollWidth).toBeLessThanOrEqual(width);
+          expect(button.getBoundingClientRect().right).toBeLessThanOrEqual(width);
+          if (width === 390)
+            expect(button.getBoundingClientRect().height).toBeGreaterThanOrEqual(44);
+          const list = document.querySelector<HTMLElement>(".bqp-list")!;
+          expect(list.scrollHeight).toBeGreaterThan(list.clientHeight);
+          list.scrollTop = 50;
+          expect(list.scrollTop).toBeGreaterThan(0);
+          buildQueueCollapse.set(true);
+          await expect
+            .element(page.getByRole("button", { name: m.buildqueue_approve_plan() }))
+            .toBeVisible();
+          button.focus();
+          await userEvent.keyboard("{Enter}");
+          expect(approveBuildQueue).toHaveBeenCalledExactlyOnceWith("s1");
+          expect(buildQueueCollapse.collapsed).toBe(true);
+          await rerender({ queue: { ...queue, approved: true, approvalKind: "auto" } });
+          await expect
+            .element(page.getByRole("button", { name: m.buildqueue_start() }))
+            .toBeVisible();
+          expect(
+            contrast(document.querySelector<HTMLElement>(".bqp-approved")!),
+          ).toBeGreaterThanOrEqual(4.5);
+        });
+      }
+    }
+  }
+});
 
 describe("BuildQueuePanel — empty state", () => {
   it("renders the empty message when flag is on but no steps", async () => {
@@ -193,27 +445,6 @@ describe("BuildQueuePanel — awaiting-approval affordances (unapproved + steps)
     const chipAfter = document.getElementById(describedby!);
     expect(chipAfter, "chip still in DOM when collapsed").not.toBeNull();
     expect(chipAfter!.offsetParent, "chip still visible (header not collapsed)").not.toBeNull();
-  });
-
-  it("applies the amber tint, emphasized CTA, and amber chip in the browser (computed styles)", async () => {
-    render(BuildQueuePanel, {
-      sessionId: "s1",
-      enabled: true,
-      queue: curationQueue,
-      onbootstrap: noop,
-    });
-    // 6% amber wash shifts the panel off the plain --color-panel (#1a1a1a).
-    const panel = document.querySelector<HTMLElement>(".bqp.is-awaiting")!;
-    expect(getComputedStyle(panel).backgroundColor, "tint applied").not.toBe("rgb(26, 26, 26)");
-
-    // Emphasized CTA: amber text + a non-empty inner-glow box-shadow (no solid fill).
-    const approve = document.querySelector<HTMLElement>("button.bqp-approve")!;
-    const approveStyle = getComputedStyle(approve);
-    expect(approveStyle.color, "CTA text is amber").toBe("rgb(245, 166, 35)");
-    expect(approveStyle.boxShadow, "CTA carries the inner-glow emphasis").not.toBe("none");
-
-    const chip = document.querySelector<HTMLElement>(".bqp-awaiting-chip")!;
-    expect(getComputedStyle(chip).color, "chip is amber").toBe("rgb(245, 166, 35)");
   });
 });
 

--- a/ui/src/lib/components/BuildQueuePanel.svelte
+++ b/ui/src/lib/components/BuildQueuePanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import type { BuildQueue, BuildStep, BuildStepStatus } from "$lib/types";
-  import { getBuildQueue, putBuildQueue, approveBuildQueue } from "$lib/api";
+  import type { BuildQueue, BuildStep, BuildStepStatus, Session } from "$lib/types";
+  import { getBuildQueue, putBuildQueue, approveBuildQueue, replySession } from "$lib/api";
   import { m } from "$lib/paraglide/messages";
   import { buildQueueCollapse } from "$lib/build-queue-collapse.svelte";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
@@ -10,6 +10,11 @@
     enabled,
     queue,
     onbootstrap,
+    sessionStatus,
+    planPhase = null,
+    planReview = null,
+    terminalEnded = false,
+    folded = false,
   }: {
     sessionId: string;
     /** Whether the build-queue feature flag is on for this repo. */
@@ -18,11 +23,18 @@
     queue: BuildQueue | null;
     /** Called after a bootstrap GET to seed the store. */
     onbootstrap: (q: BuildQueue) => void;
+    sessionStatus?: Session["status"];
+    planPhase?: Session["planPhase"];
+    planReview?: "reviewing" | "available" | null;
+    terminalEnded?: boolean;
+    folded?: boolean;
   } = $props();
 
+  // A primitive derived id keeps queue/store updates from re-triggering bootstrap.
+  const currentSessionId = $derived(sessionId);
   // Bootstrap from the server on mount / session change.
   $effect(() => {
-    const id = sessionId;
+    const id = currentSessionId;
     let alive = true;
     getBuildQueue(id)
       .then((q) => {
@@ -37,18 +49,56 @@
     };
   });
 
-  // Derived: show the panel when the flag is on OR there's already a queue with steps.
-  const visible = $derived(enabled || (queue !== null && queue.steps.length > 0));
   const steps = $derived(queue?.steps ?? []);
   const approved = $derived(queue?.approved ?? false);
 
   const contentId = $derived(`bqp-content-${sessionId}`);
   const awaitingId = $derived(`bqp-awaiting-${sessionId}`);
 
+  const allResolved = $derived(
+    steps.length > 0 && steps.every((s) => s.status === "done" || s.status === "skipped"),
+  );
+  const anyStarted = $derived(steps.some((s) => s.status === "active" || s.status === "done"));
+  const runState = $derived(allResolved ? "done" : anyStarted ? "running" : "queued");
+
   // Curation state: the agent has authored steps and paused for the operator to
   // review + approve. This is a needs-you moment (Design Principle 2), so it gets
   // a distinct amber treatment the calm default states never carry.
   const awaiting = $derived(!approved && steps.length > 0);
+  const planning = $derived(planPhase === "planning");
+  const reviewBlocked = $derived(planning && planReview !== null);
+  const canApprove = $derived(
+    awaiting && !reviewBlocked && !terminalEnded && sessionStatus !== "archived",
+  );
+  const canStart = $derived(
+    approved &&
+      steps.length > 0 &&
+      runState === "queued" &&
+      !reviewBlocked &&
+      !terminalEnded &&
+      (sessionStatus === "idle" || sessionStatus === "blocked" || sessionStatus === "done"),
+  );
+  const actionable = $derived(canApprove || canStart);
+  let action = $state<{ busy: boolean; feedback: "sent" | "failed" | null } | null>(null);
+  let actionSessionId: string | undefined;
+  $effect(() => {
+    if (actionSessionId !== sessionId) {
+      actionSessionId = sessionId;
+      action = null;
+    }
+  });
+  const visible = $derived(
+    action !== null || ((enabled || steps.length > 0) && (!folded || actionable)),
+  );
+  const actionHint = $derived(
+    canApprove
+      ? planning
+        ? m.buildqueue_approve_plan_hint()
+        : m.buildqueue_awaiting_hint()
+      : planning
+        ? m.buildqueue_start_plan_hint()
+        : m.buildqueue_start_hint(),
+  );
 
   // ------------- edit helpers -------------
 
@@ -105,22 +155,27 @@
     );
   }
 
-  async function approve() {
+  async function sendAction(kind: "approve" | "start") {
+    if (action?.busy || (kind === "approve" ? !canApprove : !canStart)) return;
+    const id = sessionId;
+    action = { busy: true, feedback: null };
+    const pending = action;
     try {
-      const updated = await approveBuildQueue(sessionId);
-      onbootstrap(updated);
+      if (kind === "approve") {
+        const updated = await approveBuildQueue(id);
+        if (action === pending && sessionId === id) onbootstrap(updated);
+      } else {
+        await replySession(id, m.buildqueue_start_steer());
+      }
+      pending.feedback = "sent";
     } catch {
-      /* toast would be nice; keep it simple for now */
+      pending.feedback = "failed";
+    } finally {
+      pending.busy = false;
     }
   }
 
   // ------------- approved-header derived state -------------
-
-  const allResolved = $derived(
-    steps.length > 0 && steps.every((s) => s.status === "done" || s.status === "skipped"),
-  );
-  const anyStarted = $derived(steps.some((s) => s.status === "active" || s.status === "done"));
-  const runState = $derived(allResolved ? "done" : anyStarted ? "running" : "queued");
 
   const approvalLabel = $derived(
     queue?.approvalKind === "auto"
@@ -167,7 +222,7 @@
 {#if visible}
   <div
     class="bqp"
-    class:is-awaiting={awaiting}
+    class:is-awaiting={actionable}
     role="region"
     aria-label={m.buildqueue_panel_title()}
   >
@@ -180,7 +235,7 @@
       aria-label={buildQueueCollapse.collapsed
         ? m.buildqueue_expand_aria()
         : m.buildqueue_collapse_aria()}
-      aria-describedby={awaiting ? awaitingId : undefined}
+      aria-describedby={canApprove ? awaitingId : undefined}
       title={buildQueueCollapse.collapsed
         ? m.buildqueue_expand_aria()
         : m.buildqueue_collapse_aria()}
@@ -189,7 +244,7 @@
       <span class="bqp-title">{m.buildqueue_panel_title()}</span>
       {#if approved && steps.length > 0}
         <span class={["bqp-approved", `bqp-run-${runState}`]}>{approvalLabel} · {runLabel}</span>
-      {:else if awaiting}
+      {:else if canApprove}
         <!-- Needs-you chip: mirrors the approved chip's slot so the header always
              narrates queue status. Lives in the always-rendered header, so the
              signal (and its aria-describedby target) survives collapse. -->
@@ -202,12 +257,42 @@
       >
     </button>
 
+    {#if reviewBlocked && steps.length > 0}
+      <p class="bqp-notice">
+        {planReview === "reviewing"
+          ? m.buildqueue_plan_reviewing()
+          : m.buildqueue_plan_review_hint()}
+      </p>
+    {:else if actionable}
+      <div class="bqp-action-row">
+        <p class="bqp-hint">{actionHint}</p>
+        <button
+          type="button"
+          class="bqp-btn bqp-approve"
+          disabled={action?.busy}
+          onclick={() => sendAction(canApprove ? "approve" : "start")}
+        >
+          <span class="bqp-approve-glyph" aria-hidden="true">▸</span>{canApprove
+            ? planning
+              ? m.buildqueue_approve_plan()
+              : m.buildqueue_approve()
+            : m.buildqueue_start()}
+        </button>
+      </div>
+    {/if}
+    {#if action?.busy}
+      <p class="bqp-notice" role="status">{m.buildqueue_sending()}</p>
+    {:else if action?.feedback === "failed"}
+      <p class="bqp-notice" role="alert">{m.buildqueue_action_failed()}</p>
+    {:else if action?.feedback === "sent"}
+      <p class="bqp-notice" role="status">{m.buildqueue_action_sent()}</p>
+    {/if}
+
     <div class="bqp-content" id={contentId} class:collapsed={buildQueueCollapse.collapsed}>
       {#if steps.length === 0}
         <p class="bqp-empty">{m.buildqueue_empty()}</p>
       {:else if !approved}
         <!-- Curation mode: editable list -->
-        <p class="bqp-hint">{m.buildqueue_awaiting_hint()}</p>
         <ol class="bqp-list" aria-label={m.buildqueue_panel_title()}>
           {#each steps as step, i (step.id)}
             <li class="bqp-row">
@@ -286,9 +371,6 @@
           <button type="button" class="bqp-btn bqp-add" onclick={addStep}>
             {m.buildqueue_add_step()}
           </button>
-          <button type="button" class="bqp-btn bqp-approve" onclick={approve}>
-            <span class="bqp-approve-glyph" aria-hidden="true">▸</span>{m.buildqueue_approve()}
-          </button>
         </div>
       {:else}
         <!-- Approved/running: read-only list -->
@@ -318,6 +400,8 @@
     display: flex;
     flex-direction: column;
     gap: 6px;
+    flex: none;
+    min-width: 0;
     padding: 8px 10px;
     background: var(--color-panel);
     border-top: 1px solid var(--color-line);
@@ -325,10 +409,10 @@
     font-size: var(--fs-meta);
   }
 
-  /* Awaiting operator approval: a faint amber wash so the paused panel reads as
-     distinct from calm sibling panels without shouting (Design Principle 2). */
+  /* An available approval/start action carries attention in either theme. */
   .is-awaiting {
-    background: color-mix(in oklab, var(--color-amber) 6%, var(--color-panel));
+    background: color-mix(in oklab, var(--color-amber) 8%, var(--color-panel));
+    border: 1px solid var(--color-amber);
   }
 
   /* The whole header is the collapse toggle (mirrors IntegratedEpicRow's
@@ -338,6 +422,7 @@
     display: flex;
     align-items: center;
     gap: 8px;
+    flex-wrap: wrap;
     flex-shrink: 0;
     width: 100%;
     padding: 0;
@@ -376,7 +461,7 @@
     font-size: var(--fs-micro);
     letter-spacing: 0.08em;
     text-transform: uppercase;
-    color: var(--color-amber);
+    color: var(--color-ink-bright);
   }
 
   .bqp-awaiting-dot {
@@ -388,14 +473,14 @@
   }
 
   /* Run-state modifier colors (design-system rule 4 — tokens only, never literals).
-     running = in-progress amber; queued = faint (approved, not started);
+     running = in-progress amber; queued = readable muted (approved, not started);
      done = slate (finished-but-parked; NOT green — green is reserved for actionable-complete/READY). */
   .bqp-run-running {
     color: var(--color-amber);
   }
 
   .bqp-run-queued {
-    color: var(--color-faint);
+    color: var(--color-muted);
   }
 
   .bqp-run-done {
@@ -436,17 +521,25 @@
     font-size: var(--fs-micro);
   }
 
-  /* Explains the paused state and what to do. Full-surface amber wash + full
-     border (never a side-stripe); ink-bright text keeps the copy legible. */
+  .bqp-action-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+  }
+
   .bqp-hint {
     margin: 0;
-    padding: 5px 8px;
-    border: 1px solid color-mix(in oklab, var(--color-amber) 30%, transparent);
-    border-radius: 3px;
-    background: color-mix(in oklab, var(--color-amber) 10%, transparent);
+    flex: 1 1 220px;
     color: var(--color-ink-bright);
-    font-size: var(--fs-micro);
+    font-size: var(--fs-meta);
     line-height: 1.45;
+  }
+
+  .bqp-notice {
+    margin: 0;
+    color: var(--color-ink);
+    font-size: var(--fs-meta);
   }
 
   .bqp-list {
@@ -487,7 +580,7 @@
   }
 
   .badge-pending {
-    color: var(--color-faint);
+    color: var(--color-ink);
     background: color-mix(in oklab, var(--color-faint) 12%, transparent);
   }
 
@@ -591,26 +684,24 @@
     padding-top: 2px;
   }
 
-  /* Emphasized primary: the design system's loudest-action recipe
-     (.chip-action.primary) — amber text + amber border + an inner amber glow.
-     Deliberately NOT a solid fill: --color-amber flips light↔dark across themes,
-     so on-amber text would drop below AA in light theme. Amber text on the panel
-     stays contrast-safe in both themes and both high-contrast variants. */
+  /* Amber outline signals the action; ink text preserves AA on the light wash. */
   .bqp-approve {
     display: inline-flex;
     align-items: center;
     gap: 4px;
-    color: var(--color-amber);
+    color: var(--color-ink-bright);
     border-color: var(--color-amber);
     font-weight: 600;
+    font-size: var(--fs-meta);
+    padding: 6px 10px;
+    min-height: 32px;
+    max-width: 100%;
     box-shadow: inset 0 0 18px -10px var(--color-amber);
   }
 
-  /* :not(:disabled) keeps specificity on par with the base .bqp-btn hover so this
-     later rule wins and the CTA stays amber (never the ink hover). */
   .bqp-approve:hover:not(:disabled),
   .bqp-approve:focus-visible:not(:disabled) {
-    color: var(--color-amber);
+    color: var(--color-ink-bright);
     border-color: var(--color-amber);
     box-shadow:
       inset 0 0 0 1px var(--color-amber),
@@ -618,7 +709,14 @@
   }
 
   .bqp-approve-glyph {
+    color: var(--color-amber);
     font-size: var(--fs-micro);
     line-height: 1;
+  }
+
+  @media (pointer: coarse), (max-width: 600px) {
+    .bqp-approve {
+      min-height: var(--mobile-actionbar-hit);
+    }
   }
 </style>

--- a/ui/src/lib/components/Viewport.browser.test.ts
+++ b/ui/src/lib/components/Viewport.browser.test.ts
@@ -29,6 +29,25 @@ const getLeftoversFn = vi.fn(async () => ({
   leftovers: [] as Leftover[],
   probesUnavailable: false,
 }));
+const getBuildQueueFn = vi.fn(async (sessionId: string): Promise<BuildQueue> => ({
+  sessionId,
+  approved: false,
+  steps: [],
+}));
+const approveBuildQueueFn = vi.fn(async (sessionId: string): Promise<BuildQueue> => ({
+  sessionId,
+  approved: true,
+  approvalKind: "operator",
+  steps: [],
+}));
+const replySessionFn = vi.fn(async () => {});
+const putBuildQueueFn = vi.fn(
+  async (sessionId: string, steps: BuildQueue["steps"]): Promise<BuildQueue> => ({
+    sessionId,
+    steps,
+    approved: false,
+  }),
+);
 
 vi.mock("$lib/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("$lib/api")>();
@@ -38,6 +57,10 @@ vi.mock("$lib/api", async (importOriginal) => {
     stopPreview: stopPreviewFn,
     renameSession: renameSessionFn,
     getLeftovers: getLeftoversFn,
+    getBuildQueue: getBuildQueueFn,
+    approveBuildQueue: approveBuildQueueFn,
+    replySession: replySessionFn,
+    putBuildQueue: putBuildQueueFn,
   };
 });
 
@@ -50,6 +73,7 @@ const { reviews, planGates, repoConfig } = await import("$lib/reviews.svelte");
 const { recaps } = await import("$lib/recaps.svelte");
 // Dynamic import for same reason: epic-draft.svelte imports $lib/api via getEpicDraft.
 const { epicDrafts } = await import("$lib/epic-draft.svelte");
+const { buildQueueCollapse } = await import("$lib/build-queue-collapse.svelte");
 import { toasts } from "$lib/toasts.svelte";
 import { m } from "$lib/paraglide/messages";
 import type {
@@ -169,6 +193,129 @@ function fakeTouch(type: string, x: number, y: number): Event {
   });
   return e;
 }
+
+describe("Viewport — build queue with persisted compact header fold", () => {
+  beforeEach(async () => {
+    localStorage.setItem("shepherd-vp-header-collapsed", "1");
+    buildQueueCollapse.set(true);
+    document.documentElement.dataset.theme = "light";
+    await page.viewport(390, 844);
+    replySessionFn.mockReset().mockResolvedValue(undefined);
+    approveBuildQueueFn.mockClear();
+    putBuildQueueFn.mockClear();
+  });
+  afterEach(async () => {
+    localStorage.removeItem("shepherd-vp-header-collapsed");
+    buildQueueCollapse.set(false);
+    document.documentElement.removeAttribute("data-theme");
+    await page.viewport(1280, 900);
+  });
+  function queue(approved: boolean): BuildQueue {
+    return {
+      sessionId: "folded-queue",
+      approved,
+      approvalKind: approved ? "auto" : undefined,
+      steps: [{ id: "a", title: "Review requirements", status: "pending", position: 0 }],
+    };
+  }
+  function props(approved: boolean) {
+    return {
+      session: session({ id: "folded-queue", status: "blocked", planPhase: "planning" }),
+      mobile: true,
+      buildQueue: queue(approved),
+      previewPort: null,
+      openPreviewTick: 0,
+    };
+  }
+  for (const approved of [false, true]) {
+    it(`keeps the ${approved ? "start" : "planning approval"} operable after remount with both folds saved`, async () => {
+      let mounted = await render(Viewport, props(approved));
+      const label = approved ? m.buildqueue_start() : m.buildqueue_approve_plan();
+      await expect.element(page.getByRole("button", { name: label })).toBeVisible();
+      expect(localStorage.getItem("shepherd-vp-header-collapsed")).toBe("1");
+      expect(localStorage.getItem("shepherd:build-queue-collapsed")).toBe("1");
+      await mounted.unmount();
+      mounted = await render(Viewport, props(approved));
+      const cta = page.getByRole("button", { name: label });
+      await expect.element(cta).toBeVisible();
+      const button = cta.element() as HTMLButtonElement;
+      expect(button.getBoundingClientRect().right).toBeLessThanOrEqual(390);
+      expect(button.getBoundingClientRect().height).toBeGreaterThanOrEqual(44);
+      if (approved) {
+        button.focus();
+        await userEvent.keyboard("{Enter}");
+        expect(replySessionFn).toHaveBeenCalledTimes(1);
+        expect(approveBuildQueueFn).not.toHaveBeenCalled();
+      } else {
+        await page.getByRole("button", { name: m.buildqueue_expand_aria() }).click();
+        const title = page.getByRole("textbox", { name: `${m.buildqueue_step_title_aria()} 1` });
+        await expect.element(title).toBeVisible();
+        await title.fill("Review requirements carefully");
+        await cta.click();
+        expect(putBuildQueueFn).toHaveBeenCalledTimes(1);
+        expect(putBuildQueueFn.mock.calls[0][1][0].title).toBe("Review requirements carefully");
+        expect(approveBuildQueueFn).toHaveBeenCalledExactlyOnceWith("folded-queue");
+        expect(replySessionFn).not.toHaveBeenCalled();
+      }
+      expect(localStorage.getItem("shepherd-vp-header-collapsed")).toBe("1");
+      expect(mounted.container.querySelector(".vp-fold")?.getAttribute("aria-expanded")).toBe(
+        "false",
+      );
+      await expect.element(page.getByText(m.buildqueue_action_sent())).toBeVisible();
+    });
+  }
+
+  it("loads actionable queue data while folded and follows updates without unfolding", async () => {
+    const load = Promise.withResolvers<BuildQueue>();
+    getBuildQueueFn.mockClear();
+    getBuildQueueFn.mockReturnValueOnce(load.promise);
+    const onSeedBuildQueue = vi.fn();
+    const mounted = await render(Viewport, { ...props(true), buildQueue: null, onSeedBuildQueue });
+    expect(mounted.container.querySelector(".bqp")).toBeNull();
+    onSeedBuildQueue.mockImplementation((buildQueue: BuildQueue) => {
+      void mounted.rerender({ ...props(true), buildQueue, onSeedBuildQueue });
+    });
+    load.resolve(queue(true));
+    await expect.element(page.getByRole("button", { name: m.buildqueue_start() })).toBeVisible();
+    await mounted.rerender({
+      ...props(true),
+      buildQueue: { ...queue(true), steps: [{ ...queue(true).steps[0], status: "active" }] },
+      onSeedBuildQueue,
+    });
+    expect(mounted.container.querySelector(".bqp")).toBeNull();
+    await mounted.rerender({ ...props(false), onSeedBuildQueue });
+    await expect
+      .element(page.getByRole("button", { name: m.buildqueue_approve_plan() }))
+      .toBeVisible();
+    expect(localStorage.getItem("shepherd-vp-header-collapsed")).toBe("1");
+    expect(getBuildQueueFn).toHaveBeenCalledExactlyOnceWith("folded-queue");
+  });
+
+  for (const status of ["active", "done"] as const) {
+    it(`keeps a non-actionable ${status} queue hidden when folded`, async () => {
+      const mounted = await render(Viewport, {
+        ...props(true),
+        buildQueue: { ...queue(true), steps: [{ ...queue(true).steps[0], status }] },
+      });
+      expect(mounted.container.querySelector(".bqp")).toBeNull();
+    });
+  }
+
+  it("keeps in-flight and failure feedback visible when the session starts working", async () => {
+    const pending = Promise.withResolvers<void>();
+    replySessionFn.mockReturnValueOnce(pending.promise);
+    const mounted = await render(Viewport, props(true));
+    await page.getByRole("button", { name: m.buildqueue_start() }).click();
+    await mounted.rerender({
+      ...props(true),
+      session: session({ id: "folded-queue", status: "running", planPhase: "planning" }),
+    });
+    await expect.element(page.getByText(m.buildqueue_sending())).toBeVisible();
+    pending.reject(new Error("network unavailable"));
+    await expect.element(page.getByText(m.buildqueue_action_failed())).toBeVisible();
+    expect(localStorage.getItem("shepherd-vp-header-collapsed")).toBe("1");
+  });
+});
 
 // The Preview tab is driven by a server-fed `previewPort` (single source of truth
 // for tab+pane) plus a monotonic `openPreviewTick`/`lastPreviewTick` guard so a

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2921,16 +2921,18 @@
     </div>
   {/if}
 
-  <!-- build queue panel: shown when the flag is on OR a queue already exists for this
-       session — folded away with the rest of the secondary chrome on mobile -->
-  {#if !headerFolded}
-    <BuildQueuePanel
-      sessionId={session.id}
-      enabled={repoConfig.flags(session.repoPath).buildQueue}
-      queue={buildQueue ?? null}
-      onbootstrap={(q) => onSeedBuildQueue?.(q)}
-    />
-  {/if}
+  <!-- Keep approval/start actions reachable even with the compact header folded. -->
+  <BuildQueuePanel
+    sessionId={session.id}
+    enabled={repoConfig.flags(session.repoPath).buildQueue}
+    queue={buildQueue ?? null}
+    sessionStatus={session.status}
+    planPhase={session.planPhase}
+    planReview={planGates.isReviewing(session.id) ? "reviewing" : planGate ? "available" : null}
+    terminalEnded={ended}
+    folded={headerFolded}
+    onbootstrap={(q) => onSeedBuildQueue?.(q)}
+  />
 
   <!-- epic draft review (issue #1507): a one-line bar — the draft itself opens in EpicDraftModal, so
        the terminal keeps the column. Deliberately OUTSIDE the !headerFolded gate: it takes `folded`

--- a/ui/src/lib/feature-announcements/entries/v1.48.0-build-queue-start.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.48.0-build-queue-start.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "build-queue-start",
+  sinceVersion: "1.48.0",
+  titleKey: "feat_build_queue_start_title",
+  bodyKey: "feat_build_queue_start_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
## Summary

Automatically approved queues with pending steps now show **Start now**, and manual approval is labeled **Approve & plan** during planning. The action row stays visible when the queue or compact mobile header is folded, with readable light/dark theme contrast and visible request feedback.

The existing approval API reads the stored planning phase and sends a planning-only instruction until plan approval. Starting an approved queue preserves its approval kind and the plan gate. Includes EN/DE copy and a 1.48.0 feature announcement.

## Validation

- Root: `bun run lint`; `bun run test --timeout 30000` — 9,132 passed, 16 skipped (isolated Bun 1.4.2; the host Bun 1.3.10 hung on a Git child).
- UI: `bun run check`, `bun run check:i18n`, `bun run test` — 4,819 passed.
- Browser regressions: 125 passed, covering saved mobile folds, bootstrap updates, request failures, plan review, keyboard/touch access, and real light/dark palettes with high contrast and enlarged text.
- `bun run check:announcement-versions`; Prettier; self-review of the changed code.
- Full pre-push gate passed: root typecheck/tests, UI and extension check/test/build, catalog gates, and fallow audit with no issues in the changed files.

## Checklist

- [x] Conventional-commit title; linear branch from `origin/main`.
- [x] Relevant lint/check/test commands pass.
- [x] User-facing copy in both i18n catalogs; feature announcement included.
- [x] UI uses existing design tokens; behavior described in the feature announcement.
