### PR TITLE
feat(ui): show session model only when the rail shows a mix

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3903,6 +3903,8 @@
   "topbar_usage_binding_title": "Engstes Fenster",
   "feat_usage_popover_compact_title": "Auslastungs-Panel zeigt zuerst, was wirklich klemmt",
   "feat_usage_popover_compact_body": "Das Auslastungs-Popover holt jetzt das Fenster nach oben, das seinem Limit am nächsten ist — über Claude Code und Codex hinweg — und setzt es groß. Damit steht das Limit, das über den nächsten Agenten entscheidet, ganz oben statt ganz unten. Die Reset-Zeit jedes Fensters ist als Countdown in die Balkenzeile gewandert, der Datenstand wird einmal oben gestempelt; das Panel wird dadurch rund ein Drittel kürzer. Das Mobile-Sheet nutzt jetzt dasselbe Layout.",
+  "feat_model_label_on_mix_title": "Sitzungszeilen nennen das Modell nur, wenn es etwas aussagt",
+  "feat_model_label_on_mix_body": "Bisher stand auf jeder Sitzungskarte das Modell — bei einer Herde mit nur einem Modell also immer dasselbe Wort, Zeile für Zeile. Das Modell erscheint jetzt nur noch, wenn sich die angezeigten Sitzungen tatsächlich unterscheiden: Sobald ein Codex-Lauf neben den Claude-Läufen steht oder ein Vergleichsexperiment läuft, beschriftet sich wieder jede Zeile. Sitzungen ohne bekanntes Modell zählen dabei nicht als zweites Modell. Beim Überfahren einer Zeile steht weiterhin, welches Modell lief und woher die Angabe stammt — mit oder ohne Label.",
   "topbar_usage_free_in": "Wieder frei in {rel}",
   "topbar_codex_tokens_checked_age": "Token-Datenstand vor {age}",
   "topbar_codex_tokens_checked_now": "Token-Datenstand von gerade eben",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3903,6 +3903,8 @@
   "topbar_usage_binding_title": "Tightest window",
   "feat_usage_popover_compact_title": "Usage panel leads with the window that is actually blocking",
   "feat_usage_popover_compact_body": "The usage popover now promotes whichever window sits nearest its cap — across Claude Code and Codex alike — to a headline reading at the top, so the limit that decides whether you can start another agent is the first thing you see instead of the last. Each window's reset moved into its bar row as a countdown and the provider-confirmation age is stamped once in the header, which takes about a third off the panel's height. The mobile sheet now uses the same layout.",
+  "feat_model_label_on_mix_title": "Session rows name the model only when it tells you something",
+  "feat_model_label_on_mix_body": "A session row used to print its model on every card, so a herd running one model repeated the same words down the whole rail. The model now appears only when the sessions on display actually differ — start a Codex run beside your Claude ones, or a comparison experiment, and every row labels itself again. Sessions whose model was never observed don't count as a second model. Hovering a row still names the model and where that came from, whether or not the label is showing.",
   "topbar_usage_free_in": "Free again in {rel}",
   "topbar_codex_tokens_checked_age": "token data from {age} ago",
   "topbar_codex_tokens_checked_now": "token data from just now",

--- a/ui/src/lib/components/Herd.browser.test.ts
+++ b/ui/src/lib/components/Herd.browser.test.ts
@@ -1108,3 +1108,87 @@ describe("Herd jump flash", () => {
     await expect.poll(() => flashed(screen.container)).toEqual([]);
   });
 });
