### PR TITLE
fix(onboarding): size the run budget to the harness's real runtime

### DIFF
--- a/ci/onboarding-harness/README.md
+++ b/ci/onboarding-harness/README.md
@@ -86,11 +86,11 @@ The report lands at `onboarding-gap-report.md` in the working directory. Exit co
 
 ## Time budget
 
-The harness bounds itself so it always finishes on its own terms — **30 min per scenario** (`SHEPHERD_ONBOARDING_SCENARIO_TIMEOUT_MS`) and **3h per run** (`SHEPHERD_ONBOARDING_BUDGET_MS`). A scenario that blows its cap is abandoned; scenarios with no budget left are never started. Either way they are recorded **NOT VERIFIED** — not green, not a harness error, so a gate-eligible one still gates red and the report says plainly that no verdict was reached.
+The harness bounds itself so it always finishes on its own terms — **45 min per scenario** (`SHEPHERD_ONBOARDING_SCENARIO_TIMEOUT_MS`) and **6h per run** (`SHEPHERD_ONBOARDING_BUDGET_MS`). A scenario that blows its cap is abandoned; scenarios with no budget left are never started. Either way they are recorded **NOT VERIFIED** — not green, not a harness error, so a gate-eligible one still gates red and the report says plainly that no verdict was reached.
 
