### PR TITLE
feat(recap): give the recap agent the changed UI markup (#2209)

### DIFF
--- a/docs/sandbox-security.md
+++ b/docs/sandbox-security.md
@@ -100,7 +100,8 @@ execution controls below, Shepherd bounds the injection surface at ingestion
 
 - **Untrusted-content fencing.** External text an agent or helper LLM might read —
   issue title/body, issue comments, PR bodies + author-notes, captured terminal
-  tails, and the recap context — is wrapped in unforgeable `⟦UNTRUSTED:…⟧`
+  tails, the recap context, and the changed-view-file markup the recap prompt
+  carries (`ui-markup`) — is wrapped in unforgeable `⟦UNTRUSTED:…⟧`
   markers (`fenceUntrusted`, with a per-fence random nonce that the content cannot
   predict or close early) so the model treats it as **data, never instructions**.
   The fence carries its **label and nonce only**; the instruction hierarchy has one

--- a/src/recap-core.ts
+++ b/src/recap-core.ts
@@ -223,28 +223,32 @@ export function buildUiMarkupDigest(
   const maxChars = limits.maxChars ?? RECAP_UI_MARKUP_MAX_CHARS;
 
   const selected = files
-    .map((file, order) => ({ file, order }))
+    .map((file, order) => ({ file, order, after: afterSide(file.hunks) }))
+    // The post-change side is rendered BEFORE selection, because emptiness is part of the
+    // selection rule and it costs a file its slot: a component emptied but KEPT (status still
+    // `modified`, hunks non-empty, every line a deletion) has no resulting screen. Emitting its
+    // header alone would put the section — and the instruction to ground a wireframe on it — over
+    // a fence holding no markup, which is the invent-a-screen pressure this change exists to remove.
     .filter(
-      ({ file }) =>
+      ({ file, after }) =>
         isViewFile(file.path) &&
         file.status !== "deleted" &&
         !file.binary &&
         !file.truncated &&
-        file.hunks.length > 0,
+        after.trim() !== "",
     )
     .sort((a, b) => b.file.additions - a.file.additions || a.order - b.order)
     .slice(0, maxFiles);
 
   const blocks: string[] = [];
   let total = 0;
-  for (const { file } of selected) {
+  for (const { file, after } of selected) {
     const header = `${file.path} (${file.status})`;
     // Whatever is left of the section budget, never more than one file's share. Below the marker's
     // own length there is no room for content worth reading, so stop rather than emit a stub.
     const room = Math.min(maxFileChars, maxChars - total - header.length - 2);
     if (room < MIN_UI_MARKUP_FILE_CHARS) break;
-    const body = clipMarkup(afterSide(file.hunks), room);
-    const block = `${header}\n${body}`;
+    const block = `${header}\n${clipMarkup(after, room)}`;
     blocks.push(block);
     total += block.length + 2;
   }

--- a/src/recap-core.ts
+++ b/src/recap-core.ts
@@ -3,7 +3,7 @@
  * Mirrors the structure of critic-core.ts (parse/validate/clamp + prompt building).
  */
 import type { ActivityEntry } from "./activity";
-import type { DiffFileStatus, Recap, RecapVerdict } from "./types";
+import type { DiffFile, DiffFileStatus, DiffHunk, Recap, RecapVerdict } from "./types";
 import { parseVisualBlocks } from "./visual-blocks";
 import type { VisualBlock } from "./visual-blocks";
 import { UNTRUSTED_CONTENT_DIRECTIVE, fenceUntrusted } from "./untrusted";
@@ -144,6 +144,113 @@ export function buildTranscriptDigest(
   return lines.join("\n");
 }
 
+// ── UI markup (#2209) ─────────────────────────────────────────────────────────
+//
+// The recap agent runs the `writer-only` preset — Write only, a disposable temp cwd, no
+// `--add-dir` — so it can read NOTHING. `buildRecapPrompt` carried changed paths and statuses but
+// no markup, which is why `wireframe` fired 0 times across 30 regenerations over three prompt
+// variants (#2194 → #2208): a mockup of the resulting screen would have to be invented, and the
+// prompt's own grounding rule ("Never invent a path, a field, or a change") correctly stops that.
+// The model was behaving well; the input was missing.
+//
+// So the input is supplied, from the diff the service ALREADY holds in memory — no tool grant, no
+// extra I/O, no widening of what the spawn can reach.
+
+/** At most this many view files carry markup into the prompt. A wireframe is one screen, not a tour
+ *  of the diff; past a handful the section is competing with `plan` for the argv budget (#1944). */
+export const RECAP_UI_MARKUP_MAX_FILES = 3;
+
+/** Per-file ceiling, so one large component cannot crowd out the other selected files. */
+const RECAP_UI_MARKUP_MAX_FILE_CHARS = 2500;
+
+/** Section ceiling, to within one truncation marker per file (the marker rides on top of a clipped
+ *  slice). Soft either way: `fitRecapPrompt` clamps this block FIRST if the argv budget still bites. */
+const RECAP_UI_MARKUP_MAX_CHARS = 6000;
+
+/** Below this a file's slice is all marker and no markup — stop instead of emitting a stub. */
+const MIN_UI_MARKUP_FILE_CHARS = 200;
+
+/** Extensions that carry rendered markup. Deliberately EXTENSION-based, never path-based: Shepherd
+ *  drives arbitrary repos, so a `ui/**` rule would be a Shepherd-only heuristic. */
+const VIEW_FILE_RE = /\.(?:svelte|vue|astro|tsx|jsx|html|htm)$/i;
+
+/** `Foo.test.tsx`, `Foo.spec.jsx`, `Foo.browser.test.ts` — a test renders no screen the operator sees. */
+const TEST_FILE_RE = /\.(?:test|spec)\.[^./]+$/i;
+
+/** True for a changed file whose post-change side is worth showing as UI markup. */
+export function isViewFile(path: string): boolean {
+  return VIEW_FILE_RE.test(path) && !TEST_FILE_RE.test(path);
+}
+
+/** Neutral, factual truncation marker — states a count, commands nothing (it lands inside an
+ *  untrusted fence, where an instruction would be contractually ignorable; see untrusted.ts). */
+function elidedChars(n: number): string {
+  return `[… ${n} chars elided …]`;
+}
+
+function clipMarkup(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars)}\n${elidedChars(text.length - maxChars)}`;
+}
+
+/** Render the POST-CHANGE side of a file's hunks: `-` lines dropped, `+` kept on added lines, a
+ *  leading space kept on context lines. Hunk headers are dropped — they are line numbers, which the
+ *  prompt already forbids the agent from repeating back. Hunks are separated by a bare `…`. */
+function afterSide(hunks: DiffHunk[]): string {
+  const parts: string[] = [];
+  for (const h of hunks) {
+    const lines = h.lines
+      .filter((l) => l.kind !== "del")
+      .map((l) => `${l.kind === "add" ? "+" : " "}${l.content}`);
+    if (lines.length > 0) parts.push(lines.join("\n"));
+  }
+  return parts.join("\n…\n");
+}
+
+/** Build the bounded UI-markup digest handed to the recap agent, or "" when the session changed no
+ *  view file. Pure — the caller passes the diff it already computed.
+ *
+ *  Selection drops what cannot ground a mockup: deleted files (no resulting screen), binary files,
+ *  and files whose hunks `diff.ts` dropped past its per-file line cap (`truncated`) — silence beats
+ *  a lie, which is the whole lesson of #2209. Ranking is by additions descending (stable on the
+ *  diff's own order): the largest markup change is the most mock-able. */
+export function buildUiMarkupDigest(
+  files: DiffFile[],
+  limits: { maxFiles?: number; maxFileChars?: number; maxChars?: number } = {},
+): string {
+  const maxFiles = limits.maxFiles ?? RECAP_UI_MARKUP_MAX_FILES;
+  const maxFileChars = limits.maxFileChars ?? RECAP_UI_MARKUP_MAX_FILE_CHARS;
+  const maxChars = limits.maxChars ?? RECAP_UI_MARKUP_MAX_CHARS;
+
+  const selected = files
+    .map((file, order) => ({ file, order }))
+    .filter(
+      ({ file }) =>
+        isViewFile(file.path) &&
+        file.status !== "deleted" &&
+        !file.binary &&
+        !file.truncated &&
+        file.hunks.length > 0,
+    )
+    .sort((a, b) => b.file.additions - a.file.additions || a.order - b.order)
+    .slice(0, maxFiles);
+
+  const blocks: string[] = [];
+  let total = 0;
+  for (const { file } of selected) {
+    const header = `${file.path} (${file.status})`;
+    // Whatever is left of the section budget, never more than one file's share. Below the marker's
+    // own length there is no room for content worth reading, so stop rather than emit a stub.
+    const room = Math.min(maxFileChars, maxChars - total - header.length - 2);
+    if (room < MIN_UI_MARKUP_FILE_CHARS) break;
+    const body = clipMarkup(afterSide(file.hunks), room);
+    const block = `${header}\n${body}`;
+    blocks.push(block);
+    total += block.length + 2;
+  }
+  return blocks.join("\n\n");
+}
+
 /** The instruction prompt for the recap spawn. Tells the agent to summarize a COMPLETED
  *  coding session for an operator deciding whether to merge, and to Write the prose to
  *  `.shepherd-recap.md`, any visual blocks to `.shepherd-recap-blocks.json`, and
@@ -154,6 +261,7 @@ export function buildRecapPrompt(input: {
   changedFiles: { path: string; status: DiffFileStatus }[];
   digest: string;
   context: string; // pre-rendered critic verdict / CI / readyToMerge lines (may be "")
+  uiMarkup?: string; // buildUiMarkupDigest output; "" / absent when no view file changed (#2209)
   operatorLanguage?: OperatorLanguage;
 }): string {
   const lines = [
@@ -176,6 +284,23 @@ export function buildRecapPrompt(input: {
     lines.push(
       "Files changed in this session:",
       ...input.changedFiles.map((f) => `  ${f.path} (${f.status})`),
+      "",
+    );
+  }
+
+  // #2209: the ONLY sight of the UI this agent gets. It rides here — with the changed-file list it
+  // annotates, and outside the static block-guidance region, which has ~37 bytes of headroom under
+  // the ceiling its test pins. The interpreting instruction sits AFTER the fence: an instruction
+  // inside one is contractually ignorable and forgeable (see untrusted.ts), so it would be inert
+  // exactly where it matters.
+  if (input.uiMarkup?.trim()) {
+    lines.push(
+      "UI markup after this change (post-change side of the diff for the view files that changed —",
+      "`+` marks a line this session added, a leading space marks surrounding context, `…` separates",
+      "non-adjacent regions of the same file):",
+      fenceUntrusted("ui-markup", input.uiMarkup),
+      "This markup is your grounding for a `wireframe` block: mock up the screen it renders. Do not",
+      "put UI in a wireframe that you cannot see here.",
       "",
     );
   }

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -49,6 +49,7 @@ import { claudeConfigPath, readRepoRootTrusted, trustRepoRoot } from "./claude-t
 import {
   parseRecapVerdict,
   buildTranscriptDigest,
+  buildUiMarkupDigest,
   buildRecapPrompt,
   isSettledIdle,
   needsRecap,
@@ -842,6 +843,10 @@ export class RecapService {
       const plan = this._readPlan(worktreePath);
       const changedFiles = diff.files.map((f) => f.path);
       const changedFilesWithStatus = diff.files.map((f) => ({ path: f.path, status: f.status }));
+      // #2209: the agent reads nothing (writer-only, temp cwd), so the post-change side of the view
+      // files' hunks is the only way a `wireframe` can be grounded rather than invented. "" for a
+      // session that changed no view file — the section is then absent from the prompt entirely.
+      const uiMarkup = buildUiMarkupDigest(diff.files);
 
       const contextParts: string[] = [];
       const review = this.deps.store.getReview(id);
@@ -864,6 +869,7 @@ export class RecapService {
         plan: string;
         changedFiles: { path: string; status: DiffFileStatus }[];
         context: string;
+        uiMarkup: string;
       }): string =>
         buildRecapPrompt({
           taskPrompt: session.prompt,
@@ -871,6 +877,7 @@ export class RecapService {
           changedFiles: v.changedFiles,
           digest,
           context: v.context,
+          uiMarkup: v.uiMarkup,
           operatorLanguage: language,
         });
       const env = this.env();
@@ -882,7 +889,7 @@ export class RecapService {
       // #1944: fit the prompt inside the OS argv budget, or null when it cannot be made to fit.
       // The helper owns the clamp log line so this already-long orchestration carries one branch.
       const prompt = fitRecapPrompt(
-        { plan, changedFiles, changedFilesWithStatus, context },
+        { plan, changedFiles, changedFilesWithStatus, context, uiMarkup },
         composePrompt,
         (p) => ({ wrapped: argvFor(p), spawnEnv: apiKeyPassthroughEnv(false) }),
         `${session.id} (${session.desig})`,
@@ -1190,18 +1197,24 @@ function fitRecapPrompt(
     changedFiles: string[];
     changedFilesWithStatus: { path: string; status: DiffFileStatus }[];
     context: string;
+    uiMarkup: string;
   },
   compose: (v: {
     plan: string;
     changedFiles: { path: string; status: DiffFileStatus }[];
     context: string;
+    uiMarkup: string;
   }) => string,
   assemble: SpawnAssembler,
   label: string,
 ): string | null {
   const fitted = fitFrom({
     ...spawnBudget(assemble),
+    // Order IS the clamp order (fitAssembledPrompt gives blocks up in the caller's order). `uiMarkup`
+    // goes FIRST: it is the newest and most expendable input (#2209), and `plan`/`context` keep
+    // exactly the protection they had before it existed (#1944).
     specs: [
+      { id: "uiMarkup", kind: "text", text: input.uiMarkup, mode: "head" },
       { id: "plan", kind: "text", text: input.plan, mode: "head-tail" },
       { id: "changedFiles", kind: "list", items: input.changedFiles, noun: "files" },
       { id: "context", kind: "text", text: input.context, mode: "head" },
@@ -1209,6 +1222,7 @@ function fitRecapPrompt(
     compose: (v) =>
       compose({
         plan: v.plan as string,
+        uiMarkup: v.uiMarkup as string,
         // clampList emits its marker as a trailing pseudo-entry; re-attach a status so the typed
         // changedFiles shape holds without special-casing it downstream.
         changedFiles: (v.changedFiles as string[]).map(

--- a/test/recap-core.test.ts
+++ b/test/recap-core.test.ts
@@ -5,7 +5,10 @@ import { join } from "node:path";
 import {
   parseRecapVerdict,
   buildTranscriptDigest,
+  buildUiMarkupDigest,
   buildRecapPrompt,
+  isViewFile,
+  RECAP_UI_MARKUP_MAX_FILES,
   isSettledIdle,
   needsRecap,
   RECAP_VERDICTS,
@@ -17,7 +20,7 @@ import {
 } from "../src/recap-core";
 import { defaultReadVerdict } from "../src/recap";
 import { tolerantParseJson } from "../src/json-tolerant";
-import type { Recap } from "../src/types";
+import type { DiffFile, DiffLine, Recap } from "../src/types";
 
 // ── #822 regression: malformed-JSON read path (defaultReadVerdict → parseRecapVerdict) ──────────
 //
@@ -1067,4 +1070,190 @@ test("#2194 buildRecapPrompt: the block-guidance region stays inside its prompt 
   // wireframe had fired 0 times in 88 block-emitting recaps.
   const bytes = Buffer.byteLength(blockGuidanceRegion(bareRecapPrompt()), "utf8");
   expect(bytes).toBeLessThanOrEqual(7424);
+});
+
+// ── #2209: the UI markup that makes `wireframe` emittable at all ─────────────────────────────────
+//
+// #2208 moved every block type it could from the prompt alone and left `wireframe` at zero across
+// 30 regenerations over three variants. It could not move: the recap agent runs `writer-only` (no
+// Read/Grep/Glob, disposable temp cwd, no --add-dir) against a prompt carrying file PATHS and no
+// markup, so a mockup would have to be invented — which the prompt's grounding rule correctly
+// forbids. These tests pin the input that closes that gap.
+
+function uiLine(kind: DiffLine["kind"], content: string): DiffLine {
+  return { kind, content };
+}
+
+function viewFile(path: string, over: Partial<DiffFile> = {}): DiffFile {
+  return {
+    path,
+    status: "modified",
+    additions: 1,
+    deletions: 1,
+    binary: false,
+    hunks: [
+      {
+        header: "@@ -1,3 +1,3 @@",
+        lines: [
+          uiLine("ctx", '<div class="card">'),
+          uiLine("del", "  <h2>Old</h2>"),
+          uiLine("add", "  <h2>New</h2>"),
+          uiLine("ctx", "</div>"),
+        ],
+      },
+    ],
+    ...over,
+  };
+}
+
+test("#2209 isViewFile: markup extensions in, tests and non-view files out", () => {
+  for (const p of [
+    "ui/src/lib/Card.svelte",
+    "src/App.vue",
+    "site/src/pages/index.astro",
+    "web/Button.tsx",
+    "web/Button.jsx",
+    "public/shell.html",
+    "public/legacy.htm",
+  ]) {
+    expect(isViewFile(p)).toBe(true);
+  }
+  // Extension-based on purpose: Shepherd drives arbitrary repos, so a `ui/**` rule would only ever
+  // be right about this one.
+  for (const p of [
+    "src/store.ts",
+    "ui/src/lib/Card.svelte.md",
+    "ui/src/lib/Card.test.tsx",
+    "ui/src/lib/Card.spec.jsx",
+    "ui/src/lib/blocks/WireframeBlock.browser.test.ts",
+  ]) {
+    expect(isViewFile(p)).toBe(false);
+  }
+});
+
+test("#2209 buildUiMarkupDigest: renders the POST-change side only", () => {
+  const out = buildUiMarkupDigest([viewFile("ui/src/lib/Card.svelte")]);
+  expect(out).toContain("ui/src/lib/Card.svelte (modified)");
+  expect(out).toContain("+  <h2>New</h2>");
+  expect(out).toContain(' <div class="card">');
+  // A deleted line is not on the resulting screen; showing it invites a mockup of the OLD UI.
+  expect(out).not.toContain("<h2>Old</h2>");
+  // Hunk headers are line numbers, which the prompt forbids the agent from repeating back.
+  expect(out).not.toContain("@@");
+});
+
+test("#2209 buildUiMarkupDigest: separates non-adjacent regions of one file", () => {
+  const f = viewFile("ui/src/lib/Card.svelte");
+  f.hunks.push({ header: "@@ -20,2 +20,3 @@", lines: [uiLine("add", "  <footer />")] });
+  expect(buildUiMarkupDigest([f])).toContain("\n…\n");
+});
+
+test("#2209 buildUiMarkupDigest: skips what cannot ground a mockup", () => {
+  // Every one of these would otherwise contribute a header with no markup under it.
+  expect(buildUiMarkupDigest([viewFile("ui/a.svelte", { status: "deleted" })])).toBe("");
+  expect(buildUiMarkupDigest([viewFile("ui/b.svelte", { binary: true })])).toBe("");
+  // `diff.ts` drops hunks past its per-file line cap — silence beats inventing the missing half.
+  expect(buildUiMarkupDigest([viewFile("ui/c.svelte", { truncated: true })])).toBe("");
+  expect(buildUiMarkupDigest([viewFile("ui/d.svelte", { hunks: [] })])).toBe("");
+  expect(buildUiMarkupDigest([viewFile("src/store.ts")])).toBe("");
+  expect(buildUiMarkupDigest([])).toBe("");
+});
+
+test("#2209 buildUiMarkupDigest: ranks by additions and caps the file count", () => {
+  const files = [
+    viewFile("ui/small.svelte", { additions: 1 }),
+    viewFile("ui/big.svelte", { additions: 90 }),
+    viewFile("ui/mid.svelte", { additions: 40 }),
+    viewFile("ui/tiny.svelte", { additions: 0 }),
+  ];
+  const out = buildUiMarkupDigest(files);
+  const order = ["ui/big.svelte", "ui/mid.svelte", "ui/small.svelte"].map((p) => out.indexOf(p));
+  expect(order.every((i) => i > -1)).toBe(true);
+  expect(order).toEqual([...order].sort((a, b) => a - b));
+  expect(out).not.toContain("ui/tiny.svelte");
+  expect(out.split("\n").filter((l) => l.endsWith("(modified)")).length).toBe(
+    RECAP_UI_MARKUP_MAX_FILES,
+  );
+});
+
+test("#2209 buildUiMarkupDigest: per-file and section caps both bite, and are marked", () => {
+  const fat = (path: string): DiffFile =>
+    viewFile(path, {
+      additions: 500,
+      hunks: [
+        {
+          header: "@@ -1,1 +1,400 @@",
+          lines: Array.from({ length: 400 }, (_, i) => uiLine("add", `  <li>row ${i}</li>`)),
+        },
+      ],
+    });
+  const perFile = buildUiMarkupDigest([fat("ui/a.svelte")], { maxFileChars: 400 });
+  expect(perFile.length).toBeLessThan(900);
+  expect(perFile).toContain("chars elided");
+
+  // The section cap stops the whole block, not just each file — a clamp is never silent.
+  const section = buildUiMarkupDigest([fat("ui/a.svelte"), fat("ui/b.svelte")], { maxChars: 900 });
+  expect(section.length).toBeLessThan(1100);
+  expect(section).toContain("chars elided");
+  // Nothing is emitted below the useful floor: a header with a marker under it is not markup.
+  expect(buildUiMarkupDigest([fat("ui/a.svelte")], { maxChars: 100 })).toBe("");
+});
+
+test("#2209 buildRecapPrompt: the markup section is fenced, and its instruction sits OUTSIDE", () => {
+  const markup = buildUiMarkupDigest([viewFile("ui/src/lib/Card.svelte")]);
+  const p = buildRecapPrompt({
+    taskPrompt: "t",
+    plan: "",
+    changedFiles: [],
+    digest: "",
+    context: "",
+    uiMarkup: markup,
+  });
+  const open = p.indexOf("⟦UNTRUSTED:ui-markup:");
+  const close = p.indexOf("⟦/UNTRUSTED:ui-markup:");
+  expect(open).toBeGreaterThan(-1);
+  expect(p.indexOf("+  <h2>New</h2>")).toBeGreaterThan(open);
+  expect(p.indexOf("+  <h2>New</h2>")).toBeLessThan(close);
+  // An instruction INSIDE a fence is contractually ignorable — and forgeable by the fenced
+  // content — so the one line that tells the agent what to DO with the markup must sit after it.
+  const instruction = p.indexOf("This markup is your grounding for a `wireframe` block");
+  expect(instruction).toBeGreaterThan(close);
+});
+
+test("#2209 buildRecapPrompt: no view file changed ⇒ no section at all", () => {
+  const p = bareRecapPrompt();
+  expect(p).not.toContain("UI markup after this change");
+  expect(p).not.toContain("⟦UNTRUSTED:ui-markup:");
+  // Absent and empty must behave identically — `generate()` passes "" rather than omitting.
+  // Fence nonces are per-call random, so compare with them normalized away.
+  const denonce = (t: string): string => t.replace(/⟦(\/?)UNTRUSTED:([^:]+):[0-9a-f]+⟧/g, "⟦$1$2⟧");
+  const empty = buildRecapPrompt({
+    taskPrompt: "t",
+    plan: "",
+    changedFiles: [],
+    digest: "",
+    context: "",
+    uiMarkup: "",
+  });
+  expect(denonce(empty)).toBe(denonce(p));
+});
+
+test("#2209 buildRecapPrompt: the markup rides OUTSIDE the pinned block-guidance region", () => {
+  // That region sits at 7387 of its 7424-byte ceiling. Putting the wireframe grounding there would
+  // have cost the last 37 bytes; it belongs with the changed-file list it annotates anyway, and it
+  // is per-session content, not standing guidance.
+  const p = buildRecapPrompt({
+    taskPrompt: "t",
+    plan: "",
+    changedFiles: [],
+    digest: "",
+    context: "",
+    uiMarkup: buildUiMarkupDigest([viewFile("ui/src/lib/Card.svelte")]),
+  });
+  expect(p.indexOf("UI markup after this change")).toBeLessThan(
+    p.indexOf("Optionally, add `blocks`"),
+  );
+  expect(Buffer.byteLength(blockGuidanceRegion(p), "utf8")).toBe(
+    Buffer.byteLength(blockGuidanceRegion(bareRecapPrompt()), "utf8"),
+  );
 });

--- a/test/recap-core.test.ts
+++ b/test/recap-core.test.ts
@@ -1155,6 +1155,22 @@ test("#2209 buildUiMarkupDigest: skips what cannot ground a mockup", () => {
   // `diff.ts` drops hunks past its per-file line cap — silence beats inventing the missing half.
   expect(buildUiMarkupDigest([viewFile("ui/c.svelte", { truncated: true })])).toBe("");
   expect(buildUiMarkupDigest([viewFile("ui/d.svelte", { hunks: [] })])).toBe("");
+  // A component emptied but KEPT: status stays `modified` and the hunks are non-empty, yet every
+  // line is a deletion — there is no resulting screen, so a bare header must not be emitted over
+  // an empty fence. It must not cost a slot either: the next real file takes its place.
+  const gutted = viewFile("ui/e.svelte", {
+    additions: 0,
+    hunks: [{ header: "@@ -1,2 +0,0 @@", lines: [uiLine("del", "<div>gone</div>")] }],
+  });
+  expect(buildUiMarkupDigest([gutted])).toBe("");
+  const withNeighbours = buildUiMarkupDigest(
+    [gutted, viewFile("ui/f.svelte"), viewFile("ui/g.svelte"), viewFile("ui/h.svelte")],
+    { maxFiles: 3 },
+  );
+  expect(withNeighbours).not.toContain("ui/e.svelte");
+  for (const p of ["ui/f.svelte", "ui/g.svelte", "ui/h.svelte"]) {
+    expect(withNeighbours).toContain(p);
+  }
   expect(buildUiMarkupDigest([viewFile("src/store.ts")])).toBe("");
   expect(buildUiMarkupDigest([])).toBe("");
 });

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -6,6 +6,8 @@ import { RecapService, sanitizeRecapFailureDetail } from "../src/recap";
 import type { VerdictRead } from "../src/json-tolerant";
 import type { DiffResult, Recap, Session } from "../src/types";
 import type { ActivityEntry } from "../src/activity";
+import { buildRecapPrompt, buildUiMarkupDigest } from "../src/recap-core";
+import { hostArgvBudget, joinedElementBytes } from "../src/argv-limit";
 import { config } from "../src/config";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
 
@@ -289,6 +291,7 @@ function buildSvc(opts: {
     baseRef: string,
   ) => Promise<"contained" | "not-contained" | "unknown">;
   landedWorkEvidence?: () => any;
+  readPlan?: () => string;
 }): RecapService {
   let tmpIdx = 0;
   return new RecapService({
@@ -303,7 +306,7 @@ function buildSvc(opts: {
     resolveBase: opts.resolveBase,
     computeDiff: opts.computeDiff ?? (async () => (opts.diff ?? NON_EMPTY_DIFF) as any),
     readTranscript: (): ActivityEntry[] => [],
-    readPlan: () => "",
+    readPlan: opts.readPlan ?? (() => ""),
     readVerdict: opts.readVerdictFn
       ? opts.readVerdictFn
       : (): VerdictRead<unknown> =>
@@ -2536,4 +2539,121 @@ test("an old finalizer racing a forced regenerate never stops the replacement ru
   await svc.tick(); // the replacement finalizes normally off its own retained handle
   expect(herdr.stopped).toEqual(["tid-1", "tid-2"]);
   expect(store.getRecap("s1")?.state).toBe("ready");
+});
+
+// ── #2209: UI markup reaches the spawn, and yields the budget first ──────────────────────────────
+
+/** A diff carrying one view file with real hunks — the input `wireframe` needs and never had. */
+function uiDiff(lines = 3): DiffResult {
+  return {
+    ...NON_EMPTY_DIFF,
+    files: [
+      NON_EMPTY_DIFF.files[0]!,
+      {
+        path: "ui/src/lib/components/Card.svelte",
+        status: "modified" as const,
+        additions: lines,
+        deletions: 1,
+        binary: false as const,
+        hunks: [
+          {
+            header: "@@ -1,3 +1,5 @@",
+            lines: [
+              { kind: "ctx" as const, content: '<div class="card">' },
+              { kind: "del" as const, content: "  <h2>Old</h2>" },
+              ...Array.from({ length: lines }, (_, i) => ({
+                kind: "add" as const,
+                content: `  <button>Action ${i}</button>`,
+              })),
+              { kind: "ctx" as const, content: "</div>" },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+test("#2209 generate: the changed view file's post-change markup reaches the spawn prompt", async () => {
+  const s = makeSession({ status: "idle" });
+  const herdr = makeHerdr();
+  const svc = buildSvc({
+    store: makeStore([s]),
+    herdr,
+    nowFn: () => 1,
+    makeTmpDir: () => "/tmp/r",
+    computeDiff: async () => uiDiff(),
+  });
+  await svc.regenerate(s);
+  const prompt = herdr.started[0]!.argv.at(-1)!;
+  expect(prompt).toContain("UI markup after this change");
+  expect(prompt).toContain("ui/src/lib/components/Card.svelte (modified)");
+  expect(prompt).toContain("+  <button>Action 0</button>");
+  expect(prompt).toContain("This markup is your grounding for a `wireframe` block");
+  // The non-view file in the same diff still shows up as a path, never as markup.
+  expect(prompt).toContain("src/foo.ts (modified)");
+  expect(prompt).not.toContain("<h2>Old</h2>");
+});
+
+test("#2209 generate: a diff with no view file leaves the prompt exactly as it was", async () => {
+  const s = makeSession({ status: "idle" });
+  const herdr = makeHerdr();
+  const svc = buildSvc({
+    store: makeStore([s]),
+    herdr,
+    nowFn: () => 1,
+    makeTmpDir: () => "/tmp/r",
+  });
+  await svc.regenerate(s);
+  expect(herdr.started[0]!.argv.at(-1)!).not.toContain("UI markup after this change");
+});
+
+test("#2209 generate: the markup yields argv bytes BEFORE the plan does (#1944 ladder order)", async () => {
+  const budget = hostArgvBudget();
+  // Off Linux there is no per-element cap, so there is no ladder to order.
+  if (!Number.isFinite(budget)) return;
+
+  const s = makeSession({ status: "idle" });
+  const herdr = makeHerdr();
+  const markup = buildUiMarkupDigest(uiDiff(400).files);
+  expect(markup.length).toBeGreaterThan(1000);
+
+  // Size the plan so the composed prompt overruns by ~1 KB: less than the markup can give up
+  // (its length down to a 256-byte floor, ~2.3 KB here), so a correctly ordered ladder absorbs the
+  // overrun there and never touches the plan. Measured rather than guessed, so a later edit to
+  // the static prompt cannot silently turn this into a no-op.
+  const base = joinedElementBytes(
+    buildRecapPrompt({
+      taskPrompt: s.prompt,
+      plan: "",
+      changedFiles: uiDiff().files.map((f) => ({ path: f.path, status: f.status })),
+      digest: "",
+      context: "",
+      uiMarkup: markup,
+    }),
+  );
+  const plan = `PLAN-HEAD-MARKER\n${"plan detail\n".repeat(
+    Math.ceil((budget - base + 1000) / 12),
+  )}PLAN-TAIL-MARKER`;
+
+  const svc = buildSvc({
+    store: makeStore([s]),
+    herdr,
+    nowFn: () => 1,
+    makeTmpDir: () => "/tmp/r",
+    computeDiff: async () => uiDiff(400),
+    readPlan: () => plan,
+  });
+  await svc.regenerate(s);
+  const prompt = herdr.started[0]!.argv.at(-1)!;
+
+  // Exactly one block gave bytes up, and it was the markup — the marker sits inside its fence.
+  const markers = [...prompt.matchAll(/\[… \d+ bytes elided …\]/g)];
+  expect(markers.length).toBe(1);
+  const at = markers[0]!.index!;
+  expect(at).toBeGreaterThan(prompt.indexOf("⟦UNTRUSTED:ui-markup:"));
+  expect(at).toBeLessThan(prompt.indexOf("⟦/UNTRUSTED:ui-markup:"));
+  // The plan — the ground truth the recap is judged against — is untouched.
+  expect(prompt).toContain("PLAN-HEAD-MARKER");
+  expect(prompt).toContain("PLAN-TAIL-MARKER");
 });


### PR DESCRIPTION
Closes #2209.

`wireframe` had fired **0 times** — across 88 block-emitting recaps, then across 30 more regenerations over three prompt variants in #2208. It could not fire from the prompt: the recap spawn runs the `writer-only` preset (`allowedTools: ["Write"]`, disposable temp cwd, no `--add-dir`) and `buildRecapPrompt` carried changed **paths and statuses** but no markup. A mockup of the resulting screen would have to be invented, and the prompt's own grounding rule — "Never invent a path, a field, or a change" — correctly stopped that. The model was behaving well; the input was missing.

This supplies the input, from the diff `RecapService.generate()` **already holds in memory**.

## What changed

- **`src/recap-core.ts`** — `buildUiMarkupDigest()`: a pure `DiffFile[] → string` helper (sibling of `buildTranscriptDigest`) that renders the **post-change side** of the changed view files' hunks — `-` lines dropped, `+` kept on added lines, a leading space on context, hunk headers dropped (they are line numbers, which the prompt already forbids the agent from repeating back). `buildRecapPrompt` gains an optional `uiMarkup` and renders it as a fenced section, with the one line that grounds `wireframe` on it sitting **outside** the fence — an instruction inside one is contractually ignorable and forgeable (`src/untrusted.ts`).
- **`src/recap.ts`** — `generate()` builds the digest and threads it through; `fitRecapPrompt` gains a `uiMarkup` clamp spec placed **first in the spec list**, so the markup yields argv bytes before `plan` and `context` — those keep exactly the protection they had (#1944).

Selection is deliberately **extension-based, never path-based** (Shepherd drives arbitrary repos, so a `ui/**` rule would only ever be right about this one): `.svelte/.vue/.astro/.tsx/.jsx/.html/.htm`, minus tests, deleted, binary, and files whose hunks `diff.ts` dropped past its line cap — silence beats a lie. Ranked by additions, capped at 3 files / ~6 KB.

**No preset change, no `--add-dir`, no new I/O, no new tool grant.** Issue option 1 was rejected on its security shape: `--add-dir` has no read-only form, so the preset's bare `Write` would reach a live session worktree while the agent ingests untrusted transcript text.

The static block-guidance region is **byte-identical** — it sits at 7387 of the 7424-byte ceiling #2208 pinned, so the new instruction rides the per-session section instead of eating the last 37 bytes.

## Empirical result

10 archived UI-change sessions, regenerated through the real `RecapService` against a **copy** of the live DB (no live recap row was written).

| metric | #2208 (before) | this branch |
| --- | --- | --- |
| `wireframe` | **0** | **10** (in 9 of 10 recaps) |
| blocks/recap median | 5.5 | **6.5** (target 3-7) |
| blocks/recap max | 7 | **8** (must not exceed 14) |
| zero-block recaps | 0 | **0** |
| blocks total | 54 | 64 |

Per-type: `diff`=19 `wireframe`=10 `callout`=9 `file-tree`=9 `checklist`=8 `rich-text`=4 `mermaid`=4 `code`=1.

The harness also compared the **raw** `.shepherd-recap-blocks.json` against the parsed output: **0 blocks dropped by the validator**. That check exists because `validateWireframe` silently drops a wireframe carrying an inline hex/`rgb()`/`font-family`/`box-shadow`, a bad `surface`, or >20k chars — so #2208's zero could not distinguish "never emitted" from "emitted and dropped". It can now: they were genuinely never emitted, and the ones produced here are clean (helper classes, class-based color, no inline color anywhere).

Spot-read of a produced wireframe (TASK-2241): a `mobile` surface showing the notification-shade icon before/after, captioned, built from `wf-card`/`wf-box`/`wf-pill`/`wf-muted` — grounded in the markup, not invented.

## Caveats

- **n=10, one sample per session.** The categorical result (`wireframe > 0`, and 10/10 recaps produced) is robust to that; the medians are not distributions.
- **Not a perfectly matched A/B.** `.shepherd-plan.md` is never committed and the sessions' worktrees are gone, so regenerated recaps ran without plan text. Same bias #2208 noted — the new run saw *less* input, not more.
- A modified component yields markup **fragments**, not a whole screen; the mockup is then of the region that changed. That is what the operator needs to see, and it is what the measurement tested.
- A UI change whose file exceeded `diff.ts`'s per-file line cap contributes nothing — deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
