### PR TITLE
feat(usage): switch the default coding CLI when one runs out of weekly capacity

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ import {
 import { normalizeDefaultEffortSetting, effortBelowHigh } from "./default-effort";
 import { normalizeAuthModeSetting } from "./auth-mode";
 import { normalizeAgentProvider } from "./agent-provider";
+import type { AgentProvider } from "./types";
 import { normalizeTelemetryConsent } from "./telemetry-consent";
 import { normalizeOperatorLanguage } from "./operator-language";
 import { thresholdsFromEnv } from "./maintain-core";
@@ -909,6 +910,11 @@ export const config = {
   // UI-configurable; env seeds a fresh DB.
   defaultAgentProvider:
     normalizeAgentProvider(process.env.SHEPHERD_DEFAULT_AGENT_PROVIDER) ?? "claude",
+  // Capacity failover (src/provider-failover.ts): the provider `defaultAgentProvider` was
+  // switched AWAY from because its weekly window ran out of headroom, and which the 30s usage
+  // tick restores once that headroom is back. null = no failover active. Runtime state, not
+  // configuration — persisted, but deliberately not env-seeded (like previewHost).
+  providerFailoverFrom: null as AgentProvider | null,
   // Global fable availability flag. When false, any spawn requesting --model fable is
   // transparently rerouted to opus[1m] at argv-assembly time without rewriting the
   // stored session model (so cost accounting + fable intent survive for later replay).

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,6 +195,7 @@ import { detectPendingAuthUrl, detectLoginAuthUrl } from "./auth-url";
 import { readTranscriptTail } from "./activity";
 import { verifyApiKey, VERIFY_KEY_LABEL } from "./verify-key";
 import { releaseHeldTasks } from "./held-release";
+import { PROVIDER_FAILOVER_FROM_KEY, releaseProviderFailover } from "./provider-failover";
 import { snapshotSessionUsage } from "./usage-snapshot";
 import { hasCommittedChanges } from "./diff";
 import { HoldReasonService } from "./hold-service";
@@ -385,6 +386,10 @@ if (savedProvider !== null) {
   const v = normalizeAgentProvider(savedProvider);
   if (v !== null) config.defaultAgentProvider = v;
 }
+// An in-flight capacity failover outlives a restart — otherwise the temporary substitution above
+// would silently become the operator's permanent default. "" (the cleared marker, since the
+// settings store has no delete) normalizes to null, i.e. no failover.
+config.providerFailoverFrom = normalizeAgentProvider(store.getSetting(PROVIDER_FAILOVER_FROM_KEY));
 // a UI-set fableAvailable flag (persisted) overrides the env seed; absent or unrecognised → keep default.
 const savedFa = store.getSetting("fableAvailable");
 if (savedFa !== null) {
@@ -2640,6 +2645,10 @@ deferredStarts.push(() => {
     timerTask("usage", async () => {
       await accountIndex.refresh(Date.now());
       events.emit("usage:limits", usageLimits.limits(Date.now()));
+      // Restore the operator's default CLI once the provider a capacity failover switched away
+      // from has weekly headroom again. Synchronous and self-guarding (no-op unless a failover
+      // is active), so it needs no re-entrancy flag of its own.
+      releaseProviderFailover({ store, usageLimits }, Date.now());
       if (releasingHeld) return; // prior release still draining — skip this tick's release
       releasingHeld = true;
       try {

--- a/src/provider-failover.ts
+++ b/src/provider-failover.ts
@@ -1,0 +1,167 @@
+/**
+ * Capacity failover between the two coding CLIs.
+ *
+ * When the WEEKLY window of the operator's default CLI drops below
+ * PROVIDER_FAILOVER_MIN_FREE_PCT remaining and the other CLI measurably has room, the usage
+ * popover offers a one-click switch of `config.defaultAgentProvider` to that counterpart. The
+ * origin is remembered so the 30s usage tick can switch back on its own once the exhausted
+ * provider has weekly headroom again.
+ *
+ * Deliberately weekly-only: a 5h window recovers within hours, so switching the global default
+ * "until it frees up" would churn the setting for a squeeze that resolves itself.
+ *
+ * Unmeasurable is NOT free. `weeklyFreePct` returns null when a provider reports no weekly
+ * window (api-key mode, a provider that never produced a sample, a failed scrape), and both the
+ * offer and the release treat null as "don't act": we never switch INTO an unknown, and we never
+ * switch BACK to one either — the popover's manual revert is the escape hatch. Staleness, by
+ * contrast, participates normally; it dims presentation, it never reroutes a decision (same rule
+ * as `hottestCapacityWindow` in the UI).
+ *
+ * The UI predicts `providerFailoverOffer` in `ui/src/lib/provider-capacity.ts` so it knows whether
+ * to render the button — the same shape as `claudeUsageHoldLikely` predicting `shouldHold`. THIS
+ * module is authoritative: the route re-derives the offer and rejects a stale HUD's request.
+ */
+import { config } from "./config";
+import type { SessionStore } from "./store";
+import {
+  AGENT_PROVIDERS,
+  type AgentProvider,
+  type DiagnosticsSnapshot,
+  type ProviderFailoverStatus,
+} from "./types";
+import type { UsageLimits } from "./usage-limits";
+
+/** Remaining-capacity floor, in percent. Hardcoded on purpose — no setting, no env. */
+const PROVIDER_FAILOVER_MIN_FREE_PCT = 30;
+
+/** Persisted origin of an active failover ("" once cleared — the store has no delete). */
+export const PROVIDER_FAILOVER_FROM_KEY = "providerFailoverFrom";
+
+/**
+ * Weekly remaining capacity for one provider, or null when nothing measured it.
+ *
+ * Claude reads the OPERATOR-VISIBLE number (provider-confirmed observation preferred over the
+ * locally computed window), matching `claudeDisplayGauges` in the UI. The button sits two lines
+ * under that number in the same popover; deciding on a different one would let it contradict
+ * what the operator is reading.
+ */
+export function weeklyFreePct(limits: UsageLimits | null, provider: AgentProvider): number | null {
+  const pct = weeklyUsedPct(limits, provider);
+  // Clamped like the UI's `capacityWindows`, so an over-cap sample reads 0 % free on both sides.
+  return pct === null ? null : Math.min(Math.max(100 - pct, 0), 100);
+}
+
+function weeklyUsedPct(limits: UsageLimits | null, provider: AgentProvider): number | null {
+  if (!limits) return null;
+  if (provider === "codex") {
+    const codex = limits.providers?.find((p) => p.provider === "codex" && p.kind === "tokens");
+    return codex?.kind === "tokens" ? (codex.week?.pct ?? null) : null;
+  }
+  const claude = limits.providers?.find((p) => p.provider === "claude" && p.kind === "limits");
+  const observed =
+    limits.observed?.week ?? (claude?.kind === "limits" ? claude.observed?.week : undefined);
+  if (observed) return observed.pct;
+  const computed = limits.week ?? (claude?.kind === "limits" ? claude.week : null);
+  return computed?.pct ?? null;
+}
+
+/** The agent CLIs the environment probe currently reports as usable. */
+export function readyAgentProviders(
+  diagnostics: DiagnosticsSnapshot | null,
+): readonly AgentProvider[] {
+  return AGENT_PROVIDERS.filter((provider) =>
+    diagnostics?.checks.some((check) => check.id === provider && check.state === "ok"),
+  );
+}
+
+export interface ProviderFailoverOffer {
+  /** The exhausted provider the operator would switch away from (today's default). */
+  from: AgentProvider;
+  /** The counterpart with room. */
+  to: AgentProvider;
+  fromFreePct: number;
+  toFreePct: number;
+}
+
+const OTHER: Record<AgentProvider, AgentProvider> = { claude: "codex", codex: "claude" };
+
+/**
+ * The switch worth offering right now, or null.
+ *
+ * Only ever offers moving AWAY from the current default: if the default already is the cool
+ * provider there is nothing to do, however hot the other one runs.
+ */
+export function providerFailoverOffer(input: {
+  limits: UsageLimits | null;
+  defaultProvider: AgentProvider;
+  readyProviders: readonly AgentProvider[];
+}): ProviderFailoverOffer | null {
+  const from = input.defaultProvider;
+  const to = OTHER[from];
+  if (!input.readyProviders.includes(to)) return null;
+
+  const fromFreePct = weeklyFreePct(input.limits, from);
+  const toFreePct = weeklyFreePct(input.limits, to);
+  if (fromFreePct === null || toFreePct === null) return null;
+  if (fromFreePct >= PROVIDER_FAILOVER_MIN_FREE_PCT) return null;
+  if (toFreePct < PROVIDER_FAILOVER_MIN_FREE_PCT) return null;
+
+  return { from, to, fromFreePct, toFreePct };
+}
+
+/** True once the provider we switched away from has measurable weekly headroom again. */
+export function shouldReleaseFailover(limits: UsageLimits | null, from: AgentProvider): boolean {
+  const freePct = weeklyFreePct(limits, from);
+  return freePct !== null && freePct >= PROVIDER_FAILOVER_MIN_FREE_PCT;
+}
+
+export function providerFailoverStatus(): ProviderFailoverStatus {
+  return {
+    active: config.providerFailoverFrom !== null,
+    from: config.providerFailoverFrom,
+    current: config.defaultAgentProvider,
+  };
+}
+
+type FailoverStore = Pick<SessionStore, "setSetting">;
+
+/** Persist the default provider and the remembered origin together (origin "" = none). */
+export function writeProviderFailover(
+  store: FailoverStore,
+  next: { defaultProvider: AgentProvider; from: AgentProvider | null },
+): ProviderFailoverStatus {
+  config.defaultAgentProvider = next.defaultProvider;
+  config.providerFailoverFrom = next.from;
+  store.setSetting("defaultAgentProvider", next.defaultProvider);
+  store.setSetting(PROVIDER_FAILOVER_FROM_KEY, next.from ?? "");
+  return providerFailoverStatus();
+}
+
+/** Forget an active failover without touching the default — the operator just chose one himself. */
+export function clearProviderFailover(store: FailoverStore): void {
+  if (config.providerFailoverFrom === null) return;
+  config.providerFailoverFrom = null;
+  store.setSetting(PROVIDER_FAILOVER_FROM_KEY, "");
+}
+
+export interface ProviderFailoverReleaseDeps {
+  store: FailoverStore;
+  usageLimits: { limits(now: number): UsageLimits };
+}
+
+/**
+ * The 30s tick's half of the feature: restore the operator's original default once the provider
+ * we switched away from has room again. No-op while no failover is active, and — per the
+ * unmeasurable rule above — while the origin reports no weekly window at all.
+ */
+export function releaseProviderFailover(
+  deps: ProviderFailoverReleaseDeps,
+  now: number,
+): { released: boolean } {
+  const from = config.providerFailoverFrom;
+  if (from === null) return { released: false };
+  if (!shouldReleaseFailover(deps.usageLimits.limits(now), from)) return { released: false };
+
+  writeProviderFailover(deps.store, { defaultProvider: from, from: null });
+  return { released: true };
+}

--- a/src/provider-failover.ts
+++ b/src/provider-failover.ts
@@ -29,7 +29,7 @@ import {
   type DiagnosticsSnapshot,
   type ProviderFailoverStatus,
 } from "./types";
-import type { UsageLimits } from "./usage-limits";
+import type { UsageLimits, UsageObservations } from "./usage-limits";
 
 /** Remaining-capacity floor, in percent. Hardcoded on purpose — no setting, no env. */
 const PROVIDER_FAILOVER_MIN_FREE_PCT = 30;
@@ -40,15 +40,24 @@ export const PROVIDER_FAILOVER_FROM_KEY = "providerFailoverFrom";
 /**
  * Weekly remaining capacity for one provider, or null when nothing measured it.
  *
- * Claude reads the OPERATOR-VISIBLE number (provider-confirmed observation preferred over the
- * locally computed window), matching `claudeDisplayGauges` in the UI. The button sits two lines
- * under that number in the same popover; deciding on a different one would let it contradict
- * what the operator is reading.
+ * Claude reads the OPERATOR-VISIBLE number, matching `claudeDisplayGauges` in the UI: the
+ * provider-confirmed observation is authoritative wherever the contract is present, and only a
+ * payload carrying no contract at all falls back to the locally computed window. The button sits
+ * two lines under that number in the same popover; deciding on a different one would let it
+ * contradict what the operator is reading.
  */
 export function weeklyFreePct(limits: UsageLimits | null, provider: AgentProvider): number | null {
   const pct = weeklyUsedPct(limits, provider);
   // Clamped like the UI's `capacityWindows`, so an over-cap sample reads 0 % free on both sides.
   return pct === null ? null : Math.min(Math.max(100 - pct, 0), 100);
+}
+
+/** `claudeObservedWindows` from the UI's usage-gauges: the contract is picked per SOURCE, not per
+ *  field — a present `observed` object wins whole, null windows included. */
+function claudeObservations(limits: UsageLimits): UsageObservations | undefined {
+  if (limits.observed !== undefined) return limits.observed;
+  const claude = limits.providers?.find((p) => p.provider === "claude" && p.kind === "limits");
+  return claude?.kind === "limits" ? claude.observed : undefined;
 }
 
 function weeklyUsedPct(limits: UsageLimits | null, provider: AgentProvider): number | null {
@@ -57,12 +66,15 @@ function weeklyUsedPct(limits: UsageLimits | null, provider: AgentProvider): num
     const codex = limits.providers?.find((p) => p.provider === "codex" && p.kind === "tokens");
     return codex?.kind === "tokens" ? (codex.week?.pct ?? null) : null;
   }
-  const claude = limits.providers?.find((p) => p.provider === "claude" && p.kind === "limits");
-  const observed =
-    limits.observed?.week ?? (claude?.kind === "limits" ? claude.observed?.week : undefined);
-  if (observed) return observed.pct;
-  const computed = limits.week ?? (claude?.kind === "limits" ? claude.week : null);
-  return computed?.pct ?? null;
+  const observed = claudeObservations(limits);
+  // Contract present ⇒ authoritative, INCLUDING a null week: that means "the provider never
+  // confirmed this window", not "fall back to the local estimate". `limits()` always emits the
+  // contract, so before the first /usage scrape this is the live case — reading the JSONL-computed
+  // window here would call Claude measured while the popover renders it as no observation, and
+  // the two sides must never disagree about what counts. Only a payload with NO contract at all
+  // falls back, and then to the same top-level windows `gaugeList` reads.
+  if (observed !== undefined) return observed.week?.pct ?? null;
+  return limits.week?.pct ?? null;
 }
 
 /** The agent CLIs the environment probe currently reports as usable. */

--- a/src/server.ts
+++ b/src/server.ts
@@ -255,6 +255,13 @@ import { validateHookEvent, type HookEvent, type SubagentEntry } from "./hooks-i
 import { quotaBlockReason, type BlockReason } from "./blocked";
 import { upstreamStatus } from "./upstream-status";
 import { shouldHold } from "./usage-hold";
+import {
+  clearProviderFailover,
+  providerFailoverOffer,
+  providerFailoverStatus,
+  readyAgentProviders,
+  writeProviderFailover,
+} from "./provider-failover";
 import { PluginSpawnAborted } from "./plugins/types";
 import { signedOff, type SignoffView } from "./signoff";
 import { scanInstalled, installPlugin, uninstallPlugin } from "./plugins/manage";
@@ -5107,6 +5114,36 @@ async function runStarPromptAction(
   }
 }
 
+/** GET → the current capacity-failover state. POST {action} → engage / release.
+ *
+ *  `engage` re-derives the offer from THIS process's numbers rather than trusting the client:
+ *  a HUD holding a stale snapshot must not be able to point the default CLI at a provider that
+ *  has meanwhile run out too (409). `release` is idempotent — restoring an already-restored
+ *  default is the same no-op either way. */
+async function handleProviderFailover({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (!(parts[0] === "api" && parts[1] === "provider-failover" && !parts[2])) return null;
+  if (req.method === "GET") return json(providerFailoverStatus());
+  if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+
+  const body = (await req.json().catch(() => null)) as { action?: string } | null;
+  if (body?.action === "release") {
+    const from = config.providerFailoverFrom;
+    if (from === null) return json(providerFailoverStatus());
+    return json(writeProviderFailover(deps.store, { defaultProvider: from, from: null }));
+  }
+  if (body?.action !== "engage") return json({ error: "unknown action" }, 400);
+
+  const offer = providerFailoverOffer({
+    limits: deps.usageLimits.limits(Date.now()),
+    defaultProvider: config.defaultAgentProvider,
+    readyProviders: readyAgentProviders(
+      deps.diagnostics ? await deps.diagnostics.current(Date.now()) : null,
+    ),
+  });
+  if (!offer) return json({ error: "no failover offer" }, 409);
+  return json(writeProviderFailover(deps.store, { defaultProvider: offer.to, from: offer.from }));
+}
+
 function handleUploads({ req, parts, deps }: Ctx): Promise<Response> | null {
   if (parts[0] === "api" && parts[1] === "uploads" && !parts[2]) {
     if (req.method === "POST") {
@@ -5389,6 +5426,9 @@ async function handleSettings({ req, parts, deps }: Ctx): Promise<Response | nul
       autopilotModel: config.autopilotModel,
       autopilotEffort: config.autopilotEffort,
       defaultAgentProvider: config.defaultAgentProvider,
+      // capacity failover: while active, defaultAgentProvider above is a temporary substitution
+      // and `from` names the exhausted provider it will be restored to.
+      providerFailover: providerFailoverStatus(),
       // when true, Up Next quick-start skips the "Choose coding CLI" picker and launches
       // directly with the operator's default coding CLI.
       upnextSkipCliPicker: config.upnextSkipCliPicker,
@@ -5653,6 +5693,9 @@ function putDefaultAgentProvider(value: unknown, deps: Ctx["deps"]): Response {
   if (v === null) return json({ error: "unknown agent provider" }, 400);
   config.defaultAgentProvider = v;
   deps.store.setSetting("defaultAgentProvider", v);
+  // A deliberate pick outranks an active capacity failover: forget the remembered origin so the
+  // 30s sweeper never yanks this choice back when the exhausted provider frees up.
+  clearProviderFailover(deps.store);
   return json({ defaultAgentProvider: config.defaultAgentProvider });
 }
 
@@ -8136,6 +8179,7 @@ const ROUTE_HANDLERS = [
   handleDiagnostics,
   handleDiagnosticsFix,
   handleStarPrompt,
+  handleProviderFailover,
   handleUploads,
   handleRepos,
   handleProjects,

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,15 @@ export type SessionArchiveReason = "operator" | "merged" | "drain" | "relaunch";
 export const AGENT_PROVIDERS = ["claude", "codex"] as const;
 export type AgentProvider = (typeof AGENT_PROVIDERS)[number];
 
+/** Capacity failover state (`src/provider-failover.ts`): while `active`, `current` is the
+ *  counterpart the default was switched to and `from` the exhausted provider it will be
+ *  restored to once that one has weekly headroom again. */
+export interface ProviderFailoverStatus {
+  active: boolean;
+  from: AgentProvider | null;
+  current: AgentProvider;
+}
+
 /** Role a session plays in a comparison experiment: a `variant` is one of the same-prompt
  *  runs on a different model/CLI; the `comparison` session is the read-only agent that
  *  evaluates the variants' results. Sessions with no experiment carry `null`. */

--- a/test/provider-failover.test.ts
+++ b/test/provider-failover.test.ts
@@ -1,0 +1,285 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { config } from "../src/config";
+import {
+  clearProviderFailover,
+  providerFailoverOffer,
+  providerFailoverStatus,
+  releaseProviderFailover,
+  shouldReleaseFailover,
+  weeklyFreePct,
+  writeProviderFailover,
+  PROVIDER_FAILOVER_FROM_KEY,
+} from "../src/provider-failover";
+import type { AgentProvider } from "../src/types";
+import type { UsageLimits } from "../src/usage-limits";
+
+/** `null` for a provider means "no weekly window at all" — the unmeasurable case. */
+function limits(free: { claude: number | null; codex: number | null }): UsageLimits {
+  const claudeWeek = free.claude === null ? null : { pct: 100 - free.claude, resetAt: 0 };
+  const codexWeek = free.codex === null ? null : { pct: 100 - free.codex, resetAt: 0 };
+  return {
+    session5h: null,
+    week: claudeWeek,
+    perModelWeek: [],
+    credits: null,
+    stale: false,
+    calibratedAt: null,
+    subscriptionOnly: false,
+    providers: [
+      {
+        provider: "claude",
+        kind: "limits",
+        session5h: null,
+        week: claudeWeek,
+        perModelWeek: [],
+        credits: null,
+        stale: false,
+        calibratedAt: null,
+        subscriptionOnly: false,
+      },
+      {
+        provider: "codex",
+        kind: "tokens",
+        totalTokens: 0,
+        session5hTokens: 0,
+        weekTokens: 0,
+        updatedAt: null,
+        stale: false,
+        session5h: null,
+        week: codexWeek,
+      },
+    ],
+  };
+}
+
+const BOTH: AgentProvider[] = ["claude", "codex"];
+
+describe("weeklyFreePct", () => {
+  test("prefers the provider-confirmed observation over the computed window", () => {
+    const l = limits({ claude: 79, codex: 23 });
+    l.observed = { session5h: null, week: { pct: 90, resetAt: 0, scrapedAt: 0 } };
+    expect(weeklyFreePct(l, "claude")).toBe(10);
+  });
+
+  test("falls back to the per-provider observation when the top-level one is absent", () => {
+    const l = limits({ claude: 79, codex: 23 });
+    for (const p of l.providers ?? []) {
+      if (p.provider === "claude" && p.kind === "limits") {
+        p.observed = { session5h: null, week: { pct: 90, resetAt: 0, scrapedAt: 0 } };
+      }
+    }
+    expect(weeklyFreePct(l, "claude")).toBe(10);
+  });
+
+  test("falls back to the computed window when nothing was observed", () => {
+    expect(weeklyFreePct(limits({ claude: 79, codex: 23 }), "claude")).toBe(79);
+  });
+
+  test("reads codex from its provider snapshot", () => {
+    expect(weeklyFreePct(limits({ claude: 79, codex: 23 }), "codex")).toBe(23);
+  });
+
+  test("null when the provider has no weekly window", () => {
+    expect(weeklyFreePct(limits({ claude: null, codex: 23 }), "claude")).toBeNull();
+    expect(weeklyFreePct(limits({ claude: 79, codex: null }), "codex")).toBeNull();
+    expect(weeklyFreePct(null, "claude")).toBeNull();
+  });
+
+  test("claude survives a limits payload with no providers array", () => {
+    const l = limits({ claude: 79, codex: 23 });
+    delete l.providers;
+    expect(weeklyFreePct(l, "claude")).toBe(79);
+    expect(weeklyFreePct(l, "codex")).toBeNull();
+  });
+});
+
+describe("providerFailoverOffer", () => {
+  // The shared case table — mirrored verbatim in ui/src/lib/provider-capacity.test.ts.
+  test("offers the counterpart when the default is out of weekly headroom", () => {
+    expect(
+      providerFailoverOffer({
+        limits: limits({ claude: 79, codex: 23 }),
+        defaultProvider: "codex",
+        readyProviders: BOTH,
+      }),
+    ).toEqual({ from: "codex", to: "claude", fromFreePct: 23, toFreePct: 79 });
+  });
+
+  test("no offer when the default already is the cool provider", () => {
+    expect(
+      providerFailoverOffer({
+        limits: limits({ claude: 79, codex: 23 }),
+        defaultProvider: "claude",
+        readyProviders: BOTH,
+      }),
+    ).toBeNull();
+  });
+
+  test("no offer when both are exhausted", () => {
+    expect(
+      providerFailoverOffer({
+        limits: limits({ claude: 23, codex: 23 }),
+        defaultProvider: "codex",
+        readyProviders: BOTH,
+      }),
+    ).toBeNull();
+  });
+
+  test("no offer when the counterpart is unmeasured", () => {
+    expect(
+      providerFailoverOffer({
+        limits: limits({ claude: null, codex: 23 }),
+        defaultProvider: "codex",
+        readyProviders: BOTH,
+      }),
+    ).toBeNull();
+  });
+
+  test("no offer when the default itself is unmeasured", () => {
+    expect(
+      providerFailoverOffer({
+        limits: limits({ claude: 79, codex: null }),
+        defaultProvider: "codex",
+        readyProviders: BOTH,
+      }),
+    ).toBeNull();
+  });
+
+  test("counterpart at exactly the floor still counts as room", () => {
+    expect(
+      providerFailoverOffer({
+        limits: limits({ claude: 30, codex: 23 }),
+        defaultProvider: "codex",
+        readyProviders: BOTH,
+      }),
+    ).not.toBeNull();
+  });
+
+  test("default at exactly the floor is not exhausted yet", () => {
+    expect(
+      providerFailoverOffer({
+        limits: limits({ claude: 79, codex: 30 }),
+        defaultProvider: "codex",
+        readyProviders: BOTH,
+      }),
+    ).toBeNull();
+  });
+
+  test("no offer when the counterpart is not ready", () => {
+    expect(
+      providerFailoverOffer({
+        limits: limits({ claude: 79, codex: 23 }),
+        defaultProvider: "codex",
+        readyProviders: ["codex"],
+      }),
+    ).toBeNull();
+  });
+
+  test("stale readings still decide (staleness dims, it never reroutes)", () => {
+    const l = limits({ claude: 79, codex: 23 });
+    l.stale = true;
+    for (const p of l.providers ?? []) {
+      if (p.provider === "codex" && p.kind === "tokens") p.stale = true;
+    }
+    expect(
+      providerFailoverOffer({ limits: l, defaultProvider: "codex", readyProviders: BOTH }),
+    ).not.toBeNull();
+  });
+});
+
+describe("shouldReleaseFailover", () => {
+  test("releases once the origin has weekly headroom again", () => {
+    expect(shouldReleaseFailover(limits({ claude: 79, codex: 88 }), "codex")).toBe(true);
+  });
+
+  test("holds while the origin is still exhausted", () => {
+    expect(shouldReleaseFailover(limits({ claude: 79, codex: 23 }), "codex")).toBe(false);
+  });
+
+  test("holds at exactly the floor", () => {
+    expect(shouldReleaseFailover(limits({ claude: 79, codex: 30 }), "codex")).toBe(true);
+    expect(shouldReleaseFailover(limits({ claude: 79, codex: 29 }), "codex")).toBe(false);
+  });
+
+  test("holds when the origin became unmeasurable — never switch back into an unknown", () => {
+    expect(shouldReleaseFailover(limits({ claude: 79, codex: null }), "codex")).toBe(false);
+  });
+});
+
+describe("failover state", () => {
+  // These mutate the shared config singleton; put it back so later files see it untouched.
+  const savedProvider = config.defaultAgentProvider;
+  const savedFrom = config.providerFailoverFrom;
+  afterAll(() => {
+    config.defaultAgentProvider = savedProvider;
+    config.providerFailoverFrom = savedFrom;
+  });
+
+  let written: Record<string, string>;
+  const store = {
+    setSetting(key: string, value: string) {
+      written[key] = value;
+    },
+  };
+  const usageLimits = (free: { claude: number | null; codex: number | null }) => ({
+    limits: () => limits(free),
+  });
+
+  beforeEach(() => {
+    written = {};
+    config.defaultAgentProvider = "codex";
+    config.providerFailoverFrom = null;
+  });
+
+  test("engaging persists both the new default and the remembered origin", () => {
+    const status = writeProviderFailover(store, { defaultProvider: "claude", from: "codex" });
+    expect(status).toEqual({ active: true, from: "codex", current: "claude" });
+    expect(config.defaultAgentProvider).toBe("claude");
+    expect(written).toEqual({
+      defaultAgentProvider: "claude",
+      [PROVIDER_FAILOVER_FROM_KEY]: "codex",
+    });
+  });
+
+  test("clearing forgets the origin without touching the default", () => {
+    writeProviderFailover(store, { defaultProvider: "claude", from: "codex" });
+    written = {};
+    clearProviderFailover(store);
+    expect(config.defaultAgentProvider).toBe("claude");
+    expect(providerFailoverStatus()).toEqual({ active: false, from: null, current: "claude" });
+    expect(written).toEqual({ [PROVIDER_FAILOVER_FROM_KEY]: "" });
+  });
+
+  test("clearing is a no-op when no failover is active", () => {
+    clearProviderFailover(store);
+    expect(written).toEqual({});
+  });
+
+  test("the sweeper restores the origin once it has room", () => {
+    writeProviderFailover(store, { defaultProvider: "claude", from: "codex" });
+    written = {};
+    expect(
+      releaseProviderFailover({ store, usageLimits: usageLimits({ claude: 79, codex: 88 }) }, 0),
+    ).toEqual({ released: true });
+    expect(config.defaultAgentProvider).toBe("codex");
+    expect(written).toEqual({
+      defaultAgentProvider: "codex",
+      [PROVIDER_FAILOVER_FROM_KEY]: "",
+    });
+  });
+
+  test("the sweeper leaves an exhausted origin alone", () => {
+    writeProviderFailover(store, { defaultProvider: "claude", from: "codex" });
+    expect(
+      releaseProviderFailover({ store, usageLimits: usageLimits({ claude: 79, codex: 23 }) }, 0),
+    ).toEqual({ released: false });
+    expect(config.defaultAgentProvider).toBe("claude");
+  });
+
+  test("the sweeper is a no-op with no failover active", () => {
+    expect(
+      releaseProviderFailover({ store, usageLimits: usageLimits({ claude: 79, codex: 88 }) }, 0),
+    ).toEqual({ released: false });
+    expect(written).toEqual({});
+  });
+});

--- a/test/provider-failover.test.ts
+++ b/test/provider-failover.test.ts
@@ -85,6 +85,39 @@ describe("weeklyFreePct", () => {
     expect(weeklyFreePct(null, "claude")).toBeNull();
   });
 
+  test("a present contract with a null week is UNMEASURED, computed window notwithstanding", () => {
+    // `limits()` always emits the contract, so this is the live shape before the first /usage
+    // scrape. Reading the JSONL-computed window here would call Claude measured while the popover
+    // renders "no observation" — the divergence this rule exists to prevent.
+    const l = limits({ claude: 79, codex: 23 });
+    l.observed = { session5h: null, week: null };
+    expect(weeklyFreePct(l, "claude")).toBeNull();
+    expect(
+      providerFailoverOffer({ limits: l, defaultProvider: "codex", readyProviders: BOTH }),
+    ).toBeNull();
+  });
+
+  test("a per-provider contract with a null week is unmeasured too", () => {
+    const l = limits({ claude: 79, codex: 23 });
+    for (const p of l.providers ?? []) {
+      if (p.provider === "claude" && p.kind === "limits") {
+        p.observed = { session5h: null, week: null };
+      }
+    }
+    expect(weeklyFreePct(l, "claude")).toBeNull();
+  });
+
+  test("a top-level contract wins whole — a null week does not fall through to the provider's", () => {
+    const l = limits({ claude: 79, codex: 23 });
+    l.observed = { session5h: null, week: null };
+    for (const p of l.providers ?? []) {
+      if (p.provider === "claude" && p.kind === "limits") {
+        p.observed = { session5h: null, week: { pct: 10, resetAt: 0, scrapedAt: 0 } };
+      }
+    }
+    expect(weeklyFreePct(l, "claude")).toBeNull();
+  });
+
   test("claude survives a limits payload with no providers array", () => {
     const l = limits({ claude: 79, codex: 23 });
     delete l.providers;

--- a/test/server-provider-failover.test.ts
+++ b/test/server-provider-failover.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { config } from "../src/config";
+import { EventHub } from "../src/events";
+import { PROVIDER_FAILOVER_FROM_KEY } from "../src/provider-failover";
+import { makeApp, type AppDeps } from "../src/server";
+import { SessionStore } from "../src/store";
+import type { AgentProvider, DiagnosticState } from "../src/types";
+
+let savedProvider: AgentProvider;
+let savedFailoverFrom: AgentProvider | null;
+
+beforeEach(() => {
+  savedProvider = config.defaultAgentProvider;
+  savedFailoverFrom = config.providerFailoverFrom;
+  config.defaultAgentProvider = "codex";
+  config.providerFailoverFrom = null;
+});
+
+afterEach(() => {
+  config.defaultAgentProvider = savedProvider;
+  config.providerFailoverFrom = savedFailoverFrom;
+});
+
+/** Weekly windows expressed as REMAINING percent, so the cases read like the operator's popover. */
+function harness(opts: {
+  claudeFree?: number | null;
+  codexFree?: number | null;
+  claudeReady?: boolean;
+}): { app: ReturnType<typeof makeApp>; store: SessionStore } {
+  const week = (free: number | null | undefined) =>
+    free === null || free === undefined ? null : { pct: 100 - free, resetAt: 0 };
+  const store = new SessionStore(":memory:");
+  const check = (id: string, ok: boolean) => ({
+    id,
+    state: (ok ? "ok" : "error") as DiagnosticState,
+    hintKey: "",
+  });
+  const deps: AppDeps = {
+    store,
+    events: new EventHub(),
+    service: {} as never,
+    usageLimits: {
+      limits: () => ({
+        session5h: null,
+        week: week(opts.claudeFree),
+        perModelWeek: [],
+        credits: null,
+        stale: false,
+        calibratedAt: null,
+        subscriptionOnly: false,
+        providers: [
+          {
+            provider: "codex",
+            kind: "tokens",
+            totalTokens: 0,
+            session5hTokens: 0,
+            weekTokens: 0,
+            updatedAt: null,
+            stale: false,
+            session5h: null,
+            week: week(opts.codexFree),
+          },
+        ],
+      }),
+    } as never,
+    diagnostics: {
+      current: async () => ({
+        checks: [check("claude", opts.claudeReady !== false), check("codex", true)],
+        generatedAt: 0,
+        overall: "ok" as DiagnosticState,
+      }),
+    } as never,
+  };
+  return { app: makeApp(deps), store };
+}
+
+const post = (app: ReturnType<typeof makeApp>, action: string) =>
+  app.fetch(
+    new Request("http://x/api/provider-failover", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ action }),
+    }),
+  );
+
+test("GET reports the idle state", async () => {
+  const { app } = harness({ claudeFree: 79, codexFree: 23 });
+  const res = await app.fetch(new Request("http://x/api/provider-failover"));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ active: false, from: null, current: "codex" });
+});
+
+test("engage switches the default to the counterpart and persists both halves", async () => {
+  const { app, store } = harness({ claudeFree: 79, codexFree: 23 });
+  const res = await post(app, "engage");
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ active: true, from: "codex", current: "claude" });
+  expect(config.defaultAgentProvider).toBe("claude");
+  expect(store.getSetting("defaultAgentProvider")).toBe("claude");
+  expect(store.getSetting(PROVIDER_FAILOVER_FROM_KEY)).toBe("codex");
+});
+
+test("engage is refused when this process sees no offer — a stale HUD cannot force it", async () => {
+  const { app, store } = harness({ claudeFree: 23, codexFree: 23 });
+  const res = await post(app, "engage");
+  expect(res.status).toBe(409);
+  expect(config.defaultAgentProvider).toBe("codex");
+  expect(store.getSetting("defaultAgentProvider")).toBeNull();
+});
+
+test("engage is refused when the counterpart is not ready", async () => {
+  const { app } = harness({ claudeFree: 79, codexFree: 23, claudeReady: false });
+  expect((await post(app, "engage")).status).toBe(409);
+  expect(config.defaultAgentProvider).toBe("codex");
+});
+
+test("engage is refused when the counterpart reports no weekly window", async () => {
+  const { app } = harness({ claudeFree: null, codexFree: 23 });
+  expect((await post(app, "engage")).status).toBe(409);
+});
+
+test("release restores the remembered origin", async () => {
+  const { app, store } = harness({ claudeFree: 79, codexFree: 23 });
+  await post(app, "engage");
+  const res = await post(app, "release");
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ active: false, from: null, current: "codex" });
+  expect(config.defaultAgentProvider).toBe("codex");
+  expect(store.getSetting(PROVIDER_FAILOVER_FROM_KEY)).toBe("");
+});
+
+test("release is idempotent when nothing is active", async () => {
+  const { app } = harness({ claudeFree: 79, codexFree: 23 });
+  const res = await post(app, "release");
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ active: false, from: null, current: "codex" });
+});
+
+test("an unknown action is rejected", async () => {
+  const { app } = harness({ claudeFree: 79, codexFree: 23 });
+  expect((await post(app, "sideways")).status).toBe(400);
+});
+
+test("the settings payload carries the failover state", async () => {
+  const { app } = harness({ claudeFree: 79, codexFree: 23 });
+  await post(app, "engage");
+  const body = await (await app.fetch(new Request("http://x/api/settings"))).json();
+  expect(body.defaultAgentProvider).toBe("claude");
+  expect(body.providerFailover).toEqual({ active: true, from: "codex", current: "claude" });
+});
+
+test("picking a default by hand forgets the failover origin", async () => {
+  const { app, store } = harness({ claudeFree: 79, codexFree: 23 });
+  await post(app, "engage");
+  const res = await app.fetch(
+    new Request("http://x/api/settings", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ defaultAgentProvider: "claude" }),
+    }),
+  );
+  expect(res.status).toBe(200);
+  expect(config.providerFailoverFrom).toBeNull();
+  expect(store.getSetting(PROVIDER_FAILOVER_FROM_KEY)).toBe("");
+});

