### PR TITLE
fix(harness): shape the herdr stubs the way the liveness probe reads them

### DIFF
--- a/ci/onboarding-harness/herdr-stub.ts
+++ b/ci/onboarding-harness/herdr-stub.ts
@@ -1,0 +1,115 @@
+import { HERDR_MIN_VERSION } from "../../src/config";
+import { HERDR_LAST_SUPPORTED_VERSION } from "../../src/herdr-capabilities";
+import { compareSemver } from "../../src/semver";
+
+/**
+ * Generates the network-free `herdr` STUBs the harness plants on PATH, in the two shapes the
+ * PRODUCTION liveness probe (`probeHerdrRuntime`, src/herdr-runtime.ts) actually distinguishes.
+ *
+ * Why this module exists: until #2216 diagnostics' liveness was `herdr agent list` with the exit
+ * code as its only signal, so a stub that echoed one `{"version":"…"}` line for every invocation
+ * satisfied it. #2216 made the probe run `herdr status --json` FIRST and parse the document, at
+ * which point that one-line stub started parsing as a status document with no `client`/`server`
+ * keys — `unknown`, i.e. `error` (offline-ish), never the below-floor `warning` the
+ * `herdr-outdated` scenario asserts (#2239). Both stubs were hand-written, so nothing failed until
+ * the nightly ran three weeks later.
+ *
+ * So the shape is derived from the version, and the generated script is proven against the real
+ * probe in test/onboarding-harness/herdr-stub.test.ts rather than trusted by eye.
+ */
+
+/** First herdr version that answers `status --json`. Below it the CLI has no `status` command at
+ *  all, which is why production keeps a fallback — see `probeLegacy` in src/herdr-runtime.ts
+ *  ("v0.8 and earlier have no `status` command") and docs/herdr-compat/0.9.0.md. */
+export const HERDR_FIRST_STATUS_JSON_VERSION = "0.9.0";
+
+/** The version the `herdr-outdated` scenario's stub reports: one release line below
+ *  {@link HERDR_MIN_VERSION}, DERIVED so a floor bump can never quietly turn that scenario's
+ *  seeded defect into a healthy herdr. Prefers a patch step down and falls back to a minor, which
+ *  keeps it a version that could plausibly exist rather than a synthetic `0.0.x`. */
+export function outdatedHerdrVersion(): string {
+  const [major = 0, minor = 0, patch = 0] = HERDR_MIN_VERSION.split(".").map((n) => Number(n) || 0);
+  if (patch > 0) return `${major}.${minor}.${patch - 1}`;
+  if (minor > 0) return `${major}.${minor - 1}.0`;
+  if (major > 0) return `${major - 1}.0.0`;
+  throw new Error(`cannot derive a version below HERDR_MIN_VERSION ${HERDR_MIN_VERSION}`);
+}
+
+/** The `herdr status --json` document a healthy modern daemon returns, in the shape
+ *  `parseHerdrRuntimeStatus` (src/herdr-runtime.ts) reads: client and server on the same version,
+ *  server running, both compatibility flags true. Anything less classifies as `unknown`. */
+function readyStatusDocument(version: string): string {
+  return JSON.stringify({
+    client: { version },
+    server: { running: true, version, compatible: true, endpoint_compatible: true },
+  });
+}
+
+/**
+ * The `#!/bin/sh` body of a stub reporting `version`.
+ *
+ * Modern (≥ {@link HERDR_FIRST_STATUS_JSON_VERSION}): `status --json` returns a ready document, so
+ * the probe's modern path continues to its `agent list` function check, which the catch-all
+ * answers.
+ *
+ * Legacy (below it): `status` fails the way a CLI without that command does, sending the probe
+ * down `probeLegacy` (`agent list` + `--version`) — the real path a live-but-old herdr takes, and
+ * the one that makes `herdr-outdated` read outdated rather than offline.
+ *
+ * The catch-all is load-bearing in BOTH shapes: it exits 0 (the probe's liveness evidence) and
+ * emits valid JSON, because the on-loop `HerdrDriver.list()/tabs()/panes()` do an UNGUARDED
+ * `JSON.parse` then `parsed?.result?.… ?? []`. Plain text there would throw every tick.
+ * `--version`, by contrast, answers the way herdr really does — a plain line — which is safe
+ * because every consumer (boot preflight, herdr-update's version runner, `probeLegacy`,
+ * diagnostics, and the harness's own pin assertion) reads it through a semver regex and none of
+ * them JSON-parses it.
+ */
+export function herdrStubScript(version: string): string {
+  const legacy = compareSemver(version, HERDR_FIRST_STATUS_JSON_VERSION) < 0;
+  const status = legacy
+    ? ["  echo 'unknown command: status' >&2", "  exit 2"]
+    : [`  echo '${readyStatusDocument(version)}'`, "  exit 0"];
+  return [
+    "#!/bin/sh",
+    'if [ "$1" = "status" ]; then',
+    ...status,
+    "fi",
+    'if [ "$1" = "--version" ]; then',
+    `  echo 'herdr ${version}'`,
+    "  exit 0",
+    "fi",
+    "echo '{\"result\":{}}'",
+    "exit 0",
+  ].join("\n");
+}
+
+/** The seed COMMAND that installs {@link herdrStubScript} at `~/.local/bin/herdr`. The trailing
+ *  `test -x` gives the command a non-zero exit when the write didn't land — load-bearing in the
+ *  BASELINE, whose steps are checked (a bad write fail-closes the seed rather than booting a
+ *  scenario against a herdr that isn't there); scenario seeds tolerate non-zero by design. */
+export function herdrStubCommand(version: string): string {
+  return [
+    'mkdir -p "$HOME/.local/bin"',
+    "cat > \"$HOME/.local/bin/herdr\" <<'HERDR_STUB'",
+    herdrStubScript(version),
+    "HERDR_STUB",
+    'chmod +x "$HOME/.local/bin/herdr"',
+    'test -x "$HOME/.local/bin/herdr"',
+  ].join("\n");
+}
+
+/**
+ * The baseline stub every scenario starts from. It exists so Shepherd's boot preflight
+ * (`herdr --version`) passes without a live `herdr.dev` fetch: since #1313 a MISSING herdr
+ * fail-fasts (exit 78) before the HTTP server binds, so the scenarios that don't test herdr still
+ * need one present.
+ *
+ * It reports HERDR_LAST_SUPPORTED_VERSION, derived — never hardcoded. It used to report
+ * `99.99.99`, which was fine until #1887 added the support CEILING: from then on the baseline
+ * represented a herdr Shepherd REFUSES to drive, so every scenario booted with an `unsupported`
+ * check and an UNSUPPORTED preflight banner. Deriving it means a ceiling bump can't reintroduce
+ * that drift — and the same reasoning is why the SHAPE is generated rather than hand-written.
+ */
+export function baselineHerdrStubCommand(): string {
+  return herdrStubCommand(HERDR_LAST_SUPPORTED_VERSION);
+}

