### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -242,7 +242,7 @@ one (a per-repo in-flight guard means at most one run per repo at a time):
 | `SHEPHERD_DOC_AGENT_ACT` | `0` (off) | **Phase-1 act.** Set `1` to escalate finalize to actually commit, push, and open the **pull request**. Meaningful only when `SHEPHERD_DOC_AGENT` is also on |
 | `SHEPHERD_DOC_AGENT_CLI` | `inherit` | Agent CLI for the doc-agent spawn: `inherit` follows the global default provider, or pin `claude` / `codex`. Seeds a fresh DB; persisted + UI-configurable |
 | `SHEPHERD_DOC_AGENT_MODEL` | `default` | Model for the doc-agent spawn: `default` follows the global default model, or pin a `<model alias>`. Seeds a fresh DB; persisted + UI-configurable |
-| `SHEPHERD_DOC_AGENT_EFFORT` | `low` | Reasoning-effort tier for the doc-agent spawn: `default` follows the CLI's own effort, or pin a tier (`low` / `medium` / `high` / `xhigh` / `max`). Seeds a fresh DB; persisted + UI-configurable |
+| `SHEPHERD_DOC_AGENT_EFFORT` | `low` | Reasoning-effort tier for the doc-agent spawn: `default` follows the CLI's own effort, or pin a tier (`low` / `medium` / `high` / `xhigh` / `max` / `ultra` — `ultra` is Codex-only). Seeds a fresh DB; persisted + UI-configurable |
 | `SHEPHERD_DOC_AGENT_NIGHTLY_HOUR` | `3` | Local hour (0–23) at/after which the nightly sweep evaluates each repo; invalid values fall back to `3` |
 
 ## Maintain loop (self-health bands)
@@ -330,7 +330,7 @@ its worktree reclaimed by the boot reconcile; the breach is re-diagnosed on the 
 | `SHEPHERD_MAINTAIN_HOUR` | `4` | Local hour (0–23) at/after which the once-a-day band sweep may run — an hour after the doc agent's nightly so the two spawns don't land together. Invalid values fall back to `4` |
 | `SHEPHERD_MAINTAIN_CLI` | `inherit` | Agent CLI for the diagnosis spawn: `inherit` follows the global default provider, or pin `claude` / `codex`. Env-only (not persisted or UI-configurable) |
 | `SHEPHERD_MAINTAIN_MODEL` | `default` | Model for the diagnosis spawn: `default` follows the global default model, or pin a `<model alias>`. Env-only |
-| `SHEPHERD_MAINTAIN_EFFORT` | `default` | Reasoning-effort tier for the diagnosis spawn: `default` follows the CLI's own effort, or pin a tier (`low` / `medium` / `high` / `xhigh` / `max`). Env-only |
+| `SHEPHERD_MAINTAIN_EFFORT` | `default` | Reasoning-effort tier for the diagnosis spawn: `default` follows the CLI's own effort, or pin a tier (`low` / `medium` / `high` / `xhigh` / `max` / `ultra` — `ultra` is Codex-only). Env-only |
 | `SHEPHERD_MAINTAIN_THRESHOLDS` | _(unset)_ | JSON object deep-merged over the threshold table above, so a recalibration ships without a deploy. Parsed field-by-field and **fail-soft**: an unparseable value or a typo in one number falls back to that default rather than disarming a band. E.g. `{"critic_error_rate":{"tier1":0.2}}`. Retunes numbers only — a band's tier-3 fix class is not overridable, because `SHEPHERD_MAINTAIN_PR` is the one switch that disarms tier 3 |
 
 ## Anonymous usage telemetry

--- a/docs-site/src/content/docs/reference/glossary.md
+++ b/docs-site/src/content/docs/reference/glossary.md
@@ -128,9 +128,12 @@ units, not raw token counts, reflect true usage.
 
 ### Reasoning effort
 
