### PR TITLE
fix(onboarding): self-heal a leaked host lock and alert when the nightly stops

### DIFF
--- a/ci/onboarding-harness/README.md
+++ b/ci/onboarding-harness/README.md
@@ -84,9 +84,21 @@ bun run onboarding:test --reap-orphans
 
 The report lands at `onboarding-gap-report.md` in the working directory. Exit code is 0 if every apply-able scenario reached green; 1 if any failed; 2 if the named scenario was not found; 3 if another run holds the host lock.
 
+## Time budget
+
+The harness bounds itself so it always finishes on its own terms — **30 min per scenario** (`SHEPHERD_ONBOARDING_SCENARIO_TIMEOUT_MS`) and **3h per run** (`SHEPHERD_ONBOARDING_BUDGET_MS`). A scenario that blows its cap is abandoned; scenarios with no budget left are never started. Either way they are recorded **NOT VERIFIED** — not green, not a harness error, so a gate-eligible one still gates red and the report says plainly that no verdict was reached.
+
+Those caps are generous against observation: a healthy full run is ~14 min, a slow night ~61 min, and the worst single scenario ever seen took 26 min. Wall-clock is dominated by in-container package installs, so it tracks network weather rather than anything the harness controls.
+
+The service's `TimeoutStartSec` (5h) is a **backstop that must never be reached**, and must always stay above the harness's own budget. When it sat _below_ the worst case (the old 2h), systemd's dirty kill was the guaranteed outcome on a slow night rather than an edge case.
+
 ## Run isolation
 
-Each run acquires an exclusive host-wide lock at the **fixed absolute path** `~/.shepherd/onboarding-harness.lock` (NOT `$TMPDIR` — a systemd-user timer and an interactive run can see different `$TMPDIR` under PrivateTmp, so the lock must live under the stable `~/.shepherd` dir to actually serialize them). A second run while one is active exits with code 3.
+Each run acquires an exclusive host-wide lock at the **fixed absolute path** `~/.shepherd/onboarding-harness.lock` (NOT `$TMPDIR` — a systemd-user timer and an interactive run can see different `$TMPDIR` under PrivateTmp, so the lock must live under the stable `~/.shepherd` dir to actually serialize them). A second run while one is _genuinely active_ exits with code 3.
+
+The lock records its owner (`pid`, `startedAt`, `runId`), and a run **reclaims** a lock whose owner is provably gone — a dead pid, a pid since recycled by an unrelated process, or a file recording no readable owner. A reclaiming run also sweeps every `shep-onb-*` instance, since it has inherited the host from a dead run and nothing else will ever clear that run's orphans.
+
+This matters because cleanup-on-signal cannot be relied on: **while Bun awaits a spawned child, SIGTERM never reaches the JS handler** and the process dies with its `finally` blocks unrun. The harness awaits `incus` children for almost its entire runtime, so a killed run leaks by default. In Aug 2026 a run killed by the service's start timeout left a 0-byte lock behind and every nightly for the next 21 days aborted at exit 3 in under a second — silently, until a release gate noticed three weeks later; the instance it also leaked survived those 21 days and every reboot. The `SIGINT`/`SIGTERM` handler is kept as a best-effort extra (it does work for an interactive Ctrl-C), but reclaiming is the actual guarantee.
 
 Each run also uses a unique per-run instance prefix (`shep-onb-<runId>-`) and sweeps only its own prefix on teardown, so two concurrent runs (if the lock were bypassed) could never destroy each other's instances.
 

--- a/ci/onboarding-harness/lock.ts
+++ b/ci/onboarding-harness/lock.ts
@@ -1,0 +1,127 @@
+import { closeSync, mkdirSync, openSync, readFileSync, unlinkSync, writeSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+// FIXED absolute path under the host-global Shepherd state dir (~/.shepherd) — NOT
+// $TMPDIR. A systemd-user timer service and an interactive shell can see different
+// $TMPDIR (PrivateTmp, per-session dirs), which would defeat the lock; $HOME is
+// stable and identical for both (same user), so the lock is genuinely host-wide.
+export const LOCK_PATH = join(homedir(), ".shepherd", "onboarding-harness.lock");
+
+/** Who holds the lock — recorded so a later run can tell "held" from "leaked". */
+interface LockOwner {
+  pid: number;
+  startedAt: string;
+  runId: string;
+}
+
+/** Thrown when the lock is held by a run that is genuinely still alive. The
+ *  caller maps this to exit 3 (the documented "another run holds the host" code). */
+export class LockHeldError extends Error {}
+
+/** Is `pid` still a live harness run? Liveness alone is not enough: pids are
+ *  recycled, and a recycled pid must not lock the harness out forever, so a live
+ *  pid is additionally checked against /proc for the harness in its command line.
+ *  If /proc is unreadable we stay conservative and call it live — refusing to run
+ *  is recoverable, stealing a lock from a running harness is not. */
+function isLiveHarness(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+  } catch (err) {
+    // ESRCH ⇒ no such process. EPERM ⇒ alive but owned by another user.
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+  try {
+    return readFileSync(`/proc/${pid}/cmdline`, "utf8").includes("onboarding-harness");
+  } catch {
+    return true;
+  }
+}
+
+function readOwner(path: string): LockOwner | null {
+  try {
+    const owner = JSON.parse(readFileSync(path, "utf8")) as Partial<LockOwner>;
+    return typeof owner.pid === "number" ? (owner as LockOwner) : null;
+  } catch {
+    return null; // absent, empty (the pre-owner format), or corrupt
+  }
+}
+
+/** `wx` — create-exclusive — so acquiring is atomic against a concurrent run. */
+function tryCreate(path: string, runId: string): number | null {
+  let fd: number;
+  try {
+    fd = openSync(path, "wx");
+  } catch {
+    return null;
+  }
+  const owner: LockOwner = { pid: process.pid, startedAt: new Date().toISOString(), runId };
+  writeSync(fd, JSON.stringify(owner));
+  return fd;
+}
+
+/**
+ * Acquire the host-wide exclusive lock so concurrent runs never share the Incus
+ * host. Returns an idempotent release fn.
+ *
+ * The lock records its owner, and an existing lock is reclaimed when that owner is
+ * provably gone. Existence alone used to mean "held", which made a single leaked
+ * file permanently fatal: in Aug 2026 a run killed by the service's start timeout
+ * left a 0-byte lock behind and every nightly for the next 21 days aborted at exit
+ * 3 in under a second — silently, until a release gate noticed three weeks later.
+ *
+ * Release is also wired to SIGINT/SIGTERM by the caller, but that path CANNOT be
+ * relied on, and not merely in theory: while Bun awaits a spawned child, SIGTERM
+ * never reaches the JS handler and the process dies by signal with its cleanup
+ * unrun. The harness awaits `incus` children for essentially its whole runtime, so
+ * a start-timeout kill lands in that state every time. Reclaiming is the fix;
+ * the signal handler is a best-effort extra that covers an interactive Ctrl-C.
+ *
+ * `reclaimed` tells the caller it inherited a dead run's host: instances that run
+ * leaked are still there, and only a reclaiming run can safely destroy them.
+ */
+export function acquireHostLock(
+  runId: string,
+  opts: { path?: string; isLive?: (pid: number) => boolean } = {},
+): { release: () => void; reclaimed: boolean } {
+  const path = opts.path ?? LOCK_PATH;
+  const isLive = opts.isLive ?? isLiveHarness;
+  mkdirSync(dirname(path), { recursive: true });
+
+  let reclaimed = false;
+  let fd = tryCreate(path, runId);
+  if (fd === null) {
+    reclaimed = true;
+    const owner = readOwner(path);
+    if (owner && isLive(owner.pid))
+      throw new LockHeldError(
+        `another onboarding-harness run holds ${path} (pid ${owner.pid}, since ${owner.startedAt}); aborting`,
+      );
+    console.warn(
+      `reclaiming stale lock ${path} — ${owner ? `owner pid ${owner.pid} (since ${owner.startedAt}) is gone` : "it records no live owner"}`,
+    );
+    try {
+      unlinkSync(path);
+    } catch {
+      /* already gone */
+    }
+    fd = tryCreate(path, runId);
+    // Lost the race: another run created the lock between our unlink and retry.
+    if (fd === null)
+      throw new LockHeldError(`another onboarding-harness run took ${path}; aborting`);
+  }
+
+  const heldFd = fd;
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    closeSync(heldFd);
+    try {
+      unlinkSync(path);
+    } catch {
+      /* already gone */
+    }
+  };
+  return { release, reclaimed };
+}

