### PR TITLE
fix(usage): stop repeating Auslastung in usage popover section headings

### DIFF
--- a/ui/src/lib/components/top-bar/TopBarUsagePopover.svelte
+++ b/ui/src/lib/components/top-bar/TopBarUsagePopover.svelte
@@ -109,9 +109,7 @@
   {#if hasClaude}
     <div class="gauge-pop-claude" class:stale>
       <div class="gauge-pop-title micro">
-        {m.topbar_usage_provider_title({ provider: m.agent_provider_claude() })}{stale
-          ? m.topbar_gauge_stale_suffix()
-          : ""}
+        {m.agent_provider_claude()}{stale ? m.topbar_gauge_stale_suffix() : ""}
       </div>
       {#if desktop}
         {@render mainWindows(false)}
@@ -138,7 +136,7 @@
   {/if}
   {#if codexUsage}
     <div class="gauge-pop-title micro codex-heading">
-      {m.topbar_usage_provider_title({ provider: m.agent_provider_codex() })}
+      {m.agent_provider_codex()}
     </div>
     <div class="gp-window token-window" class:stale={codexUsage.stale}>
       <CodexTokenDetail usage={codexUsage} {nowMs} {periodLabel} />


### PR DESCRIPTION
## Summary
- The top-bar usage popover already titles itself "Auslastung"; the Claude and Codex sections below it repeated the word ("Auslastung Claude Code", "Auslastung Codex"), reading redundant.
- Section headings now use the plain provider name (`Claude Code` / `Codex`) instead of the shared `topbar_usage_provider_title` "Auslastung {provider}" message.
- Left the gear menu, Limits tab, and aria-label usages of that shared message untouched — none of them sit directly under an "Auslastung" heading, so they weren't part of the reported repetition.

## Test plan
- [x] `bun run check:i18n`
- [x] `bun run check` (svelte-check, 0 errors)
- [x] `bun run test -- TopBar.browser.test.ts` (100 passed)
- [x] Verified visually against the reported screenshot

Co-Authored-By: Claude <noreply@anthropic.com>