### PR TITLE
chore(deps-dev): migrate ui to vitest 5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,15 @@ updates:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
     groups:
+      # vitest pins its own packages as *exact* peers of each other
+      # (`vitest@5.0.0` peers `@vitest/browser-playwright: 5.0.0`, and back), so
+      # the family is only ever installable as a set. Ungrouped, a major landed as
+      # one PR per package — each individually un-mergeable, and each red or (worse)
+      # green-but-inert. This group is listed first so it wins the match, and it
+      # covers majors, which the two blanket groups below deliberately do not.
+      vitest:
+        patterns: ["vitest", "@vitest/*", "vitest-browser-svelte"]
+        update-types: ["major", "minor", "patch"]
       production-dependencies:
         dependency-type: "production"
         update-types: ["minor", "patch"]

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -26,5 +26,7 @@ vite.config.ts.timestamp-*
 /src/lib/paraglide
 
 # Vitest browser-test failure artifacts (regenerated on failing runs)
+# vitest 5 writes these under .vitest/attachments (v4 used .vitest-attachments).
 __screenshots__/
+.vitest/
 .vitest-attachments/

--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -25,15 +25,15 @@
         "@sveltejs/vite-plugin-svelte": "^7.3.0",
         "@tailwindcss/vite": "^4.3.3",
         "@types/node": "^26.5.0",
-        "@vitest/browser": "^4.1.11",
-        "@vitest/browser-playwright": "^4.1.11",
+        "@vitest/browser": "^5.0.0",
+        "@vitest/browser-playwright": "^5.0.0",
         "playwright": "^1.63.0",
         "sharp": "^0.35.4",
         "svelte": "^5.57.0",
         "svelte-check": "^4.7.6",
         "typescript": "^6.0.2",
         "vite": "^8.2.2",
-        "vitest": "^4.1.11",
+        "vitest": "^5.0.0",
         "vitest-browser-svelte": "^3.1.0",
       },
     },
@@ -41,17 +41,13 @@
   "packages": {
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
-    "@blazediff/core": ["@blazediff/core@1.9.1", "", {}, "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA=="],
+    "@blazediff/core": ["@blazediff/core@1.10.0", "", {}, "sha512-AOQff0zgR7cGsZL+4E7hVkmujoPUpm0J9xzWGWZj5wCjd3gmxESXAPfKyuzs93VdpQNFhHlBhfOjrcZ+XTERtQ=="],
 
     "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
 
     "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
 
-    "@emnapi/core": ["@emnapi/core@2.0.0-alpha.3", "", { "dependencies": { "@emnapi/wasi-threads": "2.0.1", "tslib": "^2.4.0" } }, "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g=="],
-
     "@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
-
-    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@2.0.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.8.0", "", { "dependencies": { "@floating-ui/utils": "^0.2.12" } }, "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ=="],
 
@@ -145,8 +141,6 @@
 
     "@mermaid-js/parser": ["@mermaid-js/parser@1.2.1", "", { "dependencies": { "@chevrotain/types": "~11.1.2" } }, "sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw=="],
 
-    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.2", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3", "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3" } }, "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw=="],
-
     "@oxc-project/types": ["@oxc-project/types@0.146.0", "", {}, "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA=="],
 
     "@pierre/diffs": ["@pierre/diffs@1.4.1", "", { "dependencies": { "@pierre/theme": "2.0.0", "@pierre/theming": "1.0.1", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "9.0.0", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-rzvY9FeeYdGtVcErjNsW6tnrjpMb0DvGtgCFNuMoYT8wufE+gO1ZXAzKAc2VPRBS3Rl5HELEQ38WDlis4qZHkQ=="],
@@ -182,8 +176,6 @@
     "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.2.5", "", { "os": "linux", "cpu": "x64" }, "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA=="],
 
     "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.2.5", "", { "os": "none", "cpu": "arm64" }, "sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw=="],
-
-    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.2.1", "", { "dependencies": { "@emnapi/core": "2.0.0-alpha.3", "@emnapi/runtime": "2.0.0-alpha.3", "@napi-rs/wasm-runtime": "^1.2.0" } }, "sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww=="],
 
     "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.2.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw=="],
 
