### PR TITLE
fix(forge): resolve the viewer over both gh transports, keep a failure retryable (#2140)

### DIFF
--- a/src/forge/gitea.ts
+++ b/src/forge/gitea.ts
@@ -2,6 +2,7 @@ import { mapGiteaActionStatus, mapStatusState } from "./checks";
 import { classifyPr } from "./pr-kind";
 import { labelColorsFrom } from "./labels";
 import { mapBounded } from "../map-bounded";
+import { makeUserCache } from "./user-cache";
 import type {
   ChecksState,
   ForgeConfig,
@@ -183,20 +184,19 @@ export class GiteaForge implements GitForge {
     }
   }
 
-  private cachedUser: string | null | undefined;
-  /** The authenticated Gitea login (`GET /api/v1/user`), cached for the forge's
-   *  lifetime — it never changes mid-session. Drives the "mine & unassigned" issue
-   *  filter (#824) so the chip is live on Gitea too, not just GitHub. Null when it
-   *  can't be resolved (no token / network error) → fail open (show all). */
+  /** The authenticated Gitea login (`GET /api/v1/user`). Drives the "mine & unassigned"
+   *  issue filter (#824) so the chip is live on Gitea too, not just GitHub. A resolved
+   *  login is cached for the forge's lifetime (it never changes mid-session); a failure
+   *  (no token / network error) reads as "unknown me" → fail open (show all), and stays
+   *  retryable rather than pinning the viewer to null until a restart (#2140). Gitea has
+   *  a single transport, so there is no second one to fall back to. */
+  private readonly resolveUser = makeUserCache(async () => {
+    const u = (await this.req("GET", "/api/v1/user")) as { login?: string } | null;
+    return u?.login || null;
+  });
+
   async currentUser(): Promise<string | null> {
-    if (this.cachedUser !== undefined) return this.cachedUser;
-    try {
-      const u = (await this.req("GET", "/api/v1/user")) as { login?: string } | null;
-      this.cachedUser = u?.login || null;
-    } catch {
-      this.cachedUser = null; // unauth / offline → treat as "unknown me"
-    }
-    return this.cachedUser;
+    return this.resolveUser();
   }
 
   /** One combined-status call yields both the worst-of rollup (top-level `state`)

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -10,6 +10,7 @@ import {
   runningCheckNames,
 } from "./checks";
 import { classifyPr } from "./pr-kind";
+import { makeUserCache } from "./user-cache";
 import { labelColorsFrom } from "./labels";
 import {
   attachAttempts,
@@ -1678,17 +1679,42 @@ export class GithubForge implements GitForge {
       .map((r) => r.slice("refs/heads/".length));
   }
 
-  private cachedUser: string | null | undefined;
-  /** The authenticated gh login (`gh api user`), cached for the forge's lifetime —
-   *  it never changes mid-session, so one call serves every handoff computation. */
+  /** `gh api user` — the REST-bucket transport for {@link currentUser}. */
+  private async currentUserRest(): Promise<string | null> {
+    return (await this.run(["api", "user", "--jq", ".login"])).trim() || null;
+  }
+
+  /** `gh api graphql {viewer{login}}` — the GraphQL-bucket transport for
+   *  {@link currentUser}. */
+  private async currentUserGraphql(): Promise<string | null> {
+    const out = await this.run(["api", "graphql", "-f", "query=query{viewer{login}}"]);
+    const json = JSON.parse(out || "null") as { data?: { viewer?: { login?: string } } } | null;
+    return json?.data?.viewer?.login?.trim() || null;
+  }
+
+  /**
+   * The authenticated gh login, over whichever transport answers.
+   *
+   * REST first (`gh api user`), then GraphQL (`{viewer{login}}`) on ANY failure or on
+   * an answer that carries no login. The two draw on INDEPENDENT GitHub budgets, so
+   * either can be exhausted while the other is healthy — observed live on #2139, where
+   * every REST call 403'd while `gh api graphql` answered normally. The order is fixed
+   * rather than flipped on `graphRateLimit.blocked()` the way `listIssues` does it:
+   * that signal describes the GraphQL bucket only, and there is no REST-side tracker to
+   * argue for GraphQL-first. The fallback runs even inside an active GraphQL backoff —
+   * REST has just proved unusable and the backoff is only a heuristic (the same
+   * trade-off `listIssues`' REST→CLI direction makes).
+   *
+   * A resolved login is cached for the forge's lifetime; a failure only until a short
+   * TTL elapses. See {@link makeUserCache} for why the failure must stay retryable.
+   */
+  private readonly resolveUser = makeUserCache(async () => {
+    const rest = await this.currentUserRest().catch(() => null);
+    return rest ?? (await this.currentUserGraphql());
+  });
+
   async currentUser(): Promise<string | null> {
-    if (this.cachedUser !== undefined) return this.cachedUser;
-    try {
-      this.cachedUser = (await this.run(["api", "user", "--jq", ".login"])).trim() || null;
-    } catch {
-      this.cachedUser = null; // unauth / offline → treat as "unknown me"
-    }
-    return this.cachedUser;
+    return this.resolveUser();
   }
 
   /** Whether the authenticated user can push. Returns a DEFINITIVE boolean only;

--- a/src/forge/user-cache.ts
+++ b/src/forge/user-cache.ts
@@ -1,0 +1,48 @@
+/**
+ * Cache for a forge's "who am I" lookup — the operator's own login, which drives the
+ * "mine & unassigned" issue filter (#824).
+ *
+ * Caching is **asymmetric**, mirroring `makeForgeMemo` in ./resolve.ts:
+ *  - **Positive** (a login) is cached for the process lifetime. The authenticated
+ *    identity never changes mid-session, so one lookup serves every caller.
+ *  - **Negative** (the probe threw, or answered without a login) is cached only for
+ *    `negativeTtlMs`, then re-probed. This is the #2140 fix: remembering a FAILURE for
+ *    the forge's lifetime — and forge instances are memoised per process — let a single
+ *    ill-timed 403 pin the viewer to `null` until a restart, silently turning the filter
+ *    into "show everything" with no chip and no explanation.
+ *
+ * The TTL is what makes the retry affordable: `pr-poller`'s `refresh()` resolves the
+ * viewer for every session on every sweep, so an unbounded retry would mean a fresh
+ * probe per session per tick while the forge is unreachable.
+ *
+ * `now` is injectable purely so tests can drive the TTL deterministically.
+ */
+
+/** Default window before a failed resolution is re-probed. Matches `makeForgeMemo`'s. */
+const DEFAULT_NEGATIVE_TTL_MS = 30_000;
+
+export function makeUserCache(
+  probe: () => Promise<string | null>,
+  opts: { negativeTtlMs?: number; now?: () => number } = {},
+): () => Promise<string | null> {
+  const ttl = opts.negativeTtlMs ?? DEFAULT_NEGATIVE_TTL_MS;
+  const now = opts.now ?? Date.now;
+  let login: string | null = null;
+  let failedAt: number | null = null;
+
+  return async (): Promise<string | null> => {
+    if (login !== null) return login;
+    if (failedAt !== null && now() - failedAt < ttl) return null;
+
+    // A throwing probe is a failure like any other — callers want "unknown me", never
+    // an exception, since every consumer of the viewer fails open on null.
+    const resolved = await probe().catch(() => null);
+    if (resolved) {
+      login = resolved;
+      failedAt = null;
+      return login;
+    }
+    failedAt = now();
+    return null;
+  };
+}

--- a/test/forge/gitea.test.ts
+++ b/test/forge/gitea.test.ts
@@ -1188,3 +1188,14 @@ test("GiteaForge.convertToDraft: no-ops when WIP: prefix already present", async
   // already a draft → no PATCH
   expect(calls.find((c) => c.method === "PATCH")).toBeUndefined();
 });