-A cost/quality dial (`low`, `medium`, `high`, `xhigh`, `max`) that sets how much
-the model reasons before answering — higher effort spends more tokens for deeper
-reasoning, lower is faster and cheaper. Selectable per session in the New Task
+A cost/quality dial (`low`, `medium`, `high`, `xhigh`, `max`, `ultra`) that sets
+how much the model reasons before answering — higher effort spends more tokens
+for deeper reasoning, lower is faster and cheaper. `max` allows deeper
+reasoning; `ultra` also uses automatic subagents. Which levels are on offer
+depends on the CLI and the model: Claude stops at `max`, and among the curated
+Codex models only the newest ones reach `ultra`. Selectable per session in the New Task
 picker — and when spawning a variant, comparison, or replacement — with a per-repo
 or global default in Settings, plus a per-role override for each satellite pass
 (critic, planner, recap, doc-agent, distiller, optimizer, merge-suggester, namer,


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc update — sync to recent source changes

## Changes

- **`docs-site/src/content/docs/reference/glossary.md`** — the **Reasoning effort**
  entry listed only `low`/`medium`/`high`/`xhigh`/`max`. `EFFORTS` in `src/types.ts`
  now ends in `ultra` (commit `e08f6ad2d`, "feat(codex): expose supported Max and
  Ultra reasoning"). Added `ultra` to the dial, plus what distinguishes it (`max`
  allows deeper reasoning, `ultra` also uses automatic subagents) and that the
  available levels depend on CLI/model — Claude stops at `max`
  (`effortsForProvider`, `src/default-effort.ts`) and only the newest curated Codex
  models reach `ultra` (`providerEfforts`, `ui/src/lib/effort-guidance.ts`). The
  wording follows the in-app tooltip definition this page mirrors
  (`gloss_reasoning_effort_def`, `ui/messages/en.json`), which the same commit updated.
- **`docs-site/src/content/docs/reference/configuration.md`** — the tier lists for
  `SHEPHERD_DOC_AGENT_EFFORT` and `SHEPHERD_MAINTAIN_EFFORT` stopped at `max`. Both
  are validated through `normalizeDefaultEffortSetting` over `EFFORTS` (`src/config.ts`
  lines 712 / 760), so `ultra` is accepted; added it to both rows, marked Codex-only.

No other in-scope page needed a change: `docs/external-task-api.md` (the `effort`
row and the `409 herdr_restart_required` response), `docs/sandbox-security.md` (the
`ui-markup` fence) and `docs-site/src/content/docs/getting-started.md` (herdr 0.9.0
as the last supported version) were already brought current by `e08f6ad2d`,
`ce9995312` and `92aa50d3d`. The env-var defaults documented in
`configuration.md` were spot-checked against `src/config.ts` and all still match.

## Uncertain / needs human judgment

- **Undocumented env vars, not stale ones.** `configuration.md` documents a subset
  of what `src/config.ts` reads. Notably absent: the global spawn defaults
  (`SHEPHERD_DEFAULT_MODEL`, `SHEPHERD_DEFAULT_CODEX_MODEL` — whose seed moved from
  `gpt-5.5` to `gpt-5.6-sol` in `df99a06ee` — `SHEPHERD_DEFAULT_EFFORT`,
  `SHEPHERD_DEFAULT_AGENT_PROVIDER`) and the whole per-role
  `*_CLI`/`*_MODEL`/`*_EFFORT` family (critic, planner, recap, distiller, optimizer,
  merge-suggest, namer, autopilot), plus e.g. `SHEPHERD_AUTH_MODE`,
  `SHEPHERD_REVIEW_CYCLES_CAP`, `SHEPHERD_AUTOPILOT_STEP_CAP`,
  `SHEPHERD_SESSION_HOUSEKEEPING`, the VAPID keys. The omission looks like a
  deliberate scope choice rather than drift, and filling it would mean authoring new
  sections, so I left it alone.
- **Glossary "Satellite pass"** names critic/PR-review, plan-gate, recap and
  doc-agent. `5fb09b027` ("add model and role breakdowns for Claude and Codex") added
  per-role usage accounting that also covers roles outside that list (e.g. the
  maintain-loop diagnosis, the stop classifier, standalone critic). Whether the
  glossary entry is meant to be exhaustive — or a deliberately short illustrative
  list — I couldn't tell, so I did not extend it.
- **`docs/token-usage-analysis.md`** is a dated snapshot report (TASK-286…295) with
  its own "honest caveats" section; the usage-instrumentation work since
  (`5fb09b027`, `84480ff73` observed usage limits/calibration) changes what *could*
  be measured but not the historical figures. Re-running
  `scripts/usage-report.ts` and re-basing the report is a human call, not a prose fix.
- **`operating.md`** has no section on the herdr-update recovery flow added in
  `1a350b1da` (Settings → Diagnose, explicit confirmation). It may belong there, but
  adding it would be new content rather than correcting stale content.