### PR TITLE
fix(onboarding): fail fast when an instance has no usable network

### DIFF
--- a/ci/onboarding-harness/README.md
+++ b/ci/onboarding-harness/README.md
@@ -69,6 +69,33 @@ bun run onboarding:test --scenario install-e2e-service
 
 **Install-time RAM floor:** Claude Code's native installer transiently peaks at ~2 GB RSS during `claude install`. The harness sizes instances at 4 GiB to provide headroom above the ~3 GB floor; hosts below that may OOM-kill the install.
 
+### Host firewall
+
+**Instances must be able to reach the Incus bridge's DHCP and DNS, and route outbound.** Every scenario installs packages from the network, so a host firewall that filters `incusbr0` breaks the entire harness — and does so _slowly_, which is worse than breaking it fast.
+
+This is not hypothetical. On 2026-08-19 a `ufw-docker` install enabled `ufw` on the Incus host with `DEFAULT_INPUT_POLICY=DROP` + `DEFAULT_FORWARD_POLICY=DROP` and allow rules for `docker0` only. Instances stopped getting a DHCPv4 lease **and** lost DNS, fell back to an RA-supplied IPv6 address whose default route was a black hole, and every package operation sat out its own timeout and retried. The nightly went from 14 min to **4h23m** and eventually to 0/10 green ([#2229](https://github.com/erwins-enkel/shepherd/issues/2229)).
+
+On a `ufw` host, grant the bridge exactly what it needs:
+
+```bash
+sudo ufw allow in on incusbr0 to any port 53 proto udp   # DNS
+sudo ufw allow in on incusbr0 to any port 53 proto tcp
+sudo ufw allow in on incusbr0 to any port 67 proto udp   # DHCPv4
+sudo ufw allow in on incusbr0 to any port 547 proto udp  # DHCPv6
+sudo ufw route deny in on incusbr0 to 192.168.0.0/16     # keep instances off the LAN
+sudo ufw route allow in on incusbr0                      # instances → internet
+```
+
+Prefer this over the blanket `ufw allow in on incusbr0` most incus+ufw guides suggest: the blanket form exposes **every** host service bound to `0.0.0.0` (sshd, syncthing, …) to instances that install arbitrary packages and run `claude`. Adjust the LAN range to your own. Order matters — the `route deny` must be added before the `route allow`. These persist in `/etc/ufw/user*.rules` and replay on boot.
+
+To confirm the bridge is being filtered, watch the kernel log while an instance boots:
+
+```bash
+journalctl -k -f | grep 'UFW BLOCK'
+```
+
+`IN=incusbr0 … DPT=53` or `DPT=67` there is the signature. Since #2229 the harness also detects this itself: the first scenario aborts within ~60s with a diagnosis pointing here, and the run stops rather than repeating the failure ten times.
+
 ## Usage
 
 ```bash
@@ -86,11 +113,13 @@ The report lands at `onboarding-gap-report.md` in the working directory. Exit co
 
 ## Time budget
 
-The harness bounds itself so it always finishes on its own terms — **45 min per scenario** (`SHEPHERD_ONBOARDING_SCENARIO_TIMEOUT_MS`) and **6h per run** (`SHEPHERD_ONBOARDING_BUDGET_MS`). A scenario that blows its cap is abandoned; scenarios with no budget left are never started. Either way they are recorded **NOT VERIFIED** — not green, not a harness error, so a gate-eligible one still gates red and the report says plainly that no verdict was reached.
+The harness bounds itself so it always finishes on its own terms — **15 min per scenario** (`SHEPHERD_ONBOARDING_SCENARIO_TIMEOUT_MS`) and **90 min per run** (`SHEPHERD_ONBOARDING_BUDGET_MS`). A scenario that blows its cap is abandoned; scenarios with no budget left are never started. Either way they are recorded **NOT VERIFIED** — not green, not a harness error, so a gate-eligible one still gates red and the report says plainly that no verdict was reached.
 
-Those caps are sized to the runtime the harness **actually has**, not the one it ought to have: a full run was ~14 min until Aug 2026 and is now ~4h, with every scenario taking 20–28 min ([#2229](https://github.com/erwins-enkel/shepherd/issues/2229)). Wall-clock is dominated by in-container package installs and image pulls, which the harness does not control. Sizing the caps to the old runtime would cut off a legitimate, working run and report it NOT VERIFIED — a red release gate on a healthy harness. **Bring both numbers down, with `TimeoutStartSec`, once #2229 restores the runtime.**
+Those caps are sized to **measured** runtime: a full run is 8m55s (slowest scenario ~2 min), or roughly 15 min once the nightly's cold image pulls are included. They sit ~6x above that — loose enough not to cut off a slow night, tight enough that a repeat of [#2229](https://github.com/erwins-enkel/shepherd/issues/2229) is caught in 90 min rather than absorbed silently. They are deliberately not the pre-#2230 values (30 min / 3h): those were also chosen while the harness was degraded.
 
-The service's `TimeoutStartSec` (7h) is a **backstop that must never be reached**, and must always stay above the harness's own budget. When it sat _below_ the worst case (the old 2h), systemd's dirty kill was the guaranteed outcome on a slow night rather than an edge case.
+Every run reports **per-scenario durations and a total** in the gap report, so a runtime regression is visible in the artifact. #2229 had to be reconstructed from journal timestamps because nothing recorded it.
+
+The service's `TimeoutStartSec` (2h) is a **backstop that must never be reached**, and must always stay above the harness's own budget. When it sat _below_ the worst case (the old 2h against a 4h+ run), systemd's dirty kill was the guaranteed outcome rather than an edge case.
 
 ## Run isolation
 

--- a/ci/onboarding-harness/report.ts
+++ b/ci/onboarding-harness/report.ts
@@ -93,8 +93,18 @@ export function statusDescription(results: ScenarioResult[]): string {
     : `${gaps.length} gate gap(s): ${gaps.map((g) => g.scenarioId).join(", ")}${harnessNote}`;
 }
 
+/** Compact wall-clock for the report: `48s`, `2m 31s`. `—` when a scenario was never
+ *  started (budget exhausted, or abandoned), so an absent duration never reads as 0. */
+function formatDuration(ms: number | undefined): string {
+  if (ms === undefined) return "—";
+  const total = Math.round(ms / 1000);
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return minutes ? `${minutes}m ${seconds}s` : `${seconds}s`;
+}
+
 function tableRow(r: ScenarioResult, klass: Classification): string {
-  return `| ${r.scenarioId} | ${r.image} | ${r.detection.detected ? "yes" : "no"} | ${r.appliedVia} | ${r.reachedGreen ? "yes" : "no"} | ${klass} |`;
+  return `| ${r.scenarioId} | ${r.image} | ${r.detection.detected ? "yes" : "no"} | ${r.appliedVia} | ${r.reachedGreen ? "yes" : "no"} | ${formatDuration(r.durationMs)} | ${klass} |`;
 }
 
 function gapEntry(
@@ -111,6 +121,50 @@ function unverifiedEntry(r: ScenarioResult): string {
 
 function harnessErrorEntry(r: ScenarioResult): string {
   return `- **${r.scenarioId}** (HARNESS ERROR — infra, not a product gap)${r.error ? ` — ${r.error}` : ""}`;
+}
+
+/** One table row per scenario, plus each result routed to the detail section its
+ *  classification belongs in. Split out of buildGapReport so both stay legible. */
+function detailSections(results: ScenarioResult[]): {
+  rows: string[];
+  gaps: string[];
+  errors: string[];
+  unverified: string[];
+} {
+  const rows: string[] = [];
+  const gaps: string[] = [];
+  const errors: string[] = [];
+  const unverified: string[] = [];
+  for (const r of results) {
+    const klass = classify(r);
+    rows.push(tableRow(r, klass));
+    if (
+      klass === "DETECTION GAP" ||
+      klass === "ADVICE GAP" ||
+      klass === "INSTALL GAP" ||
+      klass === "BOOT CRASH"
+    ) {
+      gaps.push(gapEntry(r, klass));
+    } else if (klass === "HARNESS ERROR") {
+      errors.push(harnessErrorEntry(r));
+    } else if (klass === "NOT VERIFIED") {
+      unverified.push(unverifiedEntry(r));
+    }
+  }
+  return { rows, gaps, errors, unverified };
+}
+
+/** Total wall-clock line, so a runtime regression is visible in the artifact itself —
+ *  #2229 had to be reconstructed from journal timestamps because nothing recorded it.
+ *  Empty when no scenario ran, where a "0s" total would be misleading. */
+function runtimeTotal(results: ScenarioResult[]): string[] {
+  const timed = results.filter((r) => r.durationMs !== undefined);
+  if (!timed.length) return [];
+  const total = timed.reduce((sum, r) => sum + (r.durationMs ?? 0), 0);
+  return [
+    "",
+    `Total scenario runtime: **${formatDuration(total)}** across ${timed.length} scenario${timed.length > 1 ? "s" : ""}.`,
+  ];
 }
 
 export function buildGapReport(results: ScenarioResult[]): string {
@@ -130,28 +184,11 @@ export function buildGapReport(results: ScenarioResult[]): string {
         ? ` (${harnessErrored.length} harness error${harnessErrored.length > 1 ? "s" : ""} — infra, excluded.)`
         : ""),
     "",
-    "| Scenario | Image | Detected | Applied | Green | Classification |",
-    "| --- | --- | --- | --- | --- | --- |",
+    "| Scenario | Image | Detected | Applied | Green | Duration | Classification |",
+    "| --- | --- | --- | --- | --- | --- | --- |",
   ];
-  const gaps: string[] = [];
-  const errors: string[] = [];
-  const unverified: string[] = [];
-  for (const r of results) {
-    const klass = classify(r);
-    lines.push(tableRow(r, klass));
-    if (
-      klass === "DETECTION GAP" ||
-      klass === "ADVICE GAP" ||
-      klass === "INSTALL GAP" ||
-      klass === "BOOT CRASH"
-    ) {
-      gaps.push(gapEntry(r, klass));
-    } else if (klass === "HARNESS ERROR") {
-      errors.push(harnessErrorEntry(r));
-    } else if (klass === "NOT VERIFIED") {
-      unverified.push(unverifiedEntry(r));
-    }
-  }
+  const { rows, gaps, errors, unverified } = detailSections(results);
+  lines.push(...rows, ...runtimeTotal(results));
   if (gaps.length) {
     lines.push("", "## Gaps", "", ...gaps);
   }

--- a/ci/onboarding-harness/run.ts
+++ b/ci/onboarding-harness/run.ts
@@ -6,7 +6,7 @@ import { IncusDriver } from "./incus";
 import { acquireHostLock, LockHeldError, LOCK_PATH } from "./lock";
 import { onboardingLastRunMarker } from "../../src/onboarding-paths";
 import { SCENARIOS } from "./scenarios";
-import { seedInstance } from "./seed";
+import { NetworkUnreachableError, seedInstance } from "./seed";
 import {
   assertUnitActive,
   bootExpectingPreflightExit,
@@ -344,6 +344,21 @@ export async function runScenario(
       detectionOnly: detectionOnly || undefined,
     };
   } catch (err) {
+    // A dead container network is a HOST fault: no verdict was reached about the product,
+    // and every remaining scenario would hit the same wall. Record it as unverified (which
+    // already gates red — see report.ts gateGapScenarios) and flag it so main abandons the
+    // rest of the run rather than repeating it ten times. #2229
+    if (err instanceof NetworkUnreachableError) {
+      return {
+        ...base,
+        detection: detection ?? { scenarioId: scenario.id, detected: false, misses: [] },
+        appliedVia: "skipped",
+        reachedGreen: false,
+        unverified: true,
+        networkUnreachable: true,
+        error: err.message,
+      };
+    }
     return {
       ...base,
       detection: detection ?? { scenarioId: scenario.id, detected: false, misses: [] },
@@ -415,19 +430,22 @@ function recordRunCompleted(only: string | null | undefined): void {
  *  with many calls per scenario and ten scenarios, its own worst case sat far above
  *  the 2h unit timeout, so systemd was GUARANTEED to win on a slow night.
  *
- *  The caps are sized to the runtime the harness ACTUALLY has, not the one it ought
- *  to have. A healthy full run used to be ~14 min; it is now ~4h (every scenario
- *  20-28 min, see #2229) because the time is spent on in-container package installs
- *  and image pulls, which the harness does not control. Sizing these to the old
- *  runtime would cut off a legitimate, working run and report it NOT VERIFIED —
- *  a red release gate on a healthy harness. **Bring both numbers back down (and
- *  `TimeoutStartSec` with them) once #2229 restores the runtime.**
+ *  The caps are sized to MEASURED runtime. #2229 (a host firewall dropping all incusbr0
+ *  traffic) had inflated a 14-minute nightly to 4h23m, and the previous values here — 45m
+ *  per scenario, 6h per run — were chosen to accommodate that degradation rather than to
+ *  bound it. With the host fixed, a measured full run is 8m55s (slowest scenario ~2 min);
+ *  ~15 min is a fair healthy figure once the nightly's cold image pulls are included.
+ *
+ *  So these are deliberately NOT a revert to the pre-#2230 numbers (30m/3h) — those came
+ *  from #2226 and were also picked under the degradation. They are ~6x the measured run:
+ *  loose enough that a slow night is not cut off, tight enough that a repeat of #2229 is
+ *  caught in an hour and a half instead of being absorbed silently.
  *
  *  Because the per-scenario cap is `min(cap, budget remaining)`, total runtime is
  *  bounded by the run budget itself; the backstop only needs headroom for teardown. */
 const SCENARIO_TIMEOUT_MS =
-  Number(process.env.SHEPHERD_ONBOARDING_SCENARIO_TIMEOUT_MS) || 45 * 60_000;
-const RUN_BUDGET_MS = Number(process.env.SHEPHERD_ONBOARDING_BUDGET_MS) || 6 * 60 * 60_000;
+  Number(process.env.SHEPHERD_ONBOARDING_SCENARIO_TIMEOUT_MS) || 15 * 60_000;
+const RUN_BUDGET_MS = Number(process.env.SHEPHERD_ONBOARDING_BUDGET_MS) || 90 * 60_000;
 
 /** A scenario the run never got a verdict on. It is NOT green and NOT a launch
  *  failure, so it gates red: an unverified gate scenario must never read as a pass.
@@ -463,11 +481,63 @@ async function runScenarioBounded(
       capMs,
     );
   });
+  const startedAt = Date.now();
   try {
-    return await Promise.race([runScenario(driver, scenario, tarball), capped]);
+    const result = await Promise.race([runScenario(driver, scenario, tarball), capped]);
+    return { ...result, durationMs: Date.now() - startedAt };
   } finally {
     clearTimeout(timer);
   }
+}
+
+/** Reason recorded against every scenario abandoned after a network failure. */
+const NETWORK_ABANDON_REASON =
+  "not run — the run was abandoned after an earlier scenario found no usable network";
+
+/** Scenarios the run gave up on, as NOT VERIFIED results. Split out so the abandon
+ *  path is unit-testable without acquiring the host lock or touching Incus. */
+export function abandonRemaining(scenarios: Scenario[]): ScenarioResult[] {
+  return scenarios.map((s) => unverifiedResult(s, NETWORK_ABANDON_REASON));
+}
+
+/** Run the catalog in order under the run budget, stopping early if the host turns out
+ *  to have no usable container network. Split out of main so the budget/abandon logic
+ *  reads on its own. */
+async function runAllScenarios(
+  driver: IncusDriver,
+  scenarios: Scenario[],
+  tarball: string,
+): Promise<ScenarioResult[]> {
+  const results: ScenarioResult[] = [];
+  const deadline = Date.now() + RUN_BUDGET_MS;
+  for (const [i, s] of scenarios.entries()) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      console.error(`=== ${s.id} — NOT RUN, the run budget is exhausted ===`);
+      results.push(unverifiedResult(s, "not run — the run budget was exhausted"));
+      continue;
+    }
+    console.log(`\n=== ${s.id} (${s.image}) ===`);
+    const result = await runScenarioBounded(
+      driver,
+      s,
+      tarball,
+      Math.min(SCENARIO_TIMEOUT_MS, remaining),
+    );
+    results.push(result);
+    // A host whose bridge has no usable network fails EVERY scenario identically. Running
+    // the other nine proves nothing and, before #2229, took four hours to prove it. Stop
+    // here; the abandoned scenarios are NOT VERIFIED, which gates red.
+    if (result.networkUnreachable) {
+      console.error(
+        `\n${result.error}\n\nAbandoning the run — the remaining scenarios ` +
+          "would all fail the same way.",
+      );
+      results.push(...abandonRemaining(scenarios.slice(i + 1)));
+      break;
+    }
+  }
+  return results;
 }
 
 async function main() {
@@ -541,20 +611,7 @@ async function main() {
     // returns early above, so this is never reached on that path). Fail-closed: a wrong
     // or missing profile would silently OOM every instance, so we fix it up front.
     await driver.ensureProfile();
-    const tarball = buildTarball();
-    const deadline = Date.now() + RUN_BUDGET_MS;
-    for (const s of scenarios) {
-      const remaining = deadline - Date.now();
-      if (remaining <= 0) {
-        console.error(`=== ${s.id} — NOT RUN, the run budget is exhausted ===`);
-        results.push(unverifiedResult(s, "not run — the run budget was exhausted"));
-        continue;
-      }
-      console.log(`\n=== ${s.id} (${s.image}) ===`);
-      results.push(
-        await runScenarioBounded(driver, s, tarball, Math.min(SCENARIO_TIMEOUT_MS, remaining)),
-      );
-    }
+    results.push(...(await runAllScenarios(driver, scenarios, buildTarball())));
   } finally {
     await driver.sweep(); // teardown — own-prefix instances only
     release();

--- a/ci/onboarding-harness/seed.ts
+++ b/ci/onboarding-harness/seed.ts
@@ -20,13 +20,13 @@ const PROFILES = ["default", "shep-onb"];
  *
  *  WHY stop units first (#1738): `images:archlinux` runs its OWN keyring init at boot —
  *  `/etc/systemd/system/pacman-init.service` (`ExecStart=pacman-key --init` + `--populate`,
- *  ordered `After=time-sync.target`). We only wait for DNS (waitForDns), which resolves
- *  long before time-sync, so the pre-#1738 version of this function raced that unit: two gpg
- *  processes writing /etc/pacman.d/gnupg, and the loser died with "can't open pubring.gpg /
- *  no writable keyring found / could not be locally signed". Reproduced 3/3 by exec'ing as
- *  soon as DNS resolved; 0/3 when run after the unit had settled. Since runScenario launches
- *  a FRESH instance per scenario, BOTH Arch scenarios are exposed — which one loses on a
- *  given night is jitter, which is exactly why the nightly looked flaky.
+ *  ordered `After=time-sync.target`). We only wait for the network (waitForNetwork), which
+ *  comes up long before time-sync, so the pre-#1738 version of this function raced that unit:
+ *  two gpg processes writing /etc/pacman.d/gnupg, and the loser died with "can't open
+ *  pubring.gpg / no writable keyring found / could not be locally signed". Reproduced 3/3 by
+ *  exec'ing as soon as DNS resolved; 0/3 when run after the unit had settled. Since
+ *  runScenario launches a FRESH instance per scenario, BOTH Arch scenarios are exposed —
+ *  which one loses on a given night is jitter, which is exactly why the nightly looked flaky.
  *
  *  Enumerating `systemctl list-units --all '*keyring*' '*pacman*'` + `list-timers` on a
  *  fresh instance, pacman-init is not the only writer of that homedir:
@@ -202,25 +202,56 @@ function baselineCommands(): string[] {
   ];
 }
 
-/** Wait for the instance's network to actually resolve DNS before anything hits
- *  the package mirrors. `/bin/sh` exists instantly, so a launch alone only proves
- *  the rootfs unpacked — on Arch, systemd-resolved comes up slower than on debian/
- *  fedora and `pacman -Sy` failed with "Could not resolve host". Poll a real
- *  resolution instead (skip on images without glibc `getent`, e.g. musl). */
-async function waitForDns(driver: IncusDriver, name: string): Promise<void> {
-  await driver.exec(name, [
+/** Thrown when an instance launched but never got a usable network. Distinct from a
+ *  baseline failure because it is a HOST fault, not a product regression: every later
+ *  scenario would hit it too, so run.ts abandons the whole run on the first one rather
+ *  than repeating it ten times. */
+export class NetworkUnreachableError extends Error {}
+
+/** Seconds `waitForNetwork` polls before giving up. Sixty consecutive failed seconds in
+ *  a freshly-launched instance is a host fault, not a blip — DHCP and a bridge resolver
+ *  answer in low single-digit seconds on a healthy host. */
+const NETWORK_POLL_SECONDS = 60;
+
+/** Poll until the instance's network is actually USABLE, and report whether it got there.
+ *
+ *  Two conditions, both required — a launch alone only proves the rootfs unpacked, since
+ *  `/bin/sh` exists instantly:
+ *   - a global **IPv4** address. Waiting on DNS alone is not enough: incusbr0 hands out an
+ *     RA-derived IPv6 address and DNS server which answer BEFORE the DHCPv4 lease lands, so
+ *     a DNS-only probe passes on an instance that still cannot fetch anything. That window
+ *     is real — it is what broke `git-missing` (alpine) on 2026-09-10 with an opaque
+ *     `apk … Permission denied`, while the same scenario passes in 48s once settled.
+ *     Requiring IPv4 matches incusbr0's dual-stack default (a v6-only bridge would abort
+ *     here in 60s with a legible message rather than fail obscurely downstream).
+ *   - real DNS resolution. On Arch systemd-resolved comes up slower than on debian/fedora
+ *     and `pacman -Sy` used to fail with "Could not resolve host".
+ *
+ *  `getent` and `ip` are present on every image family in the catalog — glibc supplies
+ *  getent on debian/ubuntu/rocky/arch, and alpine's busybox supplies both (verified live),
+ *  so there is no unprobeable escape hatch and no need for a fallback resolver.
+ *
+ *  Returns `true` when the network came up, `false` when it never did. The RESULT IS
+ *  LOAD-BEARING — see seedInstance. Before #2229 this returned void and its caller ignored
+ *  it, so a host firewall that dropped all bridge traffic (DHCP + DNS) was swallowed here
+ *  and only surfaced as ten package-manager timeouts: a 14-minute nightly became 4h23m and
+ *  reported ten fake BOOT CRASHes. */
+async function waitForNetwork(driver: IncusDriver, name: string): Promise<boolean> {
+  const r = await driver.exec(name, [
     "sh",
     "-c",
-    "for i in $(seq 1 60); do command -v getent >/dev/null 2>&1 || break; " +
-      "getent hosts bun.sh >/dev/null 2>&1 && break; sleep 1; done",
+    `for i in $(seq 1 ${NETWORK_POLL_SECONDS}); do ` +
+      'if [ -n "$(ip -4 -o addr show scope global 2>/dev/null)" ] && ' +
+      "getent hosts bun.sh >/dev/null 2>&1; then exit 0; fi; sleep 1; done; exit 1",
   ]);
+  return r.code === 0;
 }
 
 /** Launch a fresh instance for `scenario`, install the bootable baseline, push
  *  the Shepherd build, then run the scenario's messy-state seed commands.
  *
  *  installE2E scenarios are the inverse: a BARE instance with NO baseline + NO
- *  defect seed. We launch, wait for DNS (the real install.sh needs network), and
+ *  defect seed. We launch, wait for the network (the real install.sh needs it), and
  *  push the tarball + install.sh; run.ts then runs the installer itself. */
 export async function seedInstance(
   driver: IncusDriver,
@@ -232,7 +263,18 @@ export async function seedInstance(
     vm: scenario.vm,
     profiles: PROFILES,
   });
-  await waitForDns(driver, scenario.id);
+  // CHECKED (#2229): a network that never comes up is a host fault, and every step past
+  // here — the tarball push, the baseline, install.sh — would otherwise burn its own
+  // multi-minute timeout discovering it separately.
+  if (!(await waitForNetwork(driver, scenario.id))) {
+    throw new NetworkUnreachableError(
+      `${scenario.id}: the instance launched but never got a usable network ` +
+        `(no global IPv4 address and/or no DNS after ${NETWORK_POLL_SECONDS}s). ` +
+        "On an Incus host this is nearly always the host firewall dropping traffic on the " +
+        "bridge — check `journalctl -k | grep 'UFW BLOCK'` and see the Host firewall section " +
+        "of ci/onboarding-harness/README.md.",
+    );
+  }
   await driver.push(scenario.id, tarballPath, "/root/shepherd.tar");
 
   if (scenario.installE2E) {

--- a/ci/onboarding-harness/shepherd-onboarding.service
+++ b/ci/onboarding-harness/shepherd-onboarding.service
@@ -15,12 +15,13 @@ Environment=SHEPHERD_ONBOARDING_REPORT_ISSUE=1
 # SIGTERM never reaches the JS handler, so no cleanup runs at all. That is what
 # happened on 2026-08-20 at the old 2h — which sat BELOW the harness's worst case,
 # making the dirty kill the guaranteed outcome on a slow night rather than an edge
-# case. The harness now caps itself at 6h per run + 45m per scenario, so 7h leaves
+# case. The harness caps itself at 90m per run + 15m per scenario, so 2h leaves
 # room for the final sweep and should never actually be reached.
 #
-# Those numbers are sized to the runtime the harness ACTUALLY has: a full run was
-# ~14 min until Aug 2026 and is now ~4h (see #2229). Bring this back down with the
-# harness's own budget once that is fixed — it only has to stay above it.
-TimeoutStartSec=7h
+# Sized to MEASURED runtime: a full run is 8m55s with the #2229 host-firewall fault
+# fixed (it had inflated the nightly to 4h23m, which is why this briefly read 7h).
+# This only has to stay strictly above the harness's own budget — if you change
+# SHEPHERD_ONBOARDING_BUDGET_MS, change this with it.
+TimeoutStartSec=2h
 # Give the teardown room to destroy up to ten instances if a stop ever does arrive.
 TimeoutStopSec=5min

--- a/ci/onboarding-harness/types.ts
+++ b/ci/onboarding-harness/types.ts
@@ -95,6 +95,15 @@ export interface ScenarioResult {
    *  a gate-eligible one still gates red. The flag exists so the report says so
    *  plainly instead of mislabelling it a crash. */
   unverified?: boolean;
+  /** The instance launched but never got a usable network (#2229). A HOST fault, not a
+   *  product regression — every later scenario would hit it too, so run.ts abandons the
+   *  rest of the run instead of repeating it ten times. */
+  networkUnreachable?: boolean;
+  /** Wall-clock this scenario took, milliseconds. Absent for scenarios the run never
+   *  started (budget exhausted). Reported per scenario plus a run total so a runtime
+   *  regression is visible in the artifact — the 2026-08 one (#2229) had to be
+   *  reconstructed from journal timestamps because nothing recorded this. */
+  durationMs?: number;
   error?: string;
 }
 

--- a/test/onboarding-harness/report.test.ts
+++ b/test/onboarding-harness/report.test.ts
@@ -360,3 +360,43 @@ describe("unverified scenarios", () => {
     expect(statusDescription([unverified()])).toContain("gh-missing");
   });
 });
+
+describe("runtime reporting (#2229)", () => {
+  const timed = (id: string, durationMs: number | undefined): ScenarioResult => ({
+    scenarioId: id,
+    image: "images:debian/12",
+    detection: { scenarioId: id, detected: true, misses: [] },
+    appliedVia: "verbatim",
+    reachedGreen: true,
+    gateEligible: true,
+    durationMs,
+  });
+
+  it("renders each scenario's wall-clock in the table", () => {
+    const report = buildGapReport([timed("a", 48_000), timed("b", 151_000)]);
+    expect(report).toContain("| Duration |");
+    expect(report).toContain("| 48s |");
+    expect(report).toContain("| 2m 31s |");
+  });
+
+  it("totals the run, so a runtime regression is visible in the artifact itself", () => {
+    // #2229 had to be reconstructed from journal timestamps because nothing recorded this.
+    const report = buildGapReport([timed("a", 60_000), timed("b", 120_000)]);
+    expect(report).toContain("Total scenario runtime: **3m 0s** across 2 scenarios");
+  });
+
+  it("shows an em dash, never 0s, for a scenario that never ran", () => {
+    const report = buildGapReport([timed("a", undefined)]);
+    expect(report).toContain("| — |");
+    expect(report).not.toContain("| 0s |");
+  });
+
+  it("omits the total entirely when nothing was timed", () => {
+    expect(buildGapReport([timed("a", undefined)])).not.toContain("Total scenario runtime");
+  });
+
+  it("counts only timed scenarios in the total", () => {
+    const report = buildGapReport([timed("a", 30_000), timed("b", undefined)]);
+    expect(report).toContain("Total scenario runtime: **30s** across 1 scenario.");
+  });
+});

--- a/test/onboarding-harness/run.test.ts
+++ b/test/onboarding-harness/run.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test";
+import { abandonRemaining } from "../../ci/onboarding-harness/run";
+import { buildGapReport, gateGapScenarios } from "../../ci/onboarding-harness/report";
+import type { Scenario } from "../../ci/onboarding-harness/types";
+
+/** A gate-eligible scenario (structured, not detection-only) — the kind whose verdict
+ *  actually drives the release gate. */
+const gating: Scenario = {
+  id: "node-too-old",
+  image: "images:debian/12",
+  seed: [],
+  expect: [{ id: "node", state: "warning" }],
+  coaching: "structured",
+};
+
+const prose: Scenario = {
+  id: "git-missing",
+  image: "images:alpine/3.21",
+  seed: [],
+  expect: [{ id: "git", state: "error" }],
+  coaching: "prose",
+};
+
+describe("abandonRemaining (#2229)", () => {
+  it("records every abandoned scenario as unverified, with a reason", () => {
+    const results = abandonRemaining([gating, prose]);
+    expect(results).toHaveLength(2);
+    for (const r of results) {
+      expect(r.unverified).toBe(true);
+      expect(r.reachedGreen).toBe(false);
+      expect(r.error).toMatch(/abandoned/i);
+    }
+    expect(results.map((r) => r.scenarioId)).toEqual(["node-too-old", "git-missing"]);
+  });
+
+  it("GATES RED — an abandoned run must never publish a green commit status", () => {
+    // The whole point: a host firewall outage verified nothing, so the release gate must
+    // not read it as a pass. Unverified is deliberately NOT classified HARNESS ERROR,
+    // because that category is de-gated.
+    expect(gateGapScenarios(abandonRemaining([gating]))).toHaveLength(1);
+  });
+
+  it("carries no duration — an abandoned scenario never ran, so 0s would be a lie", () => {
+    expect(abandonRemaining([gating])[0]!.durationMs).toBeUndefined();
+  });
+
+  it("reports abandoned scenarios as NOT VERIFIED rather than a crash", () => {
+    const report = buildGapReport(abandonRemaining([gating]));
+    expect(report).toContain("NOT VERIFIED");
+    expect(report).not.toContain("BOOT CRASH");
+    expect(report).toContain("## Not verified");
+  });
+
+  it("is a no-op on an empty tail (the failure hit the last scenario)", () => {
+    expect(abandonRemaining([])).toEqual([]);
+  });
+});

--- a/test/onboarding-harness/seed.test.ts
+++ b/test/onboarding-harness/seed.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { IncusDriver } from "../../ci/onboarding-harness/incus";
-import { seedInstance } from "../../ci/onboarding-harness/seed";
+import { NetworkUnreachableError, seedInstance } from "../../ci/onboarding-harness/seed";
 import type { IncusExec } from "../../ci/onboarding-harness/types";
 
 function recorder() {
@@ -141,5 +141,74 @@ describe("seedInstance", () => {
     const push = calls.find((c) => c[0] === "file" && c[1] === "push");
     expect(push).toBeDefined();
     expect(push!).toContain("/tmp/shepherd.tar");
+  });
+});
+
+describe("waitForNetwork (#2229)", () => {
+  /** Runner whose network probe returns `probeCode`; everything else succeeds. */
+  function withProbe(probeCode: number) {
+    const calls: string[][] = [];
+    const run = async (args: string[]): Promise<IncusExec> => {
+      calls.push(args);
+      const cmd = args.join(" ");
+      if (cmd.includes("ip -4 -o addr show")) {
+        return { stdout: "", stderr: "", code: probeCode };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+    return { calls, run };
+  }
+
+  it("waits for BOTH a global IPv4 address and DNS before touching the mirrors", async () => {
+    const { calls, run } = withProbe(0);
+    const d = new IncusDriver(run, "shep-onb-");
+    await seedInstance(d, scenario, "/tmp/shepherd.tar");
+
+    const flat = calls.map((c) => c.join(" "));
+    const probeIdx = flat.findIndex((c) => c.includes("ip -4 -o addr show"));
+    expect(probeIdx).toBeGreaterThanOrEqual(0);
+    // A DNS-only probe passes while the DHCPv4 lease is still pending, because incusbr0's
+    // RA-supplied IPv6 resolver answers first — that window broke git-missing.
+    expect(flat[probeIdx]).toContain("getent hosts bun.sh");
+    // Nothing that needs the network may run before the probe.
+    const pushIdx = flat.findIndex((c) => c.startsWith("file push"));
+    const aptIdx = flat.findIndex((c) => c.includes("apt-get update"));
+    expect(pushIdx).toBeGreaterThan(probeIdx);
+    expect(aptIdx).toBeGreaterThan(probeIdx);
+  });
+
+  it("throws NetworkUnreachableError when the network never comes up", async () => {
+    const { run } = withProbe(1);
+    const d = new IncusDriver(run, "shep-onb-");
+    await expect(seedInstance(d, scenario, "/tmp/shepherd.tar")).rejects.toThrow(
+      NetworkUnreachableError,
+    );
+  });
+
+  it("names the host firewall in the diagnosis, so the operator has somewhere to look", async () => {
+    const { run } = withProbe(1);
+    const d = new IncusDriver(run, "shep-onb-");
+    await expect(seedInstance(d, scenario, "/tmp/shepherd.tar")).rejects.toThrow(
+      /host firewall.*UFW BLOCK/s,
+    );
+  });
+
+  it("runs NO baseline step once the network probe has failed", async () => {
+    const { calls, run } = withProbe(1);
+    const d = new IncusDriver(run, "shep-onb-");
+    await expect(seedInstance(d, scenario, "/tmp/shepherd.tar")).rejects.toThrow();
+
+    const flat = calls.map((c) => c.join(" "));
+    // Burning a multi-minute package-manager timeout per step is exactly the 4h failure.
+    expect(flat.some((c) => c.includes("apt-get update"))).toBe(false);
+    expect(flat.some((c) => c.includes("bun.sh/install"))).toBe(false);
+    expect(flat.some((c) => c.startsWith("file push"))).toBe(false);
+  });
+
+  it("still deletes nothing itself — the caller owns instance teardown", async () => {
+    const { calls, run } = withProbe(1);
+    const d = new IncusDriver(run, "shep-onb-");
+    await expect(seedInstance(d, scenario, "/tmp/shepherd.tar")).rejects.toThrow();
+    expect(calls.some((c) => c[0] === "delete")).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #2229.

## The issue's premise was wrong

#2229 attributes the 16x slowdown to in-container throughput and proposes pre-baking scenario images. Measured on the host, that is not what was happening — and the harness was not "slow but passing" either. The Sep 10 nightly reported **0/10 green**, every scenario dying on `Temporary failure resolving 'archive.ubuntu.com'`.

Against a live `images:ubuntu/24.04` instance:

- Containers had **no IPv4 address at all** — DHCPv4 to the bridge was dropped.
- They were left with the `fd42::/64` ULA and an RA-supplied default v6 route; the host has no IPv6 upstream, so that route is a black hole.
- DNS to the bridge resolver timed out (`curl: Resolving timed out after 15000ms`), while the host querying `10.254.46.1` directly answered fine.
- Kernel log, live: `[UFW BLOCK] IN=incusbr0 … DPT=53`.

`ufw` on the Incus host has `DEFAULT_INPUT_POLICY=DROP` + `DEFAULT_FORWARD_POLICY=DROP`, with allow rules for `docker0`/`172.17.0.1` and none for `incusbr0`. Every file in `/etc/ufw/` is dated **2026-08-19 21:54** — a `ufw-docker` install, with an `after.rules-ufw-docker~2026-08-19-215447~` backup alongside. Aug 19 nightly: 14 min, 6/6 green. Aug 20: >2h, killed.

So the 16x was containers waiting out DNS and connect timeouts and retrying. **Pre-baking images would have hidden a host fault and could not have fixed it anyway** — `install-e2e`, `bun install` and `claude install` all need live network by design. That proposal is dropped.

The host was fixed out-of-band with an interface- and port-scoped ruleset (documented in the README), rather than the blanket `ufw allow in on incusbr0` most incus+ufw guides suggest — the blanket form exposes every host service bound to `0.0.0.0` and the whole LAN to instances that install packages and run `claude`.

## What this PR changes

The repo-side defect is what let a host fault cost four hours: `waitForDns()` polled DNS 60×1s and then **returned unconditionally either way**, unchecked.

- **`waitForNetwork` is checked, and means something.** Resolving a name is not evidence of a usable network: incusbr0's RA-supplied IPv6 resolver answers *before* the DHCPv4 lease lands, so a DNS-only probe passes on an instance that cannot fetch anything. That window is what broke `git-missing` with an opaque `apk … Permission denied`. The probe now waits for a global IPv4 address **and** DNS. `getent` and `ip` are on all five image families (verified live), so no fallback resolver and no unprobeable escape hatch.
- **One failure abandons the run.** Every remaining scenario would hit the same wall. Abandoned scenarios reuse `unverifiedResult`, so they report `NOT VERIFIED` and **gate red** — deliberately *not* `HARNESS ERROR`, which is de-gated and would recreate the silence #2226 closed.
- **Per-scenario durations + a run total in the report.** This regression had to be reconstructed from journal timestamps because nothing recorded it.
- **Caps re-sized to measured runtime** — 15 min/scenario, 90 min/run, `TimeoutStartSec=2h`. Not a revert: the pre-#2230 values (30 min/3h) came from #2226 and were also chosen while degraded. The #2226 invariant holds — the unit timeout stays strictly above the harness's own budget.
- **README documents the host firewall prerequisite**, with the scoped rules and the `UFW BLOCK` signature to look for.

## Verification (live, on the Incus host)

| | Before | After |
| --- | --- | --- |
| `node-too-old` | 28 min, red | **59.7 s, PASS** |
| Full run | 4h23m, 0/10, exit 1 | **9m 37s, 6/6 green, exit 0** |
| Broken bridge (DHCPv4 disabled) | 4h23m → ten fake BOOT CRASHes | **1m 2s, NOT VERIFIED, exit 1** |

The fail-fast path was exercised end-to-end by disabling `ipv4.dhcp` on `incusbr0`, not just unit-tested. Every scenario now runs in 42s–1m14s.

`bun run lint`, `bunx tsc --noEmit`, `bun run test` (9591 pass, 0 fail) and `fallow audit` all green.

## Not in scope

`herdr-outdated` regressed to `herdr want=warning got=error` from #2126 (Aug 28) or #2210 (Sep 8) — both landed while the harness was dead. A stale stub against a tightened liveness probe, unrelated to the network; it is `detectionOnly` so it does not gate. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Manual-Step: POST-MERGE: Re-install the nightly systemd unit on the Incus host so the new `TimeoutStartSec=2h` takes effect — the running unit still carries `7h`: `cp ci/onboarding-harness/shepherd-onboarding.{service,timer} ~/.config/systemd/user/ && systemctl --user daemon-reload`
