### PR TITLE
feat(herd): show the issue a session was spawned for on its card

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3957,5 +3957,13 @@
   "usage_failover_failed": "Standard-CLI konnte nicht umgestellt werden.",
   "settings_default_cli_desc_failover": "Vorübergehend {to} statt {from}: {from} liegt unter 30 % Wochenkapazität. Schaltet von selbst zurück; eine Wahl hier beendet die Vertretung.",
   "feat_usage_provider_failover_title": "Coding-CLI wechseln, wenn eine Wochenkapazität ausgeht",
-  "feat_usage_provider_failover_body": "Fällt dein Standard-Coding-CLI unter 30 % Wochenrestkapazität und das andere hat noch Luft, bietet das Auslastungs-Popover einen Wechsel per Klick an. Shepherd schaltet von selbst zurück, sobald das erschöpfte CLI wieder Kapazität hat."
+  "feat_usage_provider_failover_body": "Fällt dein Standard-Coding-CLI unter 30 % Wochenrestkapazität und das andere hat noch Luft, bietet das Auslastungs-Popover einen Wechsel per Klick an. Shepherd schaltet von selbst zurück, sobald das erschöpfte CLI wieder Kapazität hat.",
+  "issuebadge_label": "Issue #{number}",
+  "issuebadge_title": "Gestartet für Issue #{number}",
+  "settings_card_issue_ref_title": "Issue-Nummer auf Session-Karten",
+  "settings_card_issue_ref_hint": "Zeigt die Nummer des Issues, für das eine Session gestartet wurde (#1234), neben dem PR-Badge. Karten ohne Issue zeigen so oder so nichts. Standardmäßig an.",
+  "settings_card_issue_ref_on": "Issue-Nummer sichtbar",
+  "settings_card_issue_ref_off": "Issue-Nummer ausgeblendet",
+  "feat_card_issue_ref_title": "Erkennen, an welchem Issue eine Session arbeitet",
+  "feat_card_issue_ref_body": "Eine Session-Karte nannte ihre Aufgabe, aber nicht deren Herkunft: Die Issue-Nummer steckte in der abgeschnittenen Prompt-Zeile, also musste man eine Session öffnen, um sie von der auf dem Nachbar-Issue zu unterscheiden. Karten, die aus einem Backlog-Issue gestartet wurden, tragen jetzt einen kleinen #1234-Chip neben dem PR-Badge — unter Einstellungen → Gerät lässt er sich für die ruhigere Karte abschalten."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3957,5 +3957,13 @@
   "usage_failover_failed": "Could not switch the default CLI.",
   "settings_default_cli_desc_failover": "Temporarily {to} instead of {from}: {from} is below 30% weekly capacity. Switches back on its own; picking one here ends the substitution.",
   "feat_usage_provider_failover_title": "Switch coding CLI when one runs out of weekly capacity",
-  "feat_usage_provider_failover_body": "When your default coding CLI drops below 30% remaining weekly capacity and the other one still has room, the usage popover offers a one-click switch. Shepherd switches back on its own once the exhausted CLI has capacity again."
+  "feat_usage_provider_failover_body": "When your default coding CLI drops below 30% remaining weekly capacity and the other one still has room, the usage popover offers a one-click switch. Shepherd switches back on its own once the exhausted CLI has capacity again.",
+  "issuebadge_label": "Issue #{number}",
+  "issuebadge_title": "Spawned for issue #{number}",
+  "settings_card_issue_ref_title": "Issue number on session cards",
+  "settings_card_issue_ref_hint": "Show the number of the issue a session was spawned for (#1234) next to its PR badge. Cards launched without an issue show nothing either way. On by default.",
+  "settings_card_issue_ref_on": "Issue number shown",
+  "settings_card_issue_ref_off": "Issue number hidden",
+  "feat_card_issue_ref_title": "See which issue a session is working",
+  "feat_card_issue_ref_body": "A session card named its task but not its origin: the issue number was buried in the truncated prompt line, so telling two sessions on neighbouring issues apart meant opening one. Cards spawned from a backlog issue now carry a small #1234 chip beside the PR badge, and Settings → Device turns it off for anyone who wants the quieter card."
 }

