### PR TITLE
fix(settings): keep the settings dialog reactive after a short PUT response (#2240)

### DIFF
--- a/ui/src/lib/components/Settings.browser.test.ts
+++ b/ui/src/lib/components/Settings.browser.test.ts
@@ -9,6 +9,7 @@ import {
   verifyApiKey,
   putAnthropicApiKey,
   putDefaultCodexModel,
+  putDefaultModel,
   fixDiagnostic,
   putRoleEffort,
   putDefaultEffort,
@@ -64,6 +65,7 @@ const mockGetSettings = vi.mocked(getSettings);
 const mockVerify = vi.mocked(verifyApiKey);
 const mockPutKey = vi.mocked(putAnthropicApiKey);
 const mockPutCodexModel = vi.mocked(putDefaultCodexModel);
+const mockPutModel = vi.mocked(putDefaultModel);
 const mockFix = vi.mocked(fixDiagnostic);
 
 function settings(over: Partial<SettingsPayload> = {}): SettingsPayload {
@@ -161,6 +163,8 @@ beforeEach(() => {
   mockPutKey.mockReset();
   mockPutCodexModel.mockReset();
   mockPutCodexModel.mockImplementation(async (model) => ({ defaultCodexModel: model }));
+  mockPutModel.mockReset();
+  mockPutModel.mockImplementation(async (model) => ({ defaultModel: model }));
   // Default seed: api-key mode, key configured → Verify button renders.
   mockGetSettings.mockResolvedValue(settings());
 });
@@ -441,6 +445,52 @@ describe("Settings default coding environment", () => {
       m.settings_role_model_effective({
         model: `${m.settings_cli_claude()} · ${m.model_configured_opus_latest()}`,
       }),
+    );
+  });
+
+  // #2240: a settings PUT that answers 200 WITHOUT the field it owns must not poison the local
+  // value. `defaultModel = undefined` throws inside SettingsCodingCliPanel's `is1mModel`
+  // ($derived(defaultModel.endsWith("[1m]"))) during Svelte's flush; that abandons the batch, so
+  // every effect not yet processed stays dirty forever and the whole dialog stops reacting until a
+  // page reload. The visible tell was a role's guidance line frozen on the global default's copy
+  // while its own "Effective:" line kept tracking — so this asserts on the guidance line.
+  //
+  // Both halves matter: without the toHaveValue check the role pickers could be inert for an
+  // unrelated reason, and without the not.toContain the assertion would pass on a guidance line
+  // that merely happens to mention several models.
+  it("a settings PUT that omits its own field leaves the dialog reactive", async () => {
+    mockGetSettings.mockResolvedValue(
+      settings({ defaultAgentProvider: "claude", defaultModel: "opus", plannerCli: "inherit" }),
+    );
+    // Exactly what the demo router used to answer for every unhandled settings mutation.
+    mockPutModel.mockResolvedValue({} as { defaultModel: string });
+    await mountCodingAgents();
+
+    const { disclosure, button } = requiredCodingSectionButton(m.settings_role_models_title());
+    if (button.getAttribute("aria-expanded") === "false") await disclosure.click();
+
+    await page.getByTestId("default-environment-model").selectOptions("sonnet");
+    await vi.waitFor(() => expect(mockPutModel).toHaveBeenCalledWith("sonnet"));
+
+    const cli = page.getByRole("combobox", {
+      name: m.settings_role_cli_label({ role: roleTitle("planner") }),
+    });
+    await cli.selectOptions("codex");
+    const roleModel = page.getByRole("combobox", {
+      name: m.settings_role_model_label({ role: roleTitle("planner") }),
+    });
+    await roleModel.selectOptions("gpt-6-astra");
+    await expect.element(roleModel).toHaveValue("gpt-6-astra");
+
+    const row = (cli.query() as HTMLElement | null)?.closest(".rrow");
+    expect(row, "planner role row").not.toBeNull();
+    await vi.waitFor(() => {
+      const guidance = row!.querySelector(".model-guidance");
+      expect(guidance?.textContent).toContain(m.model_guidance_codex_6_astra());
+    });
+    // The frozen line reported in #2240 was the GLOBAL default's guidance.
+    expect(row!.querySelector(".model-guidance")!.textContent).not.toContain(
+      m.model_guidance_claude_opus(),
     );
   });
 });

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -198,13 +198,20 @@
   let repoRootDisplay = $state<string | null>(null);
   let settingsLoaded = $state(false);
 