+
+// The model segment earns its place in a row only when the rail is showing more than one model.
+// Where the unit tests pin the decision, these pin the WIRING: the flag is derived over the full
+// visible set and reaches every row, and suppressing it leaves no dangling separator behind.
+describe("Herd model label", () => {
+  // The task-id button contributes its own layout whitespace, so collapse runs before comparing —
+  // these assert the SEGMENTS, not the row's internal spacing.
+  const meta = (container: HTMLElement) =>
+    [...container.querySelectorAll(".meta-text")].map((el) =>
+      el.textContent!.replace(/\s+/g, " ").trim(),
+    );
+
+  it("one model across the rail: no row prints it, and no row is left with a trailing separator", async () => {
+    const screen = await render(Herd, {
+      ...base,
+      sessions: [
+        session({ id: "a", desig: "TASK-01", runtimeModel: "claude-opus-5" }),
+        session({ id: "b", desig: "TASK-02", runtimeModel: "claude-opus-5" }),
+      ],
+      git: {},
+    });
+    await expect.poll(() => meta(screen.container)).toEqual(["TASK-01", "TASK-02"]);
+  });
+
+  it("a second model on display brings the label back on every row", async () => {
+    const screen = await render(Herd, {
+      ...base,
+      sessions: [
+        session({ id: "a", desig: "TASK-01", runtimeModel: "claude-opus-5" }),
+        session({ id: "b", desig: "TASK-02", runtimeModel: "gpt-6-astra" }),
+      ],
+      git: {},
+    });
+    await expect
+      .poll(() => meta(screen.container))
+      .toEqual(["TASK-01 · Opus 5", "TASK-02 · GPT-6 Astra"]);
+  });
+
+  it("a session with no known model does not by itself make a mix", async () => {
+    const screen = await render(Herd, {
+      ...base,
+      sessions: [
+        session({ id: "a", desig: "TASK-01", runtimeModel: "claude-opus-5" }),
+        session({ id: "b", desig: "TASK-02" }),
+      ],
+      git: {},
+    });
+    await expect.poll(() => meta(screen.container)).toEqual(["TASK-01", "TASK-02"]);
+  });
+
+  it("the decision spans the whole visible list, not one group", async () => {
+    // The differing model sits in the Merged group at the bottom while the other row is active.
+    // A per-group decision would hide the label on the active row; deriving over `shown` (before
+    // grouping) is what makes both rows agree.
+    const screen = await render(Herd, {
+      ...base,
+      sessions: [
+        session({ id: "a", desig: "TASK-01", runtimeModel: "claude-opus-5" }),
+        session({ id: "b", desig: "TASK-02", runtimeModel: "gpt-6-astra" }),
+      ],
+      git: { b: { kind: "github", state: "merged", checks: "success", deployConfigured: false } },
+    });
+    await expect
+      .poll(() => meta(screen.container))
+      .toEqual(["TASK-01 · Opus 5", "TASK-02 · GPT-6 Astra"]);
+  });
+
+  it("the effort segment is unaffected when the model is suppressed", async () => {
+    const screen = await render(Herd, {
+      ...base,
+      sessions: [
+        session({
+          id: "a",
+          desig: "TASK-01",
+          runtimeModel: "claude-opus-5",
+          runtimeEffort: "high",
+        }),
+        session({ id: "b", desig: "TASK-02", runtimeModel: "claude-opus-5" }),
+      ],
+      git: {},
+    });
+    await expect.poll(() => meta(screen.container)).toEqual(["TASK-01 · High", "TASK-02"]);
+  });
+});

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -33,6 +33,7 @@
   import { groupSessionsByExperiment } from "./experiment-grouping";
   import { collectReadyPrs } from "./merge-train";
   import { displayStatus } from "$lib/display-status";
+  import { modelsMixed } from "$lib/session-env";
   import { isReworkRunning as isReworkRunningSession } from "./rework-running";
   import { reviews, planGates } from "$lib/reviews.svelte";
   import { m } from "$lib/paraglide/messages";
@@ -332,6 +333,11 @@
   // Global (over `shown`, not `rest`) so grouped epic-child PRs still arm the action.
   const readyPrCount = $derived(collectReadyPrs(shown, git, inReview).length);
 
+  // One model-label decision for the whole rail. Derived from `shown` — the post-filter set, BEFORE
+  // grouping — so epic- and experiment-grouped rows are judged by the set they are actually
+  // displayed in rather than by whichever partition bucket they happen to land in.
+  const modelMix = $derived(modelsMixed(shown, activity));
+
   // ONE partition per epic group, keyed by group key — the cue chips, the grouped
   // ready/merged tallies, and the "in epics above" annotation all read from it, so we
   // partition each small group exactly once. Re-derives on the same inputs the per-group
@@ -431,6 +437,7 @@
     holdFor,
     onackmanualsteps,
     onshowowed,
+    showModel: modelMix,
   });
 
   // Lifecycle groups in display order — each entry maps to a <HerdGroup> render.

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -84,6 +84,7 @@
     hold = undefined,
     onackmanualsteps,
     onshowowed,
+    showModel = true,
   }: {
     session: Session;
     selected: boolean;
@@ -140,6 +141,11 @@
     onackmanualsteps?: (id: string) => void;
     // when provided, the manual-steps chip becomes a button that opens the Owed lens (#1275)
     onshowowed?: (id: string) => void;
+    /** Print the model segment. The rail passes false when every session on display runs the same
+     *  model, where repeating one word down every row tells the operator nothing (see modelsMixed).
+     *  Defaults to TRUE: a row rendered outside a list has no peers to compare against, so showing
+     *  the model is the only honest standalone behaviour. */
+    showModel?: boolean;
   } = $props();
 
   // Every status-driven DISPLAY branch below reads this, not session.status: a