-Those caps are generous against observation: a healthy full run is ~14 min, a slow night ~61 min, and the worst single scenario ever seen took 26 min. Wall-clock is dominated by in-container package installs, so it tracks network weather rather than anything the harness controls.
+Those caps are sized to the runtime the harness **actually has**, not the one it ought to have: a full run was ~14 min until Aug 2026 and is now ~4h, with every scenario taking 20–28 min ([#2229](https://github.com/erwins-enkel/shepherd/issues/2229)). Wall-clock is dominated by in-container package installs and image pulls, which the harness does not control. Sizing the caps to the old runtime would cut off a legitimate, working run and report it NOT VERIFIED — a red release gate on a healthy harness. **Bring both numbers down, with `TimeoutStartSec`, once #2229 restores the runtime.**
 
-The service's `TimeoutStartSec` (5h) is a **backstop that must never be reached**, and must always stay above the harness's own budget. When it sat _below_ the worst case (the old 2h), systemd's dirty kill was the guaranteed outcome on a slow night rather than an edge case.
+The service's `TimeoutStartSec` (7h) is a **backstop that must never be reached**, and must always stay above the harness's own budget. When it sat _below_ the worst case (the old 2h), systemd's dirty kill was the guaranteed outcome on a slow night rather than an edge case.
 
 ## Run isolation
 

--- a/ci/onboarding-harness/run.ts
+++ b/ci/onboarding-harness/run.ts
@@ -407,20 +407,27 @@ function recordRunCompleted(only: string | null | undefined): void {
 
 /** Bound on ONE scenario, and on the whole run. Both exist so the harness always
  *  finishes on its OWN terms: the service's `TimeoutStartSec` is a backstop that
- *  must never be reached, because systemd's SIGTERM is a dirty kill — in Aug 2026
- *  it left a lock file and a running instance behind and disabled the nightly for
+ *  must never be reached, because systemd's SIGTERM is a dirty kill — while Bun
+ *  awaits a spawned child (which the harness does for nearly its whole runtime) a
+ *  SIGTERM never reaches the JS handler, so no cleanup runs at all. In Aug 2026
+ *  that left a lock file and a running instance behind and disabled the nightly for
  *  21 days. The harness's previous innermost bound was per `incus` CALL (20 min);
  *  with many calls per scenario and ten scenarios, its own worst case sat far above
  *  the 2h unit timeout, so systemd was GUARANTEED to win on a slow night.
  *
- *  The cap is generous against real observation: a healthy full run is ~14 min, a
- *  slow night ~61 min, and the worst single scenario ever seen took 26 min (the
- *  wall-clock is in-container package installs, so it tracks network weather, not
- *  anything the harness controls). 30 min per scenario / 3h per run therefore only
- *  trips when a night is genuinely pathological rather than merely slow. */
+ *  The caps are sized to the runtime the harness ACTUALLY has, not the one it ought
+ *  to have. A healthy full run used to be ~14 min; it is now ~4h (every scenario
+ *  20-28 min, see #2229) because the time is spent on in-container package installs
+ *  and image pulls, which the harness does not control. Sizing these to the old
+ *  runtime would cut off a legitimate, working run and report it NOT VERIFIED —
+ *  a red release gate on a healthy harness. **Bring both numbers back down (and
+ *  `TimeoutStartSec` with them) once #2229 restores the runtime.**
+ *
+ *  Because the per-scenario cap is `min(cap, budget remaining)`, total runtime is
+ *  bounded by the run budget itself; the backstop only needs headroom for teardown. */
 const SCENARIO_TIMEOUT_MS =
-  Number(process.env.SHEPHERD_ONBOARDING_SCENARIO_TIMEOUT_MS) || 30 * 60_000;
-const RUN_BUDGET_MS = Number(process.env.SHEPHERD_ONBOARDING_BUDGET_MS) || 3 * 60 * 60_000;
+  Number(process.env.SHEPHERD_ONBOARDING_SCENARIO_TIMEOUT_MS) || 45 * 60_000;
+const RUN_BUDGET_MS = Number(process.env.SHEPHERD_ONBOARDING_BUDGET_MS) || 6 * 60 * 60_000;
 
 /** A scenario the run never got a verdict on. It is NOT green and NOT a launch
  *  failure, so it gates red: an unverified gate scenario must never read as a pass.

--- a/ci/onboarding-harness/shepherd-onboarding.service
+++ b/ci/onboarding-harness/shepherd-onboarding.service
@@ -15,8 +15,12 @@ Environment=SHEPHERD_ONBOARDING_REPORT_ISSUE=1
 # SIGTERM never reaches the JS handler, so no cleanup runs at all. That is what
 # happened on 2026-08-20 at the old 2h — which sat BELOW the harness's worst case,
 # making the dirty kill the guaranteed outcome on a slow night rather than an edge
-# case. The harness now caps itself at 3h per run + 30m per scenario, so 5h leaves
+# case. The harness now caps itself at 6h per run + 45m per scenario, so 7h leaves
 # room for the final sweep and should never actually be reached.
-TimeoutStartSec=5h
+#
+# Those numbers are sized to the runtime the harness ACTUALLY has: a full run was
+# ~14 min until Aug 2026 and is now ~4h (see #2229). Bring this back down with the
+# harness's own budget once that is fixed — it only has to stay above it.
+TimeoutStartSec=7h
 # Give the teardown room to destroy up to ten instances if a stop ever does arrive.
 TimeoutStopSec=5min


### PR DESCRIPTION
Follow-up to #2226, which merged while this session was still running. It fixes a defect in that PR's numbers — mine.

## The problem

#2226 gave the harness a self-imposed budget so it always terminates on its own terms instead of being killed dirty by systemd. That mechanism is right. **The numbers were not.** I sized them (3h per run, 30 min per scenario) against the harness's *historical* runtime of ~14 minutes, with the worst single scenario ever observed at 26 minutes.

The **Sep 10 nightly** — the first real run since Aug 20 — took **~4 hours** for the same ten scenarios, with *every* scenario in the 20–28 minute band:

```
gh-unauthed        26 min      claude-missing     22 min
gh-missing         28 min      git-missing        11 min
tailscale-missing  26 min      node-too-old       28 min
herdr-missing      20 min      install-e2e        (9th of 10, still running at 3h03m)
herdr-outdated     20 min
```

Under #2226 as merged, that healthy, working run would have been **cut off at 3h with scenarios reported NOT VERIFIED — a red release gate on a harness that was doing its job.** I would have replaced a nightly that fails silently with one that fails loudly and wrongly, which is not obviously an improvement.

It is not live yet: the host checkout hasn't pulled main, so tonight ran the old unbounded code under the new 5h backstop and finished fine. The next deploy is what would arm it.

## The change

Budget 3h → **6h**, per-scenario 30m → **45m**, `TimeoutStartSec` 5h → **7h**.

The ordering that actually matters is unchanged and still holds: the systemd backstop sits strictly above the harness's own bound, so the harness always ends cleanly and the dirty kill stays unreachable. Because the per-scenario cap is `min(cap, budget remaining)`, total runtime is bounded by the run budget itself and the backstop only needs teardown headroom.

These are deliberately sized to the runtime the harness **actually has**, not the one it ought to have. #2229 tracks the ~16x degradation itself — host CPU is 92–97% idle, disk is fine, and the host pulls 17 MB/s, so the time is going into in-container package installs and per-run image pulls. **Bring all three numbers back down once #2229 lands**; the code and the unit both say so at the point where the values are defined.

## Why a second PR

This session already shipped #2226 and normally stops there. Filing this as an issue instead would leave a known-wrong budget on main that turns the release gate red on the next deploy — worse than the sprawl. It's a three-value change plus comments.

## Verification

Root lint + `bun run test` green (9447 pass, 0 fail); `ui/ bun run check` 0 errors and `ui/ bun run test` 4977 pass; `fallow audit` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


```shepherd:manual-steps
- [ ] POST-MERGE: install the updated unit on the Incus host — `cp ci/onboarding-harness/shepherd-onboarding.{service,timer} ~/.config/systemd/user/ && systemctl --user daemon-reload` (the running host currently has TimeoutStartSec=5h from #2226; this PR raises it to 7h, and the unit is not deployed by `bun run update`)
```