--- a/ui/src/lib/components/IssueBadge.browser.test.ts
+++ b/ui/src/lib/components/IssueBadge.browser.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import type { Session } from "$lib/types";
+import { m } from "$lib/paraglide/messages";
+
+const { default: IssueBadge } = await import("./IssueBadge.svelte");
+const { issueRef } = await import("$lib/issue-ref.svelte");
+
+function session(partial: Partial<Session> & { id: string }): Session {
+  return {
+    desig: "TASK-01",
+    name: "task one",
+    prompt: "p",
+    repoPath: "/repo/a",
+    baseBranch: "main",
+    branch: "feat/x",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "h",
+    herdrAgentId: "ha",
+    claudeSessionId: "cs",
+    model: null,
+    status: "idle",
+    readyToMerge: false,
+    mergingSince: null,
+    mergingTrainId: null,
+    mergeTrainPrs: null,
+    autopilotEnabled: null,
+    autopilotStepCount: 0,
+    autopilotPaused: false,
+    autopilotComplete: false,
+    autopilotQuestion: null,
+    planGateEnabled: null,
+    planPhase: null,
+    autoMergeEnabled: null,
+    autoMergeRebaseCount: 0,
+    auto: false,
+    sandboxApplied: null,
+    sandboxDegraded: false,
+    egressApplied: false,
+    egressDegraded: false,
+    research: false,
+    epicAuthoring: false,
+    issueNumber: null,
+    lastState: "",
+    createdAt: 0,
+    updatedAt: 0,
+    archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
+    experimentId: null,
+    experimentRole: null,
+    ...partial,
+  };
+}
+
+beforeEach(() => {
+  issueRef.set(true);
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  issueRef.set(true);
+});
+
+describe("IssueBadge", () => {
+  it("names the issue a session was spawned for", async () => {
+    render(IssueBadge, { session: session({ id: "a", issueNumber: 2244 }) });
+    await expect.element(page.getByText("#2244", { exact: true })).toBeVisible();
+  });
+
+  it("renders nothing for a session launched without an issue", () => {
+    render(IssueBadge, { session: session({ id: "b", issueNumber: null }) });
+    expect(document.querySelector(".issue-badge")).toBeNull();
+  });
+
+  it("names the issue to assistive tech and on hover", () => {
+    render(IssueBadge, { session: session({ id: "c", issueNumber: 7 }) });
+    const el = document.querySelector(".issue-badge") as HTMLElement;
+    expect(el.getAttribute("aria-label")).toBe(m.issuebadge_label({ number: 7 }));
+    expect(el.title).toBe(m.issuebadge_title({ number: 7 }));
+  });
+
+  // The whole point of the setting: an operator who finds the chip noisy turns it off
+  // and every card drops it, without the number becoming unrecoverable elsewhere.
+  it("disappears while the per-device preference is off", () => {
+    issueRef.set(false);
+    render(IssueBadge, { session: session({ id: "d", issueNumber: 2244 }) });
+    expect(document.querySelector(".issue-badge")).toBeNull();
+  });
+
+  // No statusTip: it would raise the chip above the card's .unit-hit overlay and eat the
+  // click, making a read-only identifier a dead zone in the middle of the chip row.
+  it("renders no popover overlay", async () => {
+    render(IssueBadge, { session: session({ id: "e", issueNumber: 12 }) });
+    const el = document.querySelector(".issue-badge") as HTMLElement;
+    await el.dispatchEvent(new PointerEvent("pointerenter", { bubbles: true }));
+    expect(document.querySelector(".status-tip")).toBeNull();
+  });
+});