+
+test("GiteaForge.currentUser: a failure is not re-probed within the negative TTL (#2140)", async () => {
+  const { fn, calls } = fakeFetch({ "GET /api/v1/user": { status: 403 } });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+
+  expect(await forge.currentUser()).toBeNull();
+  expect(await forge.currentUser()).toBeNull();
+  // The failure is cached for the TTL window only — never for the forge's lifetime
+  // (see test/forge/user-cache.test.ts for the re-probe once the window elapses).
+  expect(calls.filter((c) => c.url.endsWith("/api/v1/user")).length).toBe(1);
+});

--- a/test/forge/github.test.ts
+++ b/test/forge/github.test.ts
@@ -2957,3 +2957,61 @@ test("GithubForge.listPullRequests: maps mergeStateStatus so the PRs-tab conflic
   expect(prs[0]!.mergeStateStatus).toBe("dirty");
   expect(prs[0]!.mergeable).toBeNull();
 });
+
+// ── currentUser: two transports, and a failure that stays retryable (#2140) ──────
+// REST (`gh api user`) and GraphQL (`{viewer{login}}`) sit on independent GitHub
+// budgets, so the login resolves over whichever one answers. TTL expiry itself is the
+// user-cache's contract (test/forge/user-cache.test.ts); these cover the wiring.
+
+const VIEWER_JSON = JSON.stringify({ data: { viewer: { login: "octocat" } } });
+
+/** A runner keyed by `gh` subcommand path, recording every call. */
+function userRunner(responses: Record<string, string | Error>) {
+  const calls: string[][] = [];
+  const run = async (args: string[]): Promise<string> => {
+    calls.push(args);
+    const key = `${args[0]} ${args[1] ?? ""}`.trim();
+    const res = responses[key];
+    if (res instanceof Error) throw res;
+    return res ?? "";
+  };
+  return { run, calls };
+}
+
+test("GithubForge.currentUser: REST answers → login, cached for the forge's lifetime", async () => {
+  const { run, calls } = userRunner({ "api user": "octocat\n" });
+  const forge = new GithubForge("o/r", {}, run);
+
+  expect(await forge.currentUser()).toBe("octocat");
+  expect(await forge.currentUser()).toBe("octocat");
+  expect(calls.length).toBe(1);
+});
+
+test("GithubForge.currentUser: a failing REST call falls back to GraphQL (#2140)", async () => {
+  const { run, calls } = userRunner({
+    "api user": new Error("gh: HTTP 403 API rate limit exceeded for user ID"),
+    "api graphql": VIEWER_JSON,
+  });
+  const forge = new GithubForge("o/r", {}, run);
+
+  expect(await forge.currentUser()).toBe("octocat");
+  expect(calls.map((c) => `${c[0]} ${c[1]}`)).toEqual(["api user", "api graphql"]);
+});
+
+test("GithubForge.currentUser: a REST answer carrying no login also falls back", async () => {
+  const { run } = userRunner({ "api user": "\n", "api graphql": VIEWER_JSON });
+  expect(await new GithubForge("o/r", {}, run).currentUser()).toBe("octocat");
+});
+
+test("GithubForge.currentUser: both transports failing → null, not re-probed within the TTL", async () => {
+  const { run, calls } = userRunner({
+    "api user": new Error("boom"),
+    "api graphql": new Error("boom"),
+  });
+  const forge = new GithubForge("o/r", {}, run);
+
+  expect(await forge.currentUser()).toBeNull();
+  expect(await forge.currentUser()).toBeNull();
+  // One pass over both transports — the second call read the negative cache.
+  expect(calls.length).toBe(2);
+});

