### PR TITLE
refactor(prompts): align in-code manual-steps copies with skill wording (#2206)

### DIFF
--- a/scripts/tool-guard.mjs
+++ b/scripts/tool-guard.mjs
@@ -68,9 +68,10 @@ export const PR_CREATE_CONTEXT =
   "`gh issue create` a follow-up. Before opening it, declare any MANUAL OPERATOR STEPS the change " +
   "implies (feature flag, env var, backfill, restart, DNS, seeded record) in the PR body — either " +
   "a ```shepherd:manual-steps``` fenced block of `- [ ]` lines or column-0 `Manual-Step:` trailer " +
-  "lines, prefixed `POST-MERGE:` when they must happen after merge. Most PRs need NONE: declare " +
-  "nothing rather than inventing one, and use `gh pr edit --body` if you only notice one later. " +
-  "The `shepherd-pull-requests` skill has the full rules.";
+  "lines, prefixed `POST-MERGE:` when they must happen after merge. Most PRs need none — an " +
+  "un-acked non-`POST-MERGE` step blocks the PR's auto-merge, so a spurious one strands a ready " +
+  "PR; use `gh pr edit --body` if you only notice one later. The `shepherd-pull-requests` skill " +
+  "has the full rules.";
 
 /**
  * Injected when a Bash call is backgrounded. A detached job reparents to PID 1 and outlives the

--- a/src/service.ts
+++ b/src/service.ts
@@ -998,7 +998,8 @@ export function composeEpicSteer(text: string): string | null {
  * to the parser by a unit test (`parseManualSteps(MANUAL_STEPS_NOTICE)` in test/manual-steps.test.ts).
  * The fence-open line must stay EXACTLY ```shepherd:manual-steps (FENCE_OPEN regex) and each step a
  * column-0-or-indented `- [ ]` line (TASK_LINE) so a wording edit can never silently break parsing.
- * The notice is emphatically default-empty: a fabricated step is worse than none.
+ * The notice is default-empty, and says why: an un-acked non-`POST-MERGE` step blocks the PR's
+ * auto-merge (hasBlockingManualSteps, src/automerge-core.ts), so a fabricated step strands the PR.
  */
 export const MANUAL_STEPS_NOTICE =
   "Before you open the pull request, declare any MANUAL OPERATOR STEPS the change implies — work a " +
@@ -1015,10 +1016,10 @@ export const MANUAL_STEPS_NOTICE =
   "- Or column-0 `Manual-Step:` trailer lines (flush-left, outside any fence), e.g. a line reading " +
   "exactly `Manual-Step: Rotate the signing key`.\n" +
   "Prefix a step with `POST-MERGE:` when it must happen AFTER the PR merges.\n" +
-  "DEFAULT TO DECLARING NOTHING: most PRs need NO manual steps. Add a step ONLY for a real " +
-  "out-of-band action a human must take; if merging fully completes the change, OMIT the carrier " +
-  "entirely. NEVER invent steps to fill the block — a spurious step is worse than none. When in " +
-  "doubt, declare nothing.";
+  "Most PRs need no manual steps: if merging fully completes the change, omit the carrier " +
+  "entirely. Declare a step only for a real out-of-band action a human must take — an un-acked " +
+  "non-`POST-MERGE` step blocks the PR's auto-merge, so a spurious one strands a PR that was " +
+  "otherwise ready to land.";
 
 /**
  * Injected as the highest-priority directive for an attended RESEARCH task (`research: true`).

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -4812,9 +4812,11 @@ test("composeSystemPrompt rides the manual-steps notice on code spawns, never on
   for (const sp of codeSpawns) {
     expect(sp).toContain("<manual-steps-notice>");
     expect(sp).toContain("</manual-steps-notice>");
-    // Anchor on the stable carrier syntax (the parser contract) + the emphatic default-empty rule.
+    // Anchor on the stable carrier syntax (the parser contract) + the default-empty rule and the
+    // auto-merge consequence that is its reason (#2206) — both halves, so neither can drift out.
     expect(sp).toContain("```shepherd:manual-steps");
-    expect(sp).toContain("DEFAULT TO DECLARING NOTHING");
+    expect(sp).toContain("Most PRs need no manual steps");
+    expect(sp).toContain("blocks the PR's auto-merge");
   }
   expect(composeSystemPrompt(null, false, { ...noMech, research: true })).not.toContain(
     "<manual-steps-notice>",


### PR DESCRIPTION
Closes #2206.

#2195's prompt audit rewrote the manual-steps paragraph in the `shepherd-pull-requests` skill: five capped emphases (`DEFAULT TO DECLARING NOTHING`, `NO manual steps`, `ONLY`, `OMIT`, `NEVER invent`) stating one instruction five ways, replaced by a plain statement carrying the actual consequence — an un-acked non-`POST-MERGE` step blocks the PR's auto-merge (`hasBlockingManualSteps`), so a spurious one strands a PR that was otherwise ready to land. That audit was scoped to skill files, leaving the same guidance shipping in its pre-audit register from two other places.

## What changed

- **`MANUAL_STEPS_NOTICE` (`src/service.ts`)** — the full standalone rule, delivered only when `prBlocksResident`. Its closing paragraph is now the skill's, verbatim. The low-stakes half: mutually exclusive with the skill, so nothing contradicted today; this is consistency debt.
- **`PR_CREATE_CONTEXT` (`scripts/tool-guard.mjs`)** — the copy that actually mattered. It is a deliberate backstop firing on the `gh pr create` call itself, so it **co-occurs** with the skill rather than replacing it: an agent that had loaded the rewritten skill got the calm reasoned version and `declare nothing rather than inventing one` in the same turn. Same consequence, kept in the guard's compressed register and at roughly its old length.

The two are **not** merged into one shared constant — deliberately separate delivery paths with different jobs and gates, and the hook script must not import from `src/`.

## Drift guards

Both are re-pointed or kept passing deliberately, not worked around:

- `parseManualSteps(MANUAL_STEPS_NOTICE)` (`test/manual-steps.test.ts`) runs the **real parser** over the notice's embedded carrier example. Every edit here is prose *after* the fenced block, so this test passes **unmodified** — that is the proof the carrier contract held.
- `test/service.test.ts` anchored on the literal `DEFAULT TO DECLARING NOTHING`. Re-pointed at both halves of the replacement — `Most PRs need no manual steps` (the rule) and `blocks the PR's auto-merge` (its reason) — so neither can drift out silently.
- `test/tool-guard.test.ts` asserts only literals this diff does not touch (`ONE pull request`, `shepherd:manual-steps`, `Manual-Step:`, `shepherd-pull-requests`); verified by reading them, unchanged.

## Verification

`bun run lint` clean, `bun run test` green (9164 pass / 0 fail), `bunx tsc --noEmit` clean, fallow pre-push audit clean. A repo-wide grep for `DEFAULT TO DECLARING NOTHING` / `NEVER invent` / `declare nothing rather than` returns nothing outside git history; all three copies now state the default-empty rule once with the consequence attached.

## Known residual

Nothing pins the three copies to each other, so register drift can recur. Adding such a mechanism was out of scope for #2206 — flagged rather than solved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
