### PR TITLE
fix(codex): constrain role fallback output with schemas

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "@types/bun": "latest",
         "@types/node": "^26.4.1",
         "@types/web-push": "^3.6.4",
+        "ajv": "^8",
         "eslint": "^10.10.0",
         "eslint-plugin-svelte": "^3.23.0",
         "github-slugger": "^2.0.0",
@@ -169,7 +170,7 @@
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
-    "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
@@ -329,7 +330,7 @@
 
     "json-schema-to-typescript": ["json-schema-to-typescript@16.0.0", "", { "dependencies": { "@apidevtools/json-schema-ref-parser": "^11.9.3", "@types/json-schema": "^7.0.15", "@types/lodash": "^4.17.25", "js-yaml": "^5.2.3", "lodash": "^4.18.1", "minimist": "^1.2.8", "prettier": "^3.9.6", "tinyglobby": "^0.2.17" }, "bin": { "json2ts": "dist/src/cli.js" } }, "sha512-Ah6kK4q6SjlMzWBH1eNOQkdRh5Qhr5T/RCFwfjQqWZA7UDW+N47A8wfyoiN0L884s4L4bAEI54IjIuN3/u0B/A=="],
 
-    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
@@ -483,8 +484,6 @@
 
     "@apidevtools/json-schema-ref-parser/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
-    "@commitlint/config-validator/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
-
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@types/web-push/@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
@@ -509,6 +508,8 @@
 
     "cosmiconfig/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
+    "eslint/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
     "eslint-plugin-svelte/globals": ["globals@16.5.0", "", {}, "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ=="],
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
@@ -525,10 +526,10 @@
 
     "svelte-eslint-parser/espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
 
-    "@commitlint/config-validator/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
     "@types/web-push/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "@typescript-eslint/typescript-estree/tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/bun": "latest",
     "@types/node": "^26.4.1",
     "@types/web-push": "^3.6.4",
+    "ajv": "^8",
     "eslint": "^10.10.0",
     "eslint-plugin-svelte": "^3.23.0",
     "github-slugger": "^2.0.0",

--- a/src/autopilot-llm.ts
+++ b/src/autopilot-llm.ts
@@ -12,6 +12,7 @@ import type { OperatorLanguage } from "./operator-language";
 import type { TaskAmendment } from "./task-amendments";
 import { apiKeyFailClosed, apiKeyPassthroughEnv } from "./spawn-auth";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
+import { CODEX_ROLE_OUTPUT_SCHEMAS } from "./codex-role-output-schema";
 import type { SessionUsage } from "./usage";
 import { readReviewerSpawnUsage } from "./reviewer-usage";
 import {
@@ -94,6 +95,7 @@ function classifierArgv(
     effort,
     prompt,
     captureLastMessage: true,
+    outputSchemaFile: CODEX_ROLE_OUTPUT_SCHEMAS.autopilot,
   });
 }
 

--- a/src/codex-role-argv.ts
+++ b/src/codex-role-argv.ts
@@ -113,6 +113,7 @@ export function codexRoleArgv(
   prompt: string,
   effort: string | null,
   lastMessageFile: string | null,
+  outputSchemaFile: string | null = null,
 ): string[] {
   const argv = [
     "codex",
@@ -139,6 +140,9 @@ export function codexRoleArgv(
   // mode is an UNTRUSTED PR-head checkout — would let a committed symlink at that path redirect the
   // CLI's final-message write onto a real file. No consumer ⇒ no `-o` ⇒ no such surface.
   if (lastMessageFile !== null) argv.push("-o", lastMessageFile);
+  // Shape and destination are independent: the schema constrains the final response, while `-o`
+  // still delivers it to the existing fallback reader. Only structured-result consumers opt in.
+  if (outputSchemaFile !== null) argv.push("--output-schema", outputSchemaFile);
   argv.push(prompt);
   return argv;
 }

--- a/src/codex-role-output-schema.ts
+++ b/src/codex-role-output-schema.ts
@@ -1,0 +1,16 @@
+import { join } from "node:path";
+
+const schemaPath = (filename: string): string =>
+  join(import.meta.dir, "codex-role-schemas", filename);
+
+export const CODEX_ROLE_OUTPUT_SCHEMAS = {
+  autopilot: schemaPath("autopilot.json"),
+  recap: schemaPath("recap.json"),
+  planReview: schemaPath("plan-review.json"),
+  critic: schemaPath("critic.json"),
+  criticWithPlan: schemaPath("critic-with-plan.json"),
+  distiller: schemaPath("distiller.json"),
+  optimizer: schemaPath("optimizer.json"),
+  mergeIntra: schemaPath("merge-intra.json"),
+  mergeCross: schemaPath("merge-cross.json"),
+} as const;

--- a/src/codex-role-schemas/autopilot.json
+++ b/src/codex-role-schemas/autopilot.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "kind": {
+      "type": "string",
+      "enum": ["gate", "question", "finished", "complete", "unknown"]
+    },
+    "summary": { "type": "string", "maxLength": 280 }
+  },
+  "required": ["kind", "summary"],
+  "additionalProperties": false
+}

--- a/src/codex-role-schemas/critic-with-plan.json
+++ b/src/codex-role-schemas/critic-with-plan.json
@@ -1,0 +1,30 @@
+{
+  "$defs": {
+    "finding": {
+      "type": "object",
+      "properties": {
+        "text": { "type": "string", "pattern": "\\S" },
+        "severity": { "type": "string", "enum": ["important", "nit"] },
+        "pass": { "type": "string", "enum": ["bug", "security", "compliance", "scope"] }
+      },
+      "required": ["text", "severity", "pass"],
+      "additionalProperties": false
+    },
+    "nullableString": {
+      "anyOf": [{ "type": "string" }, { "type": "null" }]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "decision": { "type": "string", "enum": ["request-changes", "comment"] },
+    "summary": { "type": "string", "maxLength": 100 },
+    "body": { "type": "string" },
+    "findings": { "type": "array", "items": { "$ref": "#/$defs/finding" } },
+    "planDrift": { "type": "string", "enum": ["none", "minor", "major"] },
+    "planDriftNote": {
+      "anyOf": [{ "type": "string", "maxLength": 140 }, { "type": "null" }]
+    }
+  },
+  "required": ["decision", "summary", "body", "findings", "planDrift", "planDriftNote"],
+  "additionalProperties": false
+}

--- a/src/codex-role-schemas/critic.json
+++ b/src/codex-role-schemas/critic.json
@@ -1,0 +1,23 @@
+{
+  "$defs": {
+    "finding": {
+      "type": "object",
+      "properties": {
+        "text": { "type": "string", "pattern": "\\S" },
+        "severity": { "type": "string", "enum": ["important", "nit"] },
+        "pass": { "type": "string", "enum": ["bug", "security", "compliance", "scope"] }
+      },
+      "required": ["text", "severity", "pass"],
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "properties": {
+    "decision": { "type": "string", "enum": ["request-changes", "comment"] },
+    "summary": { "type": "string", "maxLength": 100 },
+    "body": { "type": "string" },
+    "findings": { "type": "array", "items": { "$ref": "#/$defs/finding" } }
+  },
+  "required": ["decision", "summary", "body", "findings"],
+  "additionalProperties": false
+}

--- a/src/codex-role-schemas/distiller.json
+++ b/src/codex-role-schemas/distiller.json
@@ -1,0 +1,80 @@
+{
+  "$defs": {
+    "stringArray": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "rule": {
+      "type": "object",
+      "properties": {
+        "rule": { "type": "string", "pattern": "\\S", "maxLength": 240 },
+        "rationale": { "type": "string" },
+        "evidence": { "$ref": "#/$defs/stringArray" },
+        "scopeGlobs": {
+          "type": "array",
+          "items": { "type": "string" },
+          "maxItems": 5
+        }
+      },
+      "required": ["rule", "rationale", "evidence", "scopeGlobs"],
+      "additionalProperties": false
+    },
+    "update": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "rule": { "type": "string", "pattern": "\\S", "maxLength": 240 },
+        "rationale": { "type": "string" }
+      },
+      "required": ["id", "rule", "rationale"],
+      "additionalProperties": false
+    },
+    "delete": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "reason": { "type": "string" }
+      },
+      "required": ["id", "reason"],
+      "additionalProperties": false
+    },
+    "evidenceEntry": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "evidence": { "$ref": "#/$defs/stringArray" }
+      },
+      "required": ["id", "evidence"],
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "properties": {
+    "rules": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/rule" },
+      "maxItems": 5
+    },
+    "updates": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/update" },
+      "maxItems": 5
+    },
+    "deletes": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/delete" },
+      "maxItems": 5
+    },
+    "ineffective": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/evidenceEntry" }
+    },
+    "reaffirm": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/evidenceEntry" },
+      "maxItems": 5
+    }
+  },
+  "required": ["rules", "updates", "deletes", "ineffective", "reaffirm"],
+  "additionalProperties": false
+}

--- a/src/codex-role-schemas/merge-cross.json
+++ b/src/codex-role-schemas/merge-cross.json
@@ -1,0 +1,27 @@
+{
+  "$defs": {
+    "group": {
+      "type": "object",
+      "properties": {
+        "memberIds": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 2
+        },
+        "canonicalRule": { "type": "string", "pattern": "\\S", "maxLength": 240 }
+      },
+      "required": ["memberIds", "canonicalRule"],
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "properties": {
+    "groups": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/group" },
+      "maxItems": 8
+    }
+  },
+  "required": ["groups"],
+  "additionalProperties": false
+}