+  // The three global-default savers adopt only a string from the response — the same guard the
+  // per-role savers in SettingsCodingCliPanel use. These values are required-string props that
+  // panel dereferences inside `$derived`s (`defaultModel.endsWith("[1m]")`); a response missing
+  // the field would make one throw during Svelte's flush, which aborts the batch and leaves the
+  // whole dialog stale until a reload (#2240). A short response now leaves the last good value.
   async function saveDefaultModel() {
     if (defaultModelBusy) return;
     defaultModelBusy = true;
     try {
       const r = await putDefaultModel(defaultModel);
-      defaultModel = r.defaultModel;
-      defaultModelSaved = r.defaultModel;
+      if (typeof r.defaultModel === "string") {
+        defaultModel = r.defaultModel;
+        defaultModelSaved = r.defaultModel;
+      }
     } catch {
       // revert to the last server-confirmed value; surface the failure as a
       // 12s, deduped alert so the no-op never looks like a save.
@@ -223,8 +230,10 @@
     defaultCodexModelBusy = true;
     try {
       const r = await putDefaultCodexModel(defaultCodexModel);
-      defaultCodexModel = r.defaultCodexModel;
-      defaultCodexModelSaved = r.defaultCodexModel;
+      if (typeof r.defaultCodexModel === "string") {
+        defaultCodexModel = r.defaultCodexModel;
+        defaultCodexModelSaved = r.defaultCodexModel;
+      }
     } catch {
       defaultCodexModel = defaultCodexModelSaved;
       toasts.info(m.settings_default_codex_model_save_failed(), {
@@ -241,8 +250,10 @@
     defaultAgentProviderBusy = true;
     try {
       const r = await putDefaultAgentProvider(defaultAgentProvider);
-      defaultAgentProvider = r.defaultAgentProvider;
-      defaultAgentProviderSaved = r.defaultAgentProvider;
+      if (typeof r.defaultAgentProvider === "string") {
+        defaultAgentProvider = r.defaultAgentProvider;
+        defaultAgentProviderSaved = r.defaultAgentProvider;
+      }
     } catch {
       defaultAgentProvider = defaultAgentProviderSaved;
       toasts.info(m.settings_default_agent_provider_save_failed(), {

--- a/ui/src/lib/demo/router.test.ts
+++ b/ui/src/lib/demo/router.test.ts
@@ -397,3 +397,61 @@ describe("POST /api/sessions/:id/ack-manual-steps (mirrors the real server handl
     expect((ev!.data as { manualStepsAckedAt: number | null }).manualStepsAckedAt).not.toBeNull();
   });
 });
+
+// #2240: `PUT /api/settings` had no route, so every settings control in the demo saved into the
+// permissive `{ok:true}` tail. Callers that adopt the echoed field (`defaultModel = r.defaultModel`)
+// got `undefined`, and an undefined required-string prop throws inside a `$derived` during Svelte's
+// flush — which aborts the batch and freezes the whole Settings dialog until a reload.
+describe("PUT /api/settings echoes the field the real server echoes", () => {
+  async function put(patch: Record<string, unknown>) {
+    const r = await handleApi("PUT", u("/api/settings"), patch);
+    return { status: r.status, body: await r.json() };
+  }
+
+  it("echoes a plain field and applies it to the world", async () => {
+    expect(await put({ defaultModel: "opus" })).toEqual({
+      status: 200,
+      body: { defaultModel: "opus" },
+    });
+    expect((await get("/api/settings")).body.defaultModel).toBe("opus");
+  });
+
+  it("echoes a per-role field under its own key", async () => {
+    expect((await put({ plannerCli: "codex" })).body).toEqual({ plannerCli: "codex" });
+    expect((await put({ plannerModel: "gpt-6-astra" })).body).toEqual({
+      plannerModel: "gpt-6-astra",
+    });
+    const { body } = await get("/api/settings");
+    expect(body.plannerCli).toBe("codex");
+    expect(body.plannerModel).toBe("gpt-6-astra");
+  });
+
+  it("answers authMode with the {authMode, hasApiKey} pair api.ts is typed against", async () => {
+    const { body } = await put({ authMode: "api-key" });
+    expect(body.authMode).toBe("api-key");
+    expect(typeof body.hasApiKey).toBe("boolean");
+  });
+
+  it("answers anthropicApiKey with {hasApiKey} only — the key never round-trips", async () => {
+    expect((await put({ anthropicApiKey: "sk-demo-secret" })).body).toEqual({ hasApiKey: true });
+    expect((await get("/api/settings")).body.hasApiKey).toBe(true);
+    // Nothing anywhere in the world echoes the key back.
+    expect(JSON.stringify((await get("/api/settings")).body)).not.toContain("sk-demo-secret");
+    expect((await put({ anthropicApiKey: null })).body).toEqual({ hasApiKey: false });
+  });
+
+  it("answers repoRoot with a full Settings (putRepoRoot is typed Promise<Settings>)", async () => {
+    const { body } = await put({ repoRoot: "/demo/acme" });
+    expect(body.repoRoot).toBe("/demo/acme");
+    expect(body.repoRootDisplay).toBe("/demo/acme");
+    // The Workspace panel reads more than the root off this response.
+    expect(body.defaultModel).toBeDefined();
+    expect(typeof body.upnextSkipCliPicker).toBe("boolean");
+  });
+
+  it("an empty patch is a read, not a stub", async () => {
+    const { body } = await put({});
+    expect(body.repoRoot).toBeDefined();
+    expect(body.ok).toBeUndefined();
+  });
+});

--- a/ui/src/lib/demo/router.ts
+++ b/ui/src/lib/demo/router.ts
@@ -311,8 +311,25 @@ function handleManualStepsMutation(method: string, path: string, body: unknown):
   return null;
 }
 
+// ── settings mutations ───────────────────────────────────────────────────────
+/** PUT /api/settings — every settings control in the dialog saves through here.
+ *
+ *  Without a handler this fell to the permissive `{ok:true}` tail, and callers that assign the
+ *  echoed field straight back (`defaultModel = r.defaultModel`) got `undefined`. A required-string
+ *  prop turning undefined throws inside a `$derived` during Svelte's flush, which aborts the batch
+ *  and leaves the whole Settings subtree stale until a reload (#2240). */
+function handleSettingsMutation(method: string, path: string, body: unknown): Response | null {
+  if (method !== "PUT" || path !== "/api/settings") return null;
+  // The server takes exactly one field per call and dispatches on the first it recognizes.
+  const entries = body && typeof body === "object" ? Object.entries(body) : [];
+  const patch = entries[0];
+  if (!patch) return json(demoState.settings());
+  return json(demoState.patchSettings(patch[0], patch[1]));
+}
+
 function handleMutation(method: string, path: string, url: URL, body: unknown): Response | null {
   return (
+    handleSettingsMutation(method, path, body) ??
     handleSessionMutation(method, path, url, body) ??
     handleHeldMutation(method, path) ??
     handleManualStepsMutation(method, path, body)

--- a/ui/src/lib/demo/state.ts
+++ b/ui/src/lib/demo/state.ts
@@ -467,6 +467,28 @@ export const demoState = {
     emit({ event: "session:archived", data: { id } });
   },
 
+  /** Apply one settings field (`PUT /api/settings` carries exactly one) and return the body the
+   *  real server answers with. The server's `SETTING_PATCHES` handlers each echo only the field
+   *  they own — and three of them answer with a different shape, which callers in `api.ts` are
+   *  typed against, so the demo mirrors them field by field. Anything else echoes itself.
+   *
+   *  Unlike the server this never validates: the demo is a stub, and a 400 would only make the
+   *  showcase worse. Changes live for the page load — `reset()` re-seeds the world on reload. */
+  patchSettings(field: string, value: unknown): Record<string, unknown> {
+    // The raw key never round-trips back to the client — the demo stores only the fact.
+    if (field === "anthropicApiKey") {
+      world.settings.hasApiKey = typeof value === "string" && value.trim().length > 0;
+      return { hasApiKey: world.settings.hasApiKey };
+    }
+    (world.settings as unknown as Record<string, unknown>)[field] = value;
+    if (field === "repoRoot") {
+      world.settings.repoRootDisplay = String(value);
+      return world.settings as unknown as Record<string, unknown>;
+    }
+    if (field === "authMode") return { authMode: value, hasApiKey: world.settings.hasApiKey };
+    return { [field]: value };
+  },
+
   /** Tick / un-tick one materialized post-merge step (Owed lens checkbox). Returns the
    *  updated record, or null if the session/step isn't found (mirrors the real 404). */
   setManualStepDone(sessionId: string, stepId: string, done: boolean): PostMergeSteps | null {


### PR DESCRIPTION
Closes #2240.

## The issue's diagnosis was wrong

`ModelGuidance` and `SettingsGroup` are both innocent. The collapsed group keeps its children
mounted and they update normally while hidden — I reproduced the freeze with AGENT ENVIRONMENTS
**expanded** the whole time. (The stated repro also isn't literally performable: a role's CLI
select sits inside the `hidden` group.)

## What actually happens

Reproduced live against `SHEPHERD_DEMO=1 bun run dev` in Chromium, with a `window.onerror` hook and
a temporary `data-dbg="{provider}|{model}"` attribute on `ModelGuidance`:

1. Changing GLOBAL DEFAULTS → Claude Code model calls `saveDefaultModel()`, which does
   `defaultModel = r.defaultModel` with no shape check.
2. `PUT /api/settings` had **no route** in `ui/src/lib/demo/router.ts`, so it fell through to the
   permissive `json({ ok: true })` tail — `r.defaultModel` is `undefined`.
3. `SettingsCodingCliPanel`'s `is1mModel` (`$derived(defaultModel.endsWith("[1m]"))`) throws
   **inside Svelte's `Batch.flush` → `#traverse` → `update_derived`**.
4. That uncaught throw abandons the batch traversal. Every effect not yet processed stays dirty and
   is never revisited — the whole Settings subtree freezes until a page reload.

So it isn't a guidance bug at all: after the throw, every *other* role row's `Effective:` line
freezes too. The debug attribute showed the child component's **props** stale (`claude|opus`) while
the sibling `Effective:` text in the same snippet correctly read `Codex · provider default` — the
child's effects had simply stopped running.

**Not reachable in production today** — the real `putDefaultModel` in `src/server.ts` always echoes
`{ defaultModel }`. This is a demo-mode trigger plus an unguarded client assumption, and the demo is
the marketing surface the bug was found on.

## The fix

**`ui/src/lib/demo/router.ts` + `state.ts`** — handle `PUT /api/settings`: apply the single patched
field to `world.settings` and echo the shape the real server echoes. Three fields answer differently
and are mirrored field by field, because `api.ts` is typed against them:

| Patched field | Response |
| --- | --- |
| `repoRoot` | full `Settings` (`putRepoRoot` is typed `Promise<Settings>`) |
| `anthropicApiKey` | `{ hasApiKey }` — the key is never stored or echoed |
| `authMode` | `{ authMode, hasApiKey }` |
| everything else | `{ [field]: value }` |

This fixes every settings control in the demo at once, not just the model picker. Like the rest of
the demo router it never validates — a 400 would only make the showcase worse.

**`ui/src/lib/components/Settings.svelte`** — the three global-default savers now adopt only a
string from the response, the same guard the per-role savers in `SettingsCodingCliPanel` already
use. A malformed response can no longer poison a required-string prop and wedge the tree.

## Tests

- `ui/src/lib/demo/router.test.ts` — the new route's echo shapes, the round-trip through
  `GET /api/settings`, and that the API key never comes back.
- `ui/src/lib/components/Settings.browser.test.ts` — regression test: with `putDefaultModel`
  resolving `{}`, a role's guidance must still track that role's model. Verified red against the
  unguarded code, failing with exactly the diagnosed throw at `SettingsCodingCliPanel.svelte:199`
  inside `Batch.flush`.

`cd ui && bun run check` clean; `bun run test` green (312 files / 5060 tests). Also re-ran the live
repro after the fix: guidance tracks the role's model and the console stays clean.

## Deliberately out of scope

A `<svelte:boundary>` around the settings panels (so any future throw degrades one panel instead of
the dialog) — considered and left out with Patrick. Also untouched: `ModelGuidance.svelte` /
`SettingsGroup.svelte` (not at fault), the boolean savers `fableAvailable` / `reducedPushMode` (an
`undefined` there renders wrong but cannot throw), and `src/server.ts` (already correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
