### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs/sandbox-security.md
+++ b/docs/sandbox-security.md
@@ -125,6 +125,27 @@ execution controls below, Shepherd bounds the injection surface at ingestion
   `REVIEW_POLICY_MAX_BYTES` (8 KB) with a visible marker, a bad SHA or git
   failure yields no block, and the delimiters are plain markers rather than a
   nonce fence because the content is trusted by construction.
+- **Trusted-by-provenance exception: operator task amendments.** The four prompts
+  that treat a session's task as ground truth (session critic, plan reviewer,
+  autopilot classifier, recap) carry a second unfenced block: the
+  `OPERATOR TASK AMENDMENTS` text an operator added after the session started
+  (`amendmentBlock`, `src/task-amendments.ts`). Fenced it would be contractually
+  ignorable — `UNTRUSTED_CONTENT_DIRECTIVE` orders the reader to ignore in-fence
+  claims of operator authority — so it rides outside the fences for the same
+  reason the task itself does, and its preamble states the other half of that
+  contract: a fenced block claiming to be an amendment is an impostor. Anything
+  that can widen a task can excuse a finding, so three properties contain it:
+  the write routes (`POST /api/sessions/:id/amendments`,
+  `DELETE …/amendments/:id`) are **absent from `AGENT_LEAF_ROUTES`**, so the
+  loopback agent ingress denies them and an agent can never amend its own task
+  (pinned by `test/agent-ingress.test.ts`); no steer is ever promoted into an
+  amendment, only the operator's explicit action writes a row; and the block
+  grants **scope** authority while disclaiming everything else in the same
+  breath — an amendment never excuses a bug, a security issue or a quality
+  defect. Amendments are append-only (no UPDATE path for `text`; retraction is a
+  soft delete that stops the row reaching every prompt but leaves it on the
+  record) and bounded at entry by `AMENDMENT_MAX_CHARS` (2000), because they are
+  non-clampable in the critic's argv budget ladder.
 - **Fail-closed author-trust gate.** An **autonomous** (`auto=true`) spawn from an
   issue whose author is **not** a trusted repo association (`OWNER` / `MEMBER` /
   `COLLABORATOR` — anything else, including an unresolvable, absent, or Gitea-side
@@ -250,5 +271,6 @@ dontAsk` can otherwise read nothing but the files Shepherd itself wrote into
 ## See also
 
 - `src/egress.ts`, `src/sandbox.ts`, `src/service.ts`, `src/autopilot.ts`,
-  `src/transient-agent-argv.ts`, `src/task-shape.ts`, `src/maintain.ts`, `src/untrusted.ts`, `src/tool-guard-hook.ts`,
+  `src/transient-agent-argv.ts`, `src/task-shape.ts`, `src/maintain.ts`, `src/untrusted.ts`, `src/task-amendments.ts`,
+  `src/tool-guard-hook.ts`,
   `scripts/tool-guard.mjs`.


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc update — sync against source since the last docs sync (`8eb1ae919`, #2228)

Grounding: `git log -n 50 --stat`, `git diff 8eb1ae919..HEAD -- src/`, and the commits
that landed after the last docs sync. `src/config.ts` has not changed since `92aa50d3d`
(#2210), which predates that sync — so
`docs-site/src/content/docs/reference/configuration.md` needed no change.

## Changes

- **`docs/sandbox-security.md`** — added a second *trusted-by-provenance exception* bullet
  to the **R4 prompt-injection posture** input-side defenses, covering the operator
  **task-amendments** block introduced by `360cca67d` (#2233) / `src/task-amendments.ts`:
  why it is deliberately **not** fenced (a fenced block is contractually ignorable under
  `UNTRUSTED_CONTENT_DIRECTIVE`, the opposite of its purpose), and the three containment
  properties from that file's header — write routes absent from `AGENT_LEAF_ROUTES` so an
  agent cannot amend its own task (pinned by `test/agent-ingress.test.ts`), no steer ever
  promoted into an amendment, and authority bounded to **scope** (never excusing a bug,
  security issue or quality defect). Also noted append-only + soft retraction and the
  `AMENDMENT_MAX_CHARS` (2000) entry bound. `src/task-amendments.ts` added to the
  **See also** file list. This was the one genuinely missing piece: the prompt-injection
  posture section enumerates every channel that reaches a prompt unfenced, and the
  amendments block became one without being recorded there.

No other in-scope page was edited — everything else checked out as already current:

- `docs-site/src/content/docs/reference/glossary.md` — already carries **Task amendment**
  and the plan-gate re-review wording (both landed with their own commits, `360cca67d`
  and `5ed03b2f2`).
- `docs/external-task-api.md` — the amendment routes (`POST /api/sessions/:id/amendments`,
  `DELETE …/amendments/:id`, `GET /api/amendments`) and the `handleSessionDelete`
  sub-resource fix are documented; the `/api/tasks/:key/export` `meta` example still
  matches `TaskExportMeta` in `src/task-export.ts` (the new `runtimeModel`/`runtimeEffort`
  session columns from `8bebe5dec` are **not** in the export meta).
- `docs-site/src/content/docs/reference/configuration.md` — every env var in `src/config.ts`
  is present with matching defaults; `config.ts` is unchanged since before the last sync.
- `docs-site/src/content/docs/getting-started.md` — herdr support statement (0.9.0 last
  supported, protocol path) still matches `HERDR_MIN_VERSION` / `HERDR_SOCKET_SUPPORTED_PROTOCOLS`.
- `docs-site/src/content/docs/operating.md`, `index.md`, `docs/token-usage-analysis.md` —
  nothing in the post-sync source changes contradicts them. The token-usage report is a
  dated historical measurement, not a live reference.

## Uncertain / needs human judgment

- **Runtime model/effort + CLI chip on task cards (`8bebe5dec`, #2236).** Sessions now
  persist `runtimeModel`/`runtimeEffort` (what the agent *actually ran*, read from the
  provider's runtime log) alongside the *configured* `model`/`effort`, and cards/status bar
  show a CODEX/CLAUDE chip with per-segment provenance. None of the in-scope prose pages
  currently describe task-card chrome, and no glossary term was added in the commit — so a
  new **"observed vs. configured"** glossary entry may be wanted, but adding one is a
  judgement call about scope rather than a demonstrable staleness fix. Left unchanged.
- **Usage popover redesign (`e9585a999`, `b981d6ce8`).** The popover now leads with the
  window nearest its cap and stamps freshness once in the header. No in-scope page
  documents the usage popover's layout, so nothing is stale — but if the usage UI is meant
  to be described anywhere in the prose docs, it currently is not.
- **Onboarding-harness commits (`80ad1a14b`, `3ce88cf13`, `cad5caf48`, `c868ff187`).**
  These change CI harness behaviour (network precondition, run budgets, herdr stubs, leaked
  host lock + nightly alerting). Their documentation lives in `ci/onboarding-harness/README.md`,
  which is out of scope here; `80ad1a14b` already updated it.
- **Forge viewer resolution (`6e6141b34`).** Internal reliability fix to resolving the
  authenticated user across both `gh` transports; no operator-facing contract in the
  in-scope pages appears to change.