--- a/test/server-provider-failover.test.ts
+++ b/test/server-provider-failover.test.ts
@@ -21,7 +21,10 @@ afterEach(() => {
   config.providerFailoverFrom = savedFailoverFrom;
 });
 
-/** Weekly windows expressed as REMAINING percent, so the cases read like the operator's popover. */
+/** Weekly windows expressed as REMAINING percent, so the cases read like the operator's popover.
+ *  Shaped like the real `limits()` payload: Claude's confirmed value lives in the `observed`
+ *  contract (always emitted), and `week` below it stays the local estimate the failover rule must
+ *  NOT read once that contract is present. */
 function harness(opts: {
   claudeFree?: number | null;
   codexFree?: number | null;
@@ -29,6 +32,8 @@ function harness(opts: {
 }): { app: ReturnType<typeof makeApp>; store: SessionStore } {
   const week = (free: number | null | undefined) =>
     free === null || free === undefined ? null : { pct: 100 - free, resetAt: 0 };
+  const observedWeek = (free: number | null | undefined) =>
+    free === null || free === undefined ? null : { pct: 100 - free, resetAt: 0, scrapedAt: 0 };
   const store = new SessionStore(":memory:");
   const check = (id: string, ok: boolean) => ({
     id,
@@ -41,14 +46,30 @@ function harness(opts: {
     service: {} as never,
     usageLimits: {
       limits: () => ({
+        observed: { session5h: null, week: observedWeek(opts.claudeFree) },
         session5h: null,
-        week: week(opts.claudeFree),
+        // A deliberately TEMPTING local estimate that contradicts the contract. With the contract
+        // present nothing may read it, so `claudeFree: null` must still refuse — reading this
+        // would show a healthy 79 % free and wrongly engage.
+        week: week(79),
         perModelWeek: [],
         credits: null,
         stale: false,
         calibratedAt: null,
         subscriptionOnly: false,
         providers: [
+          {
+            provider: "claude",
+            kind: "limits",
+            observed: { session5h: null, week: observedWeek(opts.claudeFree) },
+            session5h: null,
+            week: week(79),
+            perModelWeek: [],
+            credits: null,
+            stale: false,
+            calibratedAt: null,
+            subscriptionOnly: false,
+          },
           {
             provider: "codex",
             kind: "tokens",
@@ -114,7 +135,10 @@ test("engage is refused when the counterpart is not ready", async () => {
   expect(config.defaultAgentProvider).toBe("codex");
 });
 
-test("engage is refused when the counterpart reports no weekly window", async () => {
+test("engage is refused when the counterpart's CONFIRMED weekly window is absent", async () => {
+  // The contract is present with a null week while the local estimate says a healthy 79 % free.
+  // The popover renders that provider as "no observation" and offers nothing, so the server must
+  // refuse too — reading the estimate here is exactly the divergence the rule forbids.
   const { app } = harness({ claudeFree: null, codexFree: 23 });
   expect((await post(app, "engage")).status).toBe(409);
 });

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3944,5 +3944,13 @@
   "gloss_task_amendment_term": "Aufgaben-Ergänzung",
   "gloss_task_amendment_def": "Vom Operator verfasster Text, der einer laufenden Aufgabe nachträglich hinzugefügt wird. Er steht gleichrangig neben der ursprünglichen Aufgabe und wird Critic, Planprüfer und Recap gezeigt, kann den Umfang der Arbeit also erweitern oder einschränken. Einen Bug oder ein Sicherheitsproblem entschuldigt er nicht, und ein Agent kann ihn niemals selbst schreiben.",
   "feat_task_amendment_title": "Aufgaben nachträglich ergänzen",
-  "feat_task_amendment_body": "Der Wortlaut einer Aufgabe war ab dem Start eingefroren — wer mitten in der Session den Umfang erweitern oder einschränken wollte, erreichte den Critic damit nicht, und der blockierte den PR dann gegen eine längst überholte Aufgabe. Im Kartenmenü einer Session gibt es jetzt „Aufgabe ergänzen…“: Der Text wird an der Session gespeichert, steht für Critic, Planprüfer und Recap gleichrangig neben der ursprünglichen Aufgabe und kann auf Wunsch direkt an den Agenten geschickt werden. Eine Ergänzung verschiebt den Umfang, entschuldigt aber nie einen Bug — und ein Agent kann sie niemals selbst schreiben."
+  "feat_task_amendment_body": "Der Wortlaut einer Aufgabe war ab dem Start eingefroren — wer mitten in der Session den Umfang erweitern oder einschränken wollte, erreichte den Critic damit nicht, und der blockierte den PR dann gegen eine längst überholte Aufgabe. Im Kartenmenü einer Session gibt es jetzt „Aufgabe ergänzen…“: Der Text wird an der Session gespeichert, steht für Critic, Planprüfer und Recap gleichrangig neben der ursprünglichen Aufgabe und kann auf Wunsch direkt an den Agenten geschickt werden. Eine Ergänzung verschiebt den Umfang, entschuldigt aber nie einen Bug — und ein Agent kann sie niemals selbst schreiben.",
+  "usage_failover_offer_reason": "{from} Woche {fromFreePct} % frei · {to} {toFreePct} % frei",
+  "usage_failover_engage": "Standard-CLI auf {provider} umstellen",
+  "usage_failover_active_reason": "Standard-CLI ist {to} statt {from}, bis {from} wieder Wochenkapazität hat.",
+  "usage_failover_revert": "Zurück auf {provider}",
+  "usage_failover_failed": "Standard-CLI konnte nicht umgestellt werden.",
+  "settings_default_cli_desc_failover": "Vorübergehend {to} statt {from}: {from} liegt unter 30 % Wochenkapazität. Schaltet von selbst zurück; eine Wahl hier beendet die Vertretung.",
+  "feat_usage_provider_failover_title": "Coding-CLI wechseln, wenn eine Wochenkapazität ausgeht",
+  "feat_usage_provider_failover_body": "Fällt dein Standard-Coding-CLI unter 30 % Wochenrestkapazität und das andere hat noch Luft, bietet das Auslastungs-Popover einen Wechsel per Klick an. Shepherd schaltet von selbst zurück, sobald das erschöpfte CLI wieder Kapazität hat."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3944,5 +3944,13 @@
   "gloss_task_amendment_term": "task amendment",
   "gloss_task_amendment_def": "Operator-authored text added to a running task after it started. It ranks alongside the original task and is shown to the critic, the plan reviewer and the recap, so it can widen or narrow what the work may contain. It cannot excuse a bug or a security problem, and an agent can never write one.",
   "feat_task_amendment_title": "Amend a task after it starts",
-  "feat_task_amendment_body": "A task's wording used to be frozen the moment it was spawned, so deciding mid-session to widen or narrow the work never reached the critic — which then blocked the PR against the task you had already superseded. A session's card menu now has “Amend task…”: what you write is recorded on the session, ranks alongside the original task for the critic, the plan reviewer and the recap, and can optionally be sent straight to the agent. An amendment can move scope but never excuses a bug, and an agent can never write one."
+  "feat_task_amendment_body": "A task's wording used to be frozen the moment it was spawned, so deciding mid-session to widen or narrow the work never reached the critic — which then blocked the PR against the task you had already superseded. A session's card menu now has “Amend task…”: what you write is recorded on the session, ranks alongside the original task for the critic, the plan reviewer and the recap, and can optionally be sent straight to the agent. An amendment can move scope but never excuses a bug, and an agent can never write one.",
+  "usage_failover_offer_reason": "{from} weekly {fromFreePct}% free · {to} {toFreePct}% free",
+  "usage_failover_engage": "Switch default CLI to {provider}",
+  "usage_failover_active_reason": "Default CLI is {to} instead of {from} until {from} has weekly capacity again.",
+  "usage_failover_revert": "Back to {provider}",
+  "usage_failover_failed": "Could not switch the default CLI.",
+  "settings_default_cli_desc_failover": "Temporarily {to} instead of {from}: {from} is below 30% weekly capacity. Switches back on its own; picking one here ends the substitution.",
+  "feat_usage_provider_failover_title": "Switch coding CLI when one runs out of weekly capacity",
+  "feat_usage_provider_failover_body": "When your default coding CLI drops below 30% remaining weekly capacity and the other one still has room, the usage popover offers a one-click switch. Shepherd switches back on its own once the exhausted CLI has capacity again."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -35,6 +35,7 @@ import type {
   InstalledPlugin,
   PluginUpdatesStatus,
   StarPromptStatus,
+  ProviderFailoverStatus,
   Steer,
   DiffResult,
   DiffAnnotationsResult,
@@ -2597,6 +2598,21 @@ export async function actStarPrompt(
     body: JSON.stringify({ action }),
   });
   if (!r.ok) throw await failed(r, "star prompt");
+  return r.json();
+}
+
+/** Engage or undo the capacity failover of the default coding CLI. `engage` is refused with a
+ *  409 when the server, on its own numbers, sees no offer — the popover's button was drawn from a
+ *  snapshot that has since moved. */
+export async function actProviderFailover(
+  action: "engage" | "release",
+): Promise<ProviderFailoverStatus> {
+  const r = await fetch("/api/provider-failover", {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ action }),
+  });
+  if (!r.ok) throw await failed(r, "provider failover");
   return r.json();
 }
 

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -6,6 +6,8 @@
     HerdrUpdateStatus,
     CodexUpdateStatus,
     DiagnosticState,
+    DiagnosticsSnapshot,
+    ProviderFailoverStatus,
   } from "$lib/types";
   import { displayStatus } from "$lib/display-status";
   import {
@@ -27,10 +29,12 @@
     listHeld,
     spawnHeld,
     discardHeld,
+    actProviderFailover,
     getSettings,
     putUsageHoldAutoRelease,
   } from "$lib/api";
   import type { AgentProvider, HeldTask } from "$lib/types";
+  import { providerFailoverOffer } from "$lib/provider-capacity";
   import { m } from "$lib/paraglide/messages";
   import { openFeedback } from "$lib/feedback-dialog.svelte";
   import type { FeedbackKind } from "$lib/feedback-link";
@@ -67,6 +71,7 @@
     statusFilter = null,
     onstatusfilter,
     workingBlocked = {},
+    diagnostics = null,
     diagnosticsOverall = "ok",
     ondiagnose,
     learnings = 0,
@@ -103,6 +108,8 @@
     // working-while-blocked display flags (store map); tallies + gear pip read the
     // DISPLAY status through it — the halt e-stop keeps the raw status (see below)
     workingBlocked?: Record<string, boolean>;
+    /** Full diagnostics snapshot; capacity failover needs per-CLI readiness, not just worst-of. */
+    diagnostics?: DiagnosticsSnapshot | null;
     /** Worst-of diagnostics state; hidden when "ok". */
     diagnosticsOverall?: DiagnosticState;
     /** Called when the health pip is clicked — should open Settings → Diagnose tab. */
@@ -410,6 +417,8 @@
     }
   }
   function refreshOnStaleOpen() {
+    failoverFailed = false;
+    void loadFailover();
     if (claudeAvailable && !subscriptionOnly && shouldRefreshObservedOnOpen(limits, nowMs)) {
       void doRefresh();
     }
@@ -420,6 +429,50 @@
   // REFRESH control inside it stays reachable. `gaugeWrap` anchors the outside-click test.
   let popoverOpen = $state(false);
   let gaugeWrap = $state<HTMLElement | null>(null);
+
+  // ── Capacity failover ─────────────────────────────────────────────────────
+  // Whether to OFFER the switch is predicted locally from data already pushed over the WS; the
+  // server re-derives it and can still refuse (409 → failoverFailed). The default provider and
+  // the active-failover record are read from settings when the popover opens, mirroring
+  // loadHeldAutoRelease() below, so an out-of-band change (settings API, the 30s auto-release)
+  // shows up rather than a stale value.
+  // null until the first load lands. Seeding a provider instead would let the popover's first
+  // frame compute the offer against a guessed default and briefly render the OPPOSITE button —
+  // clickable, and wrong.
+  let defaultAgentProvider = $state<AgentProvider | null>(null);
+  let failover = $state<ProviderFailoverStatus | null>(null);
+  let failoverBusy = $state(false);
+  let failoverFailed = $state(false);
+  const failoverOffer = $derived(
+    defaultAgentProvider === null
+      ? null
+      : providerFailoverOffer(limits, defaultAgentProvider, diagnostics),
+  );
+
+  async function loadFailover() {
+    try {
+      const s = await getSettings();
+      failover = s.providerFailover ?? null;
+      defaultAgentProvider = s.defaultAgentProvider ?? "claude";
+    } catch {
+      // best-effort; leave the last known values
+    }
+  }
+
+  async function actFailover(action: "engage" | "release") {
+    if (failoverBusy) return;
+    failoverBusy = true;
+    failoverFailed = false;
+    try {
+      failover = await actProviderFailover(action);
+      defaultAgentProvider = failover.current;
+    } catch {
+      failoverFailed = true;
+      void loadFailover(); // the server refused — resync rather than keep a guessed state
+    } finally {
+      failoverBusy = false;
+    }
+  }
 
   // ── Held-tasks popover ────────────────────────────────────────────────────
   // Non-modal anchored popover (design-system "small anchored popover" exemption:
@@ -833,6 +886,12 @@
         onRefresh={doRefresh}
         onOpenPopover={refreshOnStaleOpen}
         {periodLabel}
+        {failoverOffer}
+        {failover}
+        {failoverBusy}
+        {failoverFailed}
+        onEngageFailover={() => void actFailover("engage")}
+        onReleaseFailover={() => void actFailover("release")}
         onusage={chooseUsage}
         bind:popoverOpen
         bind:gaugeWrap

--- a/ui/src/lib/components/settings/SettingsCodingCliPanel.svelte
+++ b/ui/src/lib/components/settings/SettingsCodingCliPanel.svelte
@@ -84,6 +84,21 @@
 
   const q = $derived(query.trim());
 
+  // Capacity failover: the default above may be a temporary substitution the operator never
+  // chose, so say so right where they'd otherwise read it as their own setting. Gated on the
+  // bound value still BEING the substitution — picking another provider in the select clears the
+  // failover server-side, and the note disappears with the same click rather than lingering
+  // until the next settings fetch.
+  const failover = $derived(payload?.providerFailover ?? null);
+  const failoverNote = $derived(
+    failover?.active && failover.from !== null && defaultAgentProvider === failover.current
+      ? m.settings_default_cli_desc_failover({
+          to: providerLabel(failover.current),
+          from: providerLabel(failover.from),
+        })
+      : null,
+  );
+
   // ── Local state (seeded from payload) ─────────────────────────────────────
   let defaultEffort = $state("default");
   let defaultEffortSaved = "default";
@@ -532,7 +547,7 @@
 
 <SettingRow
   title={m.settings_default_agent_provider_title()}
-  description={m.settings_default_cli_desc()}
+  description={failoverNote ?? m.settings_default_cli_desc()}
   {query}
 >
   {#snippet control()}

--- a/ui/src/lib/components/top-bar/TopBarUsage.svelte
+++ b/ui/src/lib/components/top-bar/TopBarUsage.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import { m } from "$lib/paraglide/messages";
-  import type { CreditWindow, ModelWeekWindow, ObservedLimitWindows } from "$lib/types";
+  import type {
+    CreditWindow,
+    ModelWeekWindow,
+    ObservedLimitWindows,
+    ProviderFailoverStatus,
+  } from "$lib/types";
+  import type { ProviderFailoverOffer } from "$lib/provider-capacity";
   import type { UsageProviderSnapshot } from "$lib/types";
   import { formatTokenLabel } from "$lib/format";
   import {
@@ -37,6 +43,12 @@
     onRefresh,
     onOpenPopover,
     periodLabel,
+    failoverOffer,
+    failover,
+    failoverBusy,
+    failoverFailed,
+    onEngageFailover,
+    onReleaseFailover,
     onusage,
     popoverOpen = $bindable(),
     gaugeWrap = $bindable(null),
@@ -63,6 +75,13 @@
     onRefresh: () => void;
     onOpenPopover: () => void;
     periodLabel: (k: GaugeKey) => string;
+    /** Capacity failover: the switch worth offering right now, and the one already in effect. */
+    failoverOffer: ProviderFailoverOffer | null;
+    failover: ProviderFailoverStatus | null;
+    failoverBusy: boolean;
+    failoverFailed: boolean;
+    onEngageFailover: () => void;
+    onReleaseFailover: () => void;
     onusage?: () => void;
     popoverOpen: boolean;
     gaugeWrap: HTMLElement | null;
@@ -137,6 +156,12 @@
     {refreshError}
     {onRefresh}
     {periodLabel}
+    {failoverOffer}
+    {failover}
+    {failoverBusy}
+    {failoverFailed}
+    {onEngageFailover}
+    {onReleaseFailover}
     onClose={closePopover}
     onOpenUsage={openUsage}
   />

--- a/ui/src/lib/components/top-bar/TopBarUsagePopover.svelte
+++ b/ui/src/lib/components/top-bar/TopBarUsagePopover.svelte
@@ -18,7 +18,10 @@
     type Gauge,
     type HottestCapacityWindow,
   } from "../usage-gauges";
+  import type { ProviderFailoverOffer } from "$lib/provider-capacity";
+  import type { ProviderFailoverStatus } from "$lib/types";
   import CreditDetail from "./CreditDetail.svelte";
+  import UsageFailoverAction from "./UsageFailoverAction.svelte";
   import UsageRefreshButton from "./UsageRefreshButton.svelte";
   import UsageWindowRow from "./UsageWindowRow.svelte";
 
@@ -40,6 +43,12 @@
     refreshError,
     onRefresh,
     periodLabel,
+    failoverOffer,
+    failover,
+    failoverBusy,
+    failoverFailed,
+    onEngageFailover,
+    onReleaseFailover,
     onClose,
     onOpenUsage,
   }: {
@@ -61,6 +70,13 @@
     refreshError: boolean;
     onRefresh: () => void;
     periodLabel: (k: GaugeKey) => string;
+    /** Capacity failover: the switch worth offering right now, and the one already in effect. */
+    failoverOffer: ProviderFailoverOffer | null;
+    failover: ProviderFailoverStatus | null;
+    failoverBusy: boolean;
+    failoverFailed: boolean;
+    onEngageFailover: () => void;
+    onReleaseFailover: () => void;
     onClose: () => void;
     onOpenUsage: () => void;
   } = $props();
@@ -123,6 +139,17 @@
       : null,
   );
 </script>
+
+{#snippet failoverAction()}
+  <UsageFailoverAction
+    offer={failoverOffer}
+    {failover}
+    busy={failoverBusy}
+    failed={failoverFailed}
+    onEngage={onEngageFailover}
+    onRelease={onReleaseFailover}
+  />
+{/snippet}
 
 {#snippet sectionRule(title: string, note: string | null)}
   <div class="section-rule">
@@ -219,8 +246,14 @@
             <span>{formatReset(hottest.window.resetAt, nowMs, { withTime: true })}</span>
           {/if}
         </div>
+        {@render failoverAction()}
       </div>
     </div>
+  {:else if failover?.active}
+    <!-- No window data at all (hero suppressed) but a failover is still in effect: render the
+         revert on its own so the switch can never become unreachable from here. An OFFER cannot
+         reach this branch — it needs measured windows on both providers, which implies a hero. -->
+    {@render failoverAction()}
   {/if}
 
   <!-- `stale` (Claude limits staleness) dims ONLY this block — the Codex section below carries its

--- a/ui/src/lib/components/top-bar/UsageFailoverAction.browser.test.ts
+++ b/ui/src/lib/components/top-bar/UsageFailoverAction.browser.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../../app.css";
+import UsageFailoverAction from "./UsageFailoverAction.svelte";
+import { m } from "$lib/paraglide/messages";
+
+const OFFER = { from: "codex", to: "claude", fromFreePct: 23, toFreePct: 79 } as const;
+const ACTIVE = { active: true, from: "codex", current: "claude" } as const;
+
+const props = (over: Partial<Record<string, unknown>> = {}) => ({
+  offer: null,
+  failover: null,
+  busy: false,
+  failed: false,
+  onEngage: vi.fn(),
+  onRelease: vi.fn(),
+  ...over,
+});
+
+describe("UsageFailoverAction", () => {
+  it("renders nothing with neither an offer nor an active failover", () => {
+    render(UsageFailoverAction, { props: props() });
+    expect(document.querySelector(".failover")).toBeNull();
+  });
+
+  it("offers the switch and names the target CLI", async () => {
+    render(UsageFailoverAction, { props: props({ offer: OFFER }) });
+    await expect
+      .element(
+        page.getByRole("button", {
+          name: m.usage_failover_engage({ provider: m.agent_provider_claude() }),
+        }),
+      )
+      .toBeVisible();
+  });
+
+  it("states both providers and both percentages, so it cannot contradict the hero", async () => {
+    render(UsageFailoverAction, { props: props({ offer: OFFER }) });
+    const reason = document.querySelector(".failover-reason")!.textContent!;
+    expect(reason).toContain("23");
+    expect(reason).toContain("79");
+    expect(reason).toContain(m.agent_provider_codex());
+    expect(reason).toContain(m.agent_provider_claude());
+  });
+
+  it("clicking the offer engages", async () => {
+    const onEngage = vi.fn();
+    render(UsageFailoverAction, { props: props({ offer: OFFER, onEngage }) });
+    await page
+      .getByRole("button", {
+        name: m.usage_failover_engage({ provider: m.agent_provider_claude() }),
+      })
+      .click();
+    expect(onEngage).toHaveBeenCalledTimes(1);
+  });
+
+  it("an active failover shows the revert instead of the offer", async () => {
+    const onRelease = vi.fn();
+    render(UsageFailoverAction, { props: props({ offer: OFFER, failover: ACTIVE, onRelease }) });
+    await page
+      .getByRole("button", {
+        name: m.usage_failover_revert({ provider: m.agent_provider_codex() }),
+      })
+      .click();
+    expect(onRelease).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the button while a request is in flight", () => {
+    render(UsageFailoverAction, { props: props({ offer: OFFER, busy: true }) });
+    expect(document.querySelector<HTMLButtonElement>(".failover-btn")!.disabled).toBe(true);
+  });
+
+  it("surfaces a refused switch as an alert", async () => {
+    render(UsageFailoverAction, { props: props({ offer: OFFER, failed: true }) });
+    await expect.element(page.getByRole("alert")).toHaveTextContent(m.usage_failover_failed());
+  });
+});

--- a/ui/src/lib/components/top-bar/UsageFailoverAction.svelte
+++ b/ui/src/lib/components/top-bar/UsageFailoverAction.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import type { ProviderFailoverOffer } from "$lib/provider-capacity";
+  import type { AgentProvider, ProviderFailoverStatus } from "$lib/types";
+
+  // The capacity-failover control inside the usage hero: switch the default coding CLI to the
+  // counterpart that still has weekly headroom, or undo a switch already in effect. Its own
+  // component so the popover's template stays inside the complexity budget (same reason as
+  // UsageRefreshButton next door).
+  //
+  // The reason line always names BOTH providers and both percentages on purpose: the hero shows
+  // the hottest window across all providers, which can be a 5h window or the non-default CLI,
+  // while the trigger is always the default CLI's WEEKLY window. Without the line the button
+  // could read as contradicting the number right above it.
+  let {
+    offer,
+    failover,
+    busy,
+    failed,
+    onEngage,
+    onRelease,
+  }: {
+    offer: ProviderFailoverOffer | null;
+    failover: ProviderFailoverStatus | null;
+    busy: boolean;
+    failed: boolean;
+    onEngage: () => void;
+    onRelease: () => void;
+  } = $props();
+
+  const providerName = (provider: AgentProvider) =>
+    provider === "claude" ? m.agent_provider_claude() : m.agent_provider_codex();
+  const active = $derived(failover?.active === true && failover.from !== null);
+</script>
+
+{#if active || offer}
+  <div class="failover">
+    {#if failed}
+      <span class="failover-error" role="alert">{m.usage_failover_failed()}</span>
+    {/if}
+    {#if active && failover?.from}
+      <span class="failover-reason"
+        >{m.usage_failover_active_reason({
+          to: providerName(failover.current),
+          from: providerName(failover.from),
+        })}</span
+      >
+      <button type="button" class="failover-btn" disabled={busy} onclick={onRelease}>
+        {m.usage_failover_revert({ provider: providerName(failover.from) })}
+      </button>
+    {:else if offer}
+      <span class="failover-reason"
+        >{m.usage_failover_offer_reason({
+          from: providerName(offer.from),
+          fromFreePct: offer.fromFreePct,
+          to: providerName(offer.to),
+          toFreePct: offer.toFreePct,
+        })}</span
+      >
+      <button type="button" class="failover-btn accent" disabled={busy} onclick={onEngage}>
+        {m.usage_failover_engage({ provider: providerName(offer.to) })}
+      </button>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .failover {
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+    margin-top: 11px;
+    padding-top: 10px;
+    border-top: 1px solid color-mix(in srgb, var(--color-amber) 22%, var(--color-line));
+  }
+  .failover-reason {
+    color: var(--color-ink);
+    font-size: var(--fs-micro);
+    line-height: 1.35;
+    font-variant-numeric: tabular-nums;
+  }
+  .failover-error {
+    color: var(--color-red);
+    font-size: var(--fs-micro);
+    line-height: 1.35;
+  }
+  /* Same button chrome as UsageRefreshButton, stretched to the hero's width so it reads as the
+     hero's own action rather than a second, unrelated control. */
+  .failover-btn {
+    display: block;
+    width: 100%;
+    background: transparent;
+    border: 1px solid var(--color-line-bright);
+    border-radius: 2px;
+    color: var(--color-ink);
+    font: inherit;
+    font-size: var(--fs-meta);
+    letter-spacing: 0.04em;
+    padding: 5px 10px;
+    min-height: 30px;
+    cursor: pointer;
+  }
+  .failover-btn.accent {
+    border-color: color-mix(in srgb, var(--color-amber) 55%, var(--color-line-bright));
+    color: var(--color-ink-bright);
+  }
+  .failover-btn:hover:not(:disabled) {
+    background: var(--color-inset);
+  }
+  .failover-btn:focus-visible {
+    outline: 1px solid var(--color-amber);
+    outline-offset: 2px;
+  }
+  .failover-btn:disabled {
+    cursor: default;
+    opacity: 0.5;
+  }
+  @media (pointer: coarse) {
+    .failover-btn {
+      min-height: 44px;
+    }
+  }
+</style>

--- a/ui/src/lib/feature-announcements/entries/v1.48.0-usage-provider-failover.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.48.0-usage-provider-failover.ts
@@ -1,0 +1,8 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+export default {
+  id: "usage-provider-failover",
+  sinceVersion: "1.48.0",
+  titleKey: "feat_usage_provider_failover_title",
+  bodyKey: "feat_usage_provider_failover_body",
+} satisfies FeatureAnnouncement;

--- a/ui/src/lib/provider-capacity.test.ts
+++ b/ui/src/lib/provider-capacity.test.ts
@@ -3,7 +3,9 @@ import {
   bothAgentProvidersReady,
   capacitySuggestedProvider,
   claudeUsageHoldLikely,
+  providerFailoverOffer,
   readyAgentProviders,
+  weeklyFreePct,
 } from "./provider-capacity";
 import type { AgentProvider, DiagnosticsSnapshot, UsageLimits } from "./types";
 
@@ -99,5 +101,112 @@ describe("readyAgentProviders", () => {
     ]);
     expect(readyAgentProviders(diagnostics({ claude: "error", codex: "ok" }))).toEqual(["codex"]);
     expect(readyAgentProviders(diagnostics({ claude: "error", codex: "optional" }))).toEqual([]);
+  });
+});
+
+// The same case table the server runs in test/provider-failover.test.ts. Both must agree —
+// this is the prediction, that one is the decision.
+function failoverLimits(free: { claude: number | null; codex: number | null }): UsageLimits {
+  const week = (f: number | null) => (f === null ? null : { pct: 100 - f, resetAt: 0 });
+  return {
+    ...limits(null, null),
+    week: week(free.claude),
+    providers: [
+      {
+        provider: "claude",
+        kind: "limits",
+        session5h: null,
+        week: week(free.claude),
+        perModelWeek: [],
+        credits: null,
+        stale: false,
+        calibratedAt: 0,
+        subscriptionOnly: false,
+      },
+      {
+        provider: "codex",
+        kind: "tokens",
+        totalTokens: 0,
+        session5hTokens: 0,
+        weekTokens: 0,
+        updatedAt: null,
+        stale: false,
+        session5h: null,
+        week: week(free.codex),
+      },
+    ],
+  };
+}
+
+const READY = diagnostics({ claude: "ok", codex: "ok" });
+
+describe("weeklyFreePct", () => {
+  it("prefers the provider-confirmed observation over the computed window", () => {
+    const l = failoverLimits({ claude: 79, codex: 23 });
+    l.observed = { session5h: null, week: { pct: 90, resetAt: 0, scrapedAt: 0 } };
+    expect(weeklyFreePct(l, "claude")).toBe(10);
+  });
+
+  it("reads codex from its provider snapshot", () => {
+    expect(weeklyFreePct(failoverLimits({ claude: 79, codex: 23 }), "codex")).toBe(23);
+  });
+
+  it("is null when the provider has no weekly window", () => {
+    expect(weeklyFreePct(failoverLimits({ claude: null, codex: 23 }), "claude")).toBeNull();
+    expect(weeklyFreePct(null, "claude")).toBeNull();
+  });
+});
+
+describe("providerFailoverOffer", () => {
+  it("offers the counterpart when the default is out of weekly headroom", () => {
+    expect(
+      providerFailoverOffer(failoverLimits({ claude: 79, codex: 23 }), "codex", READY),
+    ).toEqual({ from: "codex", to: "claude", fromFreePct: 23, toFreePct: 79 });
+  });
+
+  it("makes no offer when the default already is the cool provider", () => {
+    expect(
+      providerFailoverOffer(failoverLimits({ claude: 79, codex: 23 }), "claude", READY),
+    ).toBeNull();
+  });
+
+  it("makes no offer when both are exhausted", () => {
+    expect(
+      providerFailoverOffer(failoverLimits({ claude: 23, codex: 23 }), "codex", READY),
+    ).toBeNull();
+  });
+
+  it("makes no offer when either side is unmeasured", () => {
+    expect(
+      providerFailoverOffer(failoverLimits({ claude: null, codex: 23 }), "codex", READY),
+    ).toBeNull();
+    expect(
+      providerFailoverOffer(failoverLimits({ claude: 79, codex: null }), "codex", READY),
+    ).toBeNull();
+  });
+
+  it("treats the floor as room for the counterpart but not as exhaustion for the default", () => {
+    expect(
+      providerFailoverOffer(failoverLimits({ claude: 30, codex: 23 }), "codex", READY),
+    ).not.toBeNull();
+    expect(
+      providerFailoverOffer(failoverLimits({ claude: 79, codex: 30 }), "codex", READY),
+    ).toBeNull();
+  });
+
+  it("makes no offer when the counterpart is not ready", () => {
+    expect(
+      providerFailoverOffer(
+        failoverLimits({ claude: 79, codex: 23 }),
+        "codex",
+        diagnostics({ claude: "error", codex: "ok" }),
+      ),
+    ).toBeNull();
+  });
+
+  it("still decides on stale readings (staleness dims, it never reroutes)", () => {
+    const l = failoverLimits({ claude: 79, codex: 23 });
+    l.stale = true;
+    expect(providerFailoverOffer(l, "codex", READY)).not.toBeNull();
   });
 });

--- a/ui/src/lib/provider-capacity.test.ts
+++ b/ui/src/lib/provider-capacity.test.ts
@@ -151,6 +151,15 @@ describe("weeklyFreePct", () => {
     expect(weeklyFreePct(failoverLimits({ claude: 79, codex: 23 }), "codex")).toBe(23);
   });
 
+  it("treats a present contract with a null week as unmeasured", () => {
+    // Must match src/provider-failover.ts: the contract is authoritative wherever present, so a
+    // null week means "never confirmed", not "use the computed estimate".
+    const l = failoverLimits({ claude: 79, codex: 23 });
+    l.observed = { session5h: null, week: null };
+    expect(weeklyFreePct(l, "claude")).toBeNull();
+    expect(providerFailoverOffer(l, "codex", READY)).toBeNull();
+  });
+
   it("is null when the provider has no weekly window", () => {
     expect(weeklyFreePct(failoverLimits({ claude: null, codex: 23 }), "claude")).toBeNull();
     expect(weeklyFreePct(null, "claude")).toBeNull();

--- a/ui/src/lib/provider-capacity.ts
+++ b/ui/src/lib/provider-capacity.ts
@@ -4,6 +4,7 @@ import {
   type DiagnosticsSnapshot,
   type UsageLimits,
 } from "./types";
+import { providerDisplayCapacityRows } from "./components/usage-gauges";
 
 export function claudeUsageHoldLikely(
   limits: UsageLimits | null,
@@ -36,4 +37,51 @@ export function capacitySuggestedProvider(
     return defaultProvider;
   }
   return AGENT_PROVIDERS.find((provider) => !heldProviders.has(provider)) ?? defaultProvider;
+}
+
+// ── capacity failover ────────────────────────────────────────────────────────
+// Mirror of `src/provider-failover.ts` so the usage popover knows whether to render the switch
+// button. Same relationship as `claudeUsageHoldLikely` above and the server's `shouldHold`: the
+// UI predicts, the server decides — POST /api/provider-failover re-derives the offer and answers
+// 409 when this prediction was made on a stale snapshot.
+
+/** Remaining-capacity floor, in percent. Keep in step with the server constant of the same name. */
+const PROVIDER_FAILOVER_MIN_FREE_PCT = 30;
+
+export interface ProviderFailoverOffer {
+  /** The exhausted provider the operator would switch away from (today's default). */
+  from: AgentProvider;
+  /** The counterpart with room. */
+  to: AgentProvider;
+  fromFreePct: number;
+  toFreePct: number;
+}
+
+/** Weekly remaining capacity as the operator SEES it, or null when nothing measured it. */
+export function weeklyFreePct(limits: UsageLimits | null, provider: AgentProvider): number | null {
+  const row = providerDisplayCapacityRows(limits).find((r) => r.provider === provider);
+  const week = row?.windows.find((w) => w.key === "WK");
+  return week?.remainingPct ?? null;
+}
+
+/**
+ * The switch worth offering right now, or null. Only ever moves AWAY from the current default:
+ * if the default already is the cool provider there is nothing to do, however hot the other runs.
+ */
+export function providerFailoverOffer(
+  limits: UsageLimits | null,
+  defaultProvider: AgentProvider,
+  diagnostics: DiagnosticsSnapshot | null,
+): ProviderFailoverOffer | null {
+  const from = defaultProvider;
+  const to = AGENT_PROVIDERS.find((p) => p !== from);
+  if (!to || !readyAgentProviders(diagnostics).includes(to)) return null;
+
+  const fromFreePct = weeklyFreePct(limits, from);
+  const toFreePct = weeklyFreePct(limits, to);
+  if (fromFreePct === null || toFreePct === null) return null;
+  if (fromFreePct >= PROVIDER_FAILOVER_MIN_FREE_PCT) return null;
+  if (toFreePct < PROVIDER_FAILOVER_MIN_FREE_PCT) return null;
+
+  return { from, to, fromFreePct, toFreePct };
 }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -7,6 +7,15 @@ export type SessionArchiveReason = "operator" | "merged" | "drain" | "relaunch";
 export const AGENT_PROVIDERS = ["claude", "codex"] as const;
 export type AgentProvider = (typeof AGENT_PROVIDERS)[number];
 
+/** Capacity failover state. While `active`, `current` is the counterpart the default CLI was
+ *  switched to and `from` the exhausted provider it will be restored to once that one has
+ *  weekly headroom again. Mirrors `ProviderFailoverStatus` in the server's `src/types.ts`. */
+export interface ProviderFailoverStatus {
+  active: boolean;
+  from: AgentProvider | null;
+  current: AgentProvider;
+}
+
 /** Role a session plays in a comparison experiment (see server `ExperimentRole`). */
 export type ExperimentRole = "variant" | "comparison";
 
@@ -168,6 +177,8 @@ export interface Settings {
   distillerIntervalDaysMax?: number;
   /** Default interactive agent provider for newly spawned task sessions. */
   defaultAgentProvider?: AgentProvider;
+  /** While active, `defaultAgentProvider` above is a temporary capacity substitution. */
+  providerFailover?: ProviderFailoverStatus;
   /** When true, Up Next quick-start launches with the default coding CLI without opening the
    *  "Choose coding CLI" picker, even when more than one CLI is ready. */
   upnextSkipCliPicker: boolean;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -2804,6 +2804,7 @@
         {statusFilter}
         onstatusfilter={(s) => (statusFilter = s)}
         workingBlocked={store.workingBlocked}
+        diagnostics={store.diagnostics}
         diagnosticsOverall={store.diagnosticsOverall}
         ondiagnose={() => {
           settingsTab = "diagnose";


### PR DESCRIPTION
## Why

A weekly window that runs dry just sat there. The popover would show Codex at 77 % with four days
to reset while Claude idled at 21 %, and the only way to spend that headroom was to remember to
change the default CLI in Settings — and to remember to change it back.

## What

The usage popover's hero now offers the switch where the problem is stated:

```
ENGSTES FENSTER
77 %                      Codex · wöchentlich
████████████████░░░░░░░░
Wieder frei in 4d            15.9. 07:43
────────────────────────────────────────
Codex Woche 23 % frei · Claude Code 79 % frei
[  Standard-CLI auf Claude Code umstellen  ]
```

One click switches `defaultAgentProvider` to the counterpart. The origin is persisted, so the
existing 30 s usage tick restores it on its own once the exhausted provider has weekly capacity
again — across a restart too. While it is in effect, the hero shows the revert instead, and the
**Default coding CLI** row in Settings explains why it no longer reads what the operator set.

## Decisions

| Decision | Rationale |
| --- | --- |
| **Weekly window only** | A 5 h window recovers within hours; flipping the global default "until it frees up" would churn the setting for a squeeze that resolves itself. |
| **Releases at ≥ 30 % free, not at the reset timestamp** | Re-evaluating the same predicate self-corrects after a measurement fix, and needs no `resetAt` bookkeeping. In practice weekly usage only falls at the reset anyway. |
| **Threshold hardcoded at 30 %** | No setting, no env — as specified. |
| **Unmeasurable is not free** | A provider reporting no weekly window (api-key mode, a failed scrape, a CLI that never produced a sample) is never switched INTO, and never switched BACK to either. The popover keeps a manual revert as the escape hatch. |
| **Staleness still decides** | It dims presentation, it never reroutes a decision — same rule as `hottestCapacityWindow`. |
| **A manual pick outranks the substitution** | `putDefaultAgentProvider` forgets the origin, so the sweeper never yanks back a deliberate choice. |
| **The reason line names both providers and both percentages** | The hero shows the hottest window across ALL providers — possibly a 5 h window, or the non-default CLI — while the trigger is always the default CLI's weekly one. Without the line the button could read as contradicting the number above it. |

## The rule lives twice, on purpose

Authoritative in `src/provider-failover.ts`, predicted in `ui/src/lib/provider-capacity.ts` so the
popover knows whether to draw the button — the same shape as `claudeUsageHoldLikely` predicting
`shouldHold`. Both run the same case table, and `POST /api/provider-failover` re-derives the offer
and answers **409** when a stale HUD asks for one that no longer holds. The client never names the
target provider; the server derives it.

## Side effect worth naming

`usageHoldApplies` / `tryHoldNewTask` only hold when the resolved provider is Claude. Failing over
during a Claude squeeze therefore stops new tasks being held — without touching the hold threshold.

## Known surface gap

The mobile sheet and the gear menu render `GearMenuUsage`, not this popover, so the button is not
there. Not a dead end: the Settings row shows the active substitution and changing the dropdown
ends it. Left out to keep the diff to the surface the request named.

## Verification

| Gate | Result |
| --- | --- |
| `bun run lint` | pass |
| `tsc --noEmit` | pass |
| `bun run test` (root) | 9631 pass, 0 fail |
| `cd ui && bun run check` | 0 errors, 0 warnings |
| `cd ui && bun run check:i18n` | 2 locales in parity |
| `cd ui && bun run test` | 5079 pass (313 files) |
| `prettier --check .` | clean |
| `fallow audit --base origin/main` | no issues in 21 changed files |
| `check-feature-catalog.sh` / `check-announcement-versions.mjs` | pass (`v1.48.0-usage-provider-failover`) |

New tests: `test/provider-failover.test.ts` (25), `test/server-provider-failover.test.ts` (10),
`ui/src/lib/components/top-bar/UsageFailoverAction.browser.test.ts` (7), plus the mirrored case
table in `ui/src/lib/provider-capacity.test.ts`.