--- a/ui/src/lib/components/IssueBadge.svelte
+++ b/ui/src/lib/components/IssueBadge.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import type { Session } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  import { issueRef } from "$lib/issue-ref.svelte";
+
+  let { session }: { session: Session } = $props();
+
+  // Read into a local so the message calls below see a non-null number.
+  const number = $derived(session.issueNumber);
+</script>
+
+<!-- Deliberately NOT a `statusTip` chip: that action raises its trigger above the card's
+     full-area `.unit-hit` overlay and swallows the click, which would turn a read-only
+     identifier into a dead zone in the middle of the chip row. The number IS the
+     information here, so a native title carries the word "issue" at no such cost —
+     the same trade CliBadge makes. -->
+{#if number != null && issueRef.shown}
+  <span
+    class="issue-badge"
+    role="img"
+    aria-label={m.issuebadge_label({ number })}
+    title={m.issuebadge_title({ number })}>#{number}</span
+  >
+{/if}
+
+<style>
+  /* Quiet identifier chip, deliberately the same recipe as the open-PR badge it sits beside
+     (--color-line border, --color-muted ink, no hue): issue and PR are the two forge
+     references a card carries, and they should read as one pair. Accent hues stay reserved
+     for state that wants acting on. No `text-transform`: the value is a bare number, so
+     there is no casing to normalise. */
+  .issue-badge {
+    font-size: var(--fs-micro);
+    letter-spacing: 0.12em;
+    padding: 1px 6px;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+    white-space: nowrap;
+    font-weight: 600;
+  }
+</style>

--- a/ui/src/lib/components/Settings.browser.test.ts
+++ b/ui/src/lib/components/Settings.browser.test.ts
@@ -16,6 +16,7 @@ import {
 } from "$lib/api";
 import { toasts } from "$lib/toasts.svelte";
 import { roleTitle } from "$lib/settings-search";
+import { issueRef } from "$lib/issue-ref.svelte";
 
 // Mock the API so Settings never hits the network. The settings GET is seeded to
 // land on api-key mode WITH a key configured, so the api-key block + Verify button
@@ -986,4 +987,24 @@ it("saves ultra as the shared default effort", async () => {
   await effort.selectOptions("ultra");
   await vi.waitFor(() => expect(putDefaultEffort).toHaveBeenCalledWith("ultra"));
   await expect.element(effort).toHaveValue("ultra");
+});
+
+describe("Settings device — issue number on session cards", () => {
+  afterEach(() => {
+    issueRef.set(true); // leave the shared singleton on its default for other suites
+  });
+
+  it("flips the per-device preference and reflects it in the switch state", async () => {
+    await page.viewport(1280, 900);
+    render(Settings, { initialTab: "device", onclose: noop, onsaved: noop });
+
+    const sw = page.getByRole("switch", { name: m.settings_card_issue_ref_on() });
+    await expect.element(sw).toHaveAttribute("aria-checked", "true");
+
+    await sw.click();
+    await vi.waitFor(() => expect(issueRef.shown).toBe(false));
+    await expect
+      .element(page.getByRole("switch", { name: m.settings_card_issue_ref_off() }))
+      .toHaveAttribute("aria-checked", "false");
+  });
 });

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -1532,3 +1532,31 @@ describe("UnitRow selection cues", () => {
     await page.getByRole("button", { name: "TASK-01" }).click({ timeout: 3000 });
   });
 });