@@ -190,7 +196,14 @@
   // Model + effort, resolved observed → configured → default (see sessionEnvironment). The card and
   // the session status bar share this one resolver so they can never disagree about the same run.
   const environment = $derived(sessionEnvironment(session, activity));
-  const environmentText = $derived(environment.segments.join(" · "));
+  // Suppressing the model can leave nothing to print (an unknown effort renders no segment of its
+  // own — the ordinary Claude case), so the leading separator hangs off the text rather than the
+  // template: `TASK-01 ·` with nothing after it is the one regression this gate can produce. The
+  // hover tip still names the model either way, so nothing becomes unknowable.
+  const environmentText = $derived(
+    (showModel ? environment.segments : environment.effort ? [environment.effort] : []).join(" · "),
+  );
+  const environmentSuffix = $derived(environmentText ? ` · ${environmentText}` : "");
   function toggleRepoFilter() {
     // Non-additive: a plain click resets the filter to this repo (or clears it when this repo
     // is already the sole selection — handled by the page's nextRepoFilter).
@@ -937,7 +950,7 @@
 
     <span class="meta">
       <span class="meta-text" use:statusTip={{ text: environment.tooltip }}
-        ><TaskIdButton {session} /> · {environmentText}</span
+        ><TaskIdButton {session} />{environmentSuffix}</span
       >
       {#if session.manualSteps.length > 0}
         {#if onshowowed}

--- a/ui/src/lib/components/herd/HerdGroup.svelte
+++ b/ui/src/lib/components/herd/HerdGroup.svelte
@@ -34,6 +34,10 @@
     onackmanualsteps?: (id: string) => void;
     // manual-steps chip -> Owed lens (#1275)
     onshowowed?: (id: string) => void;
+    // print each row's model — false when every session on display runs the same one, where the
+    // label repeats down the whole rail and says nothing. Decided once, over the full visible set,
+    // so every group agrees (see modelsMixed).
+    showModel: boolean;
   };
 
   type ActionDef = {
@@ -146,6 +150,7 @@
       hold={ctx.holdFor(session.id)}
       onackmanualsteps={ctx.onackmanualsteps}
       onshowowed={ctx.onshowowed}
+      showModel={ctx.showModel}
     />
   {/each}
 {/if}

--- a/ui/src/lib/feature-announcements/entries/v1.48.0-model-label-on-mix.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.48.0-model-label-on-mix.ts
@@ -1,0 +1,8 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+export default {
+  id: "model-label-on-mix",
+  sinceVersion: "1.48.0",
+  titleKey: "feat_model_label_on_mix_title",
+  bodyKey: "feat_model_label_on_mix_body",
+} satisfies FeatureAnnouncement;

--- a/ui/src/lib/session-env.test.ts
+++ b/ui/src/lib/session-env.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "vitest";
-import { sessionEnvironment } from "./session-env";
+import { modelsMixed, sessionEnvironment } from "./session-env";
 import { runtimeModelLabel } from "./model-label";
 import { m } from "$lib/paraglide/messages";
-import type { SessionActivity } from "./types";
+import type { Session, SessionActivity } from "./types";
 
 const empty = { model: null, effort: null, runtimeModel: null, runtimeEffort: null };
 
@@ -156,5 +156,77 @@ describe("tooltip provenance is per segment", () => {
               env.tooltip.includes(m.session_env_effort_configured({ effort: env.effort ?? "x" }));
             expect(claimsEffort).toBe(env.effort !== null);
           }
+  });
+});
+
+// The rail prints each row's model only when the rows actually differ; `modelsMixed` is that
+// decision. Both rules it encodes are load-bearing and easy to "simplify" wrongly, so each gets a
+// test naming what would break.
+describe("modelsMixed", () => {
+  type EnvFields = Pick<Session, "model" | "effort" | "runtimeModel" | "runtimeEffort">;
+  const row = (id: string, fields: Partial<EnvFields>) => ({ id, ...empty, ...fields });
+
+  test("one model down the whole list is not a mix", () => {
+    expect(
+      modelsMixed(
+        [row("a", { runtimeModel: "claude-opus-5" }), row("b", { runtimeModel: "claude-opus-5" })],
+        {},
+      ),
+    ).toBe(false);
+  });
+
+  test("two different models are", () => {
+    expect(
+      modelsMixed(
+        [row("a", { runtimeModel: "claude-opus-5" }), row("b", { runtimeModel: "gpt-6-astra" })],
+        {},
+      ),
+    ).toBe(true);
+  });
+
+  test("an unknown model is not a second model", () => {
+    // The rule that makes the feature work: unknowns render the localized "default", which says
+    // only that we never learned what ran. Counting it would call nearly every list mixed and
+    // leave the label permanently on — exactly what this gate exists to stop.
+    expect(modelsMixed([row("a", { runtimeModel: "claude-opus-5" }), row("b", {})], {})).toBe(
+      false,
+    );
+  });
+
+  test("a list that knows nothing is not a mix", () => {
+    expect(modelsMixed([row("a", {}), row("b", {})], {})).toBe(false);
+  });
+
+  test("an empty list is not a mix", () => {
+    expect(modelsMixed([], {})).toBe(false);
+  });
+
+  test("the live activity signal decides, same as the rendered row", () => {
+    // Both sessions are CONFIGURED alike; only the observed models differ. Comparing the configured
+    // field instead of the resolved label would miss this and hide a genuine mix.
+    expect(
+      modelsMixed([row("a", { model: "opus" }), row("b", { model: "opus" })], {
+        a: signal({ runtimeModel: "claude-opus-5" }),
+        b: signal({ runtimeModel: "gpt-6-astra" }),
+      }),
+    ).toBe(true);
+  });
+
+  test("the same model reached by different routes is one model", () => {
+    // Observed on one row, configured (pinned) on the other: same label, so no mix.
+    expect(
+      modelsMixed(
+        [row("a", { runtimeModel: "claude-opus-5" }), row("b", { model: "claude-opus-5" })],
+        {},
+      ),
+    ).toBe(false);
+  });
+
+  test("a floating alias beside its resolved name counts as a mix", () => {
+    // Stated assumption, pinned: `opus` and `Opus 5` look like two models on screen, and the client
+    // cannot know which concrete model the alias resolved to. Folding them together is a guess.
+    expect(
+      modelsMixed([row("a", { model: "opus" }), row("b", { runtimeModel: "claude-opus-5" })], {}),
+    ).toBe(true);
   });
 });