--- a/src/codex-role-schemas/merge-intra.json
+++ b/src/codex-role-schemas/merge-intra.json
@@ -1,0 +1,29 @@
+{
+  "$defs": {
+    "group": {
+      "type": "object",
+      "properties": {
+        "memberIds": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 2
+        },
+        "anchorId": { "type": "string", "minLength": 1 },
+        "mergedRule": { "type": "string", "pattern": "\\S", "maxLength": 240 },
+        "mergedRationale": { "type": "string" }
+      },
+      "required": ["memberIds", "anchorId", "mergedRule", "mergedRationale"],
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "properties": {
+    "groups": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/group" },
+      "maxItems": 8
+    }
+  },
+  "required": ["groups"],
+  "additionalProperties": false
+}

--- a/src/codex-role-schemas/optimizer.json
+++ b/src/codex-role-schemas/optimizer.json
@@ -1,0 +1,23 @@
+{
+  "$defs": {
+    "nullableString": {
+      "anyOf": [{ "type": "string" }, { "type": "null" }]
+    },
+    "revision": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "rule": { "type": "string", "pattern": "\\S", "maxLength": 240 },
+        "rationale": { "$ref": "#/$defs/nullableString" }
+      },
+      "required": ["id", "rule", "rationale"],
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "properties": {
+    "revisions": { "type": "array", "items": { "$ref": "#/$defs/revision" } }
+  },
+  "required": ["revisions"],
+  "additionalProperties": false
+}

--- a/src/codex-role-schemas/plan-review.json
+++ b/src/codex-role-schemas/plan-review.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "decision": { "type": "string", "enum": ["approve", "request-changes"] },
+    "summary": { "type": "string", "maxLength": 100 },
+    "body": { "type": "string" },
+    "findings": { "type": "array", "items": { "type": "string" } }
+  },
+  "required": ["decision", "summary", "body", "findings"],
+  "additionalProperties": false
+}

--- a/src/codex-role-schemas/recap.json
+++ b/src/codex-role-schemas/recap.json
@@ -1,0 +1,322 @@
+{
+  "$defs": {
+    "nullableString": {
+      "anyOf": [{ "type": "string" }, { "type": "null" }]
+    },
+    "nullableBoolean": {
+      "anyOf": [{ "type": "boolean" }, { "type": "null" }]
+    },
+    "annotation": {
+      "type": "object",
+      "properties": {
+        "label": { "$ref": "#/$defs/nullableString" },
+        "note": { "type": "string" }
+      },
+      "required": ["label", "note"],
+      "additionalProperties": false
+    },
+    "nullableAnnotations": {
+      "anyOf": [{ "type": "array", "items": { "$ref": "#/$defs/annotation" } }, { "type": "null" }]
+    },
+    "richText": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["rich-text"] },
+        "id": { "type": "string", "minLength": 1 },
+        "markdown": { "type": "string" }
+      },
+      "required": ["type", "id", "markdown"],
+      "additionalProperties": false
+    },
+    "callout": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["callout"] },
+        "id": { "type": "string", "minLength": 1 },
+        "tone": {
+          "type": "string",
+          "enum": ["info", "decision", "risk", "warning", "success"]
+        },
+        "markdown": { "type": "string" }
+      },
+      "required": ["type", "id", "tone", "markdown"],
+      "additionalProperties": false
+    },
+    "fileTreeEntry": {
+      "type": "object",
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "change": {
+          "type": "string",
+          "enum": ["added", "modified", "removed", "renamed"]
+        },
+        "note": { "$ref": "#/$defs/nullableString" }
+      },
+      "required": ["path", "change", "note"],
+      "additionalProperties": false
+    },
+    "fileTree": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["file-tree"] },
+        "id": { "type": "string", "minLength": 1 },
+        "title": { "$ref": "#/$defs/nullableString" },
+        "entries": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/fileTreeEntry" },
+          "minItems": 1
+        }
+      },
+      "required": ["type", "id", "title", "entries"],
+      "additionalProperties": false
+    },
+    "diff": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["diff"] },
+        "id": { "type": "string", "minLength": 1 },
+        "path": { "type": "string", "minLength": 1 },
+        "summary": { "type": "string" },
+        "annotations": { "$ref": "#/$defs/nullableAnnotations" }
+      },
+      "required": ["type", "id", "path", "summary", "annotations"],
+      "additionalProperties": false
+    },
+    "code": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["code"] },
+        "id": { "type": "string", "minLength": 1 },
+        "filename": { "type": "string", "minLength": 1 }
+      },
+      "required": ["type", "id", "filename"],
+      "additionalProperties": false
+    },
+    "annotatedCode": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["annotated-code"] },
+        "id": { "type": "string", "minLength": 1 },
+        "filename": { "type": "string", "minLength": 1 },
+        "annotations": { "$ref": "#/$defs/nullableAnnotations" }
+      },
+      "required": ["type", "id", "filename", "annotations"],
+      "additionalProperties": false
+    },
+    "dataModelField": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "type": { "type": "string" },
+        "pk": { "$ref": "#/$defs/nullableBoolean" },
+        "fk": { "$ref": "#/$defs/nullableString" },
+        "nullable": { "$ref": "#/$defs/nullableBoolean" },
+        "change": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": ["added", "modified", "removed", "renamed"]
+            },
+            { "type": "null" }
+          ]
+        },
+        "was": { "$ref": "#/$defs/nullableString" }
+      },
+      "required": ["name", "type", "pk", "fk", "nullable", "change", "was"],
+      "additionalProperties": false
+    },
+    "dataModelEntity": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "name": { "type": "string" },
+        "fields": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/dataModelField" },
+          "minItems": 1
+        }
+      },
+      "required": ["id", "name", "fields"],
+      "additionalProperties": false
+    },
+    "relation": {
+      "type": "object",
+      "properties": {
+        "from": { "type": "string" },
+        "to": { "type": "string" },
+        "kind": { "type": "string" }
+      },
+      "required": ["from", "to", "kind"],
+      "additionalProperties": false
+    },
+    "nullableRelations": {
+      "anyOf": [{ "type": "array", "items": { "$ref": "#/$defs/relation" } }, { "type": "null" }]
+    },
+    "dataModel": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["data-model"] },
+        "id": { "type": "string", "minLength": 1 },
+        "entities": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/dataModelEntity" },
+          "minItems": 1
+        },
+        "relations": { "$ref": "#/$defs/nullableRelations" }
+      },
+      "required": ["type", "id", "entities", "relations"],
+      "additionalProperties": false
+    },
+    "apiParam": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "in": { "type": "string" },
+        "type": { "type": "string" },
+        "required": { "$ref": "#/$defs/nullableBoolean" },
+        "note": { "$ref": "#/$defs/nullableString" }
+      },
+      "required": ["name", "in", "type", "required", "note"],
+      "additionalProperties": false
+    },
+    "apiResponse": {
+      "type": "object",
+      "properties": {
+        "status": { "type": "number" },
+        "description": { "$ref": "#/$defs/nullableString" },
+        "example": { "$ref": "#/$defs/nullableString" }
+      },
+      "required": ["status", "description", "example"],
+      "additionalProperties": false
+    },
+    "nullableParams": {
+      "anyOf": [{ "type": "array", "items": { "$ref": "#/$defs/apiParam" } }, { "type": "null" }]
+    },
+    "nullableResponses": {
+      "anyOf": [{ "type": "array", "items": { "$ref": "#/$defs/apiResponse" } }, { "type": "null" }]
+    },
+    "apiEndpoint": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["api-endpoint"] },
+        "id": { "type": "string", "minLength": 1 },
+        "method": { "type": "string", "minLength": 1 },
+        "path": { "type": "string", "minLength": 1 },
+        "summary": { "$ref": "#/$defs/nullableString" },
+        "change": { "$ref": "#/$defs/nullableString" },
+        "deprecated": { "$ref": "#/$defs/nullableBoolean" },
+        "params": { "$ref": "#/$defs/nullableParams" },
+        "responses": { "$ref": "#/$defs/nullableResponses" }
+      },
+      "required": [
+        "type",
+        "id",
+        "method",
+        "path",
+        "summary",
+        "change",
+        "deprecated",
+        "params",
+        "responses"
+      ],
+      "additionalProperties": false
+    },
+    "table": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["table"] },
+        "id": { "type": "string", "minLength": 1 },
+        "columns": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        },
+        "rows": {
+          "type": "array",
+          "items": { "type": "array", "items": { "type": "string" } }
+        }
+      },
+      "required": ["type", "id", "columns", "rows"],
+      "additionalProperties": false
+    },
+    "checklistItem": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "label": { "type": "string" },
+        "note": { "$ref": "#/$defs/nullableString" },
+        "checked": { "$ref": "#/$defs/nullableBoolean" }
+      },
+      "required": ["id", "label", "note", "checked"],
+      "additionalProperties": false
+    },
+    "checklist": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["checklist"] },
+        "id": { "type": "string", "minLength": 1 },
+        "items": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/checklistItem" },
+          "minItems": 1
+        }
+      },
+      "required": ["type", "id", "items"],
+      "additionalProperties": false
+    },
+    "mermaid": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["mermaid"] },
+        "id": { "type": "string", "minLength": 1 },
+        "source": { "type": "string", "minLength": 1, "maxLength": 8000 },
+        "caption": { "$ref": "#/$defs/nullableString" }
+      },
+      "required": ["type", "id", "source", "caption"],
+      "additionalProperties": false
+    },
+    "wireframe": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["wireframe"] },
+        "id": { "type": "string", "minLength": 1 },
+        "surface": {
+          "type": "string",
+          "enum": ["browser", "desktop", "mobile", "popover", "panel"]
+        },
+        "html": { "type": "string", "minLength": 1, "maxLength": 20000 },
+        "caption": { "$ref": "#/$defs/nullableString" }
+      },
+      "required": ["type", "id", "surface", "html", "caption"],
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "properties": {
+    "verdict": { "type": "string", "enum": ["ready", "parked", "needs_attention"] },
+    "headline": { "type": "string", "maxLength": 100 },
+    "body": { "type": "string" },
+    "openItems": { "type": "array", "items": { "type": "string" } },
+    "blocks": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          { "$ref": "#/$defs/richText" },
+          { "$ref": "#/$defs/callout" },
+          { "$ref": "#/$defs/fileTree" },
+          { "$ref": "#/$defs/diff" },
+          { "$ref": "#/$defs/code" },
+          { "$ref": "#/$defs/annotatedCode" },
+          { "$ref": "#/$defs/dataModel" },
+          { "$ref": "#/$defs/apiEndpoint" },
+          { "$ref": "#/$defs/table" },
+          { "$ref": "#/$defs/checklist" },
+          { "$ref": "#/$defs/mermaid" },
+          { "$ref": "#/$defs/wireframe" }
+        ]
+      }
+    }
+  },
+  "required": ["verdict", "headline", "body", "openItems", "blocks"],
+  "additionalProperties": false
+}