+
+describe("UnitRow issue reference", () => {
+  it("names the issue the session was spawned for, ahead of its PR badge", () => {
+    render(UnitRow, {
+      session: session({ id: "with-issue", issueNumber: 2244 }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+      git: { kind: "github", state: "open", number: 2245, checks: "none" } as GitState,
+    });
+
+    const chips = [...document.querySelectorAll(".issue-badge, .pr-badge")].map((el) =>
+      el.textContent?.trim(),
+    );
+    expect(chips).toEqual(["#2244", m.prbadge_open({ number: 2245 })]);
+  });
+
+  it("shows no issue chip on a session launched without one", () => {
+    render(UnitRow, {
+      session: session({ id: "no-issue", issueNumber: null }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+    });
+
+    expect(document.querySelector(".issue-badge")).toBeNull();
+  });
+});

--- a/ui/src/lib/components/settings/SettingsDevicePanel.svelte
+++ b/ui/src/lib/components/settings/SettingsDevicePanel.svelte
@@ -12,6 +12,7 @@
   import { theme, type ThemePref } from "$lib/theme.svelte";
   import { tabTicker } from "$lib/tab-ticker.svelte";
   import { infoTips } from "$lib/info-tips.svelte";
+  import { issueRef } from "$lib/issue-ref.svelte";
   import { REPO, REPO_URL, sha, version, commitUrl, CAPTURE_EXTENSION_URL } from "$lib/build-info";
   import ThemeIcon from "$lib/components/ThemeIcon.svelte";
   import HighlightText from "./HighlightText.svelte";
@@ -146,6 +147,22 @@
     <span class="track" class:on={tabTicker.enabled}><span class="knob"></span></span>
     <span class="state"
       >{tabTicker.enabled ? m.settings_tab_ticker_on() : m.settings_tab_ticker_off()}</span
+    >
+  </button>
+</div>
+<div class="rc">
+  <span class="micro"><HighlightText text={m.settings_card_issue_ref_title()} {query} /></span>
+  <p class="hint"><HighlightText text={m.settings_card_issue_ref_hint()} {query} /></p>
+  <button
+    type="button"
+    class="toggle"
+    role="switch"
+    aria-checked={issueRef.shown}
+    onclick={() => issueRef.toggle()}
+  >
+    <span class="track" class:on={issueRef.shown}><span class="knob"></span></span>
+    <span class="state"
+      >{issueRef.shown ? m.settings_card_issue_ref_on() : m.settings_card_issue_ref_off()}</span
     >
   </button>
 </div>

--- a/ui/src/lib/components/unit-row/UnitRowRight.svelte
+++ b/ui/src/lib/components/unit-row/UnitRowRight.svelte
@@ -6,6 +6,7 @@
   import CliBadge from "../CliBadge.svelte";
   import ResearchBadge from "../ResearchBadge.svelte";
   import TerminalBadge from "../TerminalBadge.svelte";
+  import IssueBadge from "../IssueBadge.svelte";
   import PrBadge from "../PrBadge.svelte";
   import CriticBadge from "../CriticBadge.svelte";
   import BuildQueueBadge from "../BuildQueueBadge.svelte";
@@ -166,6 +167,9 @@
   <CliBadge {session} />
   <ResearchBadge {session} tip />
   <TerminalBadge {session} tip />
+  <!-- Issue before PR: the backlog issue is what the session was spawned for, the PR is
+       what came out of it — reading them left-to-right follows that order. -->
+  <IssueBadge {session} />
   {#if !stepperTerminal}<PrBadge {git} sessionId={session.id} />{/if}
   <CriticBadge sessionId={session.id} tip prUrl={git?.url} />
   <BuildQueueBadge

--- a/ui/src/lib/feature-announcements/entries/v1.48.0-card-issue-ref.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.48.0-card-issue-ref.ts
@@ -1,0 +1,8 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+export default {
+  id: "card-issue-ref",
+  sinceVersion: "1.48.0",
+  titleKey: "feat_card_issue_ref_title",
+  bodyKey: "feat_card_issue_ref_body",
+} satisfies FeatureAnnouncement;

--- a/ui/src/lib/issue-ref.svelte.test.ts
+++ b/ui/src/lib/issue-ref.svelte.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+// Stub localStorage before importing the module so the singleton's read() call
+// at init doesn't touch a real or missing localStorage.
+const store: Record<string, string> = {};
+const localStorageMock = {
+  getItem: (key: string) => store[key] ?? null,
+  setItem: (key: string, value: string) => {
+    store[key] = value;
+  },
+  removeItem: (key: string) => {
+    delete store[key];
+  },
+  clear: () => {
+    for (const k of Object.keys(store)) delete store[k];
+  },
+};
+// @ts-expect-error stubbing global
+globalThis.localStorage = localStorageMock;
+
+import { issueRef } from "./issue-ref.svelte";
+
+const KEY = "shepherd:hide-card-issue-ref";
+
+beforeEach(() => {
+  localStorageMock.clear();
+  issueRef.set(true); // reset singleton
+  localStorageMock.clear(); // clear the reset's side-effect write
+});
+
+describe("issueRef store", () => {
+  it("defaults to ON when localStorage is empty", () => {
+    expect(issueRef.shown).toBe(true);
+  });
+
+  it("set(false) persists the opt-out as '0'", () => {
+    issueRef.set(false);
+    expect(store[KEY]).toBe("0");
+    expect(issueRef.shown).toBe(false);
+  });
+
+  // Inverted default: "on" is the absence of the key, never a stored "1" — otherwise a
+  // fresh device would read as opted-out.
+  it("set(true) removes the key rather than writing one", () => {
+    store[KEY] = "0";
+    issueRef.set(true);
+    expect(store[KEY]).toBeUndefined();
+    expect(issueRef.shown).toBe(true);
+  });
+
+  it("toggle flips the value", () => {
+    expect(issueRef.shown).toBe(true);
+    issueRef.toggle();
+    expect(issueRef.shown).toBe(false);
+    issueRef.toggle();
+    expect(issueRef.shown).toBe(true);
+  });
+});

--- a/ui/src/lib/issue-ref.svelte.ts
+++ b/ui/src/lib/issue-ref.svelte.ts
@@ -1,0 +1,34 @@
+// Per-device toggle for the issue reference (#1234) shown on a session card, so an
+// operator can tell at a glance which backlog issue a session is working (#2244).
+// Default ON — a session spawned from an issue names it out of the box; whoever finds
+// the extra chip noisy turns it off in Settings → Device. Persisted in localStorage;
+// mirrors issues-filter.svelte.ts's inverted-default convention: absence of the key
+// means "on", so "0" is the value we persist.
+const KEY = "shepherd:hide-card-issue-ref";
+
+function read(): boolean {
+  try {
+    // Default true: only an explicit "0" turns it off.
+    return localStorage.getItem(KEY) !== "0";
+  } catch {
+    return true;
+  }
+}
+
+class IssueRef {
+  shown = $state(read());
+  toggle() {
+    this.set(!this.shown);
+  }
+  set(v: boolean) {
+    this.shown = v;
+    try {
+      if (v) localStorage.removeItem(KEY);
+      else localStorage.setItem(KEY, "0");
+    } catch {
+      /* private mode / SSR — preference just won't survive reload */
+    }
+  }
+}
+
+export const issueRef = new IssueRef();

--- a/ui/src/lib/settings-search.ts
+++ b/ui/src/lib/settings-search.ts
@@ -220,6 +220,7 @@ export function sectionSearchRows(ctx: {
       [m.settings_contrast_title(), m.settings_contrast_hint()],
       [m.settings_colorblind_title(), m.settings_colorblind_hint()],
       [m.settings_tab_ticker_title(), m.settings_tab_ticker_hint()],
+      [m.settings_card_issue_ref_title(), m.settings_card_issue_ref_hint()],
       [m.settings_hide_info_tips_title(), m.settings_hide_info_tips_hint()],
       [m.settings_push_title()],
       [m.settings_reduced_push_title(), m.settings_reduced_push_hint()],


### PR DESCRIPTION
## Problem

A session card names its task but not its origin. The issue number is only ever visible as the head of the truncated prompt line (`Bearbeite Issue #2244: Codex-Auslastung ignoriert …`), so telling two sessions on neighbouring issues apart means opening one of them.

## What changed

Cards spawned from a backlog issue now carry a quiet `#1234` chip in the badge rail, placed **ahead of the PR badge** — issue in, PR out, read left to right. Sessions launched without an issue (`issueNumber === null`) render nothing, so free-text and terminal cards are untouched.

The chip reuses the open-PR badge's recipe (`--color-line` border, `--color-muted` ink, no hue) so the two forge references read as one pair, and accent hues stay reserved for state that wants acting on.

It is deliberately a plain native-`title` chip rather than a `statusTip` one. `statusTip` raises its trigger above the card's full-area `.unit-hit` overlay and stops the click, which would turn a read-only identifier into a dead zone in the middle of the rail — the same trade `CliBadge` documents. The number *is* the information here; the tooltip only adds the word "issue".

## The setting

**Settings → Device → "Issue number on session cards"**, default **on**. Per-device, `localStorage`-backed, and indexed for settings search. It follows the inverted-default convention from `issues-filter.svelte.ts`: absence of the key means on, so `"0"` is what an opt-out persists — a fresh device can never read as opted-out.

## Verification

- `cd ui && bun run check` — 0 errors
- `cd ui && bun run test` — 314 files, 5074 tests passing (7 new)
- `cd ui && bun run check:i18n` — EN/DE in parity
- `bun run lint`, feature-catalog and announcement-version gates — clean
- Rendered against the demo seed (`SHEPHERD_DEMO=1`) in light and dark, at herd-rail width; the chip wraps with the rest of the badge rail on a narrow card.

New tests cover: the chip renders for a session with an issue, renders nothing without one, exposes the number to AT and on hover, disappears while the preference is off, opens no popover overlay, sits ahead of the PR badge on a real card, and the Device toggle flips and persists the preference.