--- a/ci/onboarding-harness/scenarios.ts
+++ b/ci/onboarding-harness/scenarios.ts
@@ -1,3 +1,4 @@
+import { herdrStubCommand, outdatedHerdrVersion } from "./herdr-stub";
 import type { Scenario } from "./types";
 
 /**
@@ -96,10 +97,17 @@ export const SCENARIOS: Scenario[] = [
   },
   {
     // A live-but-OUTDATED herdr: `herdr --version` reports below HERDR_MIN_VERSION → `warning`,
-    // while the daemon still answers `agent list` (liveness ok) so it reads outdated, NOT
-    // offline. The baseline stub reports HERDR_LAST_SUPPORTED_VERSION (ok); this seed overwrites
-    // it to report an old version. Present-but-old passes the boot preflight (it fail-fasts only
-    // on a MISSING binary, src/preflight.ts), so the instance boots and self-diagnoses.
+    // while the daemon still answers the liveness probe so it reads outdated, NOT offline. The
+    // baseline stub reports HERDR_LAST_SUPPORTED_VERSION (ok); this seed overwrites it with one
+    // reporting a version below the floor. Present-but-old passes the boot preflight (it
+    // fail-fasts only on a MISSING binary, src/preflight.ts), so the instance boots and
+    // self-diagnoses.
+    //
+    // The stub is LEGACY-shaped (no `status` command) because that is what a real herdr this old
+    // is: the probe falls through to `probeLegacy` and classifies it live. Hand-writing it as a
+    // single `{"version":…}` line is what broke this scenario in #2239 — #2216 taught the probe to
+    // parse `herdr status --json`, and the hand-written line parsed as a malformed document, i.e.
+    // `error`. herdr-stub.ts derives both the version (below the floor) and the shape.
     //
     // DETECTION-ONLY: applies no remediation, so it exercises NONE of the #1578
     // `herdr update --handoff` remediation and largely duplicates the outdated→warning unit
@@ -108,11 +116,7 @@ export const SCENARIOS: Scenario[] = [
     // the header NOTE (no install.sh version pinning → no real old daemon to hand off from).
     id: "herdr-outdated",
     image: "images:archlinux",
-    seed: [
-      "mkdir -p ~/.local/bin",
-      "cat > ~/.local/bin/herdr <<'HERDR_STUB'\n#!/bin/sh\necho '{\"version\":\"0.6.5\"}'\nHERDR_STUB",
-      "chmod +x ~/.local/bin/herdr",
-    ],
+    seed: [herdrStubCommand(outdatedHerdrVersion())],
     expect: [{ id: "herdr", state: "warning" }],
     coaching: "prose",
     detectionOnly: true,

--- a/ci/onboarding-harness/seed.ts
+++ b/ci/onboarding-harness/seed.ts
@@ -1,4 +1,4 @@
-import { HERDR_LAST_SUPPORTED_VERSION } from "../../src/herdr-capabilities";
+import { baselineHerdrStubCommand } from "./herdr-stub";
 import type { IncusDriver } from "./incus";
 import type { Scenario } from "./types";
 
@@ -128,39 +128,6 @@ function ensureToolchain(): string {
   );
 }
 
-/** Write a network-free `herdr` STUB onto PATH so Shepherd's boot preflight
- *  (`herdr --version`) passes without a live `herdr.dev` fetch. Since #1313 a
- *  missing herdr fail-fasts (exit 78) BEFORE the HTTP server binds, so the 6
- *  non-herdr scenarios — which don't test herdr — just need preflight satisfied.
- *
- *  The stub reports HERDR_LAST_SUPPORTED_VERSION, derived — never hardcoded. It used to
- *  report `99.99.99`, which was fine until #1887 added the support CEILING: from then on the
- *  baseline stub represented a herdr Shepherd REFUSES to drive, so every non-herdr scenario
- *  booted with an `unsupported` herdr check and an UNSUPPORTED preflight banner. Harmless
- *  (none of them expect `herdr: ok`) but a lie in the fixture, and it would confuse the next
- *  scenario that does. Deriving it means a ceiling bump can never re-introduce the drift.
- *
- *  The stub emits a single VALID JSON line for EVERY invocation. This is
- *  load-bearing, not decorative:
- *   - diagnostics' `herdrProbe` extracts a semver via `SEMVER_RE` from the output,
- *     so the JSON's version (≥ HERDR_MIN_VERSION, ≤ the ceiling) reads `ok`;
- *   - on-loop `HerdrDriver.list()/tabs()/panes()` do an UNGUARDED `JSON.parse` then
- *     `parsed?.result?.… ?? []`. A plain-text `herdr <version>` would throw a
- *     SyntaxError every tick (a different throw than the pre-#1313 ENOENT), so valid
- *     JSON is required — it parses cleanly to `[]` and never throws.
- *  A final `test -x` makes it a CHECKED step (fail-closes the baseline). */
-function herdrStub(): string {
-  return (
-    'mkdir -p "$HOME/.local/bin"\n' +
-    "cat > \"$HOME/.local/bin/herdr\" <<'HERDR_STUB'\n" +
-    "#!/bin/sh\n" +
-    `echo '{"version":"${HERDR_LAST_SUPPORTED_VERSION}"}'\n` +
-    "HERDR_STUB\n" +
-    'chmod +x "$HOME/.local/bin/herdr"\n' +
-    'test -x "$HOME/.local/bin/herdr"'
-  );
-}
-
 /** Commands that turn a fresh instance into a bootable-Shepherd baseline: bun
  *  runtime + the pushed working-tree build + deps + the claude CLI (agent path) +
  *  a herdr stub that satisfies the boot preflight (#1313). Defects are layered
@@ -196,9 +163,10 @@ function baselineCommands(): string[] {
     `cd ${SHEPHERD_DIR} && ~/.bun/bin/bun install`,
     // claude CLI for the agent apply path; harmless if a scenario removes it later.
     "curl -fsSL https://claude.ai/install.sh | bash || true",
-    // herdr stub so the boot preflight (#1313) passes with zero network; the
-    // herdr-missing scenario removes it in its seed to exercise the real fail-fast.
-    herdrStub(),
+    // herdr stub so the boot preflight (#1313) passes with zero network, shaped to satisfy the
+    // production liveness probe (see herdr-stub.ts); the herdr-missing scenario removes it in its
+    // seed to exercise the real fail-fast.
+    baselineHerdrStubCommand(),
   ];
 }
 

--- a/test/onboarding-harness/herdr-stub.test.ts
+++ b/test/onboarding-harness/herdr-stub.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import {
+  HERDR_FIRST_STATUS_JSON_VERSION,
+  baselineHerdrStubCommand,
+  herdrStubCommand,
+  herdrStubScript,
+  outdatedHerdrVersion,
+} from "../../ci/onboarding-harness/herdr-stub";
+import { HERDR_MIN_VERSION } from "../../src/config";
+import { HERDR_LAST_SUPPORTED_VERSION } from "../../src/herdr-capabilities";
+import { probeHerdrRuntime } from "../../src/herdr-runtime";
+import { compareSemver } from "../../src/semver";
+
+/**
+ * The harness's herdr stubs, executed against the REAL production liveness probe.
+ *
+ * This is the guard #2239 was missing: both stubs were hand-written one-liners that silently
+ * stopped satisfying `probeHerdrRuntime` when #2216 taught it to parse `herdr status --json`, and
+ * nothing noticed until the nightly ran three weeks later. Running the generated script through
+ * the probe here moves that detection to a one-second unit test.
+ */
+
+const execFileAsync = promisify(execFile);
+const sandboxes: string[] = [];
+
+afterEach(() => {
+  for (const dir of sandboxes.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+/** Plant a generated stub as an executable and hand back its path. */
+function plant(version: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-herdr-stub-"));
+  sandboxes.push(dir);
+  const path = join(dir, "herdr");
+  writeFileSync(path, `${herdrStubScript(version)}\n`);
+  chmodSync(path, 0o755);
+  return path;
+}
+
+describe("harness herdr stub", () => {
+  test("the baseline stub reads as a live, current daemon", async () => {
+    await expect(
+      probeHerdrRuntime({ bin: plant(HERDR_LAST_SUPPORTED_VERSION), timeoutMs: 5_000 }),
+    ).resolves.toEqual({
+      state: "ready",
+      installedVersion: HERDR_LAST_SUPPORTED_VERSION,
+      serverVersion: HERDR_LAST_SUPPORTED_VERSION,
+    });
+  });
+
+  // A `ready` liveness is what lets versionProbe reach its version comparison at all; the
+  // ok/warning split from there is src/diagnostics.ts' own, covered in test/diagnostics.test.ts.
+  test("the outdated stub reads as LIVE — outdated, never offline", async () => {
+    const version = outdatedHerdrVersion();
+    await expect(
+      probeHerdrRuntime({ bin: plant(version), timeoutMs: 5_000 }),
+    ).resolves.toMatchObject({ state: "ready", installedVersion: version });
+  });
+
+  test("the outdated stub's version stays below the floor the scenario asserts against", () => {
+    expect(compareSemver(outdatedHerdrVersion(), HERDR_MIN_VERSION)).toBeLessThan(0);
+  });
+
+  // The baseline must sit at or above the floor, or the six scenarios that merely need a herdr
+  // present would each carry an unseeded `warning` they never asked for.
+  test("the baseline stub's version is at or above the floor", () => {
+    expect(compareSemver(HERDR_LAST_SUPPORTED_VERSION, HERDR_MIN_VERSION)).toBeGreaterThanOrEqual(
+      0,
+    );
+  });
+
+  test("each stub carries the shape its version really had", () => {
+    expect(compareSemver(outdatedHerdrVersion(), HERDR_FIRST_STATUS_JSON_VERSION)).toBeLessThan(0);
+    // Legacy: no `status` command at all, and a plain-text --version line.
+    expect(herdrStubScript(outdatedHerdrVersion())).toContain("unknown command: status");
+    // Modern: a real status document, so the probe's modern path is the one exercised.
+    expect(herdrStubScript(HERDR_FIRST_STATUS_JSON_VERSION)).toContain(
+      '"endpoint_compatible":true',
+    );
+  });
+
+  test("every response is valid JSON or a parseable version line", async () => {
+    for (const version of [HERDR_LAST_SUPPORTED_VERSION, outdatedHerdrVersion()]) {
+      const bin = plant(version);
+      // The on-loop driver JSON.parses list/tabs/panes output unguarded — a non-JSON reply there
+      // throws every tick.
+      for (const args of [
+        ["agent", "list"],
+        ["tab", "list"],
+        ["pane", "list"],
+      ]) {
+        const { stdout } = await execFileAsync(bin, args);
+        expect(() => JSON.parse(stdout)).not.toThrow();
+      }
+      // Every --version consumer (boot preflight, herdr-update, probeLegacy, the harness's own
+      // pin assertion) reads this through a semver regex, so plain text is fine — but the version
+      // must be in there.
+      const { stdout } = await execFileAsync(bin, ["--version"]);
+      expect(stdout).toContain(version);
+    }
+  });
+
+  test("the seed command installs the script and fail-closes on a bad write", () => {
+    const command = baselineHerdrStubCommand();
+    expect(command).toBe(herdrStubCommand(HERDR_LAST_SUPPORTED_VERSION));
+    expect(command).toContain(herdrStubScript(HERDR_LAST_SUPPORTED_VERSION));
+    expect(command).toContain('chmod +x "$HOME/.local/bin/herdr"');
+    expect(command.trimEnd().endsWith('test -x "$HOME/.local/bin/herdr"')).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #2239.

## What broke

Not #2126 or #2210 as the issue suspected — **#2216**. It replaced diagnostics' exit-code-only `herdr agent list` liveness with `probeHerdrRuntime()`, which now runs **`herdr status --json` first** and parses the document.

Both harness stubs answered *every* invocation with a single `{"version":"…"}` line and exit 0. That parses as a status document with no `client`/`server` keys → `unknown` → liveness throws → `versionProbe` returns `error` (`diagnostics_hint_herdr_unknown`) and never reaches the below-floor `warning` branch. Reproduced directly against the production probe:

```
OLD one-line stub => { state: "unknown", installedVersion: null, reason: "probe_failed" }
```

The scenario's `warning` expectation was never stale: a real live herdr 0.6.x has no `status` command, so production falls through to `probeLegacy()` (`agent list` + `--version`) → `ready` → below `HERDR_MIN_VERSION` → `warning`. The fixture was the lie.

**The baseline stub had the same defect**, so the other six scenarios have been booting with an `error` herdr row since Sep 8 — contradicting `herdrStub()`'s own comment claiming it reads `ok`. Invisible because none of them assert on `herdr`.

## The fix

New `ci/onboarding-harness/herdr-stub.ts` generates both stubs, shaped by the version it is given:

| Stub | Version source | Shape | Probe path | Check |
| --- | --- | --- | --- | --- |
| baseline | `HERDR_LAST_SUPPORTED_VERSION` | modern: real ready status document | `status --json` → `agent list` | `ok` |
| herdr-outdated | derived one step below `HERDR_MIN_VERSION` | legacy: `status` exits 2, plain-text `--version` | `probeLegacy` fallback | `warning` |

Versions are derived, never hardcoded — the way the baseline already derived its own — so a floor bump can't quietly turn the outdated scenario into a healthy herdr, and the shape follows from the version automatically.

`--version` now answers as real herdr does (a plain line). Checked first that every consumer — boot preflight, `herdr-update`'s version runner, `probeLegacy`, diagnostics, and the harness's own pin assertion — reads it through a semver regex and none JSON-parses it. The catch-all stays valid JSON because the on-loop driver's `list()/tabs()/panes()` do an unguarded `JSON.parse`.

No `src/` changes: production was behaving correctly throughout.

## Why it went unnoticed for three weeks

This is the second-order cost of the #2226 outage the issue calls out. `test/onboarding-harness/herdr-stub.test.ts` executes each **generated** stub against the **real** `probeHerdrRuntime`, so the next time the contract moves it fails in a second instead of in a nightly.

## Verification

- `bun run onboarding:test -- --scenario herdr-outdated` on a real archlinux instance → `| herdr-outdated | images:archlinux | yes | skipped | no | 57s | DETECTION-ONLY |`
- Root `bun run lint`, `bunx tsc --noEmit`, `bun run test` (9597 pass / 0 fail)
- `bunx fallow audit --base origin/main --fail-on-issues` — clean on all 4 changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