--- a/test/forge/user-cache.test.ts
+++ b/test/forge/user-cache.test.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "bun:test";
+import { makeUserCache } from "../../src/forge/user-cache";
+
+/** A probe recording its call count, answering from a scripted queue (last entry repeats). */
+function probeOf(script: Array<string | null | Error>) {
+  const state = { calls: 0 };
+  const probe = async (): Promise<string | null> => {
+    const step = script[Math.min(state.calls, script.length - 1)]!;
+    state.calls++;
+    if (step instanceof Error) throw step;
+    return step;
+  };
+  return { probe, state };
+}
+
+test("makeUserCache: a resolved login is cached for the process lifetime", async () => {
+  const { probe, state } = probeOf(["octocat"]);
+  const user = makeUserCache(probe);
+
+  expect(await user()).toBe("octocat");
+  expect(await user()).toBe("octocat");
+  expect(state.calls).toBe(1);
+});
+
+test("makeUserCache: a failure is NOT remembered past the negative TTL (#2140)", async () => {
+  let clock = 1_000;
+  const { probe, state } = probeOf([new Error("HTTP 403"), "octocat"]);
+  const user = makeUserCache(probe, { negativeTtlMs: 30_000, now: () => clock });
+
+  expect(await user()).toBeNull();
+  expect(state.calls).toBe(1);
+
+  // Inside the window: answered from the negative cache, no fresh probe.
+  clock += 29_999;
+  expect(await user()).toBeNull();
+  expect(state.calls).toBe(1);
+
+  // Window elapsed: re-probed, and the late success sticks for good.
+  clock += 1;
+  expect(await user()).toBe("octocat");
+  expect(state.calls).toBe(2);
+  expect(await user()).toBe("octocat");
+  expect(state.calls).toBe(2);
+});
+
+test("makeUserCache: an answer without a login counts as a failure, not a cached null", async () => {
+  let clock = 0;
+  const { probe, state } = probeOf([null, "", "octocat"]);
+  const user = makeUserCache(probe, { negativeTtlMs: 10, now: () => clock });
+
+  expect(await user()).toBeNull(); // probe resolved null
+  clock += 10;
+  expect(await user()).toBeNull(); // probe resolved "" — equally unusable
+  clock += 10;
+  expect(await user()).toBe("octocat");
+  expect(state.calls).toBe(3);
+});