--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -9,6 +9,7 @@ import type { Learning, Signal, SignalKind } from "./types";
 import { sanitizeScopeGlobs } from "./house-rules";
 import { apiKeyFailClosed, apiKeyPassthroughEnv } from "./spawn-auth";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
+import { CODEX_ROLE_OUTPUT_SCHEMAS } from "./codex-role-output-schema";
 import { reapTransientByLabel } from "./transient-tab-reaper";
 import type { RoleEnvironment } from "./default-model";
 import { normalizeRule } from "./learning-rule";
@@ -287,6 +288,7 @@ export class DistillerService {
       prompt: distillPrompt(),
       // The distiller READS the `-o` last-message fallback → opt in.
       captureLastMessage: true,
+      outputSchemaFile: CODEX_ROLE_OUTPUT_SCHEMAS.distiller,
     });
     const agentName = DISTILL_LABEL + sessionId.slice(0, 8);
     // Reserve the inflight slot SYNCHRONOUSLY — before the async spawn yields — so the daily

--- a/src/merge-suggest.ts
+++ b/src/merge-suggest.ts
@@ -10,6 +10,7 @@ import type { Learning, MergeSuggestionKind } from "./types";
 import { normalizeRule } from "./learning-rule";
 import { apiKeyFailClosed, apiKeyPassthroughEnv } from "./spawn-auth";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
+import { CODEX_ROLE_OUTPUT_SCHEMAS } from "./codex-role-output-schema";
 import { reapTransientByLabel } from "./transient-tab-reaper";
 import type { RoleEnvironment } from "./default-model";
 
@@ -251,6 +252,10 @@ export class MergeSuggestionService {
       prompt: kind === "cross" ? crossPrompt() : intraPrompt(),
       // The merge-suggester READS the `-o` last-message fallback → opt in.
       captureLastMessage: true,
+      outputSchemaFile:
+        kind === "cross"
+          ? CODEX_ROLE_OUTPUT_SCHEMAS.mergeCross
+          : CODEX_ROLE_OUTPUT_SCHEMAS.mergeIntra,
     });
     const agentName = MERGE_LABEL + sessionId.slice(0, 8);
     // Reserve the inflight slot SYNCHRONOUSLY — before the async spawn yields — so the daily

--- a/src/optimizer.ts
+++ b/src/optimizer.ts
@@ -8,6 +8,7 @@ import { HerdrUnavailableError } from "./herdr";
 import type { Promoter } from "./promote";
 import { apiKeyFailClosed, apiKeyPassthroughEnv } from "./spawn-auth";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
+import { CODEX_ROLE_OUTPUT_SCHEMAS } from "./codex-role-output-schema";
 import { reapTransientByLabel } from "./transient-tab-reaper";
 import type { RoleEnvironment } from "./default-model";
 import {
@@ -239,6 +240,7 @@ export class OptimizerService {
       prompt: optimizePrompt(),
       // The optimizer READS the `-o` last-message fallback → opt in.
       captureLastMessage: true,
+      outputSchemaFile: CODEX_ROLE_OUTPUT_SCHEMAS.optimizer,
     });
     const agentName = OPTIMIZE_LABEL + sessionId.slice(0, 8);
     // Reserve the inflight slot SYNCHRONOUSLY — before the async spawn yields — so a same-tick

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -29,6 +29,7 @@ import {
   groundPlanBlocks,
 } from "./visual-blocks";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
+import { CODEX_ROLE_OUTPUT_SCHEMAS } from "./codex-role-output-schema";
 import { apiKeyFailClosed } from "./spawn-auth";
 import { type SessionUsage } from "./usage";
 import {
@@ -488,6 +489,7 @@ export function reviewerArgv(
     prompt,
     effort,
     captureLastMessage: true,
+    outputSchemaFile: CODEX_ROLE_OUTPUT_SCHEMAS.planReview,
     sessionId,
   });
 }

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -15,6 +15,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
+import { CODEX_ROLE_OUTPUT_SCHEMAS } from "./codex-role-output-schema";
 import { spawnBudget, type SpawnAssembler } from "./spawn-budget";
 
 /** Operator-facing cause on a recap that could not be spawned at all (#1944). */
@@ -307,6 +308,7 @@ function recapArgv(
     effort,
     prompt,
     captureLastMessage: true,
+    outputSchemaFile: CODEX_ROLE_OUTPUT_SCHEMAS.recap,
     sessionId,
   });
 }

--- a/src/review.ts
+++ b/src/review.ts
@@ -17,6 +17,7 @@ import type {
 } from "./types";
 import type { RoleEnvironment } from "./default-model";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
