### PR TITLE
fix(buildqueue): expand toggle hit area across banner

### DIFF
--- a/ui/src/lib/components/BuildQueuePanel.browser.test.ts
+++ b/ui/src/lib/components/BuildQueuePanel.browser.test.ts
@@ -46,33 +46,52 @@ afterEach(() => {
 
 const noop = () => {};
 
-describe("BuildQueuePanel — approved queue start", () => {
-  it("starts an auto-approved waiting queue without re-approving or bypassing planning", async () => {
-    vi.mocked(replySession).mockClear();
-    vi.mocked(approveBuildQueue).mockClear();
-    const queue: BuildQueue = {
-      sessionId: "s1",
-      approved: true,
-      approvalKind: "auto",
-      steps: [{ id: "a", title: "Prepare plan", status: "pending", position: 0 }],
-    };
-    render(BuildQueuePanel, {
-      sessionId: "s1",
-      enabled: true,
-      queue,
-      onbootstrap: noop,
-      sessionStatus: "blocked",
-      planPhase: "planning",
-    });
-    const start = page.getByRole("button", { name: "Start now", exact: true });
-    await expect.element(start).toBeVisible();
-    await start.click();
-    expect(replySession).toHaveBeenCalledOnce();
-    expect(vi.mocked(replySession).mock.calls[0][0]).toBe("s1");
-    expect(vi.mocked(replySession).mock.calls[0][1]).toContain("Do not implement");
-    expect(approveBuildQueue).not.toHaveBeenCalled();
-    expect(queue.approvalKind).toBe("auto");
+// Force skips locator actionability checks, but still sends real browser pointer
+// events to the coordinates, including overlays and disabled controls.
+async function clickAt(panel: HTMLElement, x: number, y: number) {
+  const rect = panel.getBoundingClientRect();
+  await userEvent.click(panel, {
+    force: true,
+    position: { x: x - rect.left - panel.clientLeft, y: y - rect.top - panel.clientTop },
   });
+}
+
+describe("BuildQueuePanel — approved queue start", () => {
+  it.each(["click", "keyboard"])(
+    "starts an auto-approved waiting queue via %s without re-approving or bypassing planning",
+    async (activation) => {
+      vi.mocked(replySession).mockClear();
+      vi.mocked(approveBuildQueue).mockClear();
+      const queue: BuildQueue = {
+        sessionId: "s1",
+        approved: true,
+        approvalKind: "auto",
+        steps: [{ id: "a", title: "Prepare plan", status: "pending", position: 0 }],
+      };
+      buildQueueCollapse.set(true);
+      render(BuildQueuePanel, {
+        sessionId: "s1",
+        enabled: true,
+        queue,
+        onbootstrap: noop,
+        sessionStatus: "blocked",
+        planPhase: "planning",
+      });
+      const start = page.getByRole("button", { name: "Start now", exact: true });
+      await expect.element(start).toBeVisible();
+      if (activation === "click") await start.click();
+      else {
+        start.element().focus();
+        await userEvent.keyboard("{Enter}");
+      }
+      expect(replySession).toHaveBeenCalledOnce();
+      expect(vi.mocked(replySession).mock.calls[0][0]).toBe("s1");
+      expect(vi.mocked(replySession).mock.calls[0][1]).toContain("Do not implement");
+      expect(approveBuildQueue).not.toHaveBeenCalled();
+      expect(buildQueueCollapse.collapsed).toBe(true);
+      expect(queue.approvalKind).toBe("auto");
+    },
+  );
 });
 
 describe("BuildQueuePanel — action lifecycle", () => {
@@ -157,11 +176,14 @@ describe("BuildQueuePanel — action lifecycle", () => {
         folded: true,
       });
       const button = document.querySelector<HTMLButtonElement>(".bqp-approve")!;
-      button.click();
-      button.click();
+      buildQueueCollapse.set(true);
       await tick();
+      await userEvent.click(button);
+      const rect = button.getBoundingClientRect();
+      await clickAt(document.querySelector<HTMLElement>(".bqp")!, rect.left + 4, rect.top + 4);
       expect(api).toHaveBeenCalledTimes(1);
       expect(button.disabled).toBe(true);
+      expect(buildQueueCollapse.collapsed).toBe(true);
       pending.reject(new Error("offline"));
       await expect.element(page.getByRole("alert")).toHaveTextContent(m.buildqueue_action_failed());
       expect(button.disabled).toBe(false);
@@ -171,6 +193,7 @@ describe("BuildQueuePanel — action lifecycle", () => {
         })
         .click();
       expect(api).toHaveBeenCalledTimes(2);
+      expect(buildQueueCollapse.collapsed).toBe(true);
       await expect.element(page.getByRole("status")).toHaveTextContent(m.buildqueue_action_sent());
     });
   }
@@ -203,6 +226,97 @@ describe("BuildQueuePanel — action lifecycle", () => {
     await tick();
     expect(onbootstrap).not.toHaveBeenCalledWith(waiting);
     await expect.element(page.getByText(m.buildqueue_action_sent())).not.toBeInTheDocument();
+  });
+});
+
+describe("BuildQueuePanel — banner hit area", () => {
+  const locale = getLocale();
+  const queue: BuildQueue = {
+    sessionId: "s1",
+    approved: true,
+    approvalKind: "auto",
+    steps: [{ id: "a", title: "Prepare plan", status: "pending", position: 0 }],
+  };
+
+  afterEach(async () => {
+    setLocale(locale, { reload: false });
+    await page.viewport(1280, 900);
+  });
+
+  for (const width of [390, 1280]) {
+    it(`toggles from hint, whitespace and padding without starting the queue at ${width}px`, async () => {
+      await page.viewport(width, 900);
+      setLocale("de", { reload: false });
+      buildQueueCollapse.set(true);
+      await render(BuildQueuePanel, {
+        sessionId: "s1",
+        enabled: true,
+        queue,
+        onbootstrap: noop,
+        sessionStatus: "blocked",
+        planPhase: "planning",
+      });
+      const panel = document.querySelector<HTMLElement>(".bqp")!;
+      const toggle = document.querySelector<HTMLButtonElement>(".bqp-collapse-toggle")!;
+      const content = document.getElementById(toggle.getAttribute("aria-controls")!)!;
+      const rect = panel.getBoundingClientRect();
+      const head = toggle.getBoundingClientRect();
+      const hint = document.querySelector<HTMLElement>(".bqp-hint")!.getBoundingClientRect();
+      const row = document.querySelector<HTMLElement>(".bqp-action-row")!.getBoundingClientRect();
+      const points = [
+        ["hint text", hint.left + 8, hint.top + 8],
+        ["hint whitespace", hint.right - 4, hint.bottom - 2],
+        ["between rows", head.left + 20, (head.bottom + row.top) / 2],
+        ["top padding", rect.left + 4, rect.top + 4],
+        ["side padding", rect.right - 4, hint.top + 8],
+        ["bottom padding", rect.left + 4, row.bottom + 3],
+      ] as const;
+
+      for (const [name, x, y] of points) {
+        await clickAt(panel, x, y);
+        await expect
+          .poll(() => toggle.getAttribute("aria-expanded"), { message: name })
+          .toBe("true");
+        expect(content.offsetParent, name).not.toBeNull();
+        await clickAt(panel, x, y);
+        await expect
+          .poll(() => toggle.getAttribute("aria-expanded"), { message: name })
+          .toBe("false");
+        expect(content.offsetParent, name).toBeNull();
+      }
+      expect(replySession).not.toHaveBeenCalled();
+      expect(approveBuildQueue).not.toHaveBeenCalled();
+    });
+  }
+
+  it("keeps keyboard disclosure, step editing and step actions independent", async () => {
+    buildQueueCollapse.set(true);
+    await render(BuildQueuePanel, {
+      sessionId: "s1",
+      enabled: true,
+      queue: { ...queue, approved: false },
+      onbootstrap: noop,
+    });
+    const toggle = document.querySelector<HTMLButtonElement>(".bqp-collapse-toggle")!;
+    toggle.focus();
+    await userEvent.keyboard("{Enter}");
+    await expect
+      .element(page.getByRole("textbox", { name: `${m.buildqueue_step_title_aria()} 1` }))
+      .toBeVisible();
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(document.activeElement).toBe(toggle);
+    await userEvent.keyboard(" ");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    await userEvent.keyboard("{Enter}");
+    const input = page.getByRole("textbox", { name: `${m.buildqueue_step_title_aria()} 1` });
+    await input.click();
+    await input.fill("Updated plan");
+    await userEvent.keyboard("{Enter}");
+    await expect.element(input).toHaveValue("Updated plan");
+    await page.getByRole("button", { name: m.buildqueue_add_step(), exact: true }).click();
+    expect(buildQueueCollapse.collapsed).toBe(false);
+    expect(replySession).not.toHaveBeenCalled();
+    expect(approveBuildQueue).not.toHaveBeenCalled();
   });
 });
 

--- a/ui/src/lib/components/BuildQueuePanel.svelte
+++ b/ui/src/lib/components/BuildQueuePanel.svelte
@@ -226,67 +226,69 @@
     role="region"
     aria-label={m.buildqueue_panel_title()}
   >
-    <button
-      type="button"
-      class="bqp-head bqp-collapse-toggle"
-      onclick={() => buildQueueCollapse.toggle()}
-      aria-expanded={!buildQueueCollapse.collapsed}
-      aria-controls={contentId}
-      aria-label={buildQueueCollapse.collapsed
-        ? m.buildqueue_expand_aria()
-        : m.buildqueue_collapse_aria()}
-      aria-describedby={canApprove ? awaitingId : undefined}
-      title={buildQueueCollapse.collapsed
-        ? m.buildqueue_expand_aria()
-        : m.buildqueue_collapse_aria()}
-      use:coachTarget={"build-queue-collapse"}
-    >
-      <span class="bqp-title">{m.buildqueue_panel_title()}</span>
-      {#if approved && steps.length > 0}
-        <span class={["bqp-approved", `bqp-run-${runState}`]}>{approvalLabel} · {runLabel}</span>
-      {:else if canApprove}
-        <!-- Needs-you chip: mirrors the approved chip's slot so the header always
-             narrates queue status. Lives in the always-rendered header, so the
-             signal (and its aria-describedby target) survives collapse. -->
-        <span class="bqp-awaiting-chip" id={awaitingId}>
-          <span class="bqp-awaiting-dot" aria-hidden="true"></span>{m.buildqueue_awaiting_chip()}
-        </span>
-      {/if}
-      <span class="bqp-collapse-glyph" aria-hidden="true"
-        >{buildQueueCollapse.collapsed ? "▴" : "▾"}</span
+    <div class="bqp-banner" class:collapsed={buildQueueCollapse.collapsed}>
+      <button
+        type="button"
+        class="bqp-head bqp-collapse-toggle"
+        onclick={() => buildQueueCollapse.toggle()}
+        aria-expanded={!buildQueueCollapse.collapsed}
+        aria-controls={contentId}
+        aria-label={buildQueueCollapse.collapsed
+          ? m.buildqueue_expand_aria()
+          : m.buildqueue_collapse_aria()}
+        aria-describedby={canApprove ? awaitingId : undefined}
+        title={buildQueueCollapse.collapsed
+          ? m.buildqueue_expand_aria()
+          : m.buildqueue_collapse_aria()}
+        use:coachTarget={"build-queue-collapse"}
       >
-    </button>
-
-    {#if reviewBlocked && steps.length > 0}
-      <p class="bqp-notice">
-        {planReview === "reviewing"
-          ? m.buildqueue_plan_reviewing()
-          : m.buildqueue_plan_review_hint()}
-      </p>
-    {:else if actionable}
-      <div class="bqp-action-row">
-        <p class="bqp-hint">{actionHint}</p>
-        <button
-          type="button"
-          class="bqp-btn bqp-approve"
-          disabled={action?.busy}
-          onclick={() => sendAction(canApprove ? "approve" : "start")}
+        <span class="bqp-title">{m.buildqueue_panel_title()}</span>
+        {#if approved && steps.length > 0}
+          <span class={["bqp-approved", `bqp-run-${runState}`]}>{approvalLabel} · {runLabel}</span>
+        {:else if canApprove}
+          <!-- Needs-you chip: mirrors the approved chip's slot so the header always
+               narrates queue status. Lives in the always-rendered header, so the
+               signal (and its aria-describedby target) survives collapse. -->
+          <span class="bqp-awaiting-chip" id={awaitingId}>
+            <span class="bqp-awaiting-dot" aria-hidden="true"></span>{m.buildqueue_awaiting_chip()}
+          </span>
+        {/if}
+        <span class="bqp-collapse-glyph" aria-hidden="true"
+          >{buildQueueCollapse.collapsed ? "▴" : "▾"}</span
         >
-          <span class="bqp-approve-glyph" aria-hidden="true">▸</span>{canApprove
-            ? planning
-              ? m.buildqueue_approve_plan()
-              : m.buildqueue_approve()
-            : m.buildqueue_start()}
-        </button>
-      </div>
-    {/if}
-    {#if action?.busy}
-      <p class="bqp-notice" role="status">{m.buildqueue_sending()}</p>
-    {:else if action?.feedback === "failed"}
-      <p class="bqp-notice" role="alert">{m.buildqueue_action_failed()}</p>
-    {:else if action?.feedback === "sent"}
-      <p class="bqp-notice" role="status">{m.buildqueue_action_sent()}</p>
-    {/if}
+      </button>
+
+      {#if reviewBlocked && steps.length > 0}
+        <p class="bqp-notice">
+          {planReview === "reviewing"
+            ? m.buildqueue_plan_reviewing()
+            : m.buildqueue_plan_review_hint()}
+        </p>
+      {:else if actionable}
+        <div class="bqp-action-row">
+          <p class="bqp-hint">{actionHint}</p>
+          <button
+            type="button"
+            class="bqp-btn bqp-approve"
+            disabled={action?.busy}
+            onclick={() => sendAction(canApprove ? "approve" : "start")}
+          >
+            <span class="bqp-approve-glyph" aria-hidden="true">▸</span>{canApprove
+              ? planning
+                ? m.buildqueue_approve_plan()
+                : m.buildqueue_approve()
+              : m.buildqueue_start()}
+          </button>
+        </div>
+      {/if}
+      {#if action?.busy}
+        <p class="bqp-notice" role="status">{m.buildqueue_sending()}</p>
+      {:else if action?.feedback === "failed"}
+        <p class="bqp-notice" role="alert">{m.buildqueue_action_failed()}</p>
+      {:else if action?.feedback === "sent"}
+        <p class="bqp-notice" role="status">{m.buildqueue_action_sent()}</p>
+      {/if}
+    </div>
 
     <div class="bqp-content" id={contentId} class:collapsed={buildQueueCollapse.collapsed}>
       {#if steps.length === 0}
@@ -399,10 +401,8 @@
   .bqp {
     display: flex;
     flex-direction: column;
-    gap: 6px;
     flex: none;
     min-width: 0;
-    padding: 8px 10px;
     background: var(--color-panel);
     border-top: 1px solid var(--color-line);
     font-family: var(--font-mono);
@@ -415,9 +415,21 @@
     border: 1px solid var(--color-amber);
   }
 
-  /* The whole header is the collapse toggle (mirrors IntegratedEpicRow's
-     .row-head), so a click anywhere on the bar expands/collapses — not just
-     the ▴/▾ glyph. Button reset; the glyph keeps its boxed look below. */
+  .bqp-banner {
+    position: relative;
+    isolation: isolate;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px 10px 6px;
+  }
+
+  .bqp-banner.collapsed {
+    padding-bottom: 8px;
+  }
+
+  /* Extend the native toggle over the banner, including hints and padding.
+     The action button sits above it; the step list is outside the banner. */
   .bqp-head {
     display: flex;
     align-items: center;
@@ -432,8 +444,16 @@
     text-align: left;
     cursor: pointer;
   }
+  .bqp-head::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+  }
   .bqp-head:focus-visible {
     outline: none;
+  }
+  .bqp-head:focus-visible::after {
     box-shadow: inset 0 0 0 1px var(--color-amber);
   }
 
@@ -506,6 +526,7 @@
   }
 
   .bqp-content {
+    padding: 0 10px 8px;
     display: flex;
     flex-direction: column;
     gap: 6px;
@@ -686,6 +707,8 @@
 
   /* Amber outline signals the action; ink text preserves AA on the light wash. */
   .bqp-approve {
+    position: relative;
+    z-index: 2;
     display: inline-flex;
     align-items: center;
     gap: 4px;


### PR DESCRIPTION
## Summary

Clicking the hint text or empty space in the build-queue banner previously did nothing. Extend the existing disclosure button across the entire banner, including padding, so one click opens or closes the step list.

Start/approve buttons retain their own actions, and the expanded step list remains independently editable and scrollable. Keep native keyboard interaction and existing ARIA state, with a focus indicator covering the enlarged target.

## Validation

- Reproduced the missing hint-text click at desktop and mobile widths before the fix.
- 54 focused browser tests pass, covering banner coordinates, keyboard activation, independent start/approval, disabled actions and step editing.
- Full UI suite passed: 4,892 tests across 305 files.
- UI check: 0 errors and 0 warnings. EN/DE catalogs remain in parity.

## Checklist

- [x] Conventional-commit title (`fix`).
- [x] Rebased onto `origin/main`; one feature commit, no merge commits.
- [x] All pre-push gates pass after rebase, including root/UI/extension tests and builds, lint, type checks and the delta audit.
- [x] Existing translated labels and design-system tokens reused.
- [x] Existing interaction repaired; no new feature announcement or public API/config documentation required.