@@ -258,8 +250,6 @@
     "@tailwindcss/vite": ["@tailwindcss/vite@4.3.3", "", { "dependencies": { "@tailwindcss/node": "4.3.3", "@tailwindcss/oxide": "4.3.3", "tailwindcss": "4.3.3" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw=="],
 
     "@testing-library/svelte-core": ["@testing-library/svelte-core@1.1.3", "", { "peerDependencies": { "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0" } }, "sha512-KkMAvXeWorxN2Yn0kdC1lfoAItxpoj4uOWzxK5leDrNxonLvS5nwBFvztrroyTszQ0Wf/EU6iLT8JhY5qcn22g=="],
-
-    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -347,23 +337,19 @@
 
     "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
-    "@vitest/browser": ["@vitest/browser@4.1.11", "", { "dependencies": { "@blazediff/core": "1.9.1", "@vitest/mocker": "4.1.11", "@vitest/utils": "4.1.11", "magic-string": "^0.30.21", "pngjs": "^7.0.0", "sirv": "^3.0.2", "tinyrainbow": "^3.1.0", "ws": "^8.19.0" }, "peerDependencies": { "vitest": "4.1.11" } }, "sha512-bwMovvAeuTFOK5kIFevw4VEf+1gVEICv4SYK4k3knJOxl6b1zEWud8mYKD73e1B0odAn174h1MofURy2TPWf3w=="],
+    "@vitest/browser": ["@vitest/browser@5.0.0", "", { "dependencies": { "@blazediff/core": "1.10.0", "@vitest/mocker": "5.0.0", "@vitest/ui": "5.0.0", "@vitest/utils": "5.0.0", "magic-string": "^1.2.3", "pngjs": "^7.0.0", "sirv": "^3.0.2", "tinyrainbow": "^3.1.1", "ws": "^8.21.3" }, "peerDependencies": { "vitest": "5.0.0" } }, "sha512-JC9FG5xIRxPHXJPcdCaluIJcEoeM0IwGQ3xneuJk09LXKHRNs40BqWDWymQikbb20yOpYvzpKzmYgPRuSzKmvg=="],
 
-    "@vitest/browser-playwright": ["@vitest/browser-playwright@4.1.11", "", { "dependencies": { "@vitest/browser": "4.1.11", "@vitest/mocker": "4.1.11", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "playwright": "*", "vitest": "4.1.11" } }, "sha512-riLBxPqwnJ0lWs2DN2WeUfYeKLoAjbP2Xx8cLQdSddzMi20sksIa6K2mPz79DyMZKKVKH2ksOC2yJvtNcZg8cg=="],
+    "@vitest/browser-playwright": ["@vitest/browser-playwright@5.0.0", "", { "dependencies": { "@vitest/browser": "5.0.0", "@vitest/mocker": "5.0.0", "tinyrainbow": "^3.1.1" }, "peerDependencies": { "playwright": "*", "vitest": "5.0.0" } }, "sha512-N+gED9y4/8pypaHjz/x0ah3CjoBr+N0hWWT+Gq4VXtMzyB+rUIdHni0ulzpD1j4H77iWy5Jg8PRMlVn6kjxo6g=="],
 
-    "@vitest/expect": ["@vitest/expect@4.1.11", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.11", "@vitest/utils": "4.1.11", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw=="],
+    "@vitest/mocker": ["@vitest/mocker@5.0.0", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.31", "@vitest/spy": "5.0.0", "estree-walker": "^3.0.3", "magic-string": "^1.2.3" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA=="],
 
-    "@vitest/mocker": ["@vitest/mocker@4.1.11", "", { "dependencies": { "@vitest/spy": "4.1.11", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@5.0.0", "", { "dependencies": { "tinyrainbow": "^3.1.1" } }, "sha512-PVRNuB3wpReb4SQEs4zTKM4KWFhQ5pw3spE8naoDJNB5T5aWRzGKHwXcLUllr0WeOTXpB6bSr3CJLo5+7XQSSQ=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.11", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw=="],
+    "@vitest/spy": ["@vitest/spy@5.0.0", "", {}, "sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g=="],
 
-    "@vitest/runner": ["@vitest/runner@4.1.11", "", { "dependencies": { "@vitest/utils": "4.1.11", "pathe": "^2.0.3" } }, "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw=="],
+    "@vitest/ui": ["@vitest/ui@5.0.0", "", { "dependencies": { "@vitest/utils": "5.0.0", "fflate": "^0.8.3", "flatted": "^3.4.4", "pathe": "^2.0.3", "sirv": "^3.0.2", "tinyrainbow": "^3.1.1" }, "peerDependencies": { "vitest": "5.0.0" } }, "sha512-h2FIFwggCY2GxUd2UdQoYNVQkOIqEQLPhNREcl3FUiRsdzQep7NWwYbSmhGEA9nFLPDq5pXzRMcBZQU8Py83sg=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@4.1.11", "", { "dependencies": { "@vitest/pretty-format": "4.1.11", "@vitest/utils": "4.1.11", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog=="],
-
-    "@vitest/spy": ["@vitest/spy@4.1.11", "", {}, "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA=="],
-
-    "@vitest/utils": ["@vitest/utils@4.1.11", "", { "dependencies": { "@vitest/pretty-format": "4.1.11", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ=="],
+    "@vitest/utils": ["@vitest/utils@5.0.0", "", { "dependencies": { "@vitest/pretty-format": "5.0.0", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.1" } }, "sha512-dO++xL3vDfvhTAVimfkuQUA3k+JClIF1i1vAkPqpcGAthRmeWnXmHB7YPViPvgCwviX8u7Y5W1u2N//AaQr3fw=="],
 
     "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
 
@@ -501,7 +487,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.24.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw=="],
 
-    "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
+    "es-module-lexer": ["es-module-lexer@2.3.2", "", {}, "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw=="],
 
     "es-toolkit": ["es-toolkit@1.47.1", "", {}, "sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q=="],
 
@@ -513,13 +499,15 @@
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
-    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
     "fastdom": ["fastdom@1.0.12", "", { "dependencies": { "strictdom": "^1.0.1" } }, "sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
+
+    "flatted": ["flatted@3.4.4", "", {}, "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -639,10 +627,6 @@
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
-    "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
-
-    "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
-
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
@@ -662,8 +646,6 @@
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
-
-    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
@@ -685,7 +667,7 @@
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
-    "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
+    "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
 
     "strictdom": ["strictdom@1.0.1", "", {}, "sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg=="],
 
@@ -703,13 +685,13 @@
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
-    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+    "tinybench": ["tinybench@6.1.4", "", {}, "sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ=="],
 
-    "tinyexec": ["tinyexec@1.2.3", "", {}, "sha512-g62dB+w1/OEFnPvmX0yd/HnetYITOL+1nJW7kitOycOeAvmbWC/nu0fwmmQ/kupNojqExzyC/T++pST/jRJ2mQ=="],
+    "tinyexec": ["tinyexec@1.3.0", "", {}, "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ=="],
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
-    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
+    "tinyrainbow": ["tinyrainbow@3.1.1", "", {}, "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw=="],
 
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
@@ -749,7 +731,7 @@
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
-    "vitest": ["vitest@4.1.11", "", { "dependencies": { "@vitest/expect": "4.1.11", "@vitest/mocker": "4.1.11", "@vitest/pretty-format": "4.1.11", "@vitest/runner": "4.1.11", "@vitest/snapshot": "4.1.11", "@vitest/spy": "4.1.11", "@vitest/utils": "4.1.11", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.11", "@vitest/browser-preview": "4.1.11", "@vitest/browser-webdriverio": "4.1.11", "@vitest/coverage-istanbul": "4.1.11", "@vitest/coverage-v8": "4.1.11", "@vitest/ui": "4.1.11", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw=="],
+    "vitest": ["vitest@5.0.0", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/mocker": "5.0.0", "chai": "^6.2.2", "es-module-lexer": "^2.3.2", "expect-type": "^1.4.0", "magic-string": "^1.2.3", "obug": "^2.1.4", "picomatch": "^4.0.7", "std-env": "^4.2.0", "tinybench": "6.1.4", "tinyexec": "1.3.0", "tinyglobby": "^0.2.17", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "5.0.0", "@vitest/browser-preview": "5.0.0", "@vitest/browser-webdriverio": "^5.0.0-beta.5 || >=5.0.0", "@vitest/coverage-istanbul": "5.0.0", "@vitest/coverage-v8": "5.0.0", "@vitest/ui": "5.0.0", "happy-dom": "*", "jsdom": "*", "vite": "^6.4.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q=="],
 
     "vitest-browser-svelte": ["vitest-browser-svelte@3.1.0", "", { "dependencies": { "@testing-library/svelte-core": "^1.1.3" }, "peerDependencies": { "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0", "vitest": "^4.0.0 || ^5.0.0" } }, "sha512-+EBXSed6NArmzOC2DY4v9sI5n9TMIyfkMnewbXNQ7sR5IckQTCx7g1BbLdkH7kzm/tkgG/eEbRYlMWSbVfBtWA=="],
 
@@ -757,13 +739,13 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
-    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
 
     "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
-    "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@2.0.0-alpha.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA=="],
+    "@antfu/install-pkg/tinyexec": ["tinyexec@1.2.3", "", {}, "sha512-g62dB+w1/OEFnPvmX0yd/HnetYITOL+1nJW7kitOycOeAvmbWC/nu0fwmmQ/kupNojqExzyC/T++pST/jRJ2mQ=="],
 
     "@shikijs/transformers/@shikijs/core": ["@shikijs/core@4.3.1", "", { "dependencies": { "@shikijs/primitive": "4.3.1", "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA=="],
 
@@ -784,6 +766,10 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@vitest/browser/magic-string": ["magic-string@1.2.3", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g=="],
+
+    "@vitest/mocker/magic-string": ["magic-string@1.2.3", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g=="],
 
     "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
 
@@ -809,7 +795,11 @@
 
     "unplugin/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
-    "vitest/vite": ["vite@8.2.1", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.25", "rolldown": "~1.2.1", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw=="],
+    "vitest/magic-string": ["magic-string@1.2.3", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g=="],
+
+    "vitest/obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
+
+    "vitest/picomatch": ["picomatch@4.0.7", "", {}, "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA=="],
 
     "@shikijs/transformers/@shikijs/core/@shikijs/primitive": ["@shikijs/primitive@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A=="],
 
@@ -844,41 +834,5 @@
     "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
 
     "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
-
-    "vitest/vite/postcss": ["postcss@8.5.25", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw=="],
-
-    "vitest/vite/rolldown": ["rolldown@1.2.1", "", { "dependencies": { "@oxc-project/types": "=0.142.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.2.1", "@rolldown/binding-darwin-arm64": "1.2.1", "@rolldown/binding-darwin-x64": "1.2.1", "@rolldown/binding-freebsd-x64": "1.2.1", "@rolldown/binding-linux-arm-gnueabihf": "1.2.1", "@rolldown/binding-linux-arm64-gnu": "1.2.1", "@rolldown/binding-linux-arm64-musl": "1.2.1", "@rolldown/binding-linux-ppc64-gnu": "1.2.1", "@rolldown/binding-linux-s390x-gnu": "1.2.1", "@rolldown/binding-linux-x64-gnu": "1.2.1", "@rolldown/binding-linux-x64-musl": "1.2.1", "@rolldown/binding-openharmony-arm64": "1.2.1", "@rolldown/binding-wasm32-wasi": "1.2.1", "@rolldown/binding-win32-arm64-msvc": "1.2.1", "@rolldown/binding-win32-x64-msvc": "1.2.1" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw=="],
-
-    "vitest/vite/postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
-
-    "vitest/vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.142.0", "", {}, "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.1", "", { "os": "android", "cpu": "arm64" }, "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.2.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.2.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.2.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.2.1", "", { "os": "linux", "cpu": "arm" }, "sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.2.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.2.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.2.1", "", { "os": "none", "cpu": "arm64" }, "sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.2.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.2.1", "", { "os": "win32", "cpu": "x64" }, "sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ=="],
   }
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -29,15 +29,15 @@
     "@sveltejs/vite-plugin-svelte": "^7.3.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.5.0",
-    "@vitest/browser": "^4.1.11",
-    "@vitest/browser-playwright": "^4.1.11",
+    "@vitest/browser": "^5.0.0",
+    "@vitest/browser-playwright": "^5.0.0",
     "playwright": "^1.63.0",
     "sharp": "^0.35.4",
     "svelte": "^5.57.0",
     "svelte-check": "^4.7.6",
     "typescript": "^6.0.2",
     "vite": "^8.2.2",
-    "vitest": "^4.1.11",
+    "vitest": "^5.0.0",
     "vitest-browser-svelte": "^3.1.0"
   },
   "dependencies": {

--- a/ui/src/lib/components/BuildQueuePanel.browser.test.ts
+++ b/ui/src/lib/components/BuildQueuePanel.browser.test.ts
@@ -185,7 +185,9 @@ describe("BuildQueuePanel — action lifecycle", () => {
       expect(button.disabled).toBe(true);
       expect(buildQueueCollapse.collapsed).toBe(true);
       pending.reject(new Error("offline"));
-      await expect.element(page.getByRole("alert")).toHaveTextContent(m.buildqueue_action_failed());
+      await expect
+        .element(page.getByRole("alert"))
+        .toMatchTextContent(m.buildqueue_action_failed());
       expect(button.disabled).toBe(false);
       await page
         .getByRole("button", {
@@ -194,7 +196,7 @@ describe("BuildQueuePanel — action lifecycle", () => {
         .click();
       expect(api).toHaveBeenCalledTimes(2);
       expect(buildQueueCollapse.collapsed).toBe(true);
-      await expect.element(page.getByRole("status")).toHaveTextContent(m.buildqueue_action_sent());
+      await expect.element(page.getByRole("status")).toMatchTextContent(m.buildqueue_action_sent());
     });
   }
 
@@ -204,9 +206,9 @@ describe("BuildQueuePanel — action lifecycle", () => {
     const { rerender } = await render(BuildQueuePanel, { ...props, folded: true });
     await page.getByRole("button", { name: m.buildqueue_start() }).click();
     await rerender({ sessionStatus: "running", enabled: false, queue: { ...waiting, steps: [] } });
-    await expect.element(page.getByRole("status")).toHaveTextContent(m.buildqueue_sending());
+    await expect.element(page.getByRole("status")).toMatchTextContent(m.buildqueue_sending());
     pending.resolve();
-    await expect.element(page.getByRole("status")).toHaveTextContent(m.buildqueue_action_sent());
+    await expect.element(page.getByRole("status")).toMatchTextContent(m.buildqueue_action_sent());
     await rerender({ sessionId: "s2", queue: { ...waiting, sessionId: "s2" } });
     expect(document.querySelector(".bqp")).toBeNull();
   });

--- a/ui/src/lib/components/CommandBar.browser.test.ts
+++ b/ui/src/lib/components/CommandBar.browser.test.ts
@@ -134,7 +134,7 @@ describe("CommandBar — grouping & recency", () => {
     await expect.element(page.getByText(m.commandbar_group_repos())).toBeVisible();
     await expect.element(page.getByText(m.commandbar_group_lenses())).toBeVisible();
     // First option is the most-recently-updated session ("newer" = s2).
-    await expect.element(page.getByRole("option").first()).toHaveTextContent("newer");
+    await expect.element(page.getByRole("option").first()).toMatchTextContent("newer");
   });
 
   it("promotes blocks-backed sessions above newer waiting sessions", async () => {
@@ -147,8 +147,8 @@ describe("CommandBar — grouping & recency", () => {
     });
 
     const first = page.getByRole("option").first();
-    await expect.element(first).toHaveTextContent("needs-input");
-    await expect.element(first).toHaveTextContent(m.status_blocked());
+    await expect.element(first).toMatchTextContent("needs-input");
+    await expect.element(first).toMatchTextContent(m.status_blocked());
   });
 
   it("promotes held-style blocked sessions through blocks alone", async () => {
@@ -160,7 +160,7 @@ describe("CommandBar — grouping & recency", () => {
       blocks: { held: block() },
     });
 
-    await expect.element(page.getByRole("option").first()).toHaveTextContent("held-needs-input");
+    await expect.element(page.getByRole("option").first()).toMatchTextContent("held-needs-input");
   });
 
   it("does not promote working-while-blocked sessions even with a block entry", async () => {
@@ -174,8 +174,8 @@ describe("CommandBar — grouping & recency", () => {
     });
 
     const first = page.getByRole("option").first();
-    await expect.element(first).toHaveTextContent("reviewer-cli-metadata");
-    await expect.element(first).toHaveTextContent(m.status_done());
+    await expect.element(first).toMatchTextContent("reviewer-cli-metadata");
+    await expect.element(first).toMatchTextContent(m.status_done());
   });
 
   it("promotes autopilot-paused sessions and explains them with the needs-you label", async () => {
@@ -193,10 +193,10 @@ describe("CommandBar — grouping & recency", () => {
     });
 
     const first = page.getByRole("option").first();
-    await expect.element(first).toHaveTextContent("autopilot-paused");
+    await expect.element(first).toMatchTextContent("autopilot-paused");
     await expect
       .element(first)
-      .toHaveTextContent(m.session_autopilot_paused_label().toLocaleUpperCase());
+      .toMatchTextContent(m.session_autopilot_paused_label().toLocaleUpperCase());
     expect(first.element().textContent).not.toContain(m.status_done());
   });
 
@@ -261,7 +261,7 @@ describe("CommandBar — fuzzy matching", () => {
     // Matched letters are wrapped for highlighting…
     expect(document.querySelectorAll("mark.cb-hl").length).toBeGreaterThan(0);
     // …yet the option still reads as the full, untouched title.
-    await expect.element(page.getByRole("option").first()).toHaveTextContent("newer");
+    await expect.element(page.getByRole("option").first()).toMatchTextContent("newer");
   });
 
   it("does not stitch one fuzzy match across separate session fields", async () => {
@@ -293,7 +293,7 @@ describe("CommandBar — fuzzy matching", () => {
 
     await page.getByRole("combobox").fill("task-99");
 
-    await expect.element(page.getByRole("option", { name: /alpha/ })).toHaveTextContent("TASK-99");
+    await expect.element(page.getByRole("option", { name: /alpha/ })).toMatchTextContent("TASK-99");
   });
 
   it("highlights the repository name when it is the winning session field", async () => {
@@ -411,11 +411,11 @@ describe("CommandBar — repo secondary action (filter)", () => {
     const betaRow = page.getByRole("option", {
       name: new RegExp(m.commandbar_repo_affordance()),
     });
-    await expect.element(betaRow).toHaveTextContent(m.commandbar_repo_filter_affordance());
+    await expect.element(betaRow).toMatchTextContent(m.commandbar_repo_filter_affordance());
     // The session-less repo (gamma) keeps "Repository" but shows no filter hint.
     await page.getByRole("combobox").fill("gamma");
     const gammaRow = page.getByRole("option").first();
-    await expect.element(gammaRow).toHaveTextContent(m.commandbar_repo_affordance());
+    await expect.element(gammaRow).toMatchTextContent(m.commandbar_repo_affordance());
     expect(gammaRow.element().textContent).not.toContain(m.commandbar_repo_filter_affordance());
   });
 });
@@ -427,7 +427,7 @@ describe("CommandBar — demo showcase seeding", () => {
     await expect.element(page.getByRole("combobox")).toHaveValue("newer");
     const opts = page.getByRole("option");
     expect(opts.elements()).toHaveLength(1);
-    await expect.element(opts.first()).toHaveTextContent("newer");
+    await expect.element(opts.first()).toMatchTextContent("newer");
   });
 
   it("without initialFilter the filter stays empty (inert by default)", async () => {
@@ -470,7 +470,7 @@ describe("CommandBar — Commands group", () => {
     await page.getByRole("combobox").fill("cost");
     await expect.element(page.getByText(m.commandbar_group_commands())).toBeVisible();
     const opts = page.getByRole("option");
-    await expect.element(opts.first()).toHaveTextContent("Usage");
+    await expect.element(opts.first()).toMatchTextContent("Usage");
     expect(opts.elements()).toHaveLength(1);
   });
 
@@ -507,7 +507,7 @@ describe("CommandBar — Commands group", () => {
     await page.getByRole("combobox").fill("new");
 
     const first = page.getByRole("option").first();
-    await expect.element(first).toHaveTextContent(m.commandbar_cmd_new_task());
+    await expect.element(first).toMatchTextContent(m.commandbar_cmd_new_task());
     expect(document.querySelector(".cb-group")?.textContent).toBe(m.commandbar_group_commands());
     expect(
       page
@@ -547,7 +547,7 @@ describe("CommandBar — Commands group", () => {
     await page.getByRole("combobox").fill("learn");
     await expect.element(page.getByText(m.commandbar_group_commands())).toBeVisible();
     const opts = page.getByRole("option");
-    await expect.element(opts.first()).toHaveTextContent("Learnings");
+    await expect.element(opts.first()).toMatchTextContent("Learnings");
     expect(opts.elements()).toHaveLength(1);
 
     await page.getByRole("option", { name: /Learnings/ }).click();
@@ -742,7 +742,7 @@ describe("CommandBar — destructive command two-step arm", () => {
 
     await userEvent.keyboard("{Enter}");
     // Armed: the row swaps to the confirm copy, nothing has run, the bar stays open.
-    await expect.element(decomRow()).toHaveTextContent(CONFIRM);
+    await expect.element(decomRow()).toMatchTextContent(CONFIRM);
     expect(decomRow().element().classList.contains("armed")).toBe(true);
     expect(run).not.toHaveBeenCalled();
     expect(onclose).not.toHaveBeenCalled();
@@ -773,7 +773,7 @@ describe("CommandBar — destructive command two-step arm", () => {
     await page.getByRole("combobox").fill("decom");
 
     await decomRow().click();
-    await expect.element(decomRow()).toHaveTextContent(CONFIRM);
+    await expect.element(decomRow()).toMatchTextContent(CONFIRM);
     expect(run).not.toHaveBeenCalled();
 
     await pastDwell();
@@ -842,7 +842,7 @@ describe("CommandBar — destructive command two-step arm", () => {
 
     // Arm for real, then hold Enter / Space on the row itself: cannot confirm.
     await decomRow().click();
-    await expect.element(decomRow()).toHaveTextContent(CONFIRM);
+    await expect.element(decomRow()).toMatchTextContent(CONFIRM);
     await pastDwell();
     repeatKey(decomRow().element(), "Enter");
     repeatKey(decomRow().element(), " ");
@@ -871,7 +871,7 @@ describe("CommandBar — destructive command two-step arm", () => {
       await decomRow().click(); // second click, still at t0 — inside the dwell
       expect(run).not.toHaveBeenCalled();
       // Still armed, so a deliberate confirm afterwards works.
-      await expect.element(decomRow()).toHaveTextContent(CONFIRM);
+      await expect.element(decomRow()).toMatchTextContent(CONFIRM);
 
       now.mockReturnValue(t0 + 320); // past the dwell
       await decomRow().click();
@@ -888,15 +888,15 @@ describe("CommandBar — destructive command two-step arm", () => {
 
     await input.fill("decom");
     await userEvent.keyboard("{Enter}");
-    await expect.element(decomRow()).toHaveTextContent(CONFIRM);
+    await expect.element(decomRow()).toMatchTextContent(CONFIRM);
     await input.fill("decomm"); // query change re-ranks the list → arm abandoned
-    await expect.element(decomRow()).toHaveTextContent("Decommission TASK-07");
+    await expect.element(decomRow()).toMatchTextContent("Decommission TASK-07");
     await vi.waitFor(() => expect(srText()).toBe(""));
 
     await userEvent.keyboard("{Enter}");
-    await expect.element(decomRow()).toHaveTextContent(CONFIRM);
+    await expect.element(decomRow()).toMatchTextContent(CONFIRM);
     await userEvent.keyboard("{ArrowDown}"); // cursor move → arm abandoned
-    await expect.element(decomRow()).toHaveTextContent("Decommission TASK-07");
+    await expect.element(decomRow()).toMatchTextContent("Decommission TASK-07");
 
     expect(run).not.toHaveBeenCalled();
   });
@@ -982,7 +982,7 @@ describe("CommandBar — armed row survives a live option-list change", () => {
     });
 
     await decomRow().click();
-    await expect.element(decomRow()).toHaveTextContent(CONFIRM); // arms afresh, does not fire
+    await expect.element(decomRow()).toMatchTextContent(CONFIRM); // arms afresh, does not fire
     expect(run).not.toHaveBeenCalled();
   });
 });
@@ -998,18 +998,18 @@ describe("CommandBar — arming by click keeps focus on the combobox", () => {
     await input.fill("decom");
 
     await decomRow().click();
-    await expect.element(decomRow()).toHaveTextContent(CONFIRM);
+    await expect.element(decomRow()).toMatchTextContent(CONFIRM);
     expect(document.activeElement).toBe(input.element());
 
     // Escape hatch 1: typing disarms (the keystroke reaches the input's oninput).
     await userEvent.keyboard("m");
-    await expect.element(decomRow()).toHaveTextContent("Decommission TASK-07");
+    await expect.element(decomRow()).toMatchTextContent("Decommission TASK-07");
 
     // Escape hatch 2: moving the cursor disarms (the arrow reaches onKey).
     await decomRow().click();
-    await expect.element(decomRow()).toHaveTextContent(CONFIRM);
+    await expect.element(decomRow()).toMatchTextContent(CONFIRM);
     await userEvent.keyboard("{ArrowDown}");
-    await expect.element(decomRow()).toHaveTextContent("Decommission TASK-07");
+    await expect.element(decomRow()).toMatchTextContent("Decommission TASK-07");
 
     expect(run).not.toHaveBeenCalled();
   });

--- a/ui/src/lib/components/GlossaryTerm.browser.test.ts
+++ b/ui/src/lib/components/GlossaryTerm.browser.test.ts
@@ -16,7 +16,7 @@ describe("GlossaryTerm — activation-only inline disclosure", () => {
 
     // inline panel present with correct role and body text
     await expect.element(page.getByRole("note")).toBeVisible();
-    await expect.element(page.getByRole("note")).toHaveTextContent(m.gloss_epic_def());
+    await expect.element(page.getByRole("note")).toMatchTextContent(m.gloss_epic_def());
 
     // no floating tooltip open
     const tooltips = document.querySelectorAll(".gloss-tooltip:popover-open");

--- a/ui/src/lib/components/PrReviewRequestPopover.browser.test.ts
+++ b/ui/src/lib/components/PrReviewRequestPopover.browser.test.ts
@@ -196,7 +196,7 @@ describe("PrReviewRequestPopover", () => {
       },
     });
 
-    await expect.element(page.getByRole("alert")).toHaveTextContent(m.prreview_load_failed());
+    await expect.element(page.getByRole("alert")).toMatchTextContent(m.prreview_load_failed());
     await page.getByRole("button", { name: m.common_retry() }).click();
     await expect
       .element(page.getByRole("combobox", { name: m.roles_reviewer_label() }))
@@ -217,7 +217,7 @@ describe("PrReviewRequestPopover", () => {
       },
     });
 
-    await expect.element(page.getByRole("alert")).toHaveTextContent(m.prreview_load_failed());
+    await expect.element(page.getByRole("alert")).toMatchTextContent(m.prreview_load_failed());
     await expect
       .element(page.getByRole("link", { name: m.prbadge_open_pr() }))
       .toHaveAttribute("href", "https://github.test/upstream/project/pull/42");
@@ -246,11 +246,13 @@ describe("PrReviewRequestPopover", () => {
     await expect
       .element(page.getByRole("combobox", { name: m.roles_reviewer_label() }))
       .toBeVisible();
-    const rect = document.querySelector<HTMLElement>(".review-popover")!.getBoundingClientRect();
+    const rectOf = () =>
+      document.querySelector<HTMLElement>(".review-popover")!.getBoundingClientRect();
+    await expect.poll(() => rectOf().bottom).toBeLessThanOrEqual(window.innerHeight - 8);
+    const rect = rectOf();
     expect(rect.left).toBeGreaterThanOrEqual(8);
     expect(rect.right).toBeLessThanOrEqual(window.innerWidth - 8);
     expect(rect.top).toBeGreaterThanOrEqual(8);
-    expect(rect.bottom).toBeLessThanOrEqual(window.innerHeight - 8);
     await expect.element(dialog).toBeVisible();
   });
 
@@ -278,7 +280,7 @@ describe("PrReviewRequestPopover", () => {
     });
 
     await page.getByRole("button", { name: m.prreview_title() }).click();
-    await expect.element(page.getByRole("alert")).toHaveTextContent(message());
+    await expect.element(page.getByRole("alert")).toMatchTextContent(message());
   });
 
   it("focuses the select and closes on Escape, outside click, or a changed PR", async () => {

--- a/ui/src/lib/components/RepoSelect.browser.test.ts
+++ b/ui/src/lib/components/RepoSelect.browser.test.ts
@@ -50,7 +50,7 @@ describe("RepoSelect — keyboard cursor on open", () => {
     await expect.element(selected).toBeVisible();
 
     // The cursor row must contain "gamma", not "alpha" (which is row 0 / pinned).
-    await expect.element(selected).toHaveTextContent("gamma");
+    await expect.element(selected).toMatchTextContent("gamma");
     // And confirm row 0 (alpha) is NOT the cursor.
     const alphaRow = page.getByRole("option", { name: /alpha/ }).first();
     await expect.element(alphaRow).toHaveAttribute("aria-selected", "false");
@@ -77,7 +77,7 @@ describe("RepoSelect — keyboard cursor on open", () => {
     // The first (and only) option should now have aria-selected="true".
     const firstOption = page.getByRole("option").first();
     await expect.element(firstOption).toHaveAttribute("aria-selected", "true");
-    await expect.element(firstOption).toHaveTextContent("alpha");
+    await expect.element(firstOption).toMatchTextContent("alpha");
   });
 
   it("falls back to the first row when value matches no repo in the list", async () => {
@@ -98,7 +98,7 @@ describe("RepoSelect — keyboard cursor on open", () => {
     // Row 0 (alpha, the first pinned repo) must be the keyboard cursor.
     const firstOption = page.getByRole("option").first();
     await expect.element(firstOption).toHaveAttribute("aria-selected", "true");
-    await expect.element(firstOption).toHaveTextContent("alpha");
+    await expect.element(firstOption).toMatchTextContent("alpha");
   });
 });
 

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -994,11 +994,11 @@ describe("TopBarHeldBadge — mobile held-task dialog", () => {
 
     // The failure surfaces inline (a toast would render behind the fullscreen dialog),
     // announced assertively so it reaches a screen reader.
-    await expect.element(page.getByRole("alert")).toHaveTextContent(m.topbar_held_spawn_failed());
+    await expect.element(page.getByRole("alert")).toMatchTextContent(m.topbar_held_spawn_failed());
     // …and carries the server's real cause so the operator can see *why* it failed.
     await expect
       .element(page.getByRole("alert"))
-      .toHaveTextContent("task name already in use, retry");
+      .toMatchTextContent("task name already in use, retry");
   });
 
   it("shows in-flight state on the spawn button while a held-task spawn is pending", async () => {
@@ -1119,8 +1119,8 @@ describe("TopBar — working-while-blocked counts in the working tally, not bloc
       m.topbar_tally_filter_title({ status: m.topbar_blocked_label() }),
     );
     // display tallies: flagged session counts as working (2), not blocked (1)
-    await expect.element(working).toHaveTextContent("2");
-    await expect.element(blocked).toHaveTextContent("1");
+    await expect.element(working).toMatchTextContent("2");
+    await expect.element(blocked).toMatchTextContent("1");
     // the e-stop stays RAW: only 1 raw-running agent is haltable, so the gear menu
     // offers "Halt 1", not 2 (the server's haltAll can't reach the latched session)
     await page.getByRole("button", { name: m.topbar_menu_aria() }).click();

--- a/ui/src/lib/components/usage/DeliveryLens.browser.test.ts
+++ b/ui/src/lib/components/usage/DeliveryLens.browser.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
-import { page } from "@vitest/browser/context";
+import { page } from "vitest/browser";
 import "../../../app.css";
 import type {
   BandReading,

--- a/ui/src/lib/vite-config.test.ts
+++ b/ui/src/lib/vite-config.test.ts
@@ -5,16 +5,17 @@ describe("vite config browser project", () => {
   const projects = (config.test as { projects?: unknown[] })?.projects ?? [];
   const browserProject = projects.find(
     (p) => (p as { test?: { name?: string } })?.test?.name === "browser",
-  ) as { test?: { browser?: { api?: { strictPort?: boolean } } } } | undefined;
+  ) as { test?: { api?: { strictPort?: boolean } } } | undefined;
 
   it("has a project named browser", () => {
     expect(browserProject).toBeDefined();
   });
 
-  it("sets browser.api.strictPort = false to avoid port 63315 collision (#817)", () => {
+  it("sets api.strictPort = false to avoid port 63315 collision (#817)", () => {
     // vitest browser mode defaults its server to port 63315 with strictPort on;
     // without this, concurrent test runs hard-fail. strictPort:false lets Vite
-    // pick the next free port and hand it to the browser client.
-    expect(browserProject?.test?.browser?.api?.strictPort).toBe(false);
+    // pick the next free port and hand it to the browser client. vitest 5 moved
+    // this option off `browser.api` onto the project's `test.api`.
+    expect(browserProject?.test?.api?.strictPort).toBe(false);
   });
 });

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -108,17 +108,23 @@ export default defineConfig({
           // `bun run test` is unchanged. Note: a global `--maxWorkers` CLI flag does
           // NOT cap the browser pool — it must live in the project's test config.
           ...(process.env.CI ? { maxWorkers: 2, sequence: { groupOrder: 1 } } : {}),
+          // vitest's default browser server port (63315) has strictPort on by
+          // default, causing a hard failure when a leftover/concurrent test
+          // process holds the port. strictPort:false lets Vite auto-increment
+          // to the next free port; vitest discovers the bound port and hands
+          // it to the browser client, so a predictable port isn't needed. (#817)
+          // vitest 5 moved this off `browser.api` onto the project's `test.api`.
+          api: { strictPort: false },
           browser: {
             enabled: true,
             provider: playwright(),
             headless: true,
             instances: [{ browser: "chromium" }],
-            // vitest's default browser server port (63315) has strictPort on by
-            // default, causing a hard failure when a leftover/concurrent test
-            // process holds the port. strictPort:false lets Vite auto-increment
-            // to the next free port; vitest discovers the bound port and hands
-            // it to the browser client, so a predictable port isn't needed. (#817)
-            api: { strictPort: false },
+            // vitest 5 flipped locator text matching to exact + case-sensitive by
+            // default; this suite was written against the substring semantics of
+            // v4 (e.g. getByText("limit") matching a cell reading "limit required").
+            // Revert to the previous default rather than rewrite every assertion.
+            locators: { exact: false },
           },
         },
       },
@@ -131,12 +137,13 @@ export default defineConfig({
           // emulation does not restore Chromium's desktop pointer/hover media queries.
           maxWorkers: 1,
           sequence: { groupOrder: 2 },
+          api: { strictPort: false },
           browser: {
             enabled: true,
             provider: playwright({ contextOptions: { hasTouch: true } }),
             headless: true,
             instances: [{ browser: "chromium" }],
-            api: { strictPort: false },
+            locators: { exact: false },
           },
         },
       },


### PR DESCRIPTION
Replaces #2256, #2255 and #2254 with a single coherent upgrade.

## Why one PR

Vitest 5 pins its own packages as **exact peers** of each other — `vitest@5.0.0`
peers `@vitest/browser-playwright: 5.0.0`, `@vitest/browser@5.0.0` peers
`vitest: 5.0.0`. All three are direct devDeps in `ui/`, so the family is only
ever installable as a set. Dependabot opened one PR per package and none of them
could land:

| PR | | |
|---|---|---|
| #2256 | vitest 5 alone | red — 1304 svelte-check errors against browser@4 |
| #2254 | browser-playwright 5 alone | red — `vitest/node` has no `BrowserConnectionError` in v4 |
| #2255 | @vitest/browser 5 alone | **green but inert** — browser-playwright@4 drags a nested `@vitest/browser@4` which is what actually runs |

#2255 is the interesting one: it would have merged clean and delivered none of
the upgrade.

## Breaking changes handled

**`test.browser.api` → `test.api`.** Vitest 5 removed the nested option. The
`#817` `strictPort: false` workaround is preserved (both browser projects), and
the guard test in `vite-config.test.ts` now asserts the new path.

**Locators are strict by default.** Per the migration guide, browser locators
now require an exact, case-sensitive match — `getByText("limit")` no longer
matches a cell reading `limit required`. This suite was written against v4's
substring semantics, so it's reverted with the documented knob,
`browser.locators.exact = false`, rather than rewriting ~60 assertions.

**`toHaveTextContent` now does strict equality**; partial matching moved to the
new `toMatchTextContent`. Renamed **all 44 call sites**, not only the ones that
failed — leaving the rest would silently tighten assertions that happen to match
exactly today, which isn't something a dependency bump should do unreviewed.

**`@vitest/browser/context` no longer resolves inside browser mode.** Exactly one
spec still used that legacy path; `DeliveryLens` now imports `vitest/browser`
like every other spec in the repo.

## Two incidental fixes

`PrReviewRequestPopover`'s narrow-viewport test read `getBoundingClientRect()`
once while the popover's async `ResizeObserver` was still settling — a
pre-existing race that v5's timing exposed. It now polls until the popover
settles inside the viewport; verified it converges (not a component bug) and
re-ran it 3× clean.

`ui/.gitignore` listed `.vitest-attachments/`, the v4 directory name. Vitest 5
writes failure screenshots to `.vitest/`, which would otherwise have been
committed.

## Preventing the recurrence

Adds a `vitest` Dependabot group covering **majors**, listed first so it wins the
match. The two existing blanket groups are `["minor", "patch"]` only, which is
why this major arrived ungrouped in the first place — any exact-peer-pinned
family will keep splitting until it has its own group.

## Verification

| | |
|---|---|
| `ui`: `bun run check` | 0 errors, 6225 files |
| `ui`: `bun run check:i18n` | 2 locales in parity (3947 keys) |
| `ui`: `bun run test` | **312/312 files**, exit 0 |
| root: `bun run lint` | clean |
| root: `bunx tsc --noEmit` | clean |
| root: `bun run test` | 9621 pass, 0 fail |
| `fallow audit --base origin/main` | no issues in 13 changed files |
| branch hygiene | linear off origin/main |

No user-facing strings changed, so the i18n catalogs are untouched.

## Note for review

`browser.locators.exact = false` **preserves** current assertion strength rather
than weakening it — it restores the semantics every one of these tests was
written against. Tightening the suite to exact matching is a genuine improvement
and probably worth doing, but as its own piece of work, not smuggled into a
dependency bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