--- a/ui/src/lib/session-env.ts
+++ b/ui/src/lib/session-env.ts
@@ -11,6 +11,11 @@ export interface SessionEnvironment {
   /** True when `model` is what the agent was OBSERVED to run, false when it is the configured value
    *  (or the default standing in for one). */
   modelObserved: boolean;
+  /** True when a model is actually KNOWN (observed or configured), false when `model` is only the
+   *  localized "default" standing in for one. Distinct from {@link modelObserved}, which says where
+   *  a known value came from. Read by {@link modelsMixed}, so the precedence below stays in one
+   *  place instead of being re-derived by every caller that needs to know. */
+  modelKnown: boolean;
   /** Effort segment, or null when it is not worth its own segment (see {@link segments}). */
   effort: string | null;
   /** True when `effort` is observed rather than configured. Always false for Claude sessions, whose
@@ -20,6 +25,20 @@ export interface SessionEnvironment {
   /** Ready-to-show explanation: one complete sentence per rendered segment, each naming where THAT
    *  segment came from. Both session surfaces show this verbatim. */
   tooltip: string;
+}
+
+/**
+ * The model segment's label, observed → configured → the honest "default".
+ *
+ * Its own function rather than a ternary chain inside the resolver below: that chain plus the
+ * per-field provenance bookkeeping put `sessionEnvironment` over the repo's cognitive-complexity
+ * bar. The labeling split matters — see {@link sessionEnvironment} on why observed and configured
+ * values must not share one vocabulary.
+ */
+function modelSegment(observed: string | null, configured: string | null): string {
+  if (observed) return runtimeModelLabel(observed);
+  if (configured) return modelLabel(configured);
+  return m.newtask_model_default();
 }
 
 /**
@@ -55,11 +74,7 @@ export function sessionEnvironment(
   const configuredModel = session.model ?? null;
   const configuredEffort = session.effort ?? null;
 
-  const model = observedModel
-    ? runtimeModelLabel(observedModel)
-    : configuredModel
-      ? modelLabel(configuredModel)
-      : m.newtask_model_default();
+  const model = modelSegment(observedModel, configuredModel);
   const knownEffort = observedEffort ?? configuredEffort;
   const effort = knownEffort ? effortLabel(knownEffort) : m.effort_default();
 
@@ -86,6 +101,7 @@ export function sessionEnvironment(
   return {
     model,
     modelObserved,
+    modelKnown: !!(observedModel ?? configuredModel),
     effort: effortKnown ? effort : null,
     effortObserved,
     // The model segment always stands, so the operator can always see which model a task ran on;
@@ -94,4 +110,40 @@ export function sessionEnvironment(
     segments: effortKnown ? [model, effort] : [model],
     tooltip: sentences.join(" "),
   };
+}
+
+/**
+ * Do the sessions on display run MORE THAN ONE model?
+ *
+ * The session list prints each row's model, which is only worth the line when the rows differ:
+ * a herd where every session ran the same model repeats one word down the whole rail and tells
+ * the operator nothing. Callers gate the model segment on this.
+ *
+ * Two rules, both deliberate:
+ *
+ *   - **The comparison is over the WHOLE visible list**, so every row agrees — either all of them
+ *     print their model or none does. Deciding per group would show the same model in one group
+ *     and hide it in the next, and a row would gain or lose its label just by moving between
+ *     lifecycle stages.
+ *   - **Sessions with no known model do not count.** Their label is the localized "default", which
+ *     says only that we never learned what ran; letting that stand as a distinct value would call
+ *     almost every list mixed and leave the label permanently on.
+ *
+ * "Same model" means the same rendered LABEL, not the same underlying id: a configured floating
+ * alias (`opus`, never run) reads differently from an observed `Opus 5` and genuinely looks like a
+ * second model on screen. The client cannot know which concrete model an alias resolved to, so
+ * folding the two together would be a guess.
+ */
+export function modelsMixed(
+  sessions: readonly Pick<Session, "id" | "model" | "effort" | "runtimeModel" | "runtimeEffort">[],
+  activity: Record<string, SessionActivity>,
+): boolean {
+  const labels = new Set<string>();
+  for (const session of sessions) {
+    const env = sessionEnvironment(session, activity[session.id]);
+    if (!env.modelKnown) continue;
+    labels.add(env.model);
+    if (labels.size > 1) return true;
+  }
+  return false;
 }