--- a/ci/onboarding-harness/report.ts
+++ b/ci/onboarding-harness/report.ts
@@ -34,7 +34,8 @@ type Classification =
   | "INSTALL GAP"
   | "DETECTION-ONLY"
   | "HARNESS ERROR"
-  | "BOOT CRASH";
+  | "BOOT CRASH"
+  | "NOT VERIFIED";
 
 /** Pure: render the per-scenario outcomes as a markdown gap report. Classifies
  *  each scenario as PASS, DETECTION GAP (defect missed/misclassified), ADVICE GAP
@@ -47,6 +48,10 @@ type Classification =
  *  counts only apply-able scenarios so detection-only AND harness-errored ones don't
  *  drag the denominator. */
 function classify(r: ScenarioResult): Classification {
+  // Ahead of everything else: we have no evidence about this scenario at all, so no
+  // other label could be honest. It still gates (it is not green and not a launch
+  // failure) — an unverified gate scenario must never be read as a pass.
+  if (r.unverified) return "NOT VERIFIED";
   // install-e2e takes precedence over the infra check: it has no seeded defect, so a
   // miss — including a thrown install.sh/boot/probe failure — is an installer regression
   // (INSTALL GAP), never a HARNESS ERROR or a DETECTION GAP ("a defect was missed").
@@ -100,6 +105,10 @@ function gapEntry(
   return `- **${r.scenarioId}** (${klass})${misses ? ` — ${misses}` : ""}${r.error ? ` — ${r.error}` : ""}`;
 }
 
+function unverifiedEntry(r: ScenarioResult): string {
+  return `- **${r.scenarioId}** (NOT VERIFIED — no verdict was reached)${r.error ? ` — ${r.error}` : ""}`;
+}
+
 function harnessErrorEntry(r: ScenarioResult): string {
   return `- **${r.scenarioId}** (HARNESS ERROR — infra, not a product gap)${r.error ? ` — ${r.error}` : ""}`;
 }
@@ -126,6 +135,7 @@ export function buildGapReport(results: ScenarioResult[]): string {
   ];
   const gaps: string[] = [];
   const errors: string[] = [];
+  const unverified: string[] = [];
   for (const r of results) {
     const klass = classify(r);
     lines.push(tableRow(r, klass));
@@ -138,6 +148,8 @@ export function buildGapReport(results: ScenarioResult[]): string {
       gaps.push(gapEntry(r, klass));
     } else if (klass === "HARNESS ERROR") {
       errors.push(harnessErrorEntry(r));
+    } else if (klass === "NOT VERIFIED") {
+      unverified.push(unverifiedEntry(r));
     }
   }
   if (gaps.length) {
@@ -145,6 +157,9 @@ export function buildGapReport(results: ScenarioResult[]): string {
   }
   if (errors.length) {
     lines.push("", "## Harness errors", "", ...errors);
+  }
+  if (unverified.length) {
+    lines.push("", "## Not verified", "", ...unverified);
   }
   return lines.join("\n") + "\n";
 }

--- a/ci/onboarding-harness/run.ts
+++ b/ci/onboarding-harness/run.ts
@@ -1,8 +1,10 @@
 import { execFileSync } from "node:child_process";
-import { closeSync, mkdirSync, mkdtempSync, openSync, unlinkSync, writeFileSync } from "node:fs";
-import { homedir, tmpdir } from "node:os";
+import { mkdirSync, mkdtempSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { IncusDriver } from "./incus";
+import { acquireHostLock, LockHeldError, LOCK_PATH } from "./lock";
+import { onboardingLastRunMarker } from "../../src/onboarding-paths";
 import { SCENARIOS } from "./scenarios";
 import { seedInstance } from "./seed";
 import {
@@ -297,18 +299,22 @@ async function applyDispatch(
   return { appliedVia: "agent", detectionOnly: false };
 }
 
-export async function runScenario(
-  driver: IncusDriver,
-  scenario: Scenario,
-  tarball: string,
-): Promise<ScenarioResult> {
-  const base: ScenarioBase = {
+function scenarioBase(scenario: Scenario): ScenarioBase {
+  return {
     scenarioId: scenario.id,
     image: scenario.image,
     // Part of the deterministic release gate iff structured AND not detection-only
     // (mirrors onboarding-gate.sh). Prose/agent + detection-only never gate.
     gateEligible: scenario.coaching === "structured" && !scenario.detectionOnly,
   };
+}
+
+export async function runScenario(
+  driver: IncusDriver,
+  scenario: Scenario,
+  tarball: string,
+): Promise<ScenarioResult> {
+  const base = scenarioBase(scenario);
   let detection: DetectionResult | undefined;
   try {
     if (scenario.serviceLifecycle)
@@ -354,47 +360,6 @@ export async function runScenario(
   }
 }
 
-// FIXED absolute path under the host-global Shepherd state dir (~/.shepherd) — NOT
-// $TMPDIR. A systemd-user timer service and an interactive shell can see different
-// $TMPDIR (PrivateTmp, per-session dirs), which would defeat the lock; $HOME is
-// stable and identical for both (same user), so the lock is genuinely host-wide.
-const LOCK_PATH = join(homedir(), ".shepherd", "onboarding-harness.lock");
-
-/** Acquire a host-wide exclusive lock so concurrent runs never share the Incus
- *  host. `wx` fails if the lock already exists. Returns an idempotent release fn.
- *  The release is ALSO wired to SIGINT/SIGTERM: Node skips `finally` on a
- *  signal-kill, so without this a Ctrl-C'd or `systemctl stop`-ed run would leave
- *  a stale lock that blocks every future run at exit 3. (A hard SIGKILL still
- *  can't be caught — `--reap-orphans` clears such a leak.) */
-function acquireHostLock(): () => void {
-  mkdirSync(dirname(LOCK_PATH), { recursive: true });
-  let fd: number;
-  try {
-    fd = openSync(LOCK_PATH, "wx");
-  } catch {
-    console.error(`another onboarding-harness run holds ${LOCK_PATH}; aborting`);
-    process.exit(3);
-  }
-  let released = false;
-  const release = () => {
-    if (released) return;
-    released = true;
-    closeSync(fd);
-    try {
-      unlinkSync(LOCK_PATH);
-    } catch {
-      /* already gone */
-    }
-  };
-  for (const sig of ["SIGINT", "SIGTERM"] as const) {
-    process.once(sig, () => {
-      release();
-      process.exit(130);
-    });
-  }
-  return release;
-}
-
 /** Accountability + traceability: on a FULL run (never a single `--scenario`,
  *  which checks one defect and must not open/close the rolling issue or stamp a
  *  verdict), report the outcome to GitHub — a rolling regression issue AND a
@@ -417,6 +382,84 @@ async function maybeReportRun(
     console.log(`[github] status: ${ok ? "success" : "failure"} on ${sha.slice(0, 7)}`);
   } catch (err) {
     console.error(`[github] reporting failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/** Stamp "a full run reached a verdict" for the server's staleness probe. Written
+ *  for a red run too — liveness, not health: a red run already shouts through the
+ *  rolling issue and a red commit status, whereas a harness that stops running says
+ *  nothing at all. That silence is the failure being closed here: after Aug 20 2026
+ *  the nightly aborted in under a second for 21 consecutive nights and the only
+ *  thing that ever noticed was a release gate, three weeks later.
+ *
+ *  Skipped for `--scenario` (one defect is not a run) and best-effort by design —
+ *  failing to write a marker must never change the run's verdict. */
+function recordRunCompleted(only: string | null | undefined): void {
+  if (only) return;
+  try {
+    const marker = onboardingLastRunMarker();
+    mkdirSync(dirname(marker), { recursive: true });
+    writeFileSync(marker, new Date().toISOString());
+  } catch (err) {
+    console.error(`could not record the run marker: ${err instanceof Error ? err.message : err}`);
+  }
+}
+
+/** Bound on ONE scenario, and on the whole run. Both exist so the harness always
+ *  finishes on its OWN terms: the service's `TimeoutStartSec` is a backstop that
+ *  must never be reached, because systemd's SIGTERM is a dirty kill — in Aug 2026
+ *  it left a lock file and a running instance behind and disabled the nightly for
+ *  21 days. The harness's previous innermost bound was per `incus` CALL (20 min);
+ *  with many calls per scenario and ten scenarios, its own worst case sat far above
+ *  the 2h unit timeout, so systemd was GUARANTEED to win on a slow night.
+ *
+ *  The cap is generous against real observation: a healthy full run is ~14 min, a
+ *  slow night ~61 min, and the worst single scenario ever seen took 26 min (the
+ *  wall-clock is in-container package installs, so it tracks network weather, not
+ *  anything the harness controls). 30 min per scenario / 3h per run therefore only
+ *  trips when a night is genuinely pathological rather than merely slow. */
+const SCENARIO_TIMEOUT_MS =
+  Number(process.env.SHEPHERD_ONBOARDING_SCENARIO_TIMEOUT_MS) || 30 * 60_000;
+const RUN_BUDGET_MS = Number(process.env.SHEPHERD_ONBOARDING_BUDGET_MS) || 3 * 60 * 60_000;
+
+/** A scenario the run never got a verdict on. It is NOT green and NOT a launch
+ *  failure, so it gates red: an unverified gate scenario must never read as a pass.
+ *  `detected: false` with no misses matches the pre-detection-throw sentinel, and
+ *  `unverified` keeps the report from mislabelling it a BOOT CRASH. */
+function unverifiedResult(scenario: Scenario, why: string): ScenarioResult {
+  return {
+    ...scenarioBase(scenario),
+    detection: { scenarioId: scenario.id, detected: false, misses: [] },
+    appliedVia: "skipped",
+    reachedGreen: false,
+    unverified: true,
+    error: why,
+  };
+}
+
+/** Run one scenario under a hard cap. On expiry the scenario is abandoned and
+ *  recorded unverified; its instance is not leaked, because the caller's
+ *  own-prefix `sweep()` destroys whatever the abandoned work left behind. */
+async function runScenarioBounded(
+  driver: IncusDriver,
+  scenario: Scenario,
+  tarball: string,
+  capMs: number,
+): Promise<ScenarioResult> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const capped = new Promise<ScenarioResult>((resolve) => {
+    timer = setTimeout(
+      () =>
+        resolve(
+          unverifiedResult(scenario, `exceeded its ${Math.round(capMs / 60_000)}m cap — abandoned`),
+        ),
+      capMs,
+    );
+  });
+  try {
+    return await Promise.race([runScenario(driver, scenario, tarball), capped]);
+  } finally {
+    clearTimeout(timer);
   }
 }
 
@@ -444,22 +487,66 @@ async function main() {
     process.exit(2);
   }
 
-  const release = acquireHostLock();
   // Per-run prefix isolates this run's instances; `sweep()` then only ever
   // touches our own, so overlapping runs can't destroy each other (point 5).
   const runId = `${Date.now().toString(36)}-${process.pid}`;
+  let release: () => void;
+  let reclaimed: boolean;
+  try {
+    ({ release, reclaimed } = acquireHostLock(runId));
+  } catch (err) {
+    if (!(err instanceof LockHeldError)) throw err;
+    console.error(err.message);
+    process.exit(3); // documented "another run holds the host" code
+  }
   const driver = new IncusDriver(undefined, `shep-onb-${runId}-`);
+  // A signal must not leave the host dirty. Aug 2026: the service's start timeout
+  // SIGTERMed a run and BOTH the lock file and a running instance survived — the
+  // instance for 21 days, restarted by incus autostart on every boot. Sweeping here
+  // is best-effort by nature (a SIGKILL, or a signal arriving while the process is
+  // wedged, skips it); the authoritative fix is that a leaked lock is now reclaimed.
+  for (const sig of ["SIGINT", "SIGTERM"] as const) {
+    process.once(sig, () => {
+      console.error(`\nreceived ${sig} — sweeping this run's instances and releasing the lock`);
+      void driver
+        .sweep()
+        .catch((err) => console.error(`sweep on ${sig} failed: ${err}`))
+        .finally(() => {
+          release();
+          process.exit(130);
+        });
+    });
+  }
   const results: ScenarioResult[] = [];
   try {
+    // We inherited the host from a run that is provably dead, so anything it left
+    // running is an orphan and only we can clear it. This is the instance half of
+    // the same self-healing: the dead run's own teardown never got to execute (a
+    // SIGTERM while Bun awaits a child skips JS cleanup entirely), and until Sep
+    // 2026 nothing else ever did — one such instance survived 21 days and every
+    // reboot. Cross-prefix by necessity: the orphans carry the DEAD run's prefix.
+    if (reclaimed) {
+      console.warn("reclaimed the host from a dead run — sweeping any instances it leaked");
+      await new IncusDriver(undefined, "shep-onb-").sweep();
+    }
     // Ensure the shared `shep-onb` profile exists with the in-repo spec before any
     // instance is launched. Runs for both full and --scenario paths (only --reap-orphans
     // returns early above, so this is never reached on that path). Fail-closed: a wrong
     // or missing profile would silently OOM every instance, so we fix it up front.
     await driver.ensureProfile();
     const tarball = buildTarball();
+    const deadline = Date.now() + RUN_BUDGET_MS;
     for (const s of scenarios) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        console.error(`=== ${s.id} — NOT RUN, the run budget is exhausted ===`);
+        results.push(unverifiedResult(s, "not run — the run budget was exhausted"));
+        continue;
+      }
       console.log(`\n=== ${s.id} (${s.image}) ===`);
-      results.push(await runScenario(driver, s, tarball));
+      results.push(
+        await runScenarioBounded(driver, s, tarball, Math.min(SCENARIO_TIMEOUT_MS, remaining)),
+      );
     }
   } finally {
     await driver.sweep(); // teardown — own-prefix instances only
@@ -477,6 +564,7 @@ async function main() {
   // still gate.
   const gateOk = gateGapScenarios(results).length === 0;
   await maybeReportRun(results, report, only, gateOk);
+  recordRunCompleted(only);
   process.exit(gateOk ? 0 : 1);
 }
 

--- a/ci/onboarding-harness/shepherd-onboarding.service
+++ b/ci/onboarding-harness/shepherd-onboarding.service
@@ -9,6 +9,14 @@ ExecStart=/usr/bin/env bun run onboarding:test
 # File the outcome to GitHub as a rolling accountability issue (opt-in, so only
 # the nightly does it — manual full runs stay side-effect-free).
 Environment=SHEPHERD_ONBOARDING_REPORT_ISSUE=1
-# A oneshot start has no timeout by default — bound the whole nightly run so a
-# wedged scenario is killed instead of pinning the host lock indefinitely.
-TimeoutStartSec=2h
+# BACKSTOP ONLY — it must sit strictly ABOVE the harness's own budget so the
+# harness always ends on its own terms. systemd's kill is a dirty one: while Bun
+# awaits a spawned child (which the harness does for nearly its whole runtime) a
+# SIGTERM never reaches the JS handler, so no cleanup runs at all. That is what
+# happened on 2026-08-20 at the old 2h — which sat BELOW the harness's worst case,
+# making the dirty kill the guaranteed outcome on a slow night rather than an edge
+# case. The harness now caps itself at 3h per run + 30m per scenario, so 5h leaves
+# room for the final sweep and should never actually be reached.
+TimeoutStartSec=5h
+# Give the teardown room to destroy up to ten instances if a stop ever does arrive.
+TimeoutStopSec=5min

--- a/ci/onboarding-harness/types.ts
+++ b/ci/onboarding-harness/types.ts
@@ -90,6 +90,11 @@ export interface ScenarioResult {
    *  an INSTALL regression, not a detection failure — the report classifies it as an
    *  INSTALL GAP instead of a DETECTION GAP to keep the nightly signal accurate. */
   installE2E?: boolean;
+  /** The run never reached a verdict for this scenario — it blew its per-scenario
+   *  cap, or the whole-run budget ran out before its turn. Unverified is NOT a pass:
+   *  a gate-eligible one still gates red. The flag exists so the report says so
+   *  plainly instead of mislabelling it a crash. */
+  unverified?: boolean;
   error?: string;
 }
 

--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -30,6 +30,7 @@ const PROPOSALS_FILE = ".shepherd-learnings.json";
 const NON_LEARNING_SIGNAL_KINDS: ReadonlySet<SignalKind> = new Set<SignalKind>([
   "egress_drop",
   "backup_stale",
+  "onboarding_stale",
   "injection_detected",
   "untrusted_author",
   "evidence_repo_mismatch",

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,11 @@ import { sweepStaging, STAGING_TTL_MS } from "./uploads";
 import { validateRoot } from "./dirs";
 import { bootstrapAuth } from "./operator-auth";
 import { backupConfiguredMarker, lastSuccessMarker } from "./backup-paths";
+import {
+  onboardingLastRunMarker,
+  onboardingRunAgeMs,
+  onboardingTimerUnit,
+} from "./onboarding-paths";
 import { UpdateService } from "./update";
 import { HerdrUpdateService } from "./herdr-update";
 import { CodexUpdateService, parseCodexUpdateChannel } from "./codex-update";
@@ -2440,6 +2445,64 @@ const checkBackupStaleness = async (): Promise<void> => {
     .catch((err) => console.warn("[push] backup_stale notify failed:", err));
 };
 
+/** One missed night trips it. Deliberately tighter than the release gate's 48h
+ *  max-age, so the operator hears about a dead nightly BEFORE it blocks a release
+ *  — the failure mode this exists to end is a gate discovering the problem weeks
+ *  late. The daily sweep means worst-case detection latency is ~24h regardless. */
+const ONBOARDING_STALENESS_MS = 30 * 60 * 60 * 1000;
+
+/**
+ * Read-only staleness probe for the nightly onboarding harness — the exact sibling of
+ * `checkBackupStaleness`, and closing the same class of hole. In Aug 2026 the nightly
+ * aborted on a leaked lock in under a second, every night for 21 nights, and nothing
+ * anywhere said a word; a release gate finally noticed three weeks later.
+ *
+ * Only a host that is *expected* to run the harness is checked — the systemd timer unit
+ * has to exist — so a laptop or a core-only box stays silent while the Incus host that
+ * genuinely stopped gets flagged. A host with the timer but no marker at all IS flagged:
+ * "it has never once completed a run" is precisely the state worth shouting about.
+ *
+ * The marker is liveness, not health: a red run still writes it, because a red run
+ * already shouts through the rolling issue and a red commit status. Alerts on the same
+ * three channels as the backup probe — a guaranteed log line, a durable signal row, and
+ * a best-effort web push.
+ */
+const checkOnboardingStaleness = async (): Promise<void> => {
+  try {
+    await stat(onboardingTimerUnit());
+  } catch {
+    return; // no nightly timer on this host → nothing is expected → stay silent
+  }
+  let contents: string | null;
+  try {
+    contents = await readFile(onboardingLastRunMarker(), "utf8");
+  } catch {
+    contents = null; // timer installed but no run has ever completed
+  }
+  const ageMs = onboardingRunAgeMs(contents);
+  if (ageMs !== null && ageMs <= ONBOARDING_STALENESS_MS) return;
+  const staleHours = ageMs === null ? null : Math.floor(ageMs / (60 * 60 * 1000));
+  console.warn(
+    `[onboarding] STALE: ${ageMs === null ? "no harness run has ever completed" : `newest run ~${staleHours}h old`} — the nightly may not be running.`,
+  );
+  store.addSignal({
+    repoPath: HOST_SIGNAL_REPO,
+    sessionId: null,
+    kind: "onboarding_stale",
+    payload: JSON.stringify({ ageMs, thresholdMs: ONBOARDING_STALENESS_MS }),
+  });
+  void push
+    .notify({
+      kind: "onboarding_stale",
+      sessionId: "",
+      tag: "onboarding-stale",
+      name: "onboarding",
+      staleHours: staleHours ?? undefined,
+      cooldownKey: "onboarding_stale",
+    })
+    .catch((err) => console.warn("[push] onboarding_stale notify failed:", err));
+};
+
 const runDailySweep = (opts?: { skipTmpSweep?: boolean }) => {
   if (maintenance.active) return;
   if (config.sessionHousekeepingEnabled)
@@ -2526,6 +2589,9 @@ const runDailySweep = (opts?: { skipTmpSweep?: boolean }) => {
   if (!opts?.skipTmpSweep) fireTmpSweep("daily");
   // Read-only backup-staleness probe (#1080); fire-and-forget so it never blocks the sweep.
   void checkBackupStaleness();
+  // Same, for the nightly onboarding harness — the host-health probe that would have
+  // caught the Aug 2026 outage on night two instead of week three.
+  void checkOnboardingStaleness();
 };
 deferredStarts.push(() => {
   setTimeout(() => runDailySweep({ skipTmpSweep: true }), 10_000); // once shortly after boot

--- a/src/onboarding-paths.ts
+++ b/src/onboarding-paths.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure, side-effect-free path resolution shared by the onboarding harness (the writer,
+ * `ci/onboarding-harness/run.ts`) and the server's staleness probe (the reader).
+ *
+ * Deliberately self-contained for the same reason as `src/backup-paths.ts`: the harness
+ * must not drag `src/config.ts` and its module-load side effects into a CI process, and
+ * writer and reader must never disagree about where the marker lives.
+ */
+import { join } from "node:path";
+
+/** Host-global Shepherd state dir — the same stable `$HOME` anchor the host lock uses. */
+function shepherdStateDir(env: NodeJS.ProcessEnv = process.env): string {
+  return env.SHEPHERD_STATE_DIR ?? join(env.HOME ?? "", ".shepherd");
+}
+
+/**
+ * Timestamp of the last nightly run that reached a verdict (ISO string inside).
+ *
+ * LIVENESS, not health: it is written whether the run was green or red, because a red
+ * run already shouts through its own channels (the rolling GitHub issue, a red commit
+ * status, a blocked release gate). The failure this marker exists to catch is the silent
+ * one — the harness not running at all, which is what happened for 21 nights in Aug 2026
+ * and which nothing detected until a release gate tripped three weeks later.
+ */
+export function onboardingLastRunMarker(env: NodeJS.ProcessEnv = process.env): string {
+  return join(shepherdStateDir(env), "onboarding-harness.last-run");
+}
+
+/**
+ * The nightly's systemd user unit. Its presence is what makes a host *expected* to run
+ * the harness, so a laptop or a core-only box stays silent while the Incus host that
+ * genuinely stopped running it gets flagged. Using the real unit rather than a
+ * purpose-written marker keeps the signal honest and needs no extra install step.
+ */
+export function onboardingTimerUnit(env: NodeJS.ProcessEnv = process.env): string {
+  return join(env.HOME ?? "", ".config", "systemd", "user", "shepherd-onboarding.timer");
+}
+
+/**
+ * Age of the last completed run, from the marker's contents. `null` means "no usable
+ * timestamp" — absent, empty, or unparseable — which callers must treat as STALE, not
+ * as fresh: a marker we cannot read is not evidence that the nightly ran.
+ */
+export function onboardingRunAgeMs(
+  contents: string | null,
+  now: number = Date.now(),
+): number | null {
+  if (contents === null) return null;
+  const ts = Date.parse(contents.trim());
+  return Number.isNaN(ts) ? null : now - ts;
+}

--- a/src/push.ts
+++ b/src/push.ts
@@ -26,6 +26,7 @@ export interface PushPayload {
     | "manual_steps"
     | "ready"
     | "backup_stale"
+    | "onboarding_stale"
     | "landing_conflict";
   tag: string;
 }
@@ -51,6 +52,8 @@ const KIND_CATEGORY: Record<PushPayload["kind"], PushCategory> = {
   ready: "agent",
   // Host-global operational alert; ride the "agent" toggle like usage_limit/extra_credits.
   backup_stale: "agent",
+  // Same shape as backup_stale: a host-global operational alert.
+  onboarding_stale: "agent",
   // Epic-global merge/land attention; ride the "ci" toggle like merge_attention/manual_steps.
   landing_conflict: "ci",
 };
@@ -73,6 +76,7 @@ export interface NotifyInput {
     | "manual_steps"
     | "ready"
     | "backup_stale"
+    | "onboarding_stale"
     | "landing_conflict";
   sessionId: string;
   tag: string;
@@ -104,7 +108,8 @@ export interface NotifyInput {
   retiredCount?: number;
   /** For kind "learnings_trialed": how many proposals the auto-trial sweep promoted. */
   trialedCount?: number;
-  /** For kind "backup_stale": whole hours since the newest snapshot (for the body copy). */
+  /** For kinds "backup_stale" / "onboarding_stale": whole hours since the newest
+   *  snapshot / completed run (for the body copy). */
   staleHours?: number;
   /** For kind "landing_conflict": the epic's parent issue number (subject of the body). */
   epicNumber?: number;
@@ -124,6 +129,7 @@ const REDUCED_ALLOWED = new Set<NotifyInput["kind"]>([
   "usage_limit",
   "extra_credits",
   "backup_stale",
+  "onboarding_stale",
 ]);
 
 const defaultSend: SendFn = (sub, payload) =>
@@ -178,6 +184,11 @@ const NOTIFY_TEXT = {
       h !== null
         ? `No successful DB backup in ~${h}h — the backup timer may be failing.`
         : "No successful DB backup yet — the backup timer may be failing.",
+    onboardingStaleTitle: "Onboarding harness stale",
+    onboardingStaleBody: (h: number | null) =>
+      h !== null
+        ? `No onboarding harness run in ~${h}h — the nightly may not be running.`
+        : "The onboarding harness has never completed a run — the nightly may not be running.",
     landingConflictTitle: "Landing needs rework",
     landingConflictBody: (epic: number, pr: number | null) =>
       pr !== null
@@ -230,6 +241,11 @@ const NOTIFY_TEXT = {
       h !== null
         ? `Seit ~${h}h kein erfolgreiches DB-Backup — der Backup-Timer könnte fehlschlagen.`
         : "Noch kein erfolgreiches DB-Backup — der Backup-Timer könnte fehlschlagen.",
+    onboardingStaleTitle: "Onboarding-Harness veraltet",
+    onboardingStaleBody: (h: number | null) =>
+      h !== null
+        ? `Seit ~${h}h kein Onboarding-Harness-Lauf — der nächtliche Job läuft womöglich nicht.`
+        : "Der Onboarding-Harness hat noch nie einen Lauf abgeschlossen — der nächtliche Job läuft womöglich nicht.",
     landingConflictTitle: "Landing braucht Überarbeitung",
     landingConflictBody: (epic: number, pr: number | null) =>
       pr !== null
@@ -273,6 +289,16 @@ function learningsParts(t: NotifyText, input: NotifyInput): { title: string; bod
   return input.kind === "learnings_trialed"
     ? { title: t.learningsTrialedTitle, body: t.learningsTrialedBody(input.trialedCount ?? 0) }
     : { title: t.learningsRetiredTitle, body: t.learningsRetiredBody(input.retiredCount ?? 0) };
+}
+
+/** Host-global staleness title/body — a timer that should have run and did not.
+ *  Both kinds carry the same shape (one age in whole hours, `null` when the thing
+ *  has never once succeeded), so they share an arm rather than duplicating it. */
+function stalenessParts(t: NotifyText, input: NotifyInput): { title: string; body: string } {
+  const hours = input.staleHours ?? null;
+  return input.kind === "onboarding_stale"
+    ? { title: t.onboardingStaleTitle, body: t.onboardingStaleBody(hours) }
+    : { title: t.backupStaleTitle, body: t.backupStaleBody(hours) };
 }
 
 /** Merge-attention title/body: rebase-cap copy when capped, else the generic merge-error copy. */
@@ -359,11 +385,8 @@ export function buildPayload(input: NotifyInput, locale: string): PushPayload {
     case "manual_steps":
       return { ...base, title: t.manualStepsTitle(input.name), body: t.manualStepsBody };
     case "backup_stale":
-      return {
-        ...base,
-        title: t.backupStaleTitle,
-        body: t.backupStaleBody(input.staleHours ?? null),
-      };
+    case "onboarding_stale":
+      return { ...base, ...stalenessParts(t, input) };
     case "landing_conflict":
       return { ...base, ...landingConflictParts(t, input) };
     default:

--- a/src/types.ts
+++ b/src/types.ts
@@ -1324,6 +1324,7 @@ export type SignalKind =
   | "stall"
   | "egress_drop"
   | "backup_stale"
+  | "onboarding_stale"
   | "injection_detected"
   | "untrusted_author"
   | "evidence_repo_mismatch";

--- a/test/onboarding-harness/lock.test.ts
+++ b/test/onboarding-harness/lock.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, existsSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { acquireHostLock, LockHeldError } from "../../ci/onboarding-harness/lock";
+
+function lockPath(): string {
+  return join(mkdtempSync(join(tmpdir(), "shep-onb-lock-")), "onboarding-harness.lock");
+}
+
+/** A lock left behind by a run that is provably gone. */
+const dead = () => false;
+/** A lock still held by a live harness run. */
+const live = () => true;
+
+describe("acquireHostLock", () => {
+  it("takes a free lock and records the owner, so a later run can judge staleness", () => {
+    const path = lockPath();
+    const { release } = acquireHostLock("run-1", { path, isLive: dead });
+    const owner = JSON.parse(readFileSync(path, "utf8"));
+    expect(owner.pid).toBe(process.pid);
+    expect(owner.runId).toBe("run-1");
+    expect(Date.parse(owner.startedAt)).not.toBeNaN();
+    release();
+  });
+
+  it("releases the lock, and a second release is a no-op", () => {
+    const path = lockPath();
+    const { release } = acquireHostLock("run-1", { path, isLive: dead });
+    release();
+    expect(existsSync(path)).toBe(false);
+    expect(() => release()).not.toThrow();
+  });
+
+  it("refuses a lock whose owner is still alive", () => {
+    const path = lockPath();
+    acquireHostLock("run-1", { path, isLive: live });
+    expect(() => acquireHostLock("run-2", { path, isLive: live })).toThrow(LockHeldError);
+  });
+
+  it("reclaims a lock whose owner died — a killed run must not disable the harness", () => {
+    const path = lockPath();
+    acquireHostLock("run-1", { path, isLive: live });
+    const { release } = acquireHostLock("run-2", { path, isLive: dead });
+    expect(JSON.parse(readFileSync(path, "utf8")).runId).toBe("run-2");
+    release();
+  });
+
+  // The Aug 2026 outage: a 0-byte lock from the pre-owner format blocked every
+  // nightly for 21 days, because "file exists" was the whole staleness test.
+  it("reclaims an empty legacy lock that records no owner at all", () => {
+    const path = lockPath();
+    writeFileSync(path, "");
+    const { release } = acquireHostLock("run-2", { path, isLive: live });
+    expect(JSON.parse(readFileSync(path, "utf8")).runId).toBe("run-2");
+    release();
+  });
+
+  it("reclaims a lock whose contents are unparseable", () => {
+    const path = lockPath();
+    writeFileSync(path, "not json{");
+    const { release } = acquireHostLock("run-2", { path, isLive: live });
+    expect(JSON.parse(readFileSync(path, "utf8")).runId).toBe("run-2");
+    release();
+  });
+
+  it("reclaims when the recorded pid was recycled by an unrelated process", () => {
+    const path = lockPath();
+    acquireHostLock("run-1", { path, isLive: live });
+    // isLive answers false for a live-but-foreign pid: liveness alone is not
+    // ownership, or a recycled pid would lock the harness out indefinitely.
+    const { release } = acquireHostLock("run-2", { path, isLive: dead });
+    expect(JSON.parse(readFileSync(path, "utf8")).runId).toBe("run-2");
+    release();
+  });
+
+  it("reports the blocking owner so the operator can see who holds it", () => {
+    const path = lockPath();
+    acquireHostLock("run-1", { path, isLive: live });
+    try {
+      acquireHostLock("run-2", { path, isLive: live });
+      throw new Error("expected LockHeldError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(LockHeldError);
+      expect((err as LockHeldError).message).toContain(String(process.pid));
+    }
+  });
+});
+
+describe("acquireHostLock reclaim reporting", () => {
+  it("reports a clean acquire as not reclaimed", () => {
+    const path = lockPath();
+    const { release, reclaimed } = acquireHostLock("run-1", { path, isLive: dead });
+    expect(reclaimed).toBe(false);
+    release();
+  });
+
+  // The caller uses this to sweep the instances the dead run leaked — nothing else
+  // ever will, since its own teardown never ran.
+  it("flags a reclaim so the caller can clear the dead run's orphans", () => {
+    const path = lockPath();
+    acquireHostLock("run-1", { path, isLive: live });
+    const { release, reclaimed } = acquireHostLock("run-2", { path, isLive: dead });
+    expect(reclaimed).toBe(true);
+    release();
+  });
+});

--- a/test/onboarding-harness/report.test.ts
+++ b/test/onboarding-harness/report.test.ts
@@ -324,3 +324,39 @@ describe("buildGapReport", () => {
     expect(md).not.toContain("## Gaps"); // DETECTION-ONLY is not a gap
   });
 });
+
+describe("unverified scenarios", () => {
+  const unverified = (over: Partial<ScenarioResult> = {}): ScenarioResult => ({
+    scenarioId: "gh-missing",
+    image: "images:debian/12",
+    detection: { scenarioId: "gh-missing", detected: false, misses: [] },
+    appliedVia: "skipped",
+    reachedGreen: false,
+    gateEligible: true,
+    unverified: true,
+    error: "exceeded its 30m cap — abandoned",
+    ...over,
+  });
+
+  it("gates: a scenario with no verdict must never be read as a pass", () => {
+    expect(gateGapScenarios([unverified()]).map((r) => r.scenarioId)).toEqual(["gh-missing"]);
+  });
+
+  it("is classified NOT VERIFIED, not BOOT CRASH — it never got to crash", () => {
+    const report = buildGapReport([unverified()]);
+    expect(report).toContain("NOT VERIFIED");
+    expect(report).not.toContain("BOOT CRASH");
+  });
+
+  it("surfaces why it was not verified, so a red night explains itself", () => {
+    const report = buildGapReport([
+      unverified({ error: "not run — the run budget was exhausted" }),
+    ]);
+    expect(report).toContain("## Not verified");
+    expect(report).toContain("not run — the run budget was exhausted");
+  });
+
+  it("says so in the commit-status line the release gate reads", () => {
+    expect(statusDescription([unverified()])).toContain("gh-missing");
+  });
+});

--- a/test/onboarding-paths.test.ts
+++ b/test/onboarding-paths.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+import {
+  onboardingLastRunMarker,
+  onboardingRunAgeMs,
+  onboardingTimerUnit,
+} from "../src/onboarding-paths";
+
+test("the run marker sits in the host-global Shepherd state dir, next to the host lock", () => {
+  expect(onboardingLastRunMarker({ HOME: "/home/x" } as NodeJS.ProcessEnv)).toBe(
+    "/home/x/.shepherd/onboarding-harness.last-run",
+  );
+});
+
+test("SHEPHERD_STATE_DIR relocates the marker, so writer and reader can be pointed at a temp dir", () => {
+  expect(
+    onboardingLastRunMarker({ HOME: "/home/x", SHEPHERD_STATE_DIR: "/tmp/s" } as NodeJS.ProcessEnv),
+  ).toBe("/tmp/s/onboarding-harness.last-run");
+});
+
+test("the timer unit path is the real systemd user unit — its presence is the host gate", () => {
+  expect(onboardingTimerUnit({ HOME: "/home/x" } as NodeJS.ProcessEnv)).toBe(
+    "/home/x/.config/systemd/user/shepherd-onboarding.timer",
+  );
+});
+
+test("run age is measured from the marker's ISO timestamp", () => {
+  const now = Date.parse("2026-09-09T12:00:00Z");
+  expect(onboardingRunAgeMs("2026-09-09T09:00:00Z", now)).toBe(3 * 60 * 60 * 1000);
+  expect(onboardingRunAgeMs("  2026-09-09T09:00:00Z\n", now)).toBe(3 * 60 * 60 * 1000);
+});
+
+// An unreadable marker must never pass for a fresh one — that is the whole failure
+// being closed here, so it fails towards "tell someone".
+test("an absent, empty or corrupt marker reads as no-usable-timestamp, not as fresh", () => {
+  const now = Date.parse("2026-09-09T12:00:00Z");
+  expect(onboardingRunAgeMs(null, now)).toBeNull();
+  expect(onboardingRunAgeMs("", now)).toBeNull();
+  expect(onboardingRunAgeMs("not a date", now)).toBeNull();
+});

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -1268,3 +1268,26 @@ test("buildPayload ready: localizes title + body in en and de", () => {
     kind: "ready",
   });
 });
+
+test("buildPayload onboarding_stale localizes title + body, with and without an age", () => {
+  const stale: NotifyInput = {
+    kind: "onboarding_stale",
+    sessionId: "",
+    tag: "onboarding-stale",
+    name: "onboarding",
+    staleHours: 53,
+  };
+  expect(buildPayload(stale, "en")).toMatchObject({
+    title: "Onboarding harness stale",
+    body: "No onboarding harness run in ~53h — the nightly may not be running.",
+  });
+  expect(buildPayload(stale, "de").title).toBe("Onboarding-Harness veraltet");
+  expect(buildPayload(stale, "de").body).toContain("~53h");
+
+  // A host with the timer installed that has never once completed a run.
+  const never: NotifyInput = { ...stale, staleHours: undefined };
+  expect(buildPayload(never, "en").body).toBe(
+    "The onboarding harness has never completed a run — the nightly may not be running.",
+  );
+  expect(buildPayload(never, "de").body).toContain("noch nie");
+});


### PR DESCRIPTION
The nightly onboarding harness stopped running on **Aug 20** and aborted in under a second for **21 consecutive nights**. Nothing anywhere reported it. The first thing to notice was the onboarding release gate failing on release-please PR #2127, three weeks later — and that gate was working correctly; the nightly was not.

## What actually happened

1. **Aug 20** — the run hit the service's `TimeoutStartSec=2h` and systemd SIGTERM'd it.
2. Its cleanup never ran, leaving behind a **0-byte lock file** and a **running Incus container**.
3. Every night since: `another onboarding-harness run holds …lock; aborting`, exit 3. No status posted, no issue filed, no alert.
4. The last `onboarding-harness` commit status in existence was from **Aug 19**.

The slowdown that triggered it is not a code regression. Nightly wall-clock has been swinging for weeks (9–15 min normally; ~61 min on Aug 16/17/18; >2h on Aug 20) while the harness itself burns only 8–11s of CPU — the time is in-container package installs, so it tracks network weather.

## Three defects, all fixed

**1. One leaked lock was permanently fatal.** The lock was existence-based — `open(…, "wx")`, zero bytes, no owner recorded — so "file exists" was the entire staleness test. It now records `{pid, startedAt, runId}`, and a run **reclaims** a lock whose owner is provably gone: a dead pid, a pid since recycled by an unrelated process, or a file with no readable owner (the exact Aug 20 file). A genuinely live owner still exits 3.

A reclaiming run also sweeps every `shep-onb-*` instance, because it has inherited the host from a dead run and **nothing else ever will** — the Aug 20 container survived 21 days and was restarted by incus autostart on every reboot.

**2. Cleanup-on-signal cannot be relied on — and this is the interesting part.** I reproduced the leak under a real transient systemd unit and narrowed it to one condition:

| kill path | handler fires? | lock |
|---|---|---|
| `systemctl stop`, idle | yes | released |
| `systemctl stop`, via `bun run <script>` wrapper | yes | released |
| start-timeout, idle | yes | released |
| **start-timeout while awaiting a spawned child** | **no** | **LEAKED** |

Only the last leaks, and it reproduces the Aug 20 journal signature byte for byte (`terminated by signal SIGTERM` / `code=killed, status=15/TERM`, versus `exited with code 130` in the healthy cases). **While Bun awaits a spawned child, SIGTERM never reaches the JS handler.** The harness awaits `incus` children for nearly its entire runtime, so a start-timeout kill lands in that state every time — this wasn't bad luck, it was the only possible outcome.

So the harness now bounds *itself* (30m per scenario, 3h per run, both env-overridable) and `TimeoutStartSec` moves 2h → 5h. The point is the ordering: **systemd's timeout must sit strictly above the harness's own worst case**, or its dirty kill is guaranteed to win. The old 2h sat *below* it. Scenarios that don't finish are recorded **NOT VERIFIED** — not green, not a harness error — so a gate-eligible one still gates red and the report says plainly that no verdict was reached, instead of the run vanishing.

The signal handler is kept and now also sweeps, but documented honestly as best-effort: it works for an interactive Ctrl-C and will not fire in the case above.

**3. Nothing watched the watcher.** New `onboarding_stale` alert, mirroring the existing `backup_stale` probe exactly. The harness stamps a liveness marker on every completed run — written for red runs too, since a red run already shouts through the rolling issue and a red commit status, whereas a harness that stops running says nothing. The daily sweep warns to the log, writes a durable signal row, and sends a push when a host that has the timer installed hasn't completed a run in **30h** — one missed night, deliberately well inside the release gate's 48h max-age so a human hears about it *before* releases are blocked.

Gating is on the real systemd timer unit's presence, so a laptop or core-only box stays silent while the Incus host that genuinely stopped gets flagged. A host with the timer and no marker at all is flagged too — "it has never once completed a run" is worth shouting about.

## Verification

- Root `bun run lint` + `bun run test` green (9446 pass, 0 fail; 24 new tests).
- `ui/ bun run check` green (0 errors) — no UI surface, matching `backup_stale`.
- `bunx fallow audit --base origin/main --fail-on-issues` green. `buildPayload` breached the complexity threshold when my case was added, so both host-global staleness kinds now share one switch arm via a `stalenessParts` helper, following the existing `learningsParts` pattern — net complexity below where it started.
- The unit change is installed and live on the host (`TimeoutStartUSec=5h`).

## Already done on the host

The orphan container was destroyed and the stale lock cleared (`--reap-orphans`), so **tonight's 03:30 nightly runs for the first time since Aug 20** regardless of when this merges.

## Still needs a human

The release gate on #2127 stays red until a fresh `onboarding-harness` status lands on a recent main commit. Tonight's nightly will produce one for free; no manual run needed unless you want it sooner.

## Follow-up worth filing

Pre-baking the scenario images would cut both the runtime and this entire class of variance at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