### PR DESCRIPTION
Closes #2140.

`GithubForge.currentUser()` resolved the operator's login with a single REST call
(`gh api user`) and, on **any** failure, cached `null`. Forge instances are memoised for
the process lifetime, so one ill-timed 403 pinned `viewer` to `null` until a restart:
`/api/issues` reported `viewer: null`, the UI failed open, and the "mine & unassigned"
filter (#824) silently showed everything with no chip and no explanation.

Both halves of the bug are fixed.

### Two transports

REST and GraphQL sit on **independent** GitHub budgets — observed live on #2139, where
every REST call 403'd while `gh api graphql` answered normally. `currentUser()` now tries
`gh api user`, then falls back to `gh api graphql '{viewer{login}}'` on any failure, or on
an answer that carries no login.

The order is fixed REST → GraphQL rather than flipped on `graphRateLimit.blocked()` the way
`listIssues()` does it: that signal describes the GraphQL bucket only, and there is no
REST-side tracker that would argue for GraphQL-first. The fallback runs even inside an
active GraphQL backoff — REST has just proved unusable and the backoff is only a heuristic
(the same trade-off `listIssues()`' REST→CLI direction already makes).

### A failure that stays retryable

New `src/forge/user-cache.ts` → `makeUserCache()`, with the asymmetric contract
`makeForgeMemo()` established in `src/forge/resolve.ts`: a resolved login is cached for the
process lifetime (the identity never changes mid-session), a failure only for a 30s
negative TTL and is then re-probed.

The TTL — rather than "always retryable" — is what makes the retry affordable:
`pr-poller`'s `refresh()` resolves the viewer for every session on every sweep, so an
unbounded retry would mean a fresh probe per session per tick while the forge is
unreachable.

`GiteaForge.currentUser()` had the identical permanent-null cache and moves onto the same
helper. It has a single transport, so it gets the retryable-failure half only.

### Scope

No UI or API-shape change: `/api/issues` still answers `viewer: string | null` and
`IssuesPanel` keeps failing open while the viewer is unknown. The same one-way-fallback
shape in `getIssue`, `listPullRequests`, `listBacklogCounts`, `prStatus` and `prReviewMeta`
stays parked, as the issue asks.

### Verification

`bun run lint`, `bun run test` (9454 pass / 0 fail), `bunx tsc --noEmit` and
`bunx fallow audit --base origin/main --fail-on-issues` all clean. TTL expiry is covered in
`test/forge/user-cache.test.ts` with an injected clock; the forge tests cover transport
order, GraphQL parsing, success caching and that a failure is not re-probed inside the
window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