### PR DESCRIPTION
## Why

A session row printed its model unconditionally, so a herd running one model repeated the same words down the whole rail — a visual distraction that bought nothing. The label is only worth the line when the rows actually differ.

## What

The model segment renders only when the **visible list** contains more than one model label.

- Uniform rail → `TASK-01 · High`, or just `TASK-01` when effort is unknown too (the ordinary Claude case).
- A Codex run, a different Claude model, or a comparison experiment on display → every row labels itself again.

## Decisions

- **Decided once over the whole visible list** (`shown` — post-filter, *before* grouping), so every group agrees. Per-group detection would show the same model in one group and hide it in the next, and a row would gain or lose its label just by moving between lifecycle stages.
- **Sessions with no known model don't count.** Their label is only the localized "default"; treating that as a second model would call nearly every list mixed and leave the label permanently on.
- **"Same model" means the same rendered label.** A configured floating alias (`opus`, never run) beside an observed `Opus 5` counts as a mix — the client cannot know which concrete model an alias resolved to, so folding them together would be a guess.
- **Nothing becomes unknowable:** the row's hover tip still names the model and its provenance whether or not the segment shows.

## Shape

`sessionEnvironment()` gains `modelKnown` plus a pure `modelsMixed()`; `Herd` derives the flag once and threads it through `HerdRowCtx` → `HerdGroup` → `UnitRow`, whose `showModel` prop **defaults to true** (a row rendered outside a list has no peers to compare against).

`SessionStatusBar` is deliberately untouched — single-session detail, where the model is the point rather than clutter. Effort, the provider label and the experiment-group header chips are unchanged, and no setting is added; the rule is automatic.

While here: `sessionEnvironment`'s model-label ternary chain moved into a small `modelSegment()` helper — the added field pushed the function over the repo's cognitive-complexity bar.

## Tests

- `session-env.test.ts` — eight cases pinning both rules (uniform / differing / known+unknown / all-unknown / empty / live-signal-decides / same model via different routes / alias-vs-resolved).
- `Herd.browser.test.ts` — rail-level wiring: uniform hides with **no dangling separator**, a second model brings labels back on every row, an unknown doesn't make a mix, the decision spans groups, and the effort segment survives suppression.

`cd ui && bun run check` clean, 5075 UI tests pass, pre-push gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