+import { CODEX_ROLE_OUTPUT_SCHEMAS } from "./codex-role-output-schema";
 import { apiKeyFailClosed } from "./spawn-auth";
 import { type SessionUsage } from "./usage";
 import {
@@ -707,7 +708,8 @@ export class ReviewService {
       planCtx.approved,
       amendments,
     );
-    const argvFor = (p: string): string[] => this.criticArgvFor(p, reviewerEnv, criticSessionId);
+    const argvFor = (p: string): string[] =>
+      this.criticArgvFor(p, reviewerEnv, criticSessionId, planCtx.planShown);
     const argv = argvFor(
       composePrompt({
         plan: planCtx.plan,
@@ -964,7 +966,12 @@ export class ReviewService {
    *  recorded `criticSessionId` keys `inflight`, `recordReviewerSpawn`, `readVerdict`, `readUsage`
    *  and the codex last-message file, so a disagreeing `--session-id` means the verdict is written
    *  where nothing ever looks. */
-  private criticArgvFor(prompt: string, env: RoleEnvironment, sessionId: string): string[] {
+  private criticArgvFor(
+    prompt: string,
+    env: RoleEnvironment,
+    sessionId: string,
+    planShown: boolean,
+  ): string[] {
     return buildTransientAgentArgv("reviewer", {
       provider: env.provider,
       model: env.model,
@@ -972,6 +979,9 @@ export class ReviewService {
       prompt,
       // The critic READS the `-o` last-message fallback (per-spawn name for its untrusted checkout).
       captureLastMessage: true,
+      outputSchemaFile: planShown
+        ? CODEX_ROLE_OUTPUT_SCHEMAS.criticWithPlan
+        : CODEX_ROLE_OUTPUT_SCHEMAS.critic,
       sessionId,
     }).argv;
   }

--- a/src/standalone-critic.ts
+++ b/src/standalone-critic.ts
@@ -25,6 +25,7 @@ import type { GitForge, PrReviewMeta, PullRequest } from "./forge/types";
 import { CRITIC_REVIEW_MARKER } from "./forge/types";
 import { randomUUID } from "node:crypto";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
+import { CODEX_ROLE_OUTPUT_SCHEMAS } from "./codex-role-output-schema";
 import type { RoleEnvironment } from "./default-model";
 import { isEpicChild, isEpicIntegrationBranch } from "./epic-branch";
 import {
@@ -545,6 +546,7 @@ export class StandalonePrCriticService {
         prompt: p,
         // The critic READS the `-o` last-message fallback (per-spawn name for its untrusted checkout).
         captureLastMessage: true,
+        outputSchemaFile: CODEX_ROLE_OUTPUT_SCHEMAS.critic,
         sessionId: criticSessionId,
       }).argv;
     // Fire plugin onSpawn hooks (issue #1205) + bind patched env THROUGH the membrane. Session-less

--- a/src/transient-agent-argv.ts
+++ b/src/transient-agent-argv.ts
@@ -121,6 +121,10 @@ export interface TransientAgentArgvOptions {
    *  (nor, for the checkout-running kinds, a fixed `-o` target a committed symlink could redirect).
    *  Claude spawns ignore it (Claude has no `-o`). Default false. */
   captureLastMessage?: boolean;
+  /** Absolute path to the consuming role's trusted JSON Schema for the Codex final response.
+   *  Opt-in alongside captureLastMessage: this constrains shape, not the `-o` destination.
+   *  Non-consumers omit it; Claude ignores it. */
+  outputSchemaFile?: string;
   /** Extra directories the agent may read, emitted as `--add-dir` (Claude only, issue #2158).
    *  This is the ONLY thing that grants file access outside the spawn's cwd: the allowlist decides
    *  WHICH tools may run, not WHERE they may reach, so a temp-cwd kind (`writer-ro`/`writer-only`)
@@ -244,6 +248,7 @@ export function buildTransientAgentArgv(
         sanitizePromptArg(opts.prompt),
         opts.effort ?? null,
         lastMessageFile,
+        opts.outputSchemaFile ?? null,
       ),
       sessionId,
     };

--- a/test/autopilot-llm.test.ts
+++ b/test/autopilot-llm.test.ts
@@ -4,6 +4,10 @@ import { config } from "../src/config";
 import { SessionStore } from "../src/store";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
 import type { SessionUsage } from "../src/usage";
+import { CODEX_ROLE_OUTPUT_SCHEMAS } from "../src/codex-role-output-schema";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 beforeEach(() => {
   __setApiKeyConfigDirProvisionForTest(() => "/tmp/shepherd-test-apikey-config");
@@ -365,7 +369,42 @@ test("classifyStop: codex provider spawns headless `codex exec` (no claude flags
   ]);
   expect(calls.started.argv).not.toContain("--settings");
   expect(calls.started.argv).not.toContain("--allowedTools");
+  expect(calls.started.argv.slice(calls.started.argv.indexOf("--output-schema"), -1)).toEqual([
+    "--output-schema",
+    CODEX_ROLE_OUTPUT_SCHEMAS.autopilot,
+  ]);
   expect(calls.started.argv[calls.started.argv.length - 1]).toContain("task");
+});
+
+test("classifyStop accepts a schema-shaped Codex chat result through its real -o reader", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "autopilot-chat-output-"));
+  const fixture = readFileSync(
+    join(import.meta.dir, "fixtures/codex-role-output/autopilot.json"),
+    "utf8",
+  );
+  try {
+    const { deps } = makeDeps({
+      provider: "codex",
+      makeTmpDir: () => cwd,
+      cleanup: () => {},
+      herdr: {
+        start: async (_name: string, spawnCwd: string, argv: string[]) => {
+          const output = argv[argv.indexOf("-o") + 1]!;
+          writeFileSync(join(spawnCwd, output), fixture);
+          return { terminalId: "term-chat", cwd: spawnCwd } as any;
+        },
+        stop: async () => {},
+      },
+    });
+
+    expect(await classifyStop(["Delivered the implementation."], "task", deps, "l")).toEqual({
+      kind: "complete",
+      summary: "Implementation and verification are complete.",
+    });
+    expect(() => readFileSync(join(cwd, VERDICT_FILE), "utf8")).toThrow();
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
 });
 
 test("classifyStop: subscription mode — --settings unchanged + no env 4th arg", async () => {

--- a/test/codex-role-output-schema.test.ts
+++ b/test/codex-role-output-schema.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test } from "bun:test";
+import { isAbsolute, join } from "node:path";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import Ajv, { type AnySchema, type ValidateFunction } from "ajv";
+import { CODEX_ROLE_OUTPUT_SCHEMAS } from "../src/codex-role-output-schema";
+import { parseRecapVerdict } from "../src/recap-core";
+import { buildVerdictCore } from "../src/critic-core";
+
+type SchemaName = keyof typeof CODEX_ROLE_OUTPUT_SCHEMAS;
+
+const FIXTURE_DIR = join(import.meta.dir, "fixtures", "codex-role-output");
+const CASES: readonly [SchemaName, string][] = [
+  ["autopilot", "autopilot.json"],
+  ["recap", "recap.json"],
+  ["planReview", "plan-review.json"],
+  ["critic", "critic.json"],
+  ["criticWithPlan", "critic-with-plan.json"],
+  ["distiller", "distiller.json"],
+  ["optimizer", "optimizer.json"],
+  ["mergeIntra", "merge-intra.json"],
+  ["mergeCross", "merge-cross.json"],
+];
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function validators(): Map<SchemaName, ValidateFunction> {
+  const ajv = new Ajv({ allErrors: true, strict: true });
+  return new Map(
+    CASES.map(([name]) => [
+      name,
+      ajv.compile(readJson(CODEX_ROLE_OUTPUT_SCHEMAS[name]) as AnySchema),
+    ]),
+  );
+}
+
+function assertStructuredOutputSubset(node: unknown, location = "root"): void {
+  if (!node || typeof node !== "object" || Array.isArray(node)) return;
+  const schema = node as Record<string, unknown>;
+  if (schema.$ref !== undefined) {
+    expect(typeof schema.$ref, `${location} $ref`).toBe("string");
+    expect((schema.$ref as string).startsWith("#/"), `${location} external $ref`).toBe(true);
+  }
+  if (schema.type === "object") {
+    expect(schema.additionalProperties, `${location} must be closed`).toBe(false);
+    const properties = (schema.properties ?? {}) as Record<string, unknown>;
+    expect(schema.required, `${location} must require every property`).toEqual(
+      Object.keys(properties),
+    );
+  }
+  for (const [key, value] of Object.entries(schema)) {
+    if (key === "enum" || key === "required") continue;
+    if (Array.isArray(value)) {
+      value.forEach((item, index) =>
+        assertStructuredOutputSubset(item, `${location}.${key}[${index}]`),
+      );
+    } else {
+      assertStructuredOutputSubset(value, `${location}.${key}`);
+    }
+  }
+}
+
+describe("Codex role output schemas", () => {
+  test("exports absolute existing paths for all nine role contracts", () => {
+    expect(Object.keys(CODEX_ROLE_OUTPUT_SCHEMAS)).toEqual(CASES.map(([name]) => name));
+    for (const path of Object.values(CODEX_ROLE_OUTPUT_SCHEMAS)) {
+      expect(isAbsolute(path)).toBe(true);
+      expect(existsSync(path)).toBe(true);
+    }
+  });
+
+  test("resolves installation schemas independently of the process cwd", () => {
+    const originalCwd = process.cwd();
+    const decoyDir = mkdtempSync(join(tmpdir(), "shepherd-schema-decoy-"));
+    const decoy = join(decoyDir, "autopilot.json");
+    writeFileSync(decoy, '{"decoy":true}');
+    try {
+      process.chdir(decoyDir);
+      expect(CODEX_ROLE_OUTPUT_SCHEMAS.autopilot).not.toBe(decoy);
+      expect(readJson(CODEX_ROLE_OUTPUT_SCHEMAS.autopilot)).toEqual(
+        expect.objectContaining({ type: "object" }),
+      );
+    } finally {
+      process.chdir(originalCwd);
+      rmSync(decoyDir, { recursive: true, force: true });
+    }
+  });
+
+  test("compiles every schema and accepts its representative fixture", () => {
+    const compiled = validators();
+    for (const [name, fixture] of CASES) {
+      const validate = compiled.get(name)!;
+      expect(validate(readJson(join(FIXTURE_DIR, fixture))), JSON.stringify(validate.errors)).toBe(
+        true,
+      );
+    }
+  });
+
+  test("uses the strict Structured Outputs object subset throughout", () => {
+    for (const path of Object.values(CODEX_ROLE_OUTPUT_SCHEMAS)) {
+      const schema = readJson(path) as Record<string, unknown>;
+      expect(schema.type).toBe("object");
+      assertStructuredOutputSubset(schema);
+    }
+  });
+
+  test("rejects missing required and extra root properties for every role", () => {
+    const compiled = validators();
+    for (const [name, fixture] of CASES) {
+      const original = readJson(join(FIXTURE_DIR, fixture)) as Record<string, unknown>;
+      const firstKey = Object.keys(original)[0]!;
+      const missing = structuredClone(original);
+      delete missing[firstKey];
+      expect(compiled.get(name)!(missing), `${name} accepted missing ${firstKey}`).toBe(false);
+
+      const extra = { ...original, unexpected: true };
+      expect(compiled.get(name)!(extra), `${name} accepted an extra root property`).toBe(false);
+    }
+  });
+
+  test("rejects wrong enums and malformed nested values", () => {
+    const compiled = validators();
+    const autopilot = readJson(join(FIXTURE_DIR, "autopilot.json")) as Record<string, unknown>;
+    expect(compiled.get("autopilot")!({ ...autopilot, kind: "done" })).toBe(false);
+
+    const planReview = readJson(join(FIXTURE_DIR, "plan-review.json")) as Record<string, unknown>;
+    expect(compiled.get("planReview")!({ ...planReview, decision: "comment" })).toBe(false);
+
+    const critic = readJson(join(FIXTURE_DIR, "critic.json")) as Record<string, unknown>;
+    const criticFindings = structuredClone(critic.findings) as Record<string, unknown>[];
+    criticFindings[0]!.severity = "warning";
+    expect(compiled.get("critic")!({ ...critic, findings: criticFindings })).toBe(false);
+
+    const recap = readJson(join(FIXTURE_DIR, "recap.json")) as Record<string, unknown>;
+    const recapBlocks = structuredClone(recap.blocks) as Record<string, unknown>[];
+    recapBlocks[0]!.markdown = 42;
+    expect(compiled.get("recap")!({ ...recap, blocks: recapBlocks })).toBe(false);
+
+    const merge = readJson(join(FIXTURE_DIR, "merge-intra.json")) as Record<string, unknown>;
+    const groups = structuredClone(merge.groups) as Record<string, unknown>[];
+    groups[0]!.memberIds = ["only-one"];
+    expect(compiled.get("mergeIntra")!({ ...merge, groups })).toBe(false);
+  });
+
+  test("enforces prompt array bounds and visual content limits", () => {
+    const compiled = validators();
+    const distiller = readJson(join(FIXTURE_DIR, "distiller.json")) as Record<string, unknown>;
+    expect(
+      compiled.get("distiller")!({
+        ...distiller,
+        rules: Array.from({ length: 6 }, () => (distiller.rules as unknown[])[0]),
+      }),
+    ).toBe(false);
+
+    const recap = readJson(join(FIXTURE_DIR, "recap.json")) as Record<string, unknown>;
+    const blocks = structuredClone(recap.blocks) as Record<string, unknown>[];
+    const mermaid = blocks.find((block) => block.type === "mermaid")!;
+    mermaid.source = "x".repeat(8001);
+    expect(compiled.get("recap")!({ ...recap, blocks })).toBe(false);
+  });
+});
+
+describe("representative role output fixtures", () => {
+  test("the recap fixture preserves inline prose and all twelve visual types", () => {
+    const raw = readJson(join(FIXTURE_DIR, "recap.json"));
+    const parsed = parseRecapVerdict(raw);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.body).toBe(
+      "**Fertig.** Die Zeile sagt: „Pfad `src\\core.ts` bleibt.\u201c\n\nNächster Absatz.",
+    );
+    expect(parsed!.blocks.map((block) => block.type)).toEqual([
+      "rich-text",
+      "callout",
+      "file-tree",
+      "diff",
+      "code",
+      "annotated-code",
+      "data-model",
+      "api-endpoint",
+      "table",
+      "checklist",
+      "mermaid",
+      "wireframe",
+    ]);
+  });
+
+  test("the critic fixture preserves inline body and structured findings", () => {
+    const raw = readJson(join(FIXTURE_DIR, "critic.json")) as Parameters<
+      typeof buildVerdictCore
+    >[0];
+    const parsed = buildVerdictCore(raw, null, [], "patch", "schema-fixture");
+    expect(parsed.body).toContain('The parser keeps "quoted" text and `C:\\\\tmp` paths.');
+    expect(parsed.findings).toEqual([
+      "src/parser.ts: Escaped input can bypass the boundary check.",
+    ]);
+    expect(parsed.findingsMeta).toHaveLength(2);
+  });
+});

--- a/test/critic-core.test.ts
+++ b/test/critic-core.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -30,6 +30,45 @@ import type { TaskAmendment } from "../src/task-amendments";
 import { tolerantParseJson } from "../src/json-tolerant";
 import { allowedToolsFor } from "../src/transient-agent-argv";
 import { planReviewPrompt } from "../src/plan-gate";
+
+for (const fixtureName of ["critic", "critic-with-plan"] as const) {
+  test(`schema-shaped Codex chat ${fixtureName} reaches the verdict core through the real reader`, () => {
+    const dir = mkdtempSync(join(tmpdir(), `critic-schema-chat-${fixtureName}-`));
+    const fixture = readFileSync(
+      join(import.meta.dir, `fixtures/codex-role-output/${fixtureName}.json`),
+      "utf8",
+    );
+    try {
+      writeFileSync(join(dir, ".shepherd-last-message-schema-chat.txt"), fixture);
+
+      const read = defaultReadVerdict(dir, "schema-chat");
+      expect(read.status).toBe("parsed");
+      if (read.status !== "parsed") throw new Error("expected parsed critic verdict");
+      const core = buildVerdictCore(read.value, "base-sha", ["src/parser.ts"], "patch-1", "sha-1");
+
+      expect(core.body).toContain((JSON.parse(fixture) as { body: string }).body);
+      if (fixtureName === "critic") {
+        expect(core.decision).toBe("changes_requested");
+        expect(core.findings).toEqual([
+          "src/parser.ts: Escaped input can bypass the boundary check.",
+        ]);
+        expect(core.findingsMeta.filter((finding) => finding.severity === "nit")).toEqual([
+          {
+            text: "src/parser.ts: Rename the local for readability.",
+            severity: "nit",
+            pass: "scope",
+          },
+        ]);
+      } else {
+        expect(core.decision).toBe("commented");
+        expect(normalizePlanDrift(read.value.planDrift)).toBe("none");
+        expect(normalizePlanDriftNote(read.value.planDriftNote)).toBeNull();
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+}
 
 // ── #822 regression: malformed-JSON read path with content fidelity ─────────────────────────────
 //

--- a/test/distiller.test.ts
+++ b/test/distiller.test.ts
@@ -14,6 +14,10 @@ import { LearningEvidenceRepoMismatchError, SessionStore } from "../src/store";
 import { config } from "../src/config";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
 import { HerdrUnavailableError } from "../src/herdr";
+import { CODEX_ROLE_OUTPUT_SCHEMAS } from "../src/codex-role-output-schema";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 beforeEach(() => {
   __setApiKeyConfigDirProvisionForTest(() => "/tmp/shepherd-test-apikey-config");
@@ -522,9 +526,44 @@ test("distill spawn: a resolved Codex environment uses codex exec with its model
     "model_reasoning_effort=high",
     "-o",
     ".shepherd-last-message.txt",
+    "--output-schema",
+    CODEX_ROLE_OUTPUT_SCHEMAS.distiller,
     expect.any(String),
   ]);
   expect(cap.env).toBeUndefined();
+});
+
+test("Codex chat-only distiller output is read by the service and persists a supported rule", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "distiller-schema-chat-"));
+  try {
+    const store = new SessionStore(":memory:");
+    seedSignals(store, "/r", 3);
+    const signalId = store.listSignals("/r")[0]!.id;
+    const fixture = JSON.parse(
+      readFileSync(join(import.meta.dir, "fixtures/codex-role-output/distiller.json"), "utf8"),
+    );
+    fixture.rules[0].evidence = [signalId];
+    const { deps, cap } = spawnCapture(store);
+    deps.environment = () => ({ provider: "codex", model: "gpt-5.5", effort: "high" });
+    deps.scratch.create = () => ({ dir });
+    deps.scratch.remove = () => {};
+    delete deps.readProposals;
+
+    const svc = new DistillerService(deps as any);
+    await svc.distillNow("/r");
+    const output = cap.argv[cap.argv.indexOf("-o") + 1]!;
+    writeFileSync(join(dir, output), JSON.stringify(fixture));
+    await svc.tick();
+
+    expect(store.listLearnings("/r", { status: "proposed" })).toContainEqual(
+      expect.objectContaining({
+        rule: "Generated protocol types come from scripts/gen-herdr-types.ts.",
+        evidence: [signalId],
+      }),
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("distill spawn: an explicit Claude environment keeps the writer-ro Claude argv", async () => {

--- a/test/fixtures/codex-role-output/autopilot.json
+++ b/test/fixtures/codex-role-output/autopilot.json
@@ -1,0 +1,4 @@
+{
+  "kind": "complete",
+  "summary": "Implementation and verification are complete."
+}

--- a/test/fixtures/codex-role-output/critic-with-plan.json
+++ b/test/fixtures/codex-role-output/critic-with-plan.json
@@ -1,0 +1,8 @@
+{
+  "decision": "comment",
+  "summary": "The implementation follows the approved plan.",
+  "body": "## Review\n\nNo blocking findings.",
+  "findings": [],
+  "planDrift": "none",
+  "planDriftNote": null
+}

--- a/test/fixtures/codex-role-output/critic.json
+++ b/test/fixtures/codex-role-output/critic.json
@@ -1,0 +1,17 @@
+{
+  "decision": "request-changes",
+  "summary": "One parser boundary needs correction.",
+  "body": "## Review\n\nThe parser keeps \"quoted\" text and `C:\\\\tmp` paths.\n\nPlease address the important finding.",
+  "findings": [
+    {
+      "text": "src/parser.ts: Escaped input can bypass the boundary check.",
+      "severity": "important",
+      "pass": "bug"
+    },
+    {
+      "text": "src/parser.ts: Rename the local for readability.",
+      "severity": "nit",
+      "pass": "scope"
+    }
+  ]
+}

--- a/test/fixtures/codex-role-output/distiller.json
+++ b/test/fixtures/codex-role-output/distiller.json
@@ -1,0 +1,35 @@
+{
+  "rules": [
+    {
+      "rule": "Generated protocol types come from scripts/gen-herdr-types.ts.",
+      "rationale": "The generated-file header is not visible from every caller.",
+      "evidence": ["signal-add"],
+      "scopeGlobs": ["src/generated/**"]
+    }
+  ],
+  "updates": [
+    {
+      "id": "active-rule",
+      "rule": "Run bun run gen:herdr-types after protocol changes.",
+      "rationale": "The failure showed the generation step is required."
+    }
+  ],
+  "deletes": [
+    {
+      "id": "stale-rule",
+      "reason": "contradicted: the generator now owns this file."
+    }
+  ],
+  "ineffective": [
+    {
+      "id": "ineffective-rule",
+      "evidence": ["signal-failure"]
+    }
+  ],
+  "reaffirm": [
+    {
+      "id": "proposed-rule",
+      "evidence": ["signal-repeat"]
+    }
+  ]
+}

--- a/test/fixtures/codex-role-output/merge-cross.json
+++ b/test/fixtures/codex-role-output/merge-cross.json
@@ -1,0 +1,8 @@
+{
+  "groups": [
+    {
+      "memberIds": ["repo-a-rule", "repo-b-rule"],
+      "canonicalRule": "Run the repository generator after editing generated inputs."
+    }
+  ]
+}

--- a/test/fixtures/codex-role-output/merge-intra.json
+++ b/test/fixtures/codex-role-output/merge-intra.json
@@ -1,0 +1,10 @@
+{
+  "groups": [
+    {
+      "memberIds": ["rule-one", "rule-two"],
+      "anchorId": "rule-one",
+      "mergedRule": "Regenerate protocol types after changing their schema.",
+      "mergedRationale": "Both entries describe the same repository generation step."
+    }
+  ]
+}

--- a/test/fixtures/codex-role-output/optimizer.json
+++ b/test/fixtures/codex-role-output/optimizer.json
@@ -1,0 +1,9 @@
+{
+  "revisions": [
+    {
+      "id": "learning-one",
+      "rule": "Regenerate protocol types after editing the protocol schema.",
+      "rationale": null
+    }
+  ]
+}

--- a/test/fixtures/codex-role-output/plan-review.json
+++ b/test/fixtures/codex-role-output/plan-review.json
@@ -1,0 +1,6 @@
+{
+  "decision": "approve",
+  "summary": "The plan covers the requested behavior.",
+  "body": "## Review\n\nThe seams and verification steps are concrete.",
+  "findings": []
+}

--- a/test/fixtures/codex-role-output/recap.json
+++ b/test/fixtures/codex-role-output/recap.json
@@ -1,0 +1,108 @@
+{
+  "verdict": "ready",
+  "headline": "Strukturierte Ausgabe ist verdrahtet",
+  "body": "**Fertig.** Die Zeile sagt: „Pfad `src\\core.ts` bleibt.“\n\nNächster Absatz.",
+  "openItems": ["CLI-Smoke ausführen"],
+  "blocks": [
+    {
+      "type": "rich-text",
+      "id": "recap-rich-text",
+      "markdown": "**Resultat:** Alle Verträge sind erfasst."
+    },
+    {
+      "type": "callout",
+      "id": "recap-callout",
+      "tone": "success",
+      "markdown": "Die Ausgabe bleibt inline verfügbar."
+    },
+    {
+      "type": "file-tree",
+      "id": "recap-file-tree",
+      "title": null,
+      "entries": [{ "path": "src/schema.ts", "change": "added", "note": null }]
+    },
+    {
+      "type": "diff",
+      "id": "recap-diff",
+      "path": "src/parser.ts",
+      "summary": "Bindet den strukturierten Vertrag an.",
+      "annotations": [{ "label": null, "note": "Der bestehende Lesepfad bleibt erhalten." }]
+    },
+    {
+      "type": "code",
+      "id": "recap-code",
+      "filename": "src/schema.ts"
+    },
+    {
+      "type": "annotated-code",
+      "id": "recap-annotated-code",
+      "filename": "src/parser.ts",
+      "annotations": [{ "label": "Fallback", "note": "Liest die letzte Nachricht." }]
+    },
+    {
+      "type": "data-model",
+      "id": "recap-data-model",
+      "entities": [
+        {
+          "id": "role-output",
+          "name": "RoleOutput",
+          "fields": [
+            {
+              "name": "kind",
+              "type": "string",
+              "pk": true,
+              "fk": null,
+              "nullable": false,
+              "change": "added",
+              "was": null
+            }
+          ]
+        }
+      ],
+      "relations": null
+    },
+    {
+      "type": "api-endpoint",
+      "id": "recap-api-endpoint",
+      "method": "POST",
+      "path": "/roles/run",
+      "summary": null,
+      "change": "structured response",
+      "deprecated": false,
+      "params": [
+        {
+          "name": "role",
+          "in": "body",
+          "type": "string",
+          "required": true,
+          "note": null
+        }
+      ],
+      "responses": [{ "status": 200, "description": "Accepted", "example": null }]
+    },
+    {
+      "type": "table",
+      "id": "recap-table",
+      "columns": ["Rolle", "Schema"],
+      "rows": [["Recap", "recap.json"]]
+    },
+    {
+      "type": "checklist",
+      "id": "recap-checklist",
+      "items": [{ "id": "schema", "label": "Schema kompiliert", "note": null, "checked": true }]
+    },
+    {
+      "type": "mermaid",
+      "id": "recap-mermaid",
+      "source": "flowchart LR\n  Chat --> Fallback --> Parser",
+      "caption": null
+    },
+    {
+      "type": "wireframe",
+      "id": "recap-wireframe",
+      "surface": "panel",
+      "html": "<section><h2>Recap</h2><p>Bereit</p></section>",
+      "caption": null
+    }
+  ]
+}

--- a/test/merge-suggest.test.ts
+++ b/test/merge-suggest.test.ts
@@ -9,6 +9,10 @@ import { SessionStore } from "../src/store";
 import { config } from "../src/config";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
 import type { Learning } from "../src/types";
+import { CODEX_ROLE_OUTPUT_SCHEMAS } from "../src/codex-role-output-schema";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 beforeEach(() => {
   __setApiKeyConfigDirProvisionForTest(() => "/tmp/shepherd-test-apikey-config");
@@ -310,6 +314,8 @@ test("intra spawn: resolved Codex uses codex exec and persists the file result",
     "model_reasoning_effort=high",
     "-o",
     ".shepherd-last-message.txt",
+    "--output-schema",
+    CODEX_ROLE_OUTPUT_SCHEMAS.mergeIntra,
     expect.stringContaining("ONE repository"),
   ]);
   expect(cap.env).toBeUndefined();
@@ -374,11 +380,50 @@ test("cross spawn: resolved Codex uses codex exec and persists the file result",
     "model_reasoning_effort=high",
     "-o",
     ".shepherd-last-message.txt",
+    "--output-schema",
+    CODEX_ROLE_OUTPUT_SCHEMAS.mergeCross,
     expect.stringContaining("MANY repositories"),
   ]);
   expect(cap.env).toBeUndefined();
   expect(store.listMergeSuggestions({ kind: "cross", status: "pending" })).toHaveLength(1);
 });
+
+for (const kind of ["intra", "cross"] as const) {
+  test(`Codex chat-only ${kind} merge output reaches the real reader and persists a suggestion`, async () => {
+    const dir = mkdtempSync(join(tmpdir(), `merge-${kind}-schema-chat-`));
+    try {
+      const store = new SessionStore(":memory:");
+      const a = seedActive(store, kind === "intra" ? "/r" : "/r1", "generated rule A");
+      const b = seedActive(store, kind === "intra" ? "/r" : "/r2", "generated rule B");
+      const fixture = JSON.parse(
+        readFileSync(
+          join(import.meta.dir, `fixtures/codex-role-output/merge-${kind}.json`),
+          "utf8",
+        ),
+      );
+      fixture.groups[0].memberIds = [a.id, b.id];
+      if (kind === "intra") fixture.groups[0].anchorId = a.id;
+      const { deps, cap } = mkDeps(store, null, {
+        environment: () => ({ provider: "codex", model: "gpt-5.5", effort: "high" }),
+      });
+      deps.scratch.create = () => ({ dir });
+      deps.scratch.remove = () => {};
+      delete (deps as any).readOutput;
+
+      const svc = new MergeSuggestionService(deps);
+      if (kind === "intra") await svc.mergeNow("/r");
+      else await svc.considerCrossRepo();
+      writeFileSync(join(dir, cap.argv[cap.argv.indexOf("-o") + 1]!), JSON.stringify(fixture));
+      await svc.tick();
+
+      expect(store.listMergeSuggestions({ kind, status: "pending" })).toContainEqual(
+        expect.objectContaining({ sourceIds: kind === "intra" ? [b.id] : [a.id, b.id] }),
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+}
 
 test("each actual spawn resolves a fresh environment", async () => {
   const store = new SessionStore(":memory:");

--- a/test/optimizer.test.ts
+++ b/test/optimizer.test.ts
@@ -15,6 +15,10 @@ import { HerdrUnavailableError } from "../src/herdr";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
 import { config } from "../src/config";
 import type { RoleEnvironment } from "../src/default-model";
+import { CODEX_ROLE_OUTPUT_SCHEMAS } from "../src/codex-role-output-schema";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 beforeEach(() => {
   __setApiKeyConfigDirProvisionForTest(() => "/tmp/shepherd-test-apikey-config");
@@ -417,6 +421,8 @@ for (const entryPoint of ["optimizeOne", "optimizeAllFlagged"] as const) {
           "model_reasoning_effort=high",
           "-o",
           ".shepherd-last-message.txt",
+          "--output-schema",
+          CODEX_ROLE_OUTPUT_SCHEMAS.optimizer,
           expect.any(String),
         ]);
       }
@@ -429,6 +435,48 @@ for (const entryPoint of ["optimizeOne", "optimizeAllFlagged"] as const) {
     });
   }
 }
+
+test("Codex chat-only optimizer output is read by the service and revises its known learning", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "optimizer-schema-chat-"));
+  try {
+    const store = new SessionStore(":memory:");
+    const learning = store.addLearning({
+      repoPath: "/r",
+      rule: "old generated protocol rule",
+      rationale: "Keep this rationale when the model returns null.",
+      evidence: [],
+    });
+    store.setLearningStatus(learning.id, "active");
+    const id = learning.id;
+    flag(store, "/r", id);
+    const fixture = JSON.parse(
+      readFileSync(join(import.meta.dir, "fixtures/codex-role-output/optimizer.json"), "utf8"),
+    );
+    fixture.revisions[0].id = id;
+    const { deps, cap } = optimizerSpawnCapture(
+      store,
+      () => null,
+      () => ({ provider: "codex", model: "gpt-5.5", effort: "high" }),
+    );
+    deps.scratch.create = () => ({ dir });
+    deps.scratch.remove = () => 0;
+    delete (deps as any).readOutput;
+
+    const svc = new OptimizerService(deps as any);
+    await svc.optimizeOne(id);
+    const argv = cap.argv[0]!;
+    writeFileSync(join(dir, argv[argv.indexOf("-o") + 1]!), JSON.stringify(fixture));
+    await svc.tick();
+
+    expect(store.getLearning(id)).toMatchObject({
+      rule: "Regenerate protocol types after editing the protocol schema.",
+      rationale: "Keep this rationale when the model returns null.",
+      ineffectiveCount: 0,
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 test("resolves a fresh environment for every optimizer spawn", async () => {
   const store = new SessionStore(":memory:");

--- a/test/plan-gate-prompt.test.ts
+++ b/test/plan-gate-prompt.test.ts
@@ -5,6 +5,7 @@ import {
   stripPlanLineRefs,
   PLAN_VERDICT_FILE,
 } from "../src/plan-gate";
+import { CODEX_ROLE_OUTPUT_SCHEMAS } from "../src/codex-role-output-schema";
 
 test("prompt embeds task + plan + prior findings + verdict file + read-only", () => {
   const p = planReviewPrompt("do X", "PLAN TEXT", ["earlier nit"]);
@@ -59,6 +60,18 @@ test("reviewerArgv mirrors critic hardening: dontAsk last, no --bare, disableAll
   expect(tools).toBeLessThan(dontAsk);
   expect(a).toContain("--safe-mode");
   expect(a.indexOf("--safe-mode")).toBeLessThan(a.indexOf("--allowedTools"));
+  expect(a).not.toContain("--output-schema");
+});
+
+test("reviewerArgv gives Codex the plan-review schema between its -o file and prompt", () => {
+  const { argv } = reviewerArgv("codex", "gpt-5.5", "PROMPT", "high", "review-session");
+  expect(argv.slice(argv.indexOf("-o"), -1)).toEqual([
+    "-o",
+    ".shepherd-last-message-review-session.txt",
+    "--output-schema",
+    CODEX_ROLE_OUTPUT_SCHEMAS.planReview,
+  ]);
+  expect(argv.at(-1)).toBe("PROMPT");
 });
 test("reviewerArgv inserts --model when given", () => {
   const { argv: a } = reviewerArgv("claude", "opus", "PROMPT");

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -8,6 +8,7 @@ import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
 import { SessionService } from "../src/service";
 import { SessionRouter } from "../src/session-router";
 import { SessionStore } from "../src/store";
+import { CODEX_ROLE_OUTPUT_SCHEMAS } from "../src/codex-role-output-schema";
 
 const CODEX_FIXTURE = join(import.meta.dir, "fixtures/codex-activity/rollout-role-exec.jsonl");
 
@@ -37,12 +38,14 @@ async function withAuth<T>(
 }
 
 function harness(over: any = {}) {
+  const useDefaultReadVerdict = over.useDefaultReadVerdict === true;
   const started: any[] = [];
   const removed: string[] = [];
   const recordedSpawns: any[] = [];
   const completedSpawns: any[] = [];
   const overWithoutStore = { ...over };
   delete overWithoutStore.store;
+  delete overWithoutStore.useDefaultReadVerdict;
   const notices = new Map<string, any>();
   const noticeEvents: string[] = [];
   const store = {
@@ -130,6 +133,7 @@ function harness(over: any = {}) {
     // deps-level spread doesn't re-overwrite it with the un-merged per-test partial.
     ...overWithoutStore,
   };
+  if (useDefaultReadVerdict) delete deps.readVerdict;
   return {
     deps,
     started,
@@ -142,6 +146,41 @@ function harness(over: any = {}) {
     svc: new PlanGateService(deps),
   };
 }
+
+test("Codex chat-only plan review is finalized through the service's default -o reader", async () => {
+  const worktreePath = mkdtempSync(join(process.cwd(), ".plan-review-schema-chat-"));
+  try {
+    const h = harness({
+      useDefaultReadVerdict: true,
+      env: () => ({ provider: "codex", model: "gpt-5.5", effort: "high" }),
+      worktree: {
+        createDetached: async () => ({ worktreePath, branch: "main" }),
+        remove: () => {},
+        gitCommonDir: () => "/fake-git-common",
+      },
+      store: { setReviewerSpawnOutcome: () => {} },
+    });
+
+    await h.svc.consider(planningSession() as any);
+    const argv = h.started[0]!.argv as string[];
+    const fixture = readFileSync(
+      join(import.meta.dir, "fixtures/codex-role-output/plan-review.json"),
+      "utf8",
+    );
+    writeFileSync(join(worktreePath, argv[argv.indexOf("-o") + 1]!), fixture);
+    await h.svc.tick();
+
+    expect(h.store.gate).toMatchObject({
+      approved: true,
+      decision: "approved",
+      summary: "The plan covers the requested behavior.",
+      body: "## Review\n\nThe seams and verification steps are concrete.",
+      findings: [],
+    });
+  } finally {
+    rmSync(worktreePath, { recursive: true, force: true });
+  }
+});
 
 const planningSession = () => ({
   id: "s1",
@@ -323,6 +362,10 @@ test("begin carries the reviewer env on the reviewing:true signal + reviewingInf
   // The inflight bootstrap snapshot exposes the same env for a mid-review reload.
   expect(h.svc.reviewingInflight()).toEqual([
     { id: "s1", provider: "codex", model: "gpt-5.5", effort: "high" },
+  ]);
+  expect(h.started[0]!.argv.slice(h.started[0]!.argv.indexOf("--output-schema"), -1)).toEqual([
+    "--output-schema",
+    CODEX_ROLE_OUTPUT_SCHEMAS.planReview,
   ]);
 });
 
@@ -2814,20 +2857,28 @@ test("#1944 an ordinary plan is untouched: no clamp, no notice, no marker", asyn
 });
 
 test.skipIf(!onLinux)(
-  "#1944 --session-id agrees with the recorded spawn (no randomUUID stub)",
+  "#1944 clamped Codex argv keeps its schema and recorded spawn in the last-message filename",
   async () => {
     // Three argvs are built per spawn (probe, clamped rebuild, final). If any minted its own id the
     // verdict would be written where readVerdict never looks.
-    const h = harness({ readPlan: () => bigPlan(200_000) });
+    const h = harness({
+      readPlan: () => bigPlan(200_000),
+      env: () => ({ provider: "codex", model: "gpt-5.5", effort: "high" }),
+    });
     await h.svc.consider(planningSession() as any);
 
     const argv = h.started[0].argv as string[];
-    const idFlag = argv[argv.indexOf("--session-id") + 1];
-    expect(idFlag).toBe(h.recordedSpawns[0].reviewerSessionId);
+    const reviewerSessionId = h.recordedSpawns[0].reviewerSessionId;
+    expect(argv[argv.indexOf("-o") + 1]).toBe(`.shepherd-last-message-${reviewerSessionId}.txt`);
+    expect(argv.slice(argv.indexOf("--output-schema"), -1)).toEqual([
+      "--output-schema",
+      CODEX_ROLE_OUTPUT_SCHEMAS.planReview,
+    ]);
     // A real minted uuid, not a test stub — randomUUID is deliberately NOT mocked here, because a
     // mock returning one constant would make the three-argv hazard invisible.
-    expect(idFlag).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
-    expect(argv.filter((t) => t === "--session-id")).toHaveLength(1);
+    expect(reviewerSessionId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
     expect(h.started[0].cwd).toBe(h.recordedSpawns[0].worktreePath);
   },
 );

--- a/test/recap-core.test.ts
+++ b/test/recap-core.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -21,6 +21,42 @@ import {
 import { defaultReadVerdict } from "../src/recap";
 import { tolerantParseJson } from "../src/json-tolerant";
 import type { DiffFile, DiffLine, Recap } from "../src/types";
+
+test("schema-shaped Codex chat recap preserves its inline body and all twelve block variants", () => {
+  const dir = mkdtempSync(join(tmpdir(), "recap-schema-chat-"));
+  const fixture = readFileSync(
+    join(import.meta.dir, "fixtures/codex-role-output/recap.json"),
+    "utf8",
+  );
+  try {
+    writeFileSync(join(dir, ".shepherd-last-message.txt"), fixture);
+
+    const read = defaultReadVerdict(dir);
+    expect(read.status).toBe("parsed");
+    if (read.status !== "parsed") throw new Error("expected parsed recap");
+    const parsed = parseRecapVerdict(read.value)!;
+
+    expect(parsed.body).toBe(
+      "**Fertig.** Die Zeile sagt: „Pfad `src\\core.ts` bleibt.“\n\nNächster Absatz.",
+    );
+    expect(parsed.blocks.map((block) => block.id)).toEqual([
+      "recap-rich-text",
+      "recap-callout",
+      "recap-file-tree",
+      "recap-diff",
+      "recap-code",
+      "recap-annotated-code",
+      "recap-data-model",
+      "recap-api-endpoint",
+      "recap-table",
+      "recap-checklist",
+      "recap-mermaid",
+      "recap-wireframe",
+    ]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 // ── #822 regression: malformed-JSON read path (defaultReadVerdict → parseRecapVerdict) ──────────
 //

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -11,6 +11,7 @@ import { buildRecapPrompt, buildUiMarkupDigest } from "../src/recap-core";
 import { hostArgvBudget, joinedElementBytes } from "../src/argv-limit";
 import { config } from "../src/config";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
+import { CODEX_ROLE_OUTPUT_SCHEMAS } from "../src/codex-role-output-schema";
 
 beforeEach(() => {
   __setApiKeyConfigDirProvisionForTest(() => "/tmp/shepherd-test-apikey-config");
@@ -1149,6 +1150,10 @@ test("generate: codex provider spawns headless `codex exec` (no claude flags)", 
   });
   await svc.regenerate(s);
   const argv = herdr.started[0]!.argv;
+  expect(argv.slice(argv.indexOf("--output-schema"), -1)).toEqual([
+    "--output-schema",
+    CODEX_ROLE_OUTPUT_SCHEMAS.recap,
+  ]);
   expect(argv.slice(0, 13)).toEqual([
     "codex",
     "exec",
@@ -2669,9 +2674,15 @@ test("#2209 generate: the markup yields argv bytes BEFORE the plan does (#1944 l
     makeTmpDir: () => "/tmp/r",
     computeDiff: async () => uiDiff(400),
     readPlan: () => plan,
+    env: () => ({ provider: "codex", model: "gpt-5.5", effort: "high" }),
   });
   await svc.regenerate(s);
-  const prompt = herdr.started[0]!.argv.at(-1)!;
+  const argv = herdr.started[0]!.argv;
+  const prompt = argv.at(-1)!;
+  expect(argv.slice(argv.indexOf("--output-schema"), -1)).toEqual([
+    "--output-schema",
+    CODEX_ROLE_OUTPUT_SCHEMAS.recap,
+  ]);
 
   // Exactly one block gave bytes up, and it was the markup — the marker sits inside its fence.
   const markers = [...prompt.matchAll(/\[… \d+ bytes elided …\]/g)];

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -24,6 +24,7 @@ import {
 import { config, clampCap, REVIEW_TIMEOUT_MS_MIN, REVIEW_TIMEOUT_MS_MAX } from "../src/config";
 import { STARTUP_GRACE_MS } from "../src/json-tolerant";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
+import { CODEX_ROLE_OUTPUT_SCHEMAS } from "../src/codex-role-output-schema";
 
 beforeEach(() => {
   __setApiKeyConfigDirProvisionForTest(() => "/tmp/shepherd-test-apikey-config");
@@ -533,8 +534,10 @@ test("Codex review records its resolved provider and completes without Claude us
     deps: d,
     recordedSpawns,
     completedSpawns,
+    started,
   } = makeDeps({
     env: () => env,
+    readPlan: () => "## Approved plan\nShip the implementation.",
     readUsage: async () => null,
   });
   const svc = new ReviewService(d as any);
@@ -548,6 +551,24 @@ test("Codex review records its resolved provider and completes without Claude us
   });
   expect(completedSpawns).toHaveLength(1);
   expect(completedSpawns[0]!.u).toBeNull();
+  expect(started[0]!.argv.slice(started[0]!.argv.indexOf("--output-schema"), -1)).toEqual([
+    "--output-schema",
+    CODEX_ROLE_OUTPUT_SCHEMAS.criticWithPlan,
+  ]);
+});
+
+test("Codex review without an approved plan uses the critic schema without drift fields", async () => {
+  const { deps: d, started } = makeDeps(
+    { env: () => ({ provider: "codex", model: "gpt-5.6", effort: "high" }) },
+    { planGate: null },
+  );
+
+  await new ReviewService(d as any).consider(session(), OPEN_GREEN);
+
+  expect(started[0]!.argv.slice(started[0]!.argv.indexOf("--output-schema"), -1)).toEqual([
+    "--output-schema",
+    CODEX_ROLE_OUTPUT_SCHEMAS.critic,
+  ]);
 });
 
 test("onReviewing fires true on spawn and false on finalize", async () => {
@@ -4373,11 +4394,27 @@ test.skipIf(!onLinux1944)(
   "#1944 an oversized plan is clamped and the critic spawn fits",
   async () => {
     const plan = bigPlan1944(200_000);
-    const { deps: d, started, notices, noticeEvents } = makeDeps({ readPlan: () => plan });
+    const {
+      deps: d,
+      started,
+      notices,
+      noticeEvents,
+      recordedSpawns,
+    } = makeDeps({
+      readPlan: () => plan,
+      env: () => ({ provider: "codex", model: "gpt-5.6", effort: "high" }),
+    });
     await new ReviewService(d as any).consider(session(), OPEN_GREEN);
 
     expect(started).toHaveLength(1);
     const s = started[0]!;
+    expect(s.argv.slice(s.argv.indexOf("--output-schema"), -1)).toEqual([
+      "--output-schema",
+      CODEX_ROLE_OUTPUT_SCHEMAS.criticWithPlan,
+    ]);
+    expect(s.argv[s.argv.indexOf("-o") + 1]).toBe(
+      `.shepherd-last-message-${recordedSpawns[0]!.reviewerSessionId}.txt`,
+    );
     expect(spawnFootprintBytes(buildWrappedArgv(s.argv, s.env))).toBeLessThanOrEqual(
       hostArgvBudget(),
     );

--- a/test/standalone-critic.test.ts
+++ b/test/standalone-critic.test.ts
@@ -8,6 +8,7 @@ import { config } from "../src/config";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
 import type { GitForge, PrReviewMeta, PullRequest } from "../src/forge/types";
 import type { PrReview, Learning } from "../src/types";
+import { CODEX_ROLE_OUTPUT_SCHEMAS } from "../src/codex-role-output-schema";
 
 beforeEach(() => {
   __setApiKeyConfigDirProvisionForTest(() => "/tmp/shepherd-test-apikey-config");
@@ -282,6 +283,9 @@ test("Codex critic records its resolved provider and completes without Claude us
   });
   expect(spies.completedSpawns).toHaveLength(1);
   expect(spies.completedSpawns[0]!.u).toBeNull();
+  expect(
+    spies.started[0]!.argv.slice(spies.started[0]!.argv.indexOf("--output-schema"), -1),
+  ).toEqual(["--output-schema", CODEX_ROLE_OUTPUT_SCHEMAS.critic]);
 });
 
 test("reviews a REST-enumerated green PR while GraphQL backoff is active", async () => {

--- a/test/transient-agent-argv.test.ts
+++ b/test/transient-agent-argv.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 import { buildTransientAgentArgv, type TransientAgentKind } from "../src/transient-agent-argv";
 import { config } from "../src/config";
+import { codexRoleArgv } from "../src/codex-role-argv";
 
 // Temporarily set config auth fields, always restoring them.
 function withAuth(mode: typeof config.authMode, helper: string | null, fn: () => void): void {
@@ -362,6 +363,53 @@ const CODEX_PREFIX = [
 // when the caller sets `captureLastMessage` (i.e. the role READS the fallback). When set, the name
 // matches the kind's trust posture: `reviewer` (untrusted checkout) → a PER-SPAWN unguessable name;
 // every other kind (disposable tmpdir) → the fixed name.
+
+test("codex: schema opt-in preserves capture names and the sanitized positional prompt", () => {
+  for (const kind of ALL_KINDS) {
+    const { argv } = buildTransientAgentArgv(kind, {
+      provider: "codex",
+      model: null,
+      prompt: "answer\0here",
+      sessionId: "schema-test-session",
+      captureLastMessage: true,
+      outputSchemaFile: "/trusted install/recap.json",
+    });
+    const name =
+      kind === "reviewer"
+        ? ".shepherd-last-message-schema-test-session.txt"
+        : ".shepherd-last-message.txt";
+    expect(argv).toEqual([
+      ...CODEX_PREFIX,
+      "-o",
+      name,
+      "--output-schema",
+      "/trusted install/recap.json",
+      "answer\\0here",
+    ]);
+  }
+});
+
+test("claude: output schema is ignored without changing its invocation", () => {
+  for (const kind of ALL_KINDS) {
+    const opts = { model: null, prompt: "answer", sessionId: "schema-test-session" };
+    expect(
+      buildTransientAgentArgv(kind, {
+        ...opts,
+        outputSchemaFile: "/trusted install/recap.json",
+      }),
+    ).toEqual(buildTransientAgentArgv(kind, opts));
+  }
+});
+
+test("codex: schema changes only the response shape, never opts into capture", () => {
+  expect(codexRoleArgv(null, "answer", null, null, "/trusted/schema.json")).toEqual([
+    ...CODEX_PREFIX,
+    "--output-schema",
+    "/trusted/schema.json",
+    "answer",
+  ]);
+  expect(codexRoleArgv(null, "answer", null, null)).toEqual([...CODEX_PREFIX, "answer"]);
+});
 
 test("codex: every role carries the explicit shepherd thread source", () => {
   for (const kind of ALL_KINDS) {


### PR DESCRIPTION
## Summary

Codex helper roles can return a correct verdict in chat without writing their result file. Add an explicit per-role `--output-schema` so the existing `-o` fallback contains JSON matching the consumer's contract. Keep the capture filenames, primary-result/sidecar precedence, prompts, and validators unchanged.

Nine trusted, installation-relative schemas cover the structured consumers, including both critic and merge-suggestion variants and all twelve recap visual types. Non-consumers and Claude receive no new flags.

Closes #2133

## Validation

- `bun run test` — 9,619 passed, 16 skipped, 0 failed (433 files).
- `bun run lint` and `bun run typecheck`.
- Schema acceptance/rejection, real chat-only consumer paths, and argv-clamp regression tests.
- Codex CLI 0.154.0 live smoke for all nine schemas: each returned the expected JSON through only its existing `-o` file; all twelve recap visual types survived.
- Self-review and independent review completed with no outstanding findings.
- Full pre-push gate passed, including UI/extension checks, tests/builds, and the delta Fallow audit.

## Checklist

- [x] Conventional-commit PR title; branch is linear from `origin/main`.
- [x] Relevant local lint, typecheck, and test commands pass.
- [x] No user-facing UI/text or repository instruction changes. [no-feature-entry]
- [x] Existing public configuration and file-result contracts remain unchanged.
