### PR TITLE
feat(usage): show observed limits and refresh around resets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,9 +52,9 @@ import { EmptyDiffError, type GitState } from "./forge/types";
 import { parseManualSteps } from "./manual-steps";
 import { annotateHandoff } from "./repo-roles";
 import { AccountUsageIndex, SessionUsageRollup } from "./usage";
-import { UsageLimitsService, calibrateDelay, type UsageLimits } from "./usage-limits";
+import { UsageLimitsService } from "./usage-limits";
 import { CodexUsageProvider, latestCodexStateDb, readCodexModelUsage } from "./codex-usage";
-import { singleFlight } from "./single-flight";
+import { UsageCalibrationCoordinator } from "./usage-calibration";
 import { HerdrUsageProbe } from "./usage-probe";
 import { sweepStaging, STAGING_TTL_MS } from "./uploads";
 import { validateRoot } from "./dirs";
@@ -2576,47 +2576,17 @@ deferredStarts.push(() => {
   );
 });
 
-// calibrate the per-window caps daily (and once on startup) by scraping `/usage`.
-// The `/usage` probe is a single ephemeral agent, so concurrent calls must never double-spawn it.
-// `singleFlight` coalesces them onto one run AND — unlike the old early-return-stale guard — makes
-// a manual refresh landing mid-scrape AWAIT that scrape's completed result instead of returning the
-// stale pre-scrape snapshot (the "refresh looks fine but stays stale" bug).
-const runCalibrate = async (): Promise<{ limits: UsageLimits; scraped: boolean }> => {
-  if (maintenance.active) return { limits: usageLimits.limits(Date.now()), scraped: false };
-  const now = Date.now();
-  try {
-    await accountIndex.refresh(now);
-    await usageLimits.calibrate(now); // boolean ignored — emit/fresh keys off the scrape, not a cap-write
-  } catch (err) {
-    console.warn("[usage] calibration failed:", err);
-  }
-  // Emit on ANY usable frame (not just a cap-write) so a fresh scrape always pushes the updated
-  // scrapedAt/stale to clients — even the degenerate "frame but nothing to write" case. Safe: the
-  // 30s recompute tick already emits unconditionally and both usage:limits push consumers dedup.
-  const scraped = usageLimits.lastScrapeAt === now;
-  if (scraped) events.emit("usage:limits", usageLimits.limits(Date.now()));
-  return { limits: usageLimits.limits(Date.now()), scraped };
-};
-const calibrate = singleFlight(runCalibrate);
-// self-rescheduling so the cadence escalates while the weekly window nears its cap (keeping
-// paid extra-credit spend fresh) and relaxes back to daily once it's clear of the cap.
-const scheduleCalibrate = () => {
-  setTimeout(
-    () => {
-      // `finally`, not a plain await-then-reschedule: a rejected calibrate (the `/usage` probe
-      // can fail) must NOT kill the self-rescheduling loop and silently stop calibration forever.
-      void calibrate()
-        .catch((err) => console.warn("[usage] calibrate failed:", err))
-        .finally(() => scheduleCalibrate());
-    },
-    calibrateDelay(usageLimits.limits(Date.now())),
-  );
-};
-deferredStarts.push(() => {
-  setTimeout(timerTask("usage", calibrate), 3_000);
-  scheduleCalibrate();
+// One coordinator owns the boot probe, reset-aware cadence, manual refreshes, and the sole timer.
+// Account indexing runs inside UsageLimitsService.calibrate's refresh lifecycle so an index failure
+// is published as a failed refresh just like a probe failure.
+const usageCalibration = new UsageCalibrationCoordinator({
+  usage: usageLimits,
+  refreshIndex: (now) => accountIndex.refresh(now),
+  publish: (limits) => events.emit("usage:limits", limits),
+  maintenanceActive: () => maintenance.active,
 });
-const refreshUsage = () => calibrate();
+deferredStarts.push(() => usageCalibration.start());
+const refreshUsage = () => usageCalibration.refresh();
 
 // watch origin/main for new commits and push the result to clients; the badge in
 // the UI keys off `behind > 0`, so it only appears when main has moved ahead.

--- a/src/usage-calibration.ts
+++ b/src/usage-calibration.ts
@@ -1,0 +1,130 @@
+import { singleFlight } from "./single-flight";
+import { calibrateDelay, type UsageLimits } from "./usage-limits";
+
+export const STARTUP_CALIBRATION_DELAY_MS = 3_000;
+
+export interface UsageCalibrationResult {
+  limits: UsageLimits;
+  scraped: boolean;
+}
+
+export interface UsageCalibrationSource {
+  readonly lastScrapeAt: number;
+  limits(now: number): UsageLimits;
+  calibrate(now: number, refreshIndex?: () => Promise<void>): Promise<boolean>;
+}
+
+export interface UsageCalibrationClock {
+  now(): number;
+  setTimeout(callback: () => void, delay: number): unknown;
+  clearTimeout(handle: unknown): void;
+}
+
+export interface UsageCalibrationDeps {
+  usage: UsageCalibrationSource;
+  refreshIndex(now: number): Promise<unknown>;
+  publish(limits: UsageLimits): void;
+  maintenanceActive(): boolean;
+}
+
+const systemClock: UsageCalibrationClock = {
+  now: Date.now,
+  setTimeout: (callback, delay) => setTimeout(callback, delay),
+  clearTimeout: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+/** Coordinates scheduled and user-requested `/usage` probes through one timer and one flight. */
+export class UsageCalibrationCoordinator {
+  private timer: unknown | null = null;
+  private lastAttemptAt: number | null = null;
+  private readonly runSingleFlight: () => Promise<UsageCalibrationResult>;
+
+  constructor(
+    private readonly deps: UsageCalibrationDeps,
+    private readonly clock: UsageCalibrationClock = systemClock,
+  ) {
+    this.runSingleFlight = singleFlight(() => this.runAttempt());
+  }
+
+  /** Start the background loop with its short boot-time probe. */
+  start(): void {
+    this.arm(STARTUP_CALIBRATION_DELAY_MS);
+  }
+
+  /** Run or join the current probe. Manual calls and timer ticks share this entry point. */
+  refresh(): Promise<UsageCalibrationResult> {
+    return this.runSingleFlight();
+  }
+
+  private async runAttempt(): Promise<UsageCalibrationResult> {
+    this.clearTimer();
+    const attemptedAt = this.clock.now();
+    this.lastAttemptAt = attemptedAt;
+    let started = false;
+
+    try {
+      if (!this.deps.maintenanceActive()) {
+        const pending = this.deps.usage.calibrate(attemptedAt, async () => {
+          await this.deps.refreshIndex(attemptedAt);
+        });
+        // calibrate() marks refresh.inProgress synchronously before its first await.
+        const loading = this.deps.usage.limits(this.clock.now());
+        started = loading.refresh?.inProgress === true;
+        if (started) this.publish(loading);
+        try {
+          await pending;
+        } catch (error) {
+          console.warn("[usage] calibration failed:", error);
+        }
+      }
+
+      const limits = this.deps.usage.limits(this.clock.now());
+      if (started) this.publish(limits);
+      return {
+        limits,
+        scraped:
+          started &&
+          this.deps.usage.lastScrapeAt === attemptedAt &&
+          limits.refresh?.failed !== true,
+      };
+    } finally {
+      this.armNext();
+    }
+  }
+
+  private armNext(): void {
+    const now = this.clock.now();
+    const limits = this.deps.usage.limits(now);
+    const serviceAttempt = limits.refresh?.lastAttemptAt ?? null;
+    const lastAttemptAt = Math.max(this.lastAttemptAt ?? -Infinity, serviceAttempt ?? -Infinity);
+    const refresh = {
+      inProgress: limits.refresh?.inProgress ?? false,
+      failed: limits.refresh?.failed ?? false,
+      lastAttemptAt: Number.isFinite(lastAttemptAt) ? lastAttemptAt : null,
+    };
+    this.arm(calibrateDelay({ ...limits, refresh }, now));
+  }
+
+  private arm(delay: number): void {
+    this.clearTimer();
+    this.timer = this.clock.setTimeout(() => {
+      this.timer = null;
+      void this.refresh().catch((error) => console.warn("[usage] calibrate failed:", error));
+    }, delay);
+  }
+
+  private publish(limits: UsageLimits): void {
+    try {
+      this.deps.publish(limits);
+    } catch (error) {
+      // A faulty event listener must not release the single-flight guard while the probe runs.
+      console.warn("[usage] publish failed:", error);
+    }
+  }
+
+  private clearTimer(): void {
+    if (this.timer === null) return;
+    this.clock.clearTimeout(this.timer);
+    this.timer = null;
+  }
+}

--- a/src/usage-limits.ts
+++ b/src/usage-limits.ts
@@ -17,19 +17,26 @@ const WINDOW_LABEL: Record<WindowKey, "5H" | "WK"> = { session5h: "5H", week: "W
 /** Below this scraped %, inverting to a cap is too noisy — keep the prior cap instead. */
 const MIN_CALIBRATION_PCT = 5;
 
-/** Weekly-window % at/above which we escalate /usage calibration cadence: close enough to the
- *  subscription cap that paid extra-credit spend becomes plausible and a daily credit snapshot is
- *  too stale to trust. */
-const CREDIT_WATCH_PCT = 90; // internal watermark for calibrateDelay; not part of the public API
-export const CREDIT_WATCH_INTERVAL_MS = 15 * 60 * 1000; // escalated cadence near the cap
-export const CALIBRATE_INTERVAL_MS = 24 * 60 * 60 * 1000; // normal daily cadence
+export const CALIBRATE_INTERVAL_MS = 5 * 60 * 1000;
+const RESET_WATCH_INTERVAL_MS = 60 * 1000;
+const RESET_WATCH_LEAD_MS = 10 * 60 * 1000;
 
-/** Delay until the next `/usage` calibration, given the latest live limits. Escalates to the
- *  watch cadence while the weekly window is near its cap so credit spend stays fresh. */
-export function calibrateDelay(limits: UsageLimits): number {
-  return (limits.week?.pct ?? 0) >= CREDIT_WATCH_PCT
-    ? CREDIT_WATCH_INTERVAL_MS
-    : CALIBRATE_INTERVAL_MS;
+/** Next probe deadline, including entry into the reset watch and the reset boundary itself. */
+export function calibrateDelay(limits: UsageLimits, now = Date.now()): number {
+  const resetAt = limits.observed?.session5h?.resetAt;
+  const watching = resetAt != null && resetAt - now <= RESET_WATCH_LEAD_MS;
+  const interval = watching ? RESET_WATCH_INTERVAL_MS : CALIBRATE_INTERVAL_MS;
+  const lastAttempt = limits.refresh?.lastAttemptAt ?? now;
+  let delay = Math.max(0, lastAttempt + interval - now);
+  if (resetAt != null) {
+    // A sample from before this boundary cannot confirm the new window. Retry at the boundary,
+    // then at most once a minute even when the provider keeps returning the expired window.
+    if (resetAt <= now && lastAttempt < resetAt) return 0;
+    for (const deadline of [resetAt - RESET_WATCH_LEAD_MS, resetAt]) {
+      if (deadline > now) delay = Math.min(delay, deadline - now);
+    }
+  }
+  return delay;
 }
 
 export interface ScrapedWindow {
@@ -69,7 +76,7 @@ function to24h(h: number, ampm?: string): number {
 /** Parse a `/usage` reset label ("9:30pm", "Jun 6, 5pm", "Jun 11 at 11pm") to a ms epoch in local time. */
 export function parseResetLabel(label: string, now: number): number | null {
   const s = label.replace(/\s+/g, "").toLowerCase();
-  let m = s.match(/^(\d{1,2})(?::(\d{2}))?(am|pm)$/);
+  let m = s.match(/^(0?[1-9]|1[0-2])(?::([0-5]\d))?(am|pm)$/);
   if (m) {
     const d = new Date(now);
     d.setHours(to24h(+m[1]!, m[3]), m[2] ? +m[2] : 0, 0, 0);
@@ -77,7 +84,7 @@ export function parseResetLabel(label: string, now: number): number | null {
     if (d.getTime() < now) d.setDate(d.getDate() + 1);
     return d.getTime();
   }
-  m = s.match(/^([a-z]{3})(\d{1,2})(?:(?:,|at)(\d{1,2})(?::(\d{2}))?(am|pm))?$/);
+  m = s.match(/^([a-z]{3})(\d{1,2})(?:(?:,|at)(0?[1-9]|1[0-2])(?::([0-5]\d))?(am|pm))?$/);
   if (m) {
     const mon = MONTHS.indexOf(m[1]!);
     if (mon < 0) return null;
@@ -272,6 +279,23 @@ export interface CapRow {
   scrapedAt: number;
 }
 
+export interface ObservedLimitWindow {
+  pct: number;
+  resetAt: number;
+  scrapedAt: number;
+}
+
+export interface UsageObservations {
+  session5h: ObservedLimitWindow | null;
+  week: ObservedLimitWindow | null;
+}
+
+export interface UsageRefreshStatus {
+  inProgress: boolean;
+  failed: boolean;
+  lastAttemptAt: number | null;
+}
+
 export interface LimitWindow {
   pct: number;
   resetAt: number;
@@ -296,6 +320,9 @@ export interface ModelWeekWindow {
   stale: boolean; // derived from scrapedAt age against MODEL_WEEK_STALE_MS
 }
 export interface UsageLimits {
+  /** Actual provider samples for display; the existing fields remain local budget estimates. */
+  observed?: UsageObservations;
+  refresh?: UsageRefreshStatus;
   session5h: LimitWindow | null;
   week: LimitWindow | null;
   perModelWeek: ModelWeekWindow[];
@@ -319,6 +346,7 @@ export type UsageProviderSnapshot =
   | {
       provider: "claude";
       kind: "limits";
+      observed?: UsageObservations;
       session5h: LimitWindow | null;
       week: LimitWindow | null;
       perModelWeek: ModelWeekWindow[];
@@ -354,18 +382,9 @@ export interface UsageProviderSource {
 // 1h, unlike the 2-week cap stale that tolerates JSONL-recomputed windows drifting.
 const CREDIT_STALE_MS = 60 * 60 * 1000;
 
-// Beyond this age the credit snapshot is treated as DEAD (extra usage was turned off): calibrate
-// runs at least daily, so a snapshot older than two calibration cycles means the `/usage` panel has
-// stopped rendering a credits section across multiple successful scrapes — the account no longer has
-// credits enabled. `limits()` drops it entirely rather than lingering a "SCRAPED Nd AGO / SNAPSHOT
-// STALE" gauge the user can't refresh away. The persisted snapshot + history are untouched, so if
-// credits are re-enabled the next scrape re-populates it and the gauge returns.
-const CREDIT_DROP_MS = 2 * CALIBRATE_INTERVAL_MS;
-
-// Per-model weekly passthrough is scrape-fresh-only too, but — unlike credits — it isn't put on
-// the near-cap 15-min watch cadence, so a 1h stale would flip it "stale" within an hour of every
-// daily calibration. Tie it to the calibration cadence, tolerant of one missed daily run.
-export const MODEL_WEEK_STALE_MS = 2 * CALIBRATE_INTERVAL_MS;
+// Keep the existing two-day retention/freshness tolerance independent of probe frequency.
+const CREDIT_DROP_MS = (2 * PERIOD_MS.week) / 7;
+export const MODEL_WEEK_STALE_MS = (2 * PERIOD_MS.week) / 7;
 
 export interface CapStore {
   getCaps(): CapRow[];
@@ -443,23 +462,45 @@ export class UsageLimitsService {
     return this._lastScrapeAt;
   }
 
+  // Do not seed observations from persisted caps: legacy cap anchors can be inferred reset times.
+  // Startup probes populate these independent samples without claiming guessed values are real.
+  private observed: UsageObservations = { session5h: null, week: null };
+  private refresh: UsageRefreshStatus = { inProgress: false, failed: false, lastAttemptAt: null };
+
   /** Scrape `/usage` and recalibrate the per-window caps from local JSONL. */
-  async calibrate(now: number): Promise<boolean> {
-    // Subscription-only: never spawn the probe under api-key auth — the /usage panel doesn't
-    // exist for API-key accounts and spawning a bare claude risks a hang on the auth prompt.
+  async calibrate(now: number, refreshIndex?: () => Promise<void>): Promise<boolean> {
     if (isApiKeyMode()) return false;
-    const raw = await this.probe.scrape();
-    if (!raw) return false;
-    this._lastScrapeAt = now; // a usable frame was scraped this run
-    const parsed = parseUsageFrame(raw, now);
-    const prior = new Map(this.caps.getCaps().map((r) => [r.window, r]));
-    let any = false;
-    for (const key of ["session5h", "week"] as WindowKey[]) {
-      if (this.calibrateWindow(key, parsed[key], prior.get(key), now)) any = true;
+    this.refresh = { inProgress: true, failed: false, lastAttemptAt: now };
+    let complete = false;
+    try {
+      if (refreshIndex) await refreshIndex();
+      const raw = await this.probe.scrape();
+      if (!raw) return false;
+      this._lastScrapeAt = now;
+      const parsed = parseUsageFrame(raw, now);
+      const prior = new Map(this.caps.getCaps().map((r) => [r.window, r]));
+      let any = false;
+      let confirmed = 0;
+      for (const key of ["session5h", "week"] as WindowKey[]) {
+        const sample = parsed[key];
+        // A past time-only label is parsed as tomorrow. That is not a confirmed new 5h
+        // window. Allow one minute for label rounding and the probe's startup/capture delay.
+        if (sample?.resetAt != null && sample.resetAt - now <= PERIOD_MS[key] + 60_000) {
+          this.observed = {
+            ...this.observed,
+            [key]: { pct: sample.pct, resetAt: sample.resetAt, scrapedAt: now },
+          };
+          confirmed++;
+        }
+        if (this.calibrateWindow(key, sample, prior.get(key), now)) any = true;
+      }
+      complete = confirmed === 2;
+      if (this.persistCredit(parsed, now)) any = true;
+      if (this.persistModelWeek(parsed, now)) any = true;
+      return any;
+    } finally {
+      this.refresh = { ...this.refresh, inProgress: false, failed: !complete };
     }
-    if (this.persistCredit(parsed, now)) any = true;
-    if (this.persistModelWeek(parsed, now)) any = true;
-    return any;
   }
 
   /**
@@ -612,6 +653,7 @@ export class UsageLimitsService {
     const claude: UsageProviderSnapshot = {
       provider: "claude",
       kind: "limits",
+      observed: this.observed,
       session5h,
       week,
       perModelWeek,
@@ -632,6 +674,8 @@ export class UsageLimitsService {
       }),
     ];
     return {
+      observed: this.observed,
+      refresh: this.refresh,
       session5h,
       week,
       perModelWeek,

--- a/test/usage-calibration.test.ts
+++ b/test/usage-calibration.test.ts
@@ -1,0 +1,265 @@
+import { expect, spyOn, test } from "bun:test";
+import {
+  STARTUP_CALIBRATION_DELAY_MS,
+  UsageCalibrationCoordinator,
+  type UsageCalibrationClock,
+  type UsageCalibrationSource,
+} from "../src/usage-calibration";
+import type { UsageLimits, UsageRefreshStatus } from "../src/usage-limits";
+
+const MINUTE = 60_000;
+
+class FakeClock implements UsageCalibrationClock {
+  nowMs = 1_000_000;
+  private nextId = 1;
+  private timers = new Map<number, { at: number; callback: () => void }>();
+
+  now = () => this.nowMs;
+
+  setTimeout = (callback: () => void, delay: number): unknown => {
+    const id = this.nextId++;
+    this.timers.set(id, { at: this.nowMs + delay, callback });
+    return id;
+  };
+
+  clearTimeout = (handle: unknown): void => {
+    this.timers.delete(handle as number);
+  };
+
+  get pendingCount(): number {
+    return this.timers.size;
+  }
+
+  get nextDelay(): number | null {
+    const next = [...this.timers.values()].sort((a, b) => a.at - b.at)[0];
+    return next ? next.at - this.nowMs : null;
+  }
+
+  fireNext(at = [...this.timers.values()].sort((a, b) => a.at - b.at)[0]?.at): void {
+    if (at == null) throw new Error("no pending timer");
+    this.nowMs = at;
+    const due = [...this.timers.entries()]
+      .filter(([, timer]) => timer.at <= at)
+      .sort((a, b) => a[1].at - b[1].at)[0];
+    if (!due) throw new Error("no timer due");
+    this.timers.delete(due[0]);
+    due[1].callback();
+  }
+}
+
+const flush = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+function snapshot(refresh: UsageRefreshStatus, resetAt: number | null = null): UsageLimits {
+  return {
+    observed: {
+      session5h:
+        resetAt == null ? null : { pct: 25, resetAt, scrapedAt: refresh.lastAttemptAt ?? 0 },
+      week: null,
+    },
+    refresh,
+    session5h: null,
+    week: null,
+    perModelWeek: [],
+    credits: null,
+    stale: false,
+    calibratedAt: null,
+    subscriptionOnly: false,
+  };
+}
+
+class FakeUsage implements UsageCalibrationSource {
+  refresh: UsageRefreshStatus = { inProgress: false, failed: false, lastAttemptAt: null };
+  resetAt: number | null = null;
+  lastScrapeAt = 0;
+  attempts: number[] = [];
+  run: (now: number) => Promise<void> = async () => {
+    this.lastScrapeAt = this.refresh.lastAttemptAt ?? 0;
+  };
+
+  limits = () => snapshot(this.refresh, this.resetAt);
+
+  async calibrate(now: number, refreshIndex?: () => Promise<void>): Promise<boolean> {
+    this.attempts.push(now);
+    this.refresh = { inProgress: true, failed: false, lastAttemptAt: now };
+    try {
+      await refreshIndex?.();
+      await this.run(now);
+      return true;
+    } catch (error) {
+      this.refresh = { ...this.refresh, failed: true };
+      throw error;
+    } finally {
+      this.refresh = { ...this.refresh, inProgress: false };
+    }
+  }
+}
+
+function coordinator(
+  usage: FakeUsage,
+  clock: FakeClock,
+  options: {
+    publish?: (limits: UsageLimits) => void;
+    refreshIndex?: (now: number) => Promise<void>;
+    maintenanceActive?: () => boolean;
+  } = {},
+) {
+  return new UsageCalibrationCoordinator(
+    {
+      usage,
+      refreshIndex: options.refreshIndex ?? (async () => {}),
+      publish: options.publish ?? (() => {}),
+      maintenanceActive: options.maintenanceActive ?? (() => false),
+    },
+    clock,
+  );
+}
+
+test("usage calibration: startup waits three seconds, then regular probes stay five minutes apart", async () => {
+  const clock = new FakeClock();
+  const usage = new FakeUsage();
+  const scheduler = coordinator(usage, clock);
+
+  scheduler.start();
+  expect(clock.nextDelay).toBe(STARTUP_CALIBRATION_DELAY_MS);
+
+  clock.fireNext();
+  await flush();
+  expect(usage.attempts).toEqual([1_003_000]);
+  expect(clock.nextDelay).toBe(5 * MINUTE);
+  expect(clock.pendingCount).toBe(1);
+});
+
+test("usage calibration: near a reset it probes each minute and a late timer still probes the crossed boundary", async () => {
+  const clock = new FakeClock();
+  const usage = new FakeUsage();
+  usage.resetAt = clock.nowMs + 2 * MINUTE;
+  const scheduler = coordinator(usage, clock);
+
+  await scheduler.refresh();
+  expect(clock.nextDelay).toBe(MINUTE);
+
+  clock.fireNext(clock.nowMs + 3 * MINUTE);
+  await flush();
+  expect(usage.attempts).toEqual([1_000_000, 1_180_000]);
+  expect(clock.nextDelay).toBe(MINUTE);
+  expect(clock.pendingCount).toBe(1);
+});
+
+test("usage calibration: a manual refresh and timer tick coalesce onto one probe", async () => {
+  const clock = new FakeClock();
+  const usage = new FakeUsage();
+  let release!: () => void;
+  usage.run = async () => new Promise<void>((resolve) => (release = resolve));
+  const scheduler = coordinator(usage, clock);
+
+  scheduler.start();
+  clock.fireNext();
+  await flush();
+  const manual = scheduler.refresh();
+  expect(usage.attempts).toHaveLength(1);
+
+  release();
+  await manual;
+  expect(clock.pendingCount).toBe(1);
+});
+
+test("usage calibration: a throwing publisher cannot release the flight before the probe settles", async () => {
+  const clock = new FakeClock();
+  const usage = new FakeUsage();
+  let release!: () => void;
+  usage.run = async () => new Promise<void>((resolve) => (release = resolve));
+  const warn = spyOn(console, "warn").mockImplementation(() => {});
+  const scheduler = coordinator(usage, clock, {
+    publish: () => {
+      throw new Error("listener failed");
+    },
+  });
+
+  const first = scheduler.refresh();
+  await flush();
+  const second = scheduler.refresh();
+  expect(usage.attempts).toHaveLength(1);
+
+  release();
+  await Promise.all([first, second]);
+  warn.mockRestore();
+  expect(clock.pendingCount).toBe(1);
+});
+
+test("usage calibration: manual completion replaces a stale long timer after the observed reset moves closer", async () => {
+  const clock = new FakeClock();
+  const usage = new FakeUsage();
+  const scheduler = coordinator(usage, clock);
+
+  const initial = await scheduler.refresh();
+  expect(initial.scraped).toBe(true);
+  expect(clock.nextDelay).toBe(5 * MINUTE);
+
+  clock.nowMs += 10_000;
+  usage.run = async () => {
+    usage.lastScrapeAt = usage.refresh.lastAttemptAt!;
+    usage.resetAt = clock.nowMs + 2 * MINUTE;
+  };
+  await scheduler.refresh();
+
+  expect(clock.nextDelay).toBe(MINUTE);
+  expect(clock.pendingCount).toBe(1);
+});
+
+test("usage calibration: a failed refresh publishes its loading and failed states and retries on a bounded cadence", async () => {
+  const clock = new FakeClock();
+  const usage = new FakeUsage();
+  usage.resetAt = clock.nowMs - 1;
+  const published: UsageLimits[] = [];
+  const warn = spyOn(console, "warn").mockImplementation(() => {});
+  const scheduler = coordinator(usage, clock, {
+    publish: (limits) => published.push(limits),
+    refreshIndex: async () => {
+      throw new Error("index unavailable");
+    },
+  });
+
+  const result = await scheduler.refresh();
+  warn.mockRestore();
+
+  expect(published.map((limits) => limits.refresh)).toEqual([
+    { inProgress: true, failed: false, lastAttemptAt: 1_000_000 },
+    { inProgress: false, failed: true, lastAttemptAt: 1_000_000 },
+  ]);
+  expect(result.scraped).toBe(false);
+  expect(clock.nextDelay).toBe(MINUTE);
+  expect(clock.pendingCount).toBe(1);
+});
+
+test("usage calibration: maintenance skips are throttled even though the usage service records no attempt", async () => {
+  const clock = new FakeClock();
+  const usage = new FakeUsage();
+  usage.resetAt = clock.nowMs - 1;
+  const scheduler = coordinator(usage, clock, { maintenanceActive: () => true });
+
+  const result = await scheduler.refresh();
+
+  expect(result.scraped).toBe(false);
+  expect(usage.attempts).toEqual([]);
+  expect(clock.nextDelay).toBe(MINUTE);
+  expect(clock.pendingCount).toBe(1);
+});
+
+test("usage calibration: scraped requires this attempt's frame and a non-failed final refresh", async () => {
+  const clock = new FakeClock();
+  const usage = new FakeUsage();
+  usage.lastScrapeAt = clock.nowMs;
+  usage.run = async () => {
+    usage.lastScrapeAt = usage.refresh.lastAttemptAt!;
+    usage.refresh = { ...usage.refresh, failed: true };
+  };
+  const scheduler = coordinator(usage, clock);
+
+  const result = await scheduler.refresh();
+
+  expect(result.scraped).toBe(false);
+});

--- a/test/usage-limits.test.ts
+++ b/test/usage-limits.test.ts
@@ -7,7 +7,6 @@ import {
   parseMonthlyReset,
   parseCredits,
   calibrateDelay,
-  CREDIT_WATCH_INTERVAL_MS,
   CALIBRATE_INTERVAL_MS,
   type UsageLimits,
   type UsageProjection,
@@ -628,19 +627,19 @@ const mkLimits = (weekPct: number | null): UsageLimits => ({
   subscriptionOnly: false,
 });
 
-test("calibrateDelay: week pct above watch threshold escalates cadence", () => {
-  expect(calibrateDelay(mkLimits(95))).toBe(CREDIT_WATCH_INTERVAL_MS);
+test("calibrateDelay: high weekly usage still receives regular five-minute probes", () => {
+  expect(calibrateDelay(mkLimits(95))).toBe(CALIBRATE_INTERVAL_MS);
 });
 
-test("calibrateDelay: week pct exactly at threshold escalates (>= boundary)", () => {
-  expect(calibrateDelay(mkLimits(90))).toBe(CREDIT_WATCH_INTERVAL_MS);
+test("calibrateDelay: weekly threshold does not replace the 5h reset schedule", () => {
+  expect(calibrateDelay(mkLimits(90))).toBe(CALIBRATE_INTERVAL_MS);
 });
 
-test("calibrateDelay: week pct below threshold stays daily", () => {
+test("calibrateDelay: week pct below threshold uses the regular cadence", () => {
   expect(calibrateDelay(mkLimits(50))).toBe(CALIBRATE_INTERVAL_MS);
 });
 
-test("calibrateDelay: null week window stays daily", () => {
+test("calibrateDelay: null week window uses the regular cadence", () => {
   expect(calibrateDelay(mkLimits(null))).toBe(CALIBRATE_INTERVAL_MS);
 });
 
@@ -861,4 +860,202 @@ test("projections: no-cap window skipped / empty caps returns []", () => {
     new MemCredits(),
   );
   expect(empty.projections(NOW)).toEqual([]);
+});
+
+// Observations are display data; local estimates remain available to budget automation.
+test("observations retain the actual 5h sample through local growth and reset", async () => {
+  const raw =
+    "Current session\n87% used\nResets 9:30pm (x)\nCurrent week\n7% used\nResets Jun 6 (x)";
+  const svc = new UsageLimitsService(
+    fakeIndex(100),
+    new MemCaps(),
+    new StubProbe(raw),
+    new MemCredits(),
+  );
+  await svc.calibrate(NOW);
+  const observed = svc.limits(NOW).observed!;
+  expect(observed.session5h?.pct).toBe(87);
+  expect(observed.session5h?.scrapedAt).toBe(NOW);
+  const after = svc.limits(observed.session5h!.resetAt + 1);
+  expect(after.observed).toEqual(observed);
+  expect(after.session5h!.resetAt).toBeGreaterThan(observed.session5h!.resetAt);
+});
+
+test("observations show a first low percentage without requiring a calibrated cap", async () => {
+  const svc = new UsageLimitsService(
+    fakeIndex(0),
+    new MemCaps(),
+    new StubProbe("Current session\n4% used\nResets 9:30pm (x)"),
+    new MemCredits(),
+  );
+  await svc.calibrate(NOW);
+  expect(svc.limits(NOW).session5h).toBeNull();
+  expect(svc.limits(NOW).observed?.session5h?.pct).toBe(4);
+});
+
+test("partial or failed scrapes cannot refresh another window or confirm a guessed reset", async () => {
+  let raw: string | null =
+    "Current session\n87% used\nResets 9:30pm (x)\nCurrent week\n7% used\nResets Jun 6 (x)";
+  const svc = new UsageLimitsService(
+    fakeIndex(100),
+    new MemCaps(),
+    { scrape: async () => raw },
+    new MemCredits(),
+  );
+  await svc.calibrate(NOW);
+  const first = svc.limits(NOW).observed!;
+  raw = "Current session\n4% used\nResets someday (x)\nCurrent week\n8% used\nResets Jun 6 (x)";
+  await svc.calibrate(NOW + 1000);
+  const partial = svc.limits(NOW + 1000);
+  expect(partial.observed?.session5h).toEqual(first.session5h);
+  expect(partial.observed?.week?.scrapedAt).toBe(NOW + 1000);
+  expect(partial.refresh?.failed).toBe(true);
+  raw = null;
+  await svc.calibrate(NOW + 2000);
+  expect(svc.limits(NOW + 2000).observed).toEqual(partial.observed);
+  expect(svc.limits(NOW + 2000).refresh).toEqual({
+    inProgress: false,
+    failed: true,
+    lastAttemptAt: NOW + 2000,
+  });
+});
+
+test("refresh status remains busy until the probe finishes", async () => {
+  let finish!: (raw: string | null) => void;
+  const svc = new UsageLimitsService(
+    fakeIndex(0),
+    new MemCaps(),
+    {
+      scrape: () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        }),
+    },
+    new MemCredits(),
+  );
+  const pending = svc.calibrate(NOW);
+  expect(svc.limits(NOW).refresh?.inProgress).toBe(true);
+  finish(null);
+  await pending;
+  expect(svc.limits(NOW).refresh?.inProgress).toBe(false);
+});
+
+test("calibrateDelay uses five minutes normally and one minute near the 5h reset regardless of week", () => {
+  const make = (resetAt: number, lastAttemptAt = NOW) => ({
+    ...mkLimits(7),
+    observed: { session5h: { pct: 87, resetAt, scrapedAt: NOW }, week: null },
+    refresh: { inProgress: false, failed: false, lastAttemptAt },
+  });
+  expect(calibrateDelay(make(NOW + 30 * 60_000), NOW)).toBe(5 * 60_000);
+  expect(calibrateDelay(make(NOW + 8 * 60_000), NOW)).toBe(60_000);
+  expect(calibrateDelay(make(NOW + 11 * 60_000), NOW)).toBe(60_000);
+  expect(calibrateDelay(make(NOW + 20_000), NOW)).toBe(20_000);
+  expect(calibrateDelay(make(NOW, NOW - 60_000), NOW)).toBe(0);
+  expect(calibrateDelay(make(NOW, NOW), NOW)).toBe(60_000);
+  expect(calibrateDelay(make(NOW - 60_000, NOW), NOW)).toBe(60_000);
+});
+
+test("a confirmed new window replaces percent and reset together, including a value below calibration threshold", async () => {
+  let raw = "Current session\n87% used\nResets 9:30pm (x)\nCurrent week\n7% used\nResets Jun 6 (x)";
+  const svc = new UsageLimitsService(
+    fakeIndex(100),
+    new MemCaps(),
+    { scrape: async () => raw },
+    new MemCredits(),
+  );
+  await svc.calibrate(NOW);
+  const previous = svc.limits(NOW).observed!.session5h!;
+  raw = "Current session\n4% used\nResets 10:30pm (x)\nCurrent week\n7% used\nResets Jun 6 (x)";
+  await svc.calibrate(NOW + 1000);
+  const limits = svc.limits(NOW + 1000);
+  expect(limits.observed?.session5h).toEqual({
+    pct: 4,
+    resetAt: previous.resetAt + 3600_000,
+    scrapedAt: NOW + 1000,
+  });
+  expect(limits.providers?.[0]).toMatchObject({ provider: "claude", observed: limits.observed });
+  expect(limits.refresh?.failed).toBe(false);
+  // The display sample is separate from the existing local budget estimate.
+  expect(limits.session5h?.pct).toBeGreaterThan(4);
+});
+
+test("a thrown probe clears busy state and leaves observed values untouched", async () => {
+  const svc = new UsageLimitsService(
+    fakeIndex(0),
+    new MemCaps(),
+    {
+      scrape: async () => {
+        throw new Error("unavailable");
+      },
+    },
+    new MemCredits(),
+  );
+  await expect(svc.calibrate(NOW)).rejects.toThrow("unavailable");
+  expect(svc.limits(NOW).refresh).toEqual({ inProgress: false, failed: true, lastAttemptAt: NOW });
+  expect(svc.limits(NOW).observed).toEqual({ session5h: null, week: null });
+});
+
+test("index refresh failure is exposed without starting a probe", async () => {
+  let probes = 0;
+  const svc = new UsageLimitsService(
+    fakeIndex(0),
+    new MemCaps(),
+    {
+      scrape: async () => {
+        probes++;
+        return null;
+      },
+    },
+    new MemCredits(),
+  );
+  await expect(
+    svc.calibrate(NOW, async () => {
+      throw new Error("index unavailable");
+    }),
+  ).rejects.toThrow("index unavailable");
+  expect(probes).toBe(0);
+  expect(svc.limits(NOW).refresh).toEqual({ inProgress: false, failed: true, lastAttemptAt: NOW });
+});
+
+test("an unchanged provider frame after reset cannot confirm tomorrow as a new 5h window", async () => {
+  const before = new Date(2026, 4, 30, 21, 29).getTime();
+  const raw =
+    "Current session\n87% used\nResets 9:30pm (x)\nCurrent week\n7% used\nResets Jun 6 (x)";
+  const svc = new UsageLimitsService(
+    fakeIndex(100),
+    new MemCaps(),
+    new StubProbe(raw),
+    new MemCredits(),
+  );
+  await svc.calibrate(before);
+  const previous = svc.limits(before).observed!.session5h!;
+  expect(previous.resetAt).toBe(before + 60_000);
+  await svc.calibrate(before + 2 * 60_000);
+  const after = svc.limits(before + 2 * 60_000);
+  expect(after.observed?.session5h).toEqual(previous);
+  expect(after.refresh?.failed).toBe(true);
+  expect(calibrateDelay(after, before + 2 * 60_000)).toBe(60_000);
+});
+
+test("malformed reset clock labels do not normalize into confirmed timestamps", () => {
+  for (const label of ["0pm", "13pm", "9:60pm", "Jun 6, 13pm", "Jun 6, 9:60pm"]) {
+    expect(parseResetLabel(label, NOW)).toBeNull();
+  }
+});
+
+test("observations tolerate minute-resolution reset labels at the start of a new window", async () => {
+  const now = new Date(2026, 4, 30, 16, 29, 30).getTime();
+  const raw = "Current session\n0% used\nResets 9:30pm (x)";
+  const svc = new UsageLimitsService(
+    fakeIndex(0),
+    new MemCaps(),
+    new StubProbe(raw),
+    new MemCredits(),
+  );
+  await svc.calibrate(now);
+  expect(svc.limits(now).observed?.session5h).toEqual({
+    pct: 0,
+    resetAt: now + 5 * 3600_000 + 30_000,
+    scrapedAt: now,
+  });
 });

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3884,5 +3884,19 @@
   "feat_classifier_usage_body": "Nutzung → Modelle zeigt die Tokens des Autopilot-Klassifizierers jetzt als eigene Rolle — einschließlich des verwendeten Claude-Modells.",
   "feat_codex_role_usage_title": "Codex-Verbrauch nach Rolle erkennen",
   "feat_codex_role_usage_body": "Klappe Coding, Review, Plan Gate und weitere Codex-Rollen unter Nutzung → Modelle auf, um zu sehen, wohin die Tokens der einzelnen Modelle geflossen sind.",
-  "usage_models_unknown": "Unbekannt"
+  "usage_models_unknown": "Unbekannt",
+  "topbar_usage_refreshing": "Wird aktualisiert…",
+  "topbar_usage_refresh_failed": "Aktualisierung fehlgeschlagen. Die letzten bestätigten Werte bleiben sichtbar.",
+  "topbar_usage_refresh_scope": "Aktualisiert Claude Code",
+  "topbar_usage_observed_age": "vor {age} abgefragt",
+  "topbar_usage_observed_now": "gerade abgefragt",
+  "topbar_usage_before_reset": "{pct}% vor Reset",
+  "topbar_usage_reset_checking": "Reset-Bestätigung ausstehend…",
+  "topbar_usage_no_observation": "Noch keine Anbieterabfrage verfügbar",
+  "topbar_codex_tokens_checked_age": "Token-Datenstand vor {age}",
+  "topbar_codex_tokens_checked_now": "Token-Datenstand von gerade eben",
+  "topbar_codex_limits_checked_age": "Limit-Ereignis vor {age} gemeldet",
+  "topbar_codex_limits_checked_now": "Limit-Ereignis gerade gemeldet",
+  "feat_observed_usage_limits_title": "Bestätigte Claude-Auslastung",
+  "feat_observed_usage_limits_body": "Die Claude-Auslastung in der Topbar zeigt jetzt für jedes Fenster den letzten bestätigten Anbieterwert und dessen Alter. Rund um den 5-Stunden-Reset prüft Shepherd häufiger, kennzeichnet den bisherigen Wert und zeigt den nächsten Countdown erst nach Bestätigung."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3884,5 +3884,19 @@
   "feat_classifier_usage_body": "Usage → Models now shows Autopilot classifier tokens as a separate role, including the Claude model that produced them.",
   "feat_codex_role_usage_title": "See Codex usage by role",
   "feat_codex_role_usage_body": "Expand Coding, Review, Plan gate, and other Codex roles in Usage → Models to see where each model's tokens went.",
-  "usage_models_unknown": "Unknown"
+  "usage_models_unknown": "Unknown",
+  "topbar_usage_refreshing": "Refreshing…",
+  "topbar_usage_refresh_failed": "Refresh failed. Last confirmed values remain shown.",
+  "topbar_usage_refresh_scope": "Refreshes Claude Code",
+  "topbar_usage_observed_age": "checked {age} ago",
+  "topbar_usage_observed_now": "checked just now",
+  "topbar_usage_before_reset": "{pct}% before reset",
+  "topbar_usage_reset_checking": "Reset confirmation pending…",
+  "topbar_usage_no_observation": "No provider sample yet",
+  "topbar_codex_tokens_checked_age": "token data from {age} ago",
+  "topbar_codex_tokens_checked_now": "token data from just now",
+  "topbar_codex_limits_checked_age": "limit event reported {age} ago",
+  "topbar_codex_limits_checked_now": "limit event reported just now",
+  "feat_observed_usage_limits_title": "Confirmed Claude usage samples",
+  "feat_observed_usage_limits_body": "Claude usage in the top bar now shows the latest provider-confirmed value and its age for each window. Near a 5-hour reset Shepherd checks more often, keeps the prior value clearly labelled, and shows the next countdown after confirmation."
 }

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -1434,7 +1434,20 @@ describe("TopBar — CR extra-credit gauge", () => {
       stale: false,
       calibratedAt: null,
       subscriptionOnly: false,
+      observed: { session5h: null, week: null },
       providers: [
+        {
+          provider: "claude",
+          kind: "limits",
+          session5h: null,
+          week: null,
+          perModelWeek: [],
+          credits: null,
+          stale: false,
+          calibratedAt: null,
+          subscriptionOnly: false,
+          observed: { session5h: null, week: null },
+        },
         {
           provider: "codex",
           kind: "tokens",
@@ -1484,6 +1497,7 @@ describe("TopBar — CR extra-credit gauge", () => {
           stale,
           session5h: windows ? { pct: 9, resetAt: 1_700_014_400_000 } : null,
           week: windows ? { pct: 1, resetAt: 1_700_600_000_000 } : null,
+          rateLimitLatestEventAt: windows ? 1_700_000_000_000 - 2 * 60_000 : null,
         },
       ],
     };
@@ -1733,6 +1747,13 @@ describe("TopBar — CR extra-credit gauge", () => {
     expect(text, "codex limits fallback").toContain(m.topbar_codex_limits_unavailable());
     expect(text, "5H token row").toContain(m.topbar_tokens_window({ period: "5H" }));
     expect(text, "weekly token row").toContain(m.topbar_tokens_window({ period: "WK" }));
+    expect(text, "Codex token snapshot has its own age").toContain(
+      m.topbar_codex_tokens_checked_now(),
+    );
+    expect(text, "empty Claude observation does not leak into Codex-only UI").not.toContain(
+      m.topbar_usage_no_observation(),
+    );
+    expect(pop!.querySelector(".usage-refresh"), "Codex-only has no Claude refresh").toBeNull();
   });
 
   it("rotates desktop compact usage from Claude to Codex limit gauges", async () => {
@@ -1759,6 +1780,9 @@ describe("TopBar — CR extra-credit gauge", () => {
     const text = pop!.textContent ?? "";
     expect(text, "full popover still has Claude").toContain(m.agent_provider_claude());
     expect(text, "full popover still has Codex").toContain(m.agent_provider_codex());
+    expect(text, "Codex limit event carries its own age").toContain(
+      m.topbar_codex_limits_checked_age({ age: "2m" }),
+    );
   });
 
   it("does not restart compact usage rotation on live percentage updates", async () => {
@@ -1897,6 +1921,7 @@ describe("TopBar — CR extra-credit gauge", () => {
   });
 
   it("mobile sheet: codex-only without rate limits explains the token-only fallback", async () => {
+    vi.mocked(refreshUsage).mockClear();
     await page.viewport(390, 800);
     document.body.style.width = "390px";
     render(TopBar, {
@@ -1919,12 +1944,230 @@ describe("TopBar — CR extra-credit gauge", () => {
     expect(text, "codex token rows remain visible").toContain(
       m.topbar_tokens_window({ period: "5H" }),
     );
+    expect(
+      sheet!.querySelector(".usage-refresh"),
+      "Codex-only mobile has no Claude refresh",
+    ).toBeNull();
+    expect(refreshUsage, "opening Codex-only details does not probe Claude").not.toHaveBeenCalled();
+  });
+
+  it("shows observed Claude values in both the compact top bar and per-window detail", async () => {
+    const now = 1_700_000_000_000;
+    const observed: UsageLimits = {
+      ...fullLimits,
+      observed: {
+        session5h: { pct: 4, resetAt: now + 4 * 60 * 60_000, scrapedAt: now - 20_000 },
+        week: { pct: 7, resetAt: now + 2 * 24 * 60 * 60_000, scrapedAt: now - 2 * 60_000 },
+      },
+    };
+    const hud = await renderDesktop(observed);
+    const toggle = hud.querySelector<HTMLElement>(".gauges-toggle");
+    expect(toggle!.textContent ?? "", "compact uses observed 5h value").toContain("4%");
+    expect(toggle!.textContent ?? "", "compact uses observed weekly value").toContain("7%");
+    expect(toggle!.textContent ?? "", "computed estimate stays internal").not.toContain("88%");
+
+    openDesktopPopover(hud);
+    await nextFrame();
+    const rows = hud.querySelectorAll<HTMLElement>(".gauge-pop-claude .gp-window");
+    expect(rows[0]?.textContent ?? "", "5h carries its own fresh timestamp").toContain(
+      m.topbar_usage_observed_now(),
+    );
+    expect(rows[1]?.textContent ?? "", "week carries its independent older timestamp").toContain(
+      m.topbar_usage_observed_age({ age: "2m" }),
+    );
+  });
+
+  it("keeps an expired observed percentage labelled as pre-reset without a countdown", async () => {
+    const now = 1_700_000_000_000;
+    const observed: UsageLimits = {
+      ...fullLimits,
+      observed: {
+        session5h: { pct: 87, resetAt: now - 1, scrapedAt: now - 60_000 },
+        week: { pct: 7, resetAt: now + 2 * 24 * 60 * 60_000, scrapedAt: now - 60_000 },
+      },
+    };
+    const hud = await renderDesktop(observed);
+    expect(
+      hud.querySelector(".gauges-toggle")?.textContent ?? "",
+      "compact value is qualified",
+    ).toContain(m.topbar_usage_before_reset({ pct: 87 }));
+
+    openDesktopPopover(hud);
+    await nextFrame();
+    const row = hud.querySelector<HTMLElement>(".gauge-pop-claude .gp-window");
+    expect(row!.textContent ?? "", "detail value is qualified").toContain(
+      m.topbar_usage_before_reset({ pct: 87 }),
+    );
+    expect(row!.textContent ?? "", "reset awaits provider confirmation").toContain(
+      m.topbar_usage_reset_checking(),
+    );
+    expect(
+      row!.querySelector(".reset-pending"),
+      "pending state replaces reset countdown",
+    ).not.toBeNull();
+  });
+
+  it("renders no observations and server-owned refresh progress", async () => {
+    const hud = await renderDesktop({
+      ...fullLimits,
+      observed: { session5h: null, week: null },
+      refresh: { inProgress: true, failed: false, lastAttemptAt: 1_700_000_000_000 },
+    });
+    const toggle = hud.querySelector<HTMLButtonElement>(".gauges-toggle");
+    expect(toggle, "empty observed Claude state remains openable").not.toBeNull();
+    toggle!.click();
+    await nextFrame();
+    const pop = hud.querySelector<HTMLElement>(".gauge-pop-desk");
+    expect(pop!.textContent ?? "", "empty state is explicit").toContain(
+      m.topbar_usage_no_observation(),
+    );
+    const refresh = pop!.querySelector<HTMLButtonElement>(".usage-refresh");
+    expect(refresh!.disabled, "server progress disables overlapping refreshes").toBe(true);
+    expect(refresh!.textContent ?? "", "server progress is visible").toContain(
+      m.topbar_usage_refreshing(),
+    );
+  });
+
+  it("marks one missing observed window without borrowing the other window's age", async () => {
+    const now = 1_700_000_000_000;
+    const hud = await renderDesktop({
+      ...fullLimits,
+      observed: {
+        session5h: null,
+        week: { pct: 7, resetAt: now + 24 * 60 * 60_000, scrapedAt: now - 2 * 60_000 },
+      },
+    });
+    openDesktopPopover(hud);
+    await nextFrame();
+    const rows = hud.querySelectorAll<HTMLElement>(".gauge-pop-claude .gp-window");
+    expect(rows, "both main windows retain a row").toHaveLength(2);
+    expect(rows[0]?.textContent ?? "", "missing 5h is explicit").toContain(
+      m.topbar_usage_no_observation(),
+    );
+    expect(rows[0]?.textContent ?? "", "missing 5h has no borrowed age").not.toContain("2m");
+    expect(rows[1]?.textContent ?? "", "weekly sample keeps its own age").toContain(
+      m.topbar_usage_observed_age({ age: "2m" }),
+    );
+  });
+
+  it("surfaces server refresh failure while retaining observed values", async () => {
+    const now = 1_700_000_000_000;
+    const hud = await renderDesktop({
+      ...fullLimits,
+      observed: {
+        session5h: { pct: 42, resetAt: now + 60 * 60_000, scrapedAt: now - 60_000 },
+        week: { pct: 9, resetAt: now + 24 * 60 * 60_000, scrapedAt: now - 60_000 },
+      },
+      refresh: { inProgress: false, failed: true, lastAttemptAt: now },
+    });
+    openDesktopPopover(hud);
+    await nextFrame();
+    const pop = hud.querySelector<HTMLElement>(".gauge-pop-desk");
+    expect(pop!.textContent ?? "", "old provider value remains visible").toContain("42%");
+    const error = pop!.querySelector<HTMLElement>(".usage-refresh-error");
+    expect(error?.getAttribute("role"), "server failure is announced").toBe("alert");
+    expect(error?.textContent ?? "", "failure explains retained values").toContain(
+      m.topbar_usage_refresh_failed(),
+    );
+  });
+
+  it("refreshes Claude when opening a popover with an old observed window", async () => {
+    vi.mocked(refreshUsage).mockClear();
+    const now = 1_700_000_000_000;
+    const hud = await renderDesktop({
+      ...fullLimits,
+      observed: {
+        session5h: { pct: 42, resetAt: now + 60 * 60_000, scrapedAt: now - 6 * 60_000 },
+        week: { pct: 9, resetAt: now + 24 * 60 * 60_000, scrapedAt: now - 10_000 },
+      },
+    });
+
+    openDesktopPopover(hud);
+    await vi.waitFor(() => {
+      expect(refreshUsage).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("puts usage details at lower left and Claude refresh at lower right", async () => {
+    const hud = await renderDesktop(fullLimits);
+    openDesktopPopover(hud);
+    await nextFrame();
+    const actions = hud.querySelector<HTMLElement>(".usage-footer-actions");
+    expect(actions, "shared footer actions render").not.toBeNull();
+    expect(actions!.firstElementChild?.classList.contains("gauge-pop-link")).toBe(true);
+    expect(actions!.lastElementChild?.querySelector(".usage-refresh")).not.toBeNull();
+  });
+
+  it("keeps the empty Claude popover open as server progress becomes a failure", async () => {
+    await page.viewport(1436, 900);
+    document.body.style.width = "1436px";
+    const empty: UsageLimits = {
+      ...fullLimits,
+      session5h: null,
+      week: null,
+      observed: { session5h: null, week: null },
+      refresh: { inProgress: true, failed: false, lastAttemptAt: 1_700_000_000_000 },
+    };
+    const { component } = await render(TopBarLimitsHarness, {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.desktop,
+      ...sessionsProp(0),
+      initialLimits: empty,
+    });
+    document.querySelector<HTMLButtonElement>(".gauges-toggle")!.click();
+    await nextFrame();
+    expect(document.querySelector(".gauge-pop-desk"), "empty popover opens").not.toBeNull();
+
+    component.setLimits({
+      ...empty,
+      refresh: { inProgress: false, failed: true, lastAttemptAt: 1_700_000_000_001 },
+    });
+    await vi.waitFor(() => {
+      const pop = document.querySelector<HTMLElement>(".gauge-pop-desk");
+      expect(pop, "failure does not close the empty popover").not.toBeNull();
+      expect(pop!.querySelector(".usage-refresh-error"), "failure remains visible").not.toBeNull();
+    });
+  });
+
+  it("clears a local request error when a newer server refresh succeeds", async () => {
+    vi.mocked(refreshUsage).mockClear();
+    vi.mocked(refreshUsage).mockRejectedValueOnce(new Error("offline"));
+    await page.viewport(1436, 900);
+    document.body.style.width = "1436px";
+    const props = {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.desktop,
+      ...sessionsProp(0),
+    };
+    const { rerender } = await render(TopBar, { ...props, limits: fullLimits });
+    const hud = document.querySelector<HTMLElement>(".hud")!;
+    openDesktopPopover(hud);
+    await nextFrame();
+    hud.querySelector<HTMLButtonElement>(".usage-refresh")!.click();
+    await vi.waitFor(() => expect(hud.querySelector(".usage-refresh-error")).not.toBeNull());
+
+    await rerender({
+      ...props,
+      limits: {
+        ...fullLimits,
+        refresh: { inProgress: false, failed: false, lastAttemptAt: 1_700_000_000_001 },
+      },
+    });
+    await vi.waitFor(() => {
+      expect(
+        hud.querySelector(".usage-refresh-error"),
+        "successful server attempt clears error",
+      ).toBeNull();
+    });
   });
 
   it("fail-closed: a rejected refresh surfaces the error state, not silent success", async () => {
     // The house-rule fail-closed path: refreshUsage() rejects → the popover must show
     // its visible error state (role=alert / .usage-refresh-error / retry message) so the user
     // sees the refresh FAILED rather than it looking like a success.
+    vi.mocked(refreshUsage).mockClear();
     vi.mocked(refreshUsage).mockRejectedValueOnce(new Error("network down"));
     const hud = await renderDesktop(limitsWithCredit({}));
     openDesktopPopover(hud);

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -10,11 +10,13 @@
   import { displayStatus } from "$lib/display-status";
   import {
     compactUsageViews as compactUsageViewList,
+    claudeDisplayGauges,
+    claudeObservedWindows,
     codexTokenUsage,
-    gaugeList,
     hotterGauge,
     modelWeekList,
     overspending,
+    shouldRefreshObservedOnOpen,
     type CompactUsageView,
     type GaugeKey,
   } from "./usage-gauges";
@@ -282,19 +284,27 @@
   // Desktop (fine pointer) shows both windows with hover tooltips. Touch has no
   // hover, so it collapses to the window closest to its cap and exposes the full
   // breakdown — including reset times — through a tap popover instead.
-  const gauges = $derived(gaugeList(limits));
+  const gauges = $derived(claudeDisplayGauges(limits));
   const hotter = $derived(hotterGauge(limits));
   // Per-model weekly passthrough sub-limits (e.g. Fable) — their own bars, never in gaugeList/hotter.
   const perModel = $derived(modelWeekList(limits));
   // api-key auth mode: subscription usage windows carry no data. Fail closed —
   // render an explicit note instead of empty/zero meters.
   const subscriptionOnly = $derived(limits?.subscriptionOnly === true);
+  const observed = $derived(claudeObservedWindows(limits));
 
   // Paid extra-credit overage. Rendered as a distinct CR element (NOT a gaugeList
   // entry — its window shape carries no credit fields, and a 0%-pct credit gauge
   // must never become the "hotter" collapsed gauge). Null → render nothing.
   const credits = $derived(limits?.credits ?? null);
   const codexUsage = $derived(codexTokenUsage(limits));
+  const claudeDisplayStale = $derived(observed === undefined ? (limits?.stale ?? false) : false);
+  const claudeAvailable = $derived(
+    gauges.length > 0 ||
+      perModel.length > 0 ||
+      !!credits ||
+      (observed !== undefined && !codexUsage),
+  );
   const overspend = $derived(overspending(limits));
   // Bar fill is spent/cap (NOT pct — pct rounds to 0 while money is already spent).
   const creditFill = $derived(
@@ -325,10 +335,11 @@
   const compactUsageViews = $derived(
     compactUsageViewList({
       gauges,
-      claudeStale: limits?.stale ?? false,
+      claudeStale: claudeDisplayStale,
       perModel,
       credits,
       codexUsage,
+      claudeAvailable,
     }),
   );
   const rotatingCompactUsageViews = $derived(
@@ -365,18 +376,37 @@
   // Refresh: POST /api/usage/refresh; the server's calibrate emit bridges back to the
   // client `ln` WS frame, so the gauge self-updates — we ignore the returned value.
   // Fail closed: a rejected refresh sets an error flag so it never looks like success.
-  let refreshing = $state(false);
-  let refreshError = $state(false);
+  let localRefreshing = $state(false);
+  let localRefreshError = $state(false);
+  let seenServerAttemptAt = $state<number | null>(null);
+  const refreshing = $derived(localRefreshing || limits?.refresh?.inProgress === true);
+  const refreshError = $derived(localRefreshError || limits?.refresh?.failed === true);
+  $effect(() => {
+    const status = limits?.refresh;
+    if (!status) return;
+    if (
+      status.inProgress ||
+      (status.lastAttemptAt !== seenServerAttemptAt && status.failed === false)
+    ) {
+      localRefreshError = false;
+    }
+    seenServerAttemptAt = status.lastAttemptAt;
+  });
   async function doRefresh() {
     if (refreshing) return;
-    refreshing = true;
-    refreshError = false;
+    localRefreshing = true;
+    localRefreshError = false;
     try {
       await refreshUsage();
     } catch {
-      refreshError = true;
+      localRefreshError = true;
     } finally {
-      refreshing = false;
+      localRefreshing = false;
+    }
+  }
+  function refreshOnStaleOpen() {
+    if (claudeAvailable && !subscriptionOnly && shouldRefreshObservedOnOpen(limits, nowMs)) {
+      void doRefresh();
     }
   }
 
@@ -564,7 +594,7 @@
     // popoverOpen now, so the only force-close is "no usage windows AND no credits AND no
     // per-model bar" (a non-empty `gauges` implies `hotter`, so this also covers the touch
     // collapse case). Keep `perModel` here or a Fable-only snapshot would force-close its own popover.
-    if (!gauges.length && !credits && !codexUsage && !perModel.length) popoverOpen = false;
+    if (!claudeAvailable && !codexUsage) popoverOpen = false;
   });
 
   // The gear adapts to herd state. When the herd is idle (haltable === 0) a click
@@ -778,11 +808,13 @@
       <TopBarUsage
         {subscriptionOnly}
         {touch}
-        stale={limits?.stale ?? false}
+        stale={claudeDisplayStale}
         {gauges}
         {perModel}
         {credits}
         {codexUsage}
+        {claudeAvailable}
+        {observed}
         {activeCompactUsageView}
         {compactUsageRotating}
         {overspend}
@@ -793,6 +825,7 @@
         {refreshing}
         {refreshError}
         onRefresh={doRefresh}
+        onOpenPopover={refreshOnStaleOpen}
         {periodLabel}
         onusage={chooseUsage}
         bind:popoverOpen

--- a/ui/src/lib/components/top-bar/CodexTokenDetail.svelte
+++ b/ui/src/lib/components/top-bar/CodexTokenDetail.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { m } from "$lib/paraglide/messages";
-  import { formatTokenLabel } from "$lib/format";
+  import { formatTokenLabel, relativeAge } from "$lib/format";
   import type { UsageProviderSnapshot } from "$lib/types";
   import { codexGaugeList, type GaugeKey } from "../usage-gauges";
   import LimitGaugeRow from "./LimitGaugeRow.svelte";
@@ -18,9 +18,31 @@
   // The 5h/weekly rate-limit windows Codex reports — rendered as Claude-style gauges so the two
   // CLIs read side by side. Empty when Shepherd cannot find a rate-limit event in Codex rollouts.
   const windows = $derived(codexGaugeList(usage));
+  const tokenAge = $derived(usage.updatedAt === null ? null : relativeAge(usage.updatedAt, nowMs));
+  const limitAge = $derived(
+    windows.length > 0 &&
+      usage.rateLimitLatestEventAt != null &&
+      usage.rateLimitLatestEventAt !== usage.updatedAt
+      ? relativeAge(usage.rateLimitLatestEventAt, nowMs)
+      : null,
+  );
 </script>
 
 <!-- Section heading ("Codex usage") is rendered by the parent popover; this is the body. -->
+{#if tokenAge !== null}
+  <div class="snapshot-age">
+    {tokenAge === "now"
+      ? m.topbar_codex_tokens_checked_now()
+      : m.topbar_codex_tokens_checked_age({ age: tokenAge })}
+  </div>
+{/if}
+{#if limitAge !== null}
+  <div class="snapshot-age limits-age">
+    {limitAge === "now"
+      ? m.topbar_codex_limits_checked_now()
+      : m.topbar_codex_limits_checked_age({ age: limitAge })}
+  </div>
+{/if}
 {#each windows as g (g.label)}
   <LimitGaugeRow label={periodLabel(g.label)} limit={g.w} {nowMs} />
 {/each}
@@ -41,6 +63,15 @@
 </div>
 
 <style>
+  .snapshot-age {
+    color: var(--color-muted);
+    font-size: var(--fs-micro);
+    letter-spacing: 0.04em;
+    margin-bottom: 6px;
+  }
+  .limits-age {
+    color: var(--color-faint);
+  }
   .limits-unavailable {
     margin: 4px 0 6px;
     padding: 6px 0;

--- a/ui/src/lib/components/top-bar/GearMenuUsage.svelte
+++ b/ui/src/lib/components/top-bar/GearMenuUsage.svelte
@@ -6,10 +6,11 @@
   import {
     codexGaugeList,
     codexTokenUsage,
-    gaugeList,
+    claudeDisplayGauges,
+    claudeObservedWindows,
     hottestCapacityWindow,
     modelWeekList,
-    providerCapacityRows,
+    providerDisplayCapacityRows,
     type GaugeKey,
   } from "../usage-gauges";
   import LimitGaugeRow from "./LimitGaugeRow.svelte";
@@ -51,14 +52,22 @@
 
   // All usage math lives in the tested model layer (usage-gauges.ts) — this component
   // only renders its output.
-  const hottest = $derived(hottestCapacityWindow(providerCapacityRows(limits)));
-  const gauges = $derived(gaugeList(limits));
+  const hottest = $derived(hottestCapacityWindow(providerDisplayCapacityRows(limits)));
+  const gauges = $derived(claudeDisplayGauges(limits));
+  const observed = $derived(claudeObservedWindows(limits));
   const perModel = $derived(modelWeekList(limits));
   const credits = $derived(limits?.credits ?? null);
   const codexUsage = $derived(codexTokenUsage(limits));
   const codexWindows = $derived(codexGaugeList(codexUsage));
   const subscriptionOnly = $derived(limits?.subscriptionOnly === true);
-  const hasClaude = $derived(gauges.length > 0 || perModel.length > 0 || !!credits);
+  const hasClaude = $derived(
+    gauges.length > 0 ||
+      perModel.length > 0 ||
+      !!credits ||
+      (observed !== undefined && !codexUsage),
+  );
+  const observedEmpty = $derived(observed !== undefined && gauges.length === 0);
+  const claudeStale = $derived(observed === undefined ? (limits?.stale ?? false) : false);
   // Window designation (CC·5H / CX·WK …): provider abbreviation + raw window key —
   // data-style codes, not translated chrome. Prefixes match selectedProviderCapacity
   // (the New Task capacity line) so the same provider never carries two codes.
@@ -113,7 +122,10 @@
           <div class="gm-section">
             {m.topbar_usage_provider_title({ provider: m.agent_provider_claude() })}
           </div>
-          <div class="gm-rows" class:stale={limits?.stale}>
+          <div class="gm-rows" class:stale={claudeStale}>
+            {#if observedEmpty}
+              <div class="gm-note">{m.topbar_usage_no_observation()}</div>
+            {/if}
             {#each gauges as g (g.label)}
               <LimitGaugeRow label={periodLabel(g.label)} limit={g.w} {nowMs} />
             {/each}
@@ -148,7 +160,7 @@
             </div>
           </div>
         {/if}
-        <UsageRefreshButton {refreshing} {refreshError} {onRefresh} />
+        {#if hasClaude}<UsageRefreshButton {refreshing} {refreshError} {onRefresh} />{/if}
       {/if}
     </div>
   {/if}

--- a/ui/src/lib/components/top-bar/LimitGaugeRow.svelte
+++ b/ui/src/lib/components/top-bar/LimitGaugeRow.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { formatReset, formatResetIn } from "$lib/format";
+  import { formatReset, formatResetIn, relativeAge } from "$lib/format";
   import { m } from "$lib/paraglide/messages";
-  import type { LimitWindow } from "$lib/types";
+  import type { LimitWindow, ObservedLimitWindow } from "$lib/types";
   import { gaugeColor } from "../usage-gauges";
 
   let {
@@ -18,7 +18,31 @@
 
   const fill = $derived(Math.min(Math.max(limit.pct, 0), 100) / 100);
   const color = $derived(gaugeColor(limit.pct));
+  const observed = $derived("scrapedAt" in limit ? (limit as ObservedLimitWindow) : null);
+  const resetPending = $derived(!!observed && observed.resetAt <= nowMs);
+  const age = $derived(observed ? relativeAge(observed.scrapedAt, nowMs) : "");
+  const valueLabel = $derived(
+    resetPending ? m.topbar_usage_before_reset({ pct: limit.pct }) : `${limit.pct}%`,
+  );
 </script>
+
+{#snippet limitMetadata()}
+  {#if resetPending}
+    <div class="gauge-pop-reset reset-pending micro">{m.topbar_usage_reset_checking()}</div>
+  {:else}
+    <div class="gauge-pop-reset micro">
+      {m.topbar_gauge_reset_rel({
+        rel: formatResetIn(limit.resetAt, nowMs),
+        abs: formatReset(limit.resetAt, nowMs),
+      })}
+    </div>
+  {/if}
+  {#if observed}
+    <div class="gauge-pop-age micro">
+      {age === "now" ? m.topbar_usage_observed_now() : m.topbar_usage_observed_age({ age })}
+    </div>
+  {/if}
+{/snippet}
 
 {#if inline}
   <div class="gauge-pop-row">
@@ -26,29 +50,20 @@
     <span class="g-bar g-bar-wide"
       ><span class="g-fill" style="transform:scaleX({fill});background:{color}"></span></span
     >
-    <span class="g-pct" style="color:{color}">{limit.pct}%</span>
+    <span class="g-pct" class:before-reset={resetPending} style="color:{color}">{valueLabel}</span>
   </div>
-  <div class="gauge-pop-reset micro">
-    {m.topbar_gauge_reset_rel({
-      rel: formatResetIn(limit.resetAt, nowMs),
-      abs: formatReset(limit.resetAt, nowMs),
-    })}
-  </div>
+  {@render limitMetadata()}
 {:else}
   <div class="sheet-gauge-row">
     <div class="sheet-gauge-head">
       <span class="gp-period">{label}</span>
-      <span class="g-pct" style="color:{color}">{limit.pct}%</span>
+      <span class="g-pct" class:before-reset={resetPending} style="color:{color}">{valueLabel}</span
+      >
     </div>
     <span class="g-bar g-bar-wide"
       ><span class="g-fill" style="transform:scaleX({fill});background:{color}"></span></span
     >
-    <div class="gauge-pop-reset micro">
-      {m.topbar_gauge_reset_rel({
-        rel: formatResetIn(limit.resetAt, nowMs),
-        abs: formatReset(limit.resetAt, nowMs),
-      })}
-    </div>
+    {@render limitMetadata()}
   </div>
 {/if}
 
@@ -74,7 +89,7 @@
     color: var(--color-muted);
   }
   .gp-period {
-    color: var(--color-text);
+    color: var(--color-ink);
     font-size: var(--fs-meta);
     text-transform: capitalize;
   }
@@ -106,6 +121,9 @@
     min-width: 30px;
     text-align: right;
   }
+  .g-pct.before-reset {
+    min-width: max-content;
+  }
   .gauge-pop-row .g-pct {
     min-width: 34px;
   }
@@ -114,6 +132,18 @@
     text-transform: none;
     letter-spacing: 0.04em;
     color: var(--color-faint);
+  }
+  .gauge-pop-reset.micro,
+  .gauge-pop-reset.reset-pending {
+    text-transform: none;
+    letter-spacing: 0.04em;
+    color: var(--color-muted);
+  }
+  .gauge-pop-age.micro {
+    margin: -2px 0 5px 30px;
+    text-transform: none;
+    letter-spacing: 0.04em;
+    color: var(--color-muted);
   }
   .gauge-pop-reset:last-child {
     margin-bottom: 0;
@@ -124,6 +154,9 @@
   }
   .sheet-gauge-row .gauge-pop-reset {
     margin: 0 0 6px;
+  }
+  .sheet-gauge-row .gauge-pop-age {
+    margin: -2px 0 6px;
   }
   .micro {
     font-size: var(--fs-meta);

--- a/ui/src/lib/components/top-bar/TopBarUsage.svelte
+++ b/ui/src/lib/components/top-bar/TopBarUsage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { m } from "$lib/paraglide/messages";
-  import type { CreditWindow, ModelWeekWindow } from "$lib/types";
+  import type { CreditWindow, ModelWeekWindow, ObservedLimitWindows } from "$lib/types";
   import type { UsageProviderSnapshot } from "$lib/types";
   import { formatTokenLabel } from "$lib/format";
   import { gaugeColor, modelDisplayName, type GaugeKey } from "../usage-gauges";
@@ -17,6 +17,8 @@
     perModel,
     credits,
     codexUsage,
+    claudeAvailable,
+    observed,
     activeCompactUsageView,
     compactUsageRotating,
     overspend,
@@ -27,6 +29,7 @@
     refreshing,
     refreshError,
     onRefresh,
+    onOpenPopover,
     periodLabel,
     onusage,
     popoverOpen = $bindable(),
@@ -39,6 +42,8 @@
     perModel: ModelWeekWindow[];
     credits: CreditWindow | null;
     codexUsage: Extract<UsageProviderSnapshot, { provider: "codex"; kind: "tokens" }> | null;
+    claudeAvailable: boolean;
+    observed: ObservedLimitWindows | undefined;
     activeCompactUsageView: CompactUsageView | null;
     compactUsageRotating: boolean;
     overspend: boolean;
@@ -49,6 +54,7 @@
     refreshing: boolean;
     refreshError: boolean;
     onRefresh: () => void;
+    onOpenPopover: () => void;
     periodLabel: (k: GaugeKey) => string;
     onusage?: () => void;
     popoverOpen: boolean;
@@ -86,7 +92,47 @@
   const activeTouchLimitLabel = $derived(
     compactUsageRotating ? `${activeProviderName} · ${activeHotGaugeLabel}` : activeHotGaugeLabel,
   );
+  function gaugeValue(gauge: Gauge): string {
+    return "scrapedAt" in gauge.w && gauge.w.resetAt <= nowMs
+      ? m.topbar_usage_before_reset({ pct: gauge.w.pct })
+      : `${gauge.w.pct}%`;
+  }
+  function togglePopover() {
+    const opening = !popoverOpen;
+    popoverOpen = opening;
+    if (opening) onOpenPopover();
+  }
+  function closePopover() {
+    popoverOpen = false;
+  }
+  function openUsage() {
+    popoverOpen = false;
+    onusage?.();
+  }
 </script>
+
+{#snippet usagePopover(desktop: boolean)}
+  <TopBarUsagePopover
+    {desktop}
+    {stale}
+    {gauges}
+    {perModel}
+    {credits}
+    {codexUsage}
+    {claudeAvailable}
+    {observed}
+    {creditFill}
+    {creditColor}
+    {creditAmount}
+    {nowMs}
+    {refreshing}
+    {refreshError}
+    {onRefresh}
+    {periodLabel}
+    onClose={closePopover}
+    onOpenUsage={openUsage}
+  />
+{/snippet}
 
 {#if subscriptionOnly && !codexUsage}
   <span class="usage-sub-only micro">{m.usage_subscription_only()}</span>
@@ -106,7 +152,7 @@
           aria-haspopup="dialog"
           aria-expanded={popoverOpen}
           aria-label={activeTouchLimitLabel}
-          onclick={() => (popoverOpen = !popoverOpen)}
+          onclick={togglePopover}
         >
           {#if compactUsageRotating}<span class="g-provider micro">{activeProviderShort}</span>{/if}
           <span class="g-label micro">{activeHotGauge.label}</span>
@@ -118,7 +164,7 @@
             ></span></span
           >
           <span class="g-pct" style="color:{gaugeColor(activeHotGauge.w.pct)}"
-            >{activeHotGauge.w.pct}%</span
+            >{gaugeValue(activeHotGauge)}</span
           >
         </button>
       {:else if activeCompactUsageView.mode === "credit" || activeCompactUsageView.mode === "tokens"}
@@ -135,7 +181,7 @@
               ? m.topbar_credits_alert_aria({ amount: creditAmount })
               : `${m.topbar_credits_period()} · ${creditAmount}`
             : `${activeProviderName} · ${formatTokenLabel(activeCompactUsageView.totalTokens)}`}
-          onclick={() => (popoverOpen = !popoverOpen)}
+          onclick={togglePopover}
         >
           {#if compactUsageRotating}<span class="g-provider micro">{activeProviderShort}</span>{/if}
           {#if activeCompactUsageView.mode === "credit"}
@@ -163,7 +209,7 @@
           aria-label={`${m.usage_limits_window_week_model({
             model: modelDisplayName(activeCompactUsageView.model.model),
           })} · ${activeCompactUsageView.model.pct}%`}
-          onclick={() => (popoverOpen = !popoverOpen)}
+          onclick={togglePopover}
         >
           {#if compactUsageRotating}<span class="g-provider micro">{activeProviderShort}</span>{/if}
           <span class="g-label micro">{modelDisplayName(activeCompactUsageView.model.model)}</span>
@@ -180,29 +226,21 @@
             >{activeCompactUsageView.model.pct}%</span
           >
         </button>
+      {:else if activeCompactUsageView.mode === "empty"}
+        <button
+          class="gauge gauge-btn empty"
+          type="button"
+          aria-haspopup="dialog"
+          aria-expanded={popoverOpen}
+          aria-label={m.topbar_usage_provider_title({ provider: m.agent_provider_claude() })}
+          onclick={togglePopover}
+        >
+          <span class="g-provider micro">{m.topbar_usage_provider_short_claude()}</span>
+          <span class="g-pct empty-value">—</span>
+        </button>
       {/if}
       {#if popoverOpen}
-        <TopBarUsagePopover
-          desktop={false}
-          {stale}
-          {gauges}
-          {perModel}
-          {credits}
-          {codexUsage}
-          {creditFill}
-          {creditColor}
-          {creditAmount}
-          {nowMs}
-          {refreshing}
-          {refreshError}
-          {onRefresh}
-          {periodLabel}
-          onClose={() => (popoverOpen = false)}
-          onOpenUsage={() => {
-            popoverOpen = false;
-            onusage?.();
-          }}
-        />
+        {@render usagePopover(false)}
       {/if}
     </div>
   {/if}
@@ -216,7 +254,7 @@
       class="gauges-link gauges-toggle"
       aria-haspopup="dialog"
       aria-expanded={popoverOpen}
-      onclick={() => (popoverOpen = !popoverOpen)}
+      onclick={togglePopover}
     >
       <!-- Phrasing-only content: a <button> may not contain block elements, so the
            gauge cluster + each gauge are <span>s (display:flex via class, blockified
@@ -243,7 +281,7 @@
                     100});background:{gaugeColor(g.w.pct)}"
                 ></span></span
               >
-              <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
+              <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{gaugeValue(g)}</span>
             </span>
           {/each}
         {:else if activeCompactUsageView.mode === "model"}
@@ -265,31 +303,16 @@
               >{activeCompactUsageView.model.pct}%</span
             >
           </span>
+        {:else if activeCompactUsageView.mode === "empty"}
+          <span class="gauge empty">
+            <span class="g-provider micro">{m.topbar_usage_provider_short_claude()}</span>
+            <span class="g-pct empty-value">—</span>
+          </span>
         {/if}
       </span>
     </button>
     {#if popoverOpen}
-      <TopBarUsagePopover
-        desktop={true}
-        {stale}
-        {gauges}
-        {perModel}
-        {credits}
-        {codexUsage}
-        {creditFill}
-        {creditColor}
-        {creditAmount}
-        {nowMs}
-        {refreshing}
-        {refreshError}
-        {onRefresh}
-        {periodLabel}
-        onClose={() => (popoverOpen = false)}
-        onOpenUsage={() => {
-          popoverOpen = false;
-          onusage?.();
-        }}
-      />
+      {@render usagePopover(true)}
     {/if}
   </div>
 {/if}
@@ -373,6 +396,9 @@
   .credit-amount {
     min-width: max-content;
     white-space: nowrap;
+  }
+  .empty-value {
+    color: var(--color-faint);
   }
   .micro {
     font-size: var(--fs-meta);

--- a/ui/src/lib/components/top-bar/TopBarUsagePopover.svelte
+++ b/ui/src/lib/components/top-bar/TopBarUsagePopover.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
   import { dialog } from "$lib/a11yDialog";
   import { m } from "$lib/paraglide/messages";
-  import type { CreditWindow, ModelWeekWindow, UsageProviderSnapshot } from "$lib/types";
+  import type {
+    CreditWindow,
+    ModelWeekWindow,
+    ObservedLimitWindow,
+    ObservedLimitWindows,
+    UsageProviderSnapshot,
+  } from "$lib/types";
   import { type GaugeKey } from "../usage-gauges";
   import type { Gauge } from "../usage-gauges";
   import CodexTokenDetail from "./CodexTokenDetail.svelte";
@@ -17,6 +23,8 @@
     perModel,
     credits,
     codexUsage,
+    claudeAvailable,
+    observed,
     creditFill,
     creditColor,
     creditAmount,
@@ -34,6 +42,8 @@
     perModel: ModelWeekWindow[];
     credits: CreditWindow | null;
     codexUsage: Extract<UsageProviderSnapshot, { provider: "codex"; kind: "tokens" }> | null;
+    claudeAvailable: boolean;
+    observed: ObservedLimitWindows | undefined;
     creditFill: number;
     creditColor: string;
     creditAmount: string;
@@ -52,8 +62,39 @@
 
   // Claude vs Codex are distinct providers with their own labelled sections. The Claude heading
   // shows only when Claude has data (else a codex-only popover would show an empty section).
-  const hasClaude = $derived(gauges.length > 0 || perModel.length > 0 || !!credits);
+  const hasClaude = $derived(claudeAvailable);
+  const observedEmpty = $derived(hasClaude && observed !== undefined && gauges.length === 0);
 </script>
+
+{#snippet observedWindow(label: GaugeKey, limit: ObservedLimitWindow | null, inline: boolean)}
+  <div class="gp-window">
+    {#if limit}
+      <LimitGaugeRow label={periodLabel(label)} {limit} {nowMs} {inline} />
+    {:else}
+      <div class="missing-window-label">{periodLabel(label)}</div>
+      <div class="missing-window-value">{m.topbar_usage_no_observation()}</div>
+    {/if}
+  </div>
+{/snippet}
+
+{#snippet mainWindows(inline: boolean)}
+  {#if observedEmpty}
+    <div class="usage-empty">{m.topbar_usage_no_observation()}</div>
+  {:else if observed !== undefined}
+    {@render observedWindow("5H", observed.session5h, inline)}
+    {@render observedWindow("WK", observed.week, inline)}
+  {:else}
+    {#each gauges as g (g.label)}
+      {#if inline}
+        <LimitGaugeRow label={g.label} limit={g.w} {nowMs} inline />
+      {:else}
+        <div class="gp-window">
+          <LimitGaugeRow label={periodLabel(g.label)} limit={g.w} {nowMs} />
+        </div>
+      {/if}
+    {/each}
+  {/if}
+{/snippet}
 
 <div
   class="gauge-pop"
@@ -62,49 +103,39 @@
   aria-label={m.topbar_gauge_popover_title()}
   use:optionalDialog
 >
+  <div class="popover-heading">{m.topbar_gauge_popover_title()}</div>
   <!-- Claude section. `stale` (Claude limits staleness) dims ONLY this block — the Codex section
        below carries its own `codexUsage.stale`, so a stale Claude snapshot must not dim fresh Codex. -->
-  <div class="gauge-pop-claude" class:stale>
-    {#if hasClaude}
+  {#if hasClaude}
+    <div class="gauge-pop-claude" class:stale>
       <div class="gauge-pop-title micro">
         {m.topbar_usage_provider_title({ provider: m.agent_provider_claude() })}{stale
           ? m.topbar_gauge_stale_suffix()
           : ""}
       </div>
-    {/if}
-    {#if desktop}
-      {#each gauges as g (g.label)}
-        <div class="gp-window">
-          <LimitGaugeRow label={periodLabel(g.label)} limit={g.w} {nowMs} />
-        </div>
-      {/each}
-      {#each perModel as entry (entry.model)}
-        <div class="gp-window">
-          <ModelWeekGauge {entry} {nowMs} />
-        </div>
-      {/each}
-      {#if credits}
-        <div class="gp-window">
-          <CreditDetail {credits} {creditFill} {creditColor} {creditAmount} {nowMs} />
-        </div>
+      {#if desktop}
+        {@render mainWindows(false)}
+        {#each perModel as entry (entry.model)}
+          <div class="gp-window">
+            <ModelWeekGauge {entry} {nowMs} />
+          </div>
+        {/each}
+        {#if credits}
+          <div class="gp-window">
+            <CreditDetail {credits} {creditFill} {creditColor} {creditAmount} {nowMs} />
+          </div>
+        {/if}
+      {:else}
+        {@render mainWindows(true)}
+        {#each perModel as entry (entry.model)}
+          <div class="gauge-pop-row-model">
+            <ModelWeekGauge {entry} {nowMs} />
+          </div>
+        {/each}
+        <CreditDetail {credits} {creditFill} {creditColor} {creditAmount} {nowMs} />
       {/if}
-    {:else}
-      {#each gauges as g (g.label)}
-        <LimitGaugeRow label={g.label} limit={g.w} {nowMs} inline />
-      {/each}
-      {#each perModel as entry (entry.model)}
-        <div class="gauge-pop-row-model">
-          <ModelWeekGauge {entry} {nowMs} />
-        </div>
-      {/each}
-      <CreditDetail {credits} {creditFill} {creditColor} {creditAmount} {nowMs} />
-    {/if}
-    {#if hasClaude}
-      <div class="gp-refresh">
-        <UsageRefreshButton {refreshing} {refreshError} {onRefresh} />
-      </div>
-    {/if}
-  </div>
+    </div>
+  {/if}
   {#if codexUsage}
     <div class="gauge-pop-title micro codex-heading">
       {m.topbar_usage_provider_title({ provider: m.agent_provider_codex() })}
@@ -113,9 +144,21 @@
       <CodexTokenDetail usage={codexUsage} {nowMs} {periodLabel} />
     </div>
   {/if}
-  <button type="button" class="gauge-pop-link" aria-haspopup="dialog" onclick={onOpenUsage}>
-    {m.topbar_usage_link()}
-  </button>
+  <footer class="usage-footer">
+    {#if hasClaude}
+      <div class="usage-refresh-scope">{m.topbar_usage_refresh_scope()}</div>
+    {/if}
+    <div class="usage-footer-actions">
+      <button type="button" class="gauge-pop-link" aria-haspopup="dialog" onclick={onOpenUsage}>
+        {m.topbar_usage_link()}
+      </button>
+      {#if hasClaude}
+        <div class="gp-refresh">
+          <UsageRefreshButton {refreshing} {refreshError} {onRefresh} />
+        </div>
+      {/if}
+    </div>
+  </footer>
 </div>
 
 <style>
@@ -124,13 +167,13 @@
     top: calc(100% + 8px);
     right: 0;
     z-index: 50;
-    min-width: 200px;
-    max-width: min(280px, 85vw);
+    width: 320px;
+    max-width: calc(100vw - 24px);
     background: var(--color-panel);
     border: 1px solid var(--color-line-bright);
     border-radius: 2px;
-    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45);
-    padding: 10px 11px;
+    box-shadow: var(--shadow-popover);
+    padding: 14px 15px 12px;
     display: flex;
     flex-direction: column;
     gap: 4px;
@@ -148,8 +191,31 @@
   .gauge-pop-claude.stale {
     opacity: 0.5;
   }
+  .popover-heading {
+    color: var(--color-ink-bright);
+    font-size: var(--fs-lg);
+    font-weight: 700;
+    line-height: 1.2;
+    margin-bottom: 16px;
+  }
   .gauge-pop-title {
     margin-bottom: 6px;
+  }
+  .usage-empty {
+    color: var(--color-faint);
+    font-size: var(--fs-meta);
+    line-height: 1.45;
+    padding: 8px 0 4px;
+  }
+  .missing-window-label {
+    color: var(--color-ink);
+    font-size: var(--fs-meta);
+  }
+  .missing-window-value {
+    color: var(--color-faint);
+    font-size: var(--fs-micro);
+    line-height: 1.4;
+    margin-top: 4px;
   }
   /* Codex is a separate provider section — set it off from the Claude block above. */
   .codex-heading {
@@ -160,10 +226,6 @@
   .gauge-pop-row-model {
     margin-bottom: 6px;
   }
-  /* Refresh control, section-level so it survives the credits gauge being hidden. */
-  .gp-refresh {
-    margin-top: 10px;
-  }
   .gauge-pop-link {
     appearance: none;
     -webkit-appearance: none;
@@ -172,12 +234,10 @@
     padding: 0;
     cursor: pointer;
     display: block;
-    width: 100%;
-    margin-top: 8px;
     font: inherit;
     font-size: var(--fs-meta);
     color: var(--color-muted);
-    text-align: right;
+    text-align: left;
   }
   .gauge-pop-link:hover,
   .gauge-pop-link:focus-visible {
@@ -192,12 +252,31 @@
     gap: 6px;
   }
   .gp-window + .gp-window {
-    margin-top: 10px;
-    padding-top: 10px;
-    border-top: 1px solid var(--color-line);
+    margin-top: 13px;
   }
   .token-window.stale {
     opacity: 0.5;
+  }
+  .usage-footer {
+    margin-top: 14px;
+    padding-top: 10px;
+    border-top: 1px solid var(--color-line);
+  }
+  .usage-refresh-scope {
+    color: var(--color-faint);
+    font-size: var(--fs-micro);
+    letter-spacing: 0.04em;
+    margin-bottom: 8px;
+  }
+  .usage-footer-actions {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 12px;
+  }
+  .gp-refresh {
+    margin-left: auto;
+    min-width: 0;
   }
   .micro {
     font-size: var(--fs-meta);

--- a/ui/src/lib/components/top-bar/UsageRefreshButton.svelte
+++ b/ui/src/lib/components/top-bar/UsageRefreshButton.svelte
@@ -17,6 +17,11 @@
 </script>
 
 <div class="usage-refresh-row">
+  {#if refreshError}
+    <span class="usage-refresh-error" role="alert"
+      >{m.topbar_usage_refresh_failed()} {m.common_retry()}</span
+    >
+  {/if}
   <button
     type="button"
     class="usage-refresh micro"
@@ -24,17 +29,16 @@
     aria-busy={refreshing}
     onclick={onRefresh}
   >
-    {refreshing ? m.common_loading() : m.topbar_usage_refresh()}
+    <span aria-hidden="true">↻</span>
+    {refreshing ? m.topbar_usage_refreshing() : m.topbar_usage_refresh()}
   </button>
-  {#if refreshError}
-    <span class="usage-refresh-error micro" role="alert">{m.common_retry()}</span>
-  {/if}
 </div>
 
 <style>
   .usage-refresh-row {
     display: flex;
-    align-items: center;
+    flex-direction: column;
+    align-items: flex-end;
     gap: 8px;
   }
   .usage-refresh {
@@ -47,19 +51,31 @@
     text-transform: none;
     letter-spacing: 0.04em;
     padding: 5px 10px;
+    min-height: 30px;
     cursor: pointer;
   }
   .usage-refresh:hover:not(:disabled) {
     background: var(--color-inset);
+  }
+  .usage-refresh:focus-visible {
+    outline: 1px solid var(--color-amber);
+    outline-offset: 2px;
   }
   .usage-refresh:disabled {
     cursor: default;
     opacity: 0.5;
   }
   .usage-refresh-error {
-    text-transform: none;
-    letter-spacing: 0.04em;
+    max-width: 24ch;
+    font-size: var(--fs-micro);
+    line-height: 1.35;
+    text-align: right;
     color: var(--color-red);
+  }
+  @media (pointer: coarse) {
+    .usage-refresh {
+      min-height: 44px;
+    }
   }
   .micro {
     font-size: var(--fs-meta);

--- a/ui/src/lib/components/usage-gauges.test.ts
+++ b/ui/src/lib/components/usage-gauges.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  claudeDisplayGauges,
   compactUsageViews,
   codexTokenUsage,
   gaugeList,
@@ -8,7 +9,9 @@ import {
   providerSnapshots,
   gaugeColor,
   providerCapacityRows,
+  providerDisplayCapacityRows,
   selectedProviderCapacity,
+  shouldRefreshObservedOnOpen,
   hottestCapacityWindow,
   modelDisplayName,
 } from "./usage-gauges";
@@ -80,6 +83,120 @@ describe("modelDisplayName", () => {
     expect(modelDisplayName("gpt-5.5")).toBe("GPT-5.5");
     expect(modelDisplayName("unknown")).toBe("Unknown");
     expect(modelDisplayName("custom_model-v2")).toBe("Custom Model V2");
+  });
+});
+
+describe("claudeDisplayGauges", () => {
+  it("uses independently observed windows and treats an observed null as no sample", () => {
+    const l = limits({
+      session5h: w(88, 10_000),
+      week: w(64, 20_000),
+      observed: {
+        session5h: null,
+        week: { pct: 7, resetAt: 30_000, scrapedAt: 4_000 },
+      },
+    } as Partial<UsageLimits>);
+
+    expect(claudeDisplayGauges(l)).toEqual([
+      { label: "WK", w: { pct: 7, resetAt: 30_000, scrapedAt: 4_000 } },
+    ]);
+  });
+
+  it("keeps legacy payloads displaying their computed windows when observed is absent", () => {
+    const l = limits({ session5h: w(12, 10_000), week: w(23, 20_000) });
+
+    expect(claudeDisplayGauges(l)).toEqual([
+      { label: "5H", w: w(12, 10_000) },
+      { label: "WK", w: w(23, 20_000) },
+    ]);
+  });
+});
+
+describe("shouldRefreshObservedOnOpen", () => {
+  const NOW = 2_000_000;
+
+  it("does not auto-refresh legacy payloads", () => {
+    expect(shouldRefreshObservedOnOpen(limits({ session5h: w(10), week: w(20) }), NOW)).toBe(false);
+  });
+
+  it("refreshes when either provider window has not been observed", () => {
+    const l = limits({
+      observed: {
+        session5h: { pct: 10, resetAt: NOW + 60 * 60_000, scrapedAt: NOW - 10_000 },
+        week: null,
+      },
+    } as Partial<UsageLimits>);
+
+    expect(shouldRefreshObservedOnOpen(l, NOW)).toBe(true);
+  });
+
+  it("checks each sample timestamp instead of using the newest window timestamp", () => {
+    const l = limits({
+      observed: {
+        session5h: { pct: 10, resetAt: NOW + 60 * 60_000, scrapedAt: NOW - 6 * 60_000 },
+        week: { pct: 20, resetAt: NOW + 4 * 24 * 60 * 60_000, scrapedAt: NOW - 5_000 },
+      },
+    } as Partial<UsageLimits>);
+
+    expect(shouldRefreshObservedOnOpen(l, NOW)).toBe(true);
+  });
+
+  it("uses one-minute freshness in the final ten minutes and after the reset boundary", () => {
+    const nearReset = limits({
+      observed: {
+        session5h: { pct: 87, resetAt: NOW + 9 * 60_000, scrapedAt: NOW - 61_000 },
+        week: { pct: 7, resetAt: NOW + 4 * 24 * 60 * 60_000, scrapedAt: NOW - 10_000 },
+      },
+    } as Partial<UsageLimits>);
+    const boundary = limits({
+      observed: {
+        session5h: { pct: 87, resetAt: NOW, scrapedAt: NOW },
+        week: { pct: 7, resetAt: NOW + 4 * 24 * 60 * 60_000, scrapedAt: NOW },
+      },
+    } as Partial<UsageLimits>);
+
+    expect(shouldRefreshObservedOnOpen(nearReset, NOW)).toBe(true);
+    expect(shouldRefreshObservedOnOpen(boundary, NOW)).toBe(true);
+  });
+
+  it("throttles automatic retries after missing-window failures while manual refresh stays separate", () => {
+    const l = limits({
+      observed: { session5h: null, week: null },
+      refresh: { inProgress: false, failed: true, lastAttemptAt: NOW - 2 * 60_000 },
+    } as Partial<UsageLimits>);
+
+    expect(shouldRefreshObservedOnOpen(l, NOW)).toBe(false);
+  });
+
+  it("keeps the one-minute reset cadence when the weekly observation is missing", () => {
+    const l = limits({
+      observed: {
+        session5h: { pct: 87, resetAt: NOW + 5 * 60_000, scrapedAt: NOW - 2 * 60_000 },
+        week: null,
+      },
+      refresh: { inProgress: false, failed: true, lastAttemptAt: NOW - 2 * 60_000 },
+    } as Partial<UsageLimits>);
+
+    expect(shouldRefreshObservedOnOpen(l, NOW)).toBe(true);
+  });
+
+  it("refreshes immediately across a reset boundary, then limits pending retries to once a minute", () => {
+    const resetAt = NOW - 30_000;
+    const observed = {
+      session5h: { pct: 87, resetAt, scrapedAt: NOW - 30_000 },
+      week: { pct: 7, resetAt: NOW + 4 * 24 * 60 * 60_000, scrapedAt: NOW - 30_000 },
+    };
+    const beforeBoundaryAttempt = limits({
+      observed,
+      refresh: { inProgress: false, failed: false, lastAttemptAt: resetAt - 1 },
+    } as Partial<UsageLimits>);
+    const recentPendingAttempt = limits({
+      observed,
+      refresh: { inProgress: false, failed: true, lastAttemptAt: NOW - 10_000 },
+    } as Partial<UsageLimits>);
+
+    expect(shouldRefreshObservedOnOpen(beforeBoundaryAttempt, NOW)).toBe(true);
+    expect(shouldRefreshObservedOnOpen(recentPendingAttempt, NOW)).toBe(false);
   });
 });
 
@@ -303,6 +420,22 @@ describe("overspending", () => {
 });
 
 describe("providerCapacityRows", () => {
+  it("keeps internal capacity on computed windows while display capacity uses observed windows", () => {
+    const l = limits({
+      session5h: w(88),
+      week: w(64),
+      observed: {
+        session5h: { pct: 4, resetAt: 10_000, scrapedAt: 1_000 },
+        week: { pct: 7, resetAt: 20_000, scrapedAt: 1_000 },
+      },
+    });
+
+    expect(providerCapacityRows(l)[0]?.windows.map((window) => window.usedPct)).toEqual([88, 64]);
+    expect(providerDisplayCapacityRows(l)[0]?.windows.map((window) => window.usedPct)).toEqual([
+      4, 7,
+    ]);
+  });
+
   it("returns per-window remaining room (5H then WK) for each provider", () => {
     const l = limits({
       session5h: w(30),

--- a/ui/src/lib/components/usage-gauges.ts
+++ b/ui/src/lib/components/usage-gauges.ts
@@ -5,6 +5,7 @@ import type {
   ModelWeekWindow,
   UsageProviderSnapshot,
   CreditWindow,
+  ObservedLimitWindows,
 } from "../types";
 import type { AgentProvider } from "../types";
 
@@ -22,6 +23,56 @@ export function gaugeList(limits: UsageLimits | null): Gauge[] {
   if (limits.session5h) out.push({ label: "5H", w: limits.session5h });
   if (limits.week) out.push({ label: "WK", w: limits.week });
   return out;
+}
+
+/** Claude windows intended for operator display. Observed values are authoritative when the
+ * contract is present, while gaugeList deliberately remains on computed windows for internal
+ * capacity, holds, and projections. */
+export function claudeObservedWindows(
+  limits: UsageLimits | null,
+): ObservedLimitWindows | undefined {
+  if (!limits) return undefined;
+  if (limits.observed !== undefined) return limits.observed;
+  const claude = limits.providers?.find(
+    (provider) => provider.provider === "claude" && provider.kind === "limits",
+  );
+  if (claude?.observed !== undefined) {
+    return claude.observed;
+  }
+  return undefined;
+}
+
+export function claudeDisplayGauges(limits: UsageLimits | null): Gauge[] {
+  const observed = claudeObservedWindows(limits);
+  if (observed === undefined) return gaugeList(limits);
+  const out: Gauge[] = [];
+  if (observed.session5h) out.push({ label: "5H", w: observed.session5h });
+  if (observed.week) out.push({ label: "WK", w: observed.week });
+  return out;
+}
+
+/** Match the server cadence when opening the popover. This checks every main window so one fresh
+ * sample cannot hide another window whose provider-confirmed value is missing or old. */
+export function shouldRefreshObservedOnOpen(limits: UsageLimits | null, nowMs: number): boolean {
+  const observed = claudeObservedWindows(limits);
+  if (observed === undefined) return false;
+  if (limits?.refresh?.inProgress) return false;
+  const lastAttemptAt = limits?.refresh?.lastAttemptAt ?? null;
+  const session = observed.session5h;
+  if (session && session.resetAt <= nowMs) {
+    if (lastAttemptAt === null || lastAttemptAt < session.resetAt) return true;
+    return nowMs - lastAttemptAt >= 60_000;
+  }
+  const nearSessionReset = !!session && session.resetAt - nowMs <= 10 * 60_000;
+  const cadence = nearSessionReset ? 60_000 : 5 * 60_000;
+  if (!session || !observed.week) {
+    return lastAttemptAt === null || nowMs - lastAttemptAt >= cadence;
+  }
+  const needsRefresh = [session, observed.week].some(
+    (window) => nowMs - window.scrapedAt >= cadence,
+  );
+  if (!needsRefresh) return false;
+  return lastAttemptAt === null || nowMs - lastAttemptAt >= cadence;
 }
 
 type CodexTokenSnapshot = Extract<UsageProviderSnapshot, { provider: "codex"; kind: "tokens" }>;
@@ -49,6 +100,13 @@ export type CompactUsageView =
       stale: boolean;
       rotationEligible: boolean;
       widthClass: "model";
+    }
+  | {
+      provider: "claude";
+      mode: "empty";
+      stale: false;
+      rotationEligible: false;
+      widthClass: "empty";
     }
   | {
       provider: "codex";
@@ -91,6 +149,7 @@ export function providerSnapshots(limits: UsageLimits | null): UsageProviderSnap
       stale: limits.stale,
       calibratedAt: limits.calibratedAt,
       subscriptionOnly: limits.subscriptionOnly,
+      ...(limits.observed === undefined ? {} : { observed: limits.observed }),
     },
   ];
 }
@@ -140,12 +199,14 @@ export function compactUsageViews({
   perModel,
   credits,
   codexUsage,
+  claudeAvailable = false,
 }: {
   gauges: Gauge[];
   claudeStale: boolean;
   perModel: ModelWeekWindow[];
   credits: CreditWindow | null;
   codexUsage: CodexTokenSnapshot | null;
+  claudeAvailable?: boolean;
 }): CompactUsageView[] {
   const views: CompactUsageView[] = [];
   const capped = gauges.some((g) => g.w.pct >= 100);
@@ -176,6 +237,14 @@ export function compactUsageViews({
       stale: perModel[0]!.stale,
       rotationEligible: true,
       widthClass: "model",
+    });
+  } else if (claudeAvailable) {
+    views.push({
+      provider: "claude",
+      mode: "empty",
+      stale: false,
+      rotationEligible: false,
+      widthClass: "empty",
     });
   }
 
@@ -304,6 +373,28 @@ export function providerCapacityRows(limits: UsageLimits | null): ProviderCapaci
       windows: claudeWindows,
       available: claudeWindows.length > 0,
       stale: limits?.stale ?? false,
+    },
+    {
+      provider: "codex",
+      windows: codexWindows,
+      available: codexWindows.length > 0,
+      stale: codexUsage?.stale ?? false,
+    },
+  ];
+}
+
+/** Capacity-shaped rows for telemetry UI only. Claude reads provider-confirmed observations;
+ * internal scheduling and hold consumers continue using providerCapacityRows above. */
+export function providerDisplayCapacityRows(limits: UsageLimits | null): ProviderCapacityRow[] {
+  const codexUsage = codexTokenUsage(limits);
+  const claudeWindows = capacityWindows(claudeDisplayGauges(limits));
+  const codexWindows = capacityWindows(codexGaugeList(codexUsage));
+  return [
+    {
+      provider: "claude",
+      windows: claudeWindows,
+      available: claudeWindows.length > 0,
+      stale: claudeObservedWindows(limits) === undefined ? (limits?.stale ?? false) : false,
     },
     {
       provider: "codex",

--- a/ui/src/lib/feature-announcements/entries/v1.48.0-observed-usage-limits.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.48.0-observed-usage-limits.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "observed-usage-limits",
+  sinceVersion: "1.48.0",
+  titleKey: "feat_observed_usage_limits_title",
+  bodyKey: "feat_observed_usage_limits_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1243,6 +1243,19 @@ export interface LimitWindow {
   pct: number;
   resetAt: number;
 }
+/** A provider-confirmed usage sample. Unlike LimitWindow, this is never rolled forward locally. */
+export interface ObservedLimitWindow extends LimitWindow {
+  scrapedAt: number;
+}
+export interface ObservedLimitWindows {
+  session5h: ObservedLimitWindow | null;
+  week: ObservedLimitWindow | null;
+}
+export interface UsageRefreshStatus {
+  inProgress: boolean;
+  failed: boolean;
+  lastAttemptAt: number | null;
+}
 /**
  * Paid pay-as-you-go extra-credit overage (mirrors the server's CreditWindow).
  * The truth signal for "running into extra credits" is `spent > 0` on a FRESH
@@ -1288,6 +1301,10 @@ export interface UsageLimits {
   calibratedAt: number | null;
   /** true in api-key auth mode: usage tracking is subscription-only, meters carry no data. */
   subscriptionOnly: boolean;
+  /** Provider-confirmed Claude values for display. Presence makes these authoritative, including null. */
+  observed?: ObservedLimitWindows;
+  /** State of the Claude-only provider refresh. */
+  refresh?: UsageRefreshStatus;
   providers?: UsageProviderSnapshot[];
 }
 
@@ -1302,6 +1319,8 @@ export type UsageProviderSnapshot =
       stale: boolean;
       calibratedAt: number | null;
       subscriptionOnly: boolean;
+      /** Provider-confirmed values for display. Presence makes these authoritative, including null. */
+      observed?: ObservedLimitWindows;
     }
   | {
       provider: "codex";


### PR DESCRIPTION
## Summary

Claude usage could jump from 87% to 4% after a manual refresh because the top bar displayed locally calculated usage between infrequent provider checks. It now shows the last observed provider percentage and sample age for each window. When a reset expires, the previous percentage stays labelled as pre-reset until a new provider window is confirmed.

- Check Claude every five minutes, every minute during the final ten minutes of the five-hour window, and at the reset boundary. Opening an outdated popover refreshes it; timer and manual requests share one probe.
- Give the popover a clearer layout with Refresh at the bottom right, visible loading/error/empty states, and independent Codex timestamps.
- Keep existing internal budget estimates and holds unchanged. Observations populate from the startup probe; no database migration or configuration changes are required.

## Validation

- Root lint, typecheck, and complete test suite.
- UI Svelte check, complete tests, and EN/DE catalog parity.
- Browser checks for the refreshed popover and reset/loading/error/empty/provider-only states.
- Scoped self-review; regression coverage for stale reset labels, partial samples, concurrent refreshes, and retry scheduling.
- Full repository pre-push checks.

## Checklist

- [x] Conventional-commit title and linear branch rebased on `origin/main`.
- [x] User-facing strings are present in both locale catalogs.
- [x] Feature announcement included for the next release.
- [x] UI uses the existing design tokens.


## Scope clarification

The initial request was mockup-first. The operator subsequently instructed: “Plan approved. Execute `.shepherd-plan.md` now, autonomously — implement it fully, commit, push, and open a pull request (`gh pr create`).” This PR implements that authorized scope.

The implementing agent failed to update the session plan at that transition, leaving contradictory design-only wording for the critic to review. The plan and visual sidecar have now been corrected retrospectively, and the [author clarification](https://github.com/erwins-enkel/shepherd/pull/2222#issuecomment-5602325432) records the documentation error. This clarification does not declare the critic's finding resolved; it supplies the missing context for reassessment.
