### PR TITLE
feat(usage): mark sessions that are expensive to resume (#2042)

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -395,9 +395,9 @@
         "files": ["ui/src/lib/components/UnitRow.svelte"],
         "functions": ["<template>"],
         "maxCyclomatic": 40,
-        "maxCognitive": 62,
+        "maxCognitive": 64,
         "maxCrap": 20000,
-        "reason": "Inline hold-reason subline + one-click CTA (#1561) adds ~+3 cognitive to the already-large row template (58 -> 61). The CTA block was extracted into the holdSubline snippet, which recovered cyclomatic back under the Tier-1 40 bar; the residual +1 over the 60 cognitive bar is genuine new-affordance cost. Keep capped until UnitRow is split into per-zone sub-components (#855), like the other large row templates."
+        "reason": "Inline hold-reason subline + one-click CTA (#1561) adds ~+3 cognitive to the already-large row template (58 -> 61). The CTA block was extracted into the holdSubline snippet, which recovered cyclomatic back under the Tier-1 40 bar; the residual +1 over the 60 cognitive bar is genuine new-affordance cost. The cold-resume chip (#2042) adds one more independent `{#if}` in the meta row (62 -> 64), cyclomatic unchanged at 39: the whole point of that feature is to warn on the surface where the operator CHOOSES a session, so the branch cannot live anywhere else. Keep capped until UnitRow is split into per-zone sub-components (#855), like the other large row templates."
       },
       {
         "files": ["ui/src/lib/components/page/AppOverlays.svelte"],

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -23,10 +23,16 @@ import {
   type BlockReason,
 } from "./blocked";
 import { DEFAULT_STALL } from "./stall";
-import { jsonlPathFor } from "./usage";
-import { readTranscriptSignals, STRIP_WINDOW_MS, type SessionActivity } from "./activity-signal";
+import { jsonlPathFor, resumeSignalFrom, type ResumeSignal } from "./usage";
+import {
+  claudeRuntimeIdentity,
+  readTranscriptSignals,
+  STRIP_WINDOW_MS,
+  type SessionActivity,
+} from "./activity-signal";
 import { readTranscriptTail } from "./activity";
 import { detectAuthUrl, detectPendingAuthUrl, detectLoginAuthUrl } from "./auth-url";
+import { isApiKeyMode } from "./spawn-auth";
 import { statSync } from "node:fs";
 import { classifyHalt, assistantSideText } from "./usage-halt";
 import type { UsageLimits } from "./usage-limits";
@@ -179,6 +185,34 @@ function readAuthUrl(s: Session): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Price a resume of a session that has just parked (default `readResumeSignal` seam, #2042).
+ *
+ * Claude-only: a Codex rollout carries no cache-write premium to model, so there is nothing to
+ * warn about. One bounded tail read serves both the model and the reading — only the LAST
+ * main-thread record matters and it is always at the end of the file, so the tail is not a
+ * compromise here.
+ *
+ * The model is the one the transcript last named, which is what a resume will actually run on —
+ * not the session's historically dominant model, and not the configured `model` (null whenever the
+ * operator left the picker on default). Falls back to the persisted observed identity.
+ *
+ * TTL follows auth mode: Claude Code requests the 1h cache only on a subscription; an api key gets
+ * 5m. Both under-warn rather than over-warn if the real TTL is shorter (plan overage, or an
+ * operator's own promptCacheTtl), which is the safe direction.
+ */
+function readParkedResumeSignal(s: Session): ResumeSignal | null {
+  if ((s.agentProvider ?? "claude") === "codex" || !s.claudeSessionId) return null;
+  let text: string;
+  try {
+    text = readTranscriptTail(jsonlPathFor(s.worktreePath, s.claudeSessionId, s.spawnAccountDir));
+  } catch {
+    return null; // transcript absent/unreadable — nothing to price
+  }
+  const model = claudeRuntimeIdentity(text).runtimeModel ?? s.runtimeModel ?? null;
+  return resumeSignalFrom(text.split("\n"), model, isApiKeyMode() ? "5m" : "1h");
 }
 
 /** Transcript mtime for the resting-auth probe (default `authMtime` seam). Missing/unreadable
@@ -518,6 +552,12 @@ export class StatusPoller {
     private archiveTerminal?: (id: string) => void,
     /** Resolves a Codex session's provider-native rollout for the default probe. */
     codexTranscripts: CodexTranscriptLocator = new CodexTranscriptLocator(),
+    /**
+     * Prices a resume of a session that has just parked (#2042), for the cold-resume marker.
+     * Injectable for tests so the park/resume edges can be driven without touching disk; defaults
+     * to a bounded tail read + `resumeSignalFrom`.
+     */
+    private readResumeSignal: (s: Session) => ResumeSignal | null = readParkedResumeSignal,
   ) {
     this.probe =
       probe ??
@@ -1060,6 +1100,49 @@ export class StatusPoller {
   private handleStatusEdge(s: Session, status: Session["status"]): void {
     if (status === "done" && s.status !== "done") this.handleDoneEdge(s);
     else if (status === "running" && s.haltReason) this.clearHaltOnResume(s);
+    // Separate statement, NOT chained onto the branches above: a running→done edge is both a done
+    // edge and a park, and an `else if` here would let handleDoneEdge swallow the capture.
+    this.trackResumeCost(s, status);
+  }
+
+  /** True when this row currently carries a cold-resume reading (#2042). All three move together,
+   *  so any one being set means there is something to clear. */
+  private hasResumeSignal(s: Session): boolean {
+    return s.contextTokens != null || s.coldResumeAt != null || s.resumeCostUnits != null;
+  }
+
+  /**
+   * Maintain the cold-resume reading across the running↔parked boundary (#2042).
+   *
+   * PARK (running → idle/done/blocked): measure what the next turn back will cost and store it. A
+   * parked session's transcript cannot change, so this is measured ONCE rather than polled — and
+   * `maybeProbe` only runs for RUNNING sessions, so a per-tick derivation would never see the
+   * parked sessions this whole feature is about. Blocked counts as parked: a session waiting on the
+   * operator goes cold exactly like an idle one.
+   *
+   * RESUME (→ running): clear it. That first turn back pays the cost the reading predicted and
+   * every turn after it is warm, so leaving the row set would strand a `coldResumeAt` in the past —
+   * permanently true against "now", pinning the HUD's warning across active, rewarmed work.
+   *
+   * Both directions skip the write when there is nothing to change, so a warm session is not
+   * rewritten on every start and a Codex session is never written at all.
+   */
+  private trackResumeCost(s: Session, status: Session["status"]): void {
+    const wasRunning = s.status === "running";
+    const isRunning = status === "running";
+    if (wasRunning === isRunning) return; // not a boundary crossing
+    if (isRunning) {
+      if (this.hasResumeSignal(s)) this.store.setResumeSignal(s.id, null);
+      return;
+    }
+    let signal: ResumeSignal | null;
+    try {
+      signal = this.readResumeSignal(s);
+    } catch (err) {
+      console.warn(`[poller] cold-resume read failed for ${s.id}:`, err);
+      return; // best-effort, same contract as maybeProbe: leave the row untouched, retry next park
+    }
+    if (signal || this.hasResumeSignal(s)) this.store.setResumeSignal(s.id, signal);
   }
 
   /**

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -137,3 +137,51 @@ export function dollars(
     1_000_000
   );
 }
+
+// ── Cold-resume estimate (#2042) ─────────────────────────────────────────────
+
+/** The cache TTL that applies to a session's MAIN conversation. Claude Code requests the one-hour
+ *  TTL only on a Claude subscription within the plan's included usage; an api key (or a cloud
+ *  provider) gets five minutes. Subagents are always on 5m and are irrelevant here — a resume
+ *  re-sends the main conversation. */
+export type CacheTtl = "5m" | "1h";
+
+/**
+ * Tokens of a resumed session's prefix that stay cached even after its conversation has gone cold.
+ *
+ * A cold resume is NOT a full rebuild. Claude Code layers each request `system prompt → project
+ * context → conversation`, and Shepherd runs many sessions against the same system prompt, so that
+ * leading layer is continuously re-warmed by the rest of the herd while an individual session's
+ * conversation body expires alone.
+ *
+ * Measured over 168 real cold resumes (>1h idle, >50% of context rebuilt) in a 211-transcript
+ * corpus, the surviving prefix was p10 20.8k / p50 23.5k / p90 28.5k tokens — stable even across a
+ * 675-hour gap. 24k is that median. Pricing the WHOLE context at the write rate instead would
+ * overstate a 175k-context resume by ~14%.
+ */
+export const WARM_PREFIX_TOKENS = 24_000;
+
+/**
+ * Weighted units the NEXT turn into a cold session will cost: the surviving prefix is re-read at
+ * the cache-read rate and everything beyond it is re-written at `ttl`'s cache-write rate.
+ *
+ * Validated against the same 168 resumes: predicted/actual p50 0.99x, 97% within ±33%.
+ *
+ * Built on the public `weightedUnits` rather than the private `weightsFor`, the same way
+ * `accumulateCostRecord` isolates cacheRead-only units.
+ */
+export function coldResumeUnits(contextTokens: number, model: string, ttl: CacheTtl): number {
+  if (contextTokens <= 0) return 0;
+  const warm = Math.min(contextTokens, WARM_PREFIX_TOKENS);
+  const rebuilt = contextTokens - warm;
+  return weightedUnits(
+    {
+      input: 0,
+      output: 0,
+      cacheRead: warm,
+      cacheWrite5m: ttl === "5m" ? rebuilt : 0,
+      cacheWrite1h: ttl === "1h" ? rebuilt : 0,
+    },
+    model,
+  );
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -65,7 +65,7 @@ import type {
   ModelWeekStore,
   WindowKey,
 } from "./usage-limits";
-import { dominantModel, type SessionUsage } from "./usage";
+import { dominantModel, type ResumeSignal, type SessionUsage } from "./usage";
 import { type SandboxProfile, isSandboxProfile } from "./sandbox";
 import { normalizeRepoDefaultModelSetting } from "./default-model";
 import { normalizeRepoDefaultEffortSetting } from "./default-effort";
@@ -644,12 +644,12 @@ const COLS = `id, desig, name, prompt, repoPath, baseBranch, branch, worktreePat
 
 /**
  * The SELECT column list: everything {@link COLS} inserts, plus the OBSERVED runtime identity
- * (#1823). Those two are never part of an INSERT — they are written by the poller once a
- * transcript/rollout actually reports what the agent ran, so a fresh row starts NULL ("not observed
- * yet") on its own. Keeping them out of `COLS` also keeps that constant aligned with `create()`'s
- * placeholder list.
+ * (#1823) and the cold-resume reading (#2042). Neither group is ever part of an INSERT — both are
+ * written by the poller from a transcript (what the agent ran; what resuming it would cost), so a
+ * fresh row starts NULL ("not observed yet" / "never parked") on its own. Keeping them out of
+ * `COLS` also keeps that constant aligned with `create()`'s placeholder list.
  */
-const READ_COLS = `${COLS}, runtimeModel, runtimeEffort`;
+const READ_COLS = `${COLS}, runtimeModel, runtimeEffort, contextTokens, coldResumeAt, resumeCostUnits`;
 
 // ── SQLite row shapes ──────────────────────────────────────────────────────────
 
@@ -673,6 +673,9 @@ type SessionRow = {
   effort: string | null;
   runtimeModel: string | null;
   runtimeEffort: string | null;
+  contextTokens: number | null;
+  coldResumeAt: number | null;
+  resumeCostUnits: number | null;
   readyToMerge: number;
   status: string;
   lastState: string;
@@ -2630,6 +2633,10 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       // These are NOT part of the INSERT (see COLS): the columns default to NULL on their own.
       runtimeModel: null,
       runtimeEffort: null,
+      // Same story for the cold-resume reading (#2042): a brand-new session has never parked.
+      contextTokens: null,
+      coldResumeAt: null,
+      resumeCostUnits: null,
       claudeSessionId: input.claudeSessionId ?? "",
       providerSessionId: strOrEmpty(input.providerSessionId),
       agentProvider: input.agentProvider ?? "claude",
@@ -4122,6 +4129,34 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
   }
 
   /**
+   * Write — or with `null`, CLEAR — a session's cold-resume reading (#2042).
+   *
+   * Unlike {@link setRuntimeIdentity} this does NOT coalesce: the three fields are one measurement
+   * of one park and must move together, so a null argument blanks all three rather than preserving
+   * the last park's numbers. That clear is what keeps a resumed session from carrying a
+   * `coldResumeAt` that is already in the past — which would otherwise satisfy "now > coldResumeAt"
+   * forever and pin the HUD's warning across active, rewarmed work.
+   *
+   * Also deliberately not routed through {@link update}: this runs off the poller's status-edge
+   * path and must not restamp `updatedAt`, for the same reason {@link setRuntimeIdentity} doesn't.
+   */
+  setResumeSignal(id: string, signal: ResumeSignal | null): void {
+    this.db.run(
+      `UPDATE sessions
+         SET contextTokens = ?,
+             coldResumeAt = ?,
+             resumeCostUnits = ?
+       WHERE id = ?`,
+      [
+        signal?.contextTokens ?? null,
+        signal?.coldResumeAt ?? null,
+        signal?.resumeCostUnits ?? null,
+        id,
+      ],
+    );
+  }
+
+  /**
    * Sessions whose observed runtime identity is still incomplete, newest first — the boot backfill's
    * candidate set (see `src/runtime-identity.ts`).
    *
@@ -4773,6 +4808,13 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     // — nothing is known at insert time.
     add("runtimeModel", `runtimeModel TEXT`);
     add("runtimeEffort", `runtimeEffort TEXT`);
+    // Cold-resume reading (#2042) — what the NEXT turn into this session will cost, measured by the
+    // poller at the moment the session parks and cleared the moment it resumes. Like the runtime
+    // identity above, nullable with no default and absent from `COLS`/`create()`: nothing is known
+    // at insert time. NULL means "not parked with a usable reading", never a cost of zero.
+    add("contextTokens", `contextTokens INTEGER`);
+    add("coldResumeAt", `coldResumeAt INTEGER`);
+    add("resumeCostUnits", `resumeCostUnits REAL`);
     add("claudeSessionId", `claudeSessionId TEXT NOT NULL DEFAULT ''`);
     add("providerSessionId", `providerSessionId TEXT NOT NULL DEFAULT ''`);
     add("agentProvider", `agentProvider TEXT NOT NULL DEFAULT 'claude'`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,19 @@ export interface Session {
    *  `runtimeEffort` stays null for Claude sessions: Claude transcripts don't record one. */
   runtimeModel?: string | null;
   runtimeEffort?: string | null;
+  /** COLD-RESUME reading (#2042) — what the next turn into this session will cost, measured by the
+   *  poller from the transcript at the moment the session PARKED, and cleared again the moment it
+   *  resumes. All three move together; null means there is no current park to price (running,
+   *  never parked, Codex, or no usable transcript record).
+   *
+   *  Captured once rather than polled because a parked session's transcript cannot change, and
+   *  persisted rather than pushed because the poller only probes RUNNING sessions — a transient
+   *  signal would be lost on restart for exactly the long-parked sessions this is about. */
+  contextTokens?: number | null;
+  /** ms epoch the main conversation's prompt cache expires. Absolute, so the client decides
+   *  cold-ness against its own ticking clock instead of waiting for a server re-evaluation. */
+  coldResumeAt?: number | null;
+  resumeCostUnits?: number | null;
   readyToMerge: boolean; // manually-toggled "parked / done" flag; orthogonal to status
   /** Epoch ms when a launched merge train marked this PR-session as in-flight;
    *  null when not in a train. Transient: cleared on merge/close, train archive,

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -2,7 +2,7 @@ import { statSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { config } from "./config";
-import { weightedUnits } from "./pricing";
+import { coldResumeUnits, weightedUnits, type CacheTtl } from "./pricing";
 
 /** Dashify a cwd into its ~/.claude/projects directory name: every `/` and `.` → `-`. */
 export function dashify(cwd: string): string {
@@ -95,7 +95,9 @@ export interface SessionUsage {
   messageCount: number;
   lastActivity: number | null;
   byModel: Record<string, number>;
-  /** Count of main-thread warm→cold prefix rebuilds: cacheRead dropped to 0 with a non-zero cache write, after a warm (cacheRead>0) main-thread record. Sidechain records are excluded. */
+  /** Count of main-thread warm→cold prefix rebuilds: a record that cache-WROTE more than half of
+   *  its own context, following a warm (cacheRead>0) main-thread record. Sidechain records are
+   *  excluded. See `tallyRecache` for why this is a ratio and not a cacheRead===0 test. */
   fullRecaches: number;
   /** Count of accepted records whose isSidechain is true. */
   sidechainCount: number;
@@ -121,10 +123,24 @@ interface RecacheCursor {
   prevMainCacheRead: number;
 }
 
+/** Share of a record's own context that must be cache-WRITTEN for it to count as a prefix rebuild.
+ *  Measured over 13,569 consecutive main-thread turn pairs: a warm turn rewrites 0.5–1.4% of its
+ *  context (median), a turn after an expired cache rewrites 82–91%. Nothing lands near the middle,
+ *  so the exact cut point is not sensitive — 0.5 sits in the empty gap. */
+const REBUILD_RATIO = 0.5;
+
 /**
  * Update fullRecaches/sidechainCount for one ACCEPTED (post-dedupe) record.
- * Main-thread warm→cold drop (cacheRead 0 with a write, after a warm record) increments
- * fullRecaches; sidechain records only bump sidechainCount and never touch the cursor.
+ * A main-thread record that rewrites most of its own context, following a warm (cacheRead>0)
+ * main-thread record, increments fullRecaches; sidechain records only bump sidechainCount and
+ * never touch the cursor.
+ *
+ * The test is a RATIO, not `cacheRead === 0`. A real cold resume does not drop cacheRead to zero:
+ * Claude Code layers each request `system prompt → project context → conversation`, and a herd of
+ * parallel sessions keeps that shared leading layer warm, so ~24k of prefix survives (p10 20.8k /
+ * p50 23.5k / p90 28.5k over 168 measured cold resumes) while the conversation body is rewritten.
+ * The old zero test therefore fired on 3 of those 168 — it reported ~0 while cache-miss premium
+ * was 12.9% of all spend in the sampled corpus.
  */
 function tallyRecache(out: SessionUsage, r: ParsedRecord, cursor: RecacheCursor): void {
   if (r.isSidechain) {
@@ -132,8 +148,66 @@ function tallyRecache(out: SessionUsage, r: ParsedRecord, cursor: RecacheCursor)
     return;
   }
   const cacheWrite = r.cacheWrite5m + r.cacheWrite1h;
-  if (cursor.prevMainCacheRead > 0 && r.cacheRead === 0 && cacheWrite > 0) out.fullRecaches += 1;
+  const context = r.input + r.cacheRead + cacheWrite;
+  if (cursor.prevMainCacheRead > 0 && context > 0 && cacheWrite / context > REBUILD_RATIO)
+    out.fullRecaches += 1;
   cursor.prevMainCacheRead = r.cacheRead;
+}
+
+// ── Cold-resume signal (#2042) ───────────────────────────────────────────────
+
+/** What resuming a parked session will cost, derived from its transcript at park time. */
+export interface ResumeSignal {
+  /** Context size the next turn must re-send: the last main-thread record's whole prompt. */
+  contextTokens: number;
+  /** ms epoch the main conversation's cache expires (last main-thread record + the TTL). */
+  coldResumeAt: number;
+  /** Weighted units that first turn back costs once the cache HAS expired. */
+  resumeCostUnits: number;
+}
+
+const TTL_MS: Record<CacheTtl, number> = { "5m": 5 * 60_000, "1h": 60 * 60_000 };
+
+/**
+ * Price the next turn into a session whose transcript is `lines`, from its LAST MAIN-THREAD
+ * record. Returns null when there is nothing to price: no usable record, no known model, or a
+ * record carrying no context.
+ *
+ * Works on any line iterable, so a bounded tail read is as valid as the whole file — only the last
+ * qualifying record matters, and it is by definition at the end.
+ *
+ * SIDECHAINS ARE IGNORED, for the timestamp as much as for the tokens. A subagent runs its own
+ * system prompt and tool set, so its requests neither read nor refresh the parent conversation's
+ * cached prefix — anchoring the TTL on one would postpone `coldResumeAt` past the moment the cache
+ * it describes has actually expired, suppressing the warning exactly when it comes due. (A *fork*
+ * does inherit and re-warm the parent prefix but is recorded the same way, so a session whose last
+ * activity was a fork can be called cold slightly early. Plain subagents dominate, and erring
+ * early is the safe direction.)
+ *
+ * `model` is the model a resume will actually run on — not the session's historical dominant one.
+ */
+export function resumeSignalFrom(
+  lines: Iterable<string>,
+  model: string | null,
+  ttl: CacheTtl,
+): ResumeSignal | null {
+  if (!model) return null;
+  let contextTokens = 0;
+  let lastMainTs = 0;
+  for (const line of lines) {
+    const r = parseLine(line);
+    if (!r || r.isSidechain) continue;
+    const context = r.input + r.cacheRead + r.cacheWrite5m + r.cacheWrite1h;
+    if (context <= 0) continue;
+    contextTokens = context;
+    lastMainTs = r.ts;
+  }
+  if (contextTokens <= 0 || lastMainTs <= 0) return null;
+  return {
+    contextTokens,
+    coldResumeAt: lastMainTs + TTL_MS[ttl],
+    resumeCostUnits: coldResumeUnits(contextTokens, model, ttl),
+  };
 }
 
 /** Accumulate per-session token totals from JSONL lines, deduping by requestId. */

--- a/test/poller-resume-cost.test.ts
+++ b/test/poller-resume-cost.test.ts
@@ -1,0 +1,281 @@
+// Cold-resume reading across the running↔parked boundary (#2042).
+//
+// The marker warns the operator what the FIRST turn back into a parked session will cost, so the
+// reading is measured once when the session parks (its transcript can no longer change) and
+// cleared when it resumes (that turn pays the cost, and every turn after it is warm). These tests
+// pin both edges — especially the clear, without which a resumed session keeps a `coldResumeAt`
+// that is already in the past, satisfies "now > coldResumeAt" forever, and pins the warning across
+// active, rewarmed work.
+import { test, expect } from "bun:test";
+import { SessionStore } from "../src/store";
+import { StatusPoller } from "../src/poller";
+import type { HerdrAgent } from "../src/herdr";
+import type { HerdrState, Session } from "../src/types";
+import type { ResumeSignal } from "../src/usage";
+
+function withListAsync<T extends { list: () => HerdrAgent[] }>(
+  herdr: T,
+): T & { listAsync: () => Promise<HerdrAgent[]> } {
+  return { ...herdr, listAsync: () => Promise.resolve(herdr.list()) };
+}
+
+const claudeSession = {
+  name: "x",
+  prompt: "x",
+  repoPath: "/r",
+  baseBranch: "main",
+  branch: "shepherd/x",
+  worktreePath: "/wt",
+  isolated: true,
+  herdrSession: "default",
+  herdrAgentId: "T1",
+  claudeSessionId: "c0ffee00-0000-4000-8000-000000000001",
+};
+
+function agentIn(state: HerdrState): HerdrAgent {
+  return {
+    agent: "claude",
+    agentStatus: state,
+    cwd: "/wt",
+    name: "",
+    paneId: "p",
+    tabId: "t",
+    terminalId: "T1",
+    workspaceId: "w",
+  };
+}
+
+const PARKED: ResumeSignal = {
+  contextTokens: 180_000,
+  coldResumeAt: 1_800_000_000_000,
+  resumeCostUnits: 1.572,
+};
+
+function makePoller(
+  store: SessionStore,
+  now: () => number,
+  state: () => HerdrState,
+  readResumeSignal: (s: Session) => ResumeSignal | null,
+) {
+  const poller = new StatusPoller(
+    store,
+    withListAsync({
+      list: () => [agentIn(state())],
+      read: () => "",
+      readAsync: async () => "",
+    } as never),
+    () => {},
+    () => {},
+    1000,
+    3000,
+    undefined, // classify: keep the real one — the blocked path dereferences its result
+    now,
+    (() => ({ snapshot: null, activity: null })) as never,
+  );
+  // The reader is the constructor's 24th parameter; assigning it here is the same seam the
+  // detectAuth tests use, rather than threading fifteen positional `undefined`s.
+  (
+    poller as unknown as { readResumeSignal: (s: Session) => ResumeSignal | null }
+  ).readResumeSignal = readResumeSignal;
+  return poller;
+}
+
+/** Drive the poller far enough that one status transition is reconciled. */
+async function settle(poller: StatusPoller, bump: (ms: number) => void, ticks = 2) {
+  for (let i = 0; i < ticks; i++) {
+    await poller.tick();
+    bump(10_000);
+  }
+}
+
+test("running → idle captures the reading", async () => {
+  const store = new SessionStore(":memory:");
+  const row = store.create(claudeSession);
+  let clock = 1_000_000;
+  let state: HerdrState = "working";
+
+  const poller = makePoller(
+    store,
+    () => clock,
+    () => state,
+    () => PARKED,
+  );
+  await settle(poller, (ms) => (clock += ms));
+  expect(store.get(row.id)?.status).toBe("running");
+  expect(store.get(row.id)?.coldResumeAt).toBeNull();
+
+  state = "idle";
+  await settle(poller, (ms) => (clock += ms), 1);
+
+  const parked = store.get(row.id)!;
+  expect(parked.contextTokens).toBe(180_000);
+  expect(parked.coldResumeAt).toBe(1_800_000_000_000);
+  expect(parked.resumeCostUnits).toBeCloseTo(1.572, 6);
+});
+
+// Awaiting the operator is parked too: the cache expires while it waits, exactly as when idle.
+test("running → blocked captures the reading", async () => {
+  const store = new SessionStore(":memory:");
+  const row = store.create(claudeSession);
+  let clock = 1_000_000;
+  let state: HerdrState = "working";
+
+  const poller = makePoller(
+    store,
+    () => clock,
+    () => state,
+    () => PARKED,
+  );
+  await settle(poller, (ms) => (clock += ms));
+
+  state = "blocked";
+  await settle(poller, (ms) => (clock += ms), 1);
+
+  expect(store.get(row.id)?.status).toBe("blocked");
+  expect(store.get(row.id)?.coldResumeAt).toBe(1_800_000_000_000);
+});
+
+test("idle → running CLEARS the reading, so a stale warning cannot survive the resume", async () => {
+  const store = new SessionStore(":memory:");
+  const row = store.create(claudeSession);
+  store.setResumeSignal(row.id, PARKED);
+  let clock = 1_000_000;
+  let state: HerdrState = "idle";
+
+  const poller = makePoller(
+    store,
+    () => clock,
+    () => state,
+    () => PARKED,
+  );
+  await settle(poller, (ms) => (clock += ms));
+
+  state = "working";
+  await settle(poller, (ms) => (clock += ms), 1);
+
+  const resumed = store.get(row.id)!;
+  expect(resumed.status).toBe("running");
+  expect(resumed.contextTokens).toBeNull();
+  expect(resumed.coldResumeAt).toBeNull();
+  expect(resumed.resumeCostUnits).toBeNull();
+});
+
+test("park → resume → park ends on the SECOND park's reading, never the first's", async () => {
+  const store = new SessionStore(":memory:");
+  const row = store.create(claudeSession);
+  let clock = 1_000_000;
+  let state: HerdrState = "working";
+  let reading: ResumeSignal = PARKED;
+
+  const poller = makePoller(
+    store,
+    () => clock,
+    () => state,
+    () => reading,
+  );
+  await settle(poller, (ms) => (clock += ms));
+
+  state = "idle";
+  await settle(poller, (ms) => (clock += ms), 1);
+  expect(store.get(row.id)?.contextTokens).toBe(180_000);
+
+  state = "working";
+  await settle(poller, (ms) => (clock += ms), 1);
+  expect(store.get(row.id)?.contextTokens).toBeNull();
+
+  // The session worked some more, so the next park measures a bigger context.
+  reading = { contextTokens: 260_000, coldResumeAt: 1_900_000_000_000, resumeCostUnits: 2.372 };
+  state = "idle";
+  await settle(poller, (ms) => (clock += ms), 1);
+
+  const reparked = store.get(row.id)!;
+  expect(reparked.contextTokens).toBe(260_000);
+  expect(reparked.coldResumeAt).toBe(1_900_000_000_000);
+});
+
+test("steady state writes nothing — no churn while running, none while parked", async () => {
+  const store = new SessionStore(":memory:");
+  store.create(claudeSession);
+  let clock = 1_000_000;
+  let state: HerdrState = "working";
+  let writes = 0;
+  const realSet = store.setResumeSignal.bind(store);
+  store.setResumeSignal = (id, signal) => {
+    writes += 1;
+    realSet(id, signal);
+  };
+
+  const poller = makePoller(
+    store,
+    () => clock,
+    () => state,
+    () => PARKED,
+  );
+  // Many ticks while running: the resume edge must not re-clear an already-null row.
+  await settle(poller, (ms) => (clock += ms), 5);
+  expect(writes).toBe(0);
+
+  // One park writes once; further parked ticks write nothing more.
+  state = "idle";
+  await settle(poller, (ms) => (clock += ms), 5);
+  expect(writes).toBe(1);
+});
+
+test("a session with no priceable reading is never written", async () => {
+  // Codex sessions and transcript-less Claude sessions both land here via the real reader's null.
+  const store = new SessionStore(":memory:");
+  const row = store.create(claudeSession);
+  let clock = 1_000_000;
+  let state: HerdrState = "working";
+  let writes = 0;
+  const realSet = store.setResumeSignal.bind(store);
+  store.setResumeSignal = (id, signal) => {
+    writes += 1;
+    realSet(id, signal);
+  };
+
+  const poller = makePoller(
+    store,
+    () => clock,
+    () => state,
+    () => null,
+  );
+  await settle(poller, (ms) => (clock += ms));
+
+  state = "idle";
+  await settle(poller, (ms) => (clock += ms), 1);
+
+  expect(writes).toBe(0);
+  expect(store.get(row.id)?.coldResumeAt).toBeNull();
+});
+
+test("a throwing reader leaves the row untouched and does not break the tick", async () => {
+  const store = new SessionStore(":memory:");
+  const row = store.create(claudeSession);
+  let clock = 1_000_000;
+  let state: HerdrState = "working";
+  const warns: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (...args: unknown[]) => void warns.push(args.map(String).join(" "));
+
+  try {
+    const poller = makePoller(
+      store,
+      () => clock,
+      () => state,
+      () => {
+        throw new Error("transcript exploded");
+      },
+    );
+    await settle(poller, (ms) => (clock += ms));
+
+    state = "idle";
+    await settle(poller, (ms) => (clock += ms), 1);
+
+    expect(store.get(row.id)?.status).toBe("idle"); // the tick still reconciled
+    expect(store.get(row.id)?.coldResumeAt).toBeNull();
+    expect(warns.some((w) => w.includes("cold-resume read failed"))).toBe(true);
+  } finally {
+    console.warn = origWarn;
+  }
+});

--- a/test/pricing.test.ts
+++ b/test/pricing.test.ts
@@ -1,5 +1,10 @@
 import { test, expect } from "bun:test";
-import { cacheWriteUnits, weightedUnits } from "../src/pricing";
+import {
+  cacheWriteUnits,
+  coldResumeUnits,
+  weightedUnits,
+  WARM_PREFIX_TOKENS,
+} from "../src/pricing";
 
 test("cacheWriteUnits — opus 5m-only: 1M tokens = 6.25 units", () => {
   expect(cacheWriteUnits({ cacheWrite5m: 1_000_000, cacheWrite1h: 0 }, "claude-opus-4-8")).toBe(
@@ -77,4 +82,53 @@ test("Fable in/out and cache-write rates are identical across both rows", () => 
   expect(cacheWriteUnits({ cacheWrite5m: 1_000_000, cacheWrite1h: 0 }, "claude-fable-5-1")).toBe(
     12.5,
   );
+});
+
+// ── coldResumeUnits (#2042) ─────────────────────────────────────────────────
+// The estimate behind the HUD's cold-resume marker. Its accuracy is what makes showing a NUMBER
+// defensible rather than a bare warning icon, so the arithmetic is pinned exactly.
+
+test("coldResumeUnits — 180k opus on the 1h TTL: 24k re-read + 156k re-written", () => {
+  // 24_000 * 0.5 + 156_000 * 10 = 1_572_000 → 1.572 units.
+  expect(coldResumeUnits(180_000, "claude-opus-5", "1h")).toBeCloseTo(1.572, 6);
+});
+
+test("coldResumeUnits — the same context WARM costs ~17x less", () => {
+  const warm = weightedUnits(
+    { input: 0, output: 0, cacheRead: 180_000, cacheWrite5m: 0, cacheWrite1h: 0 },
+    "claude-opus-5",
+  );
+  expect(warm).toBeCloseTo(0.09, 6);
+  expect(coldResumeUnits(180_000, "claude-opus-5", "1h") / warm).toBeGreaterThan(17);
+});
+
+test("coldResumeUnits — the 5m TTL is cheaper than 1h for the same context", () => {
+  // api-key mode gets the five-minute TTL, whose write rate is 6.25 vs 10 on opus.
+  // 24_000 * 0.5 + 156_000 * 6.25 = 987_000 → 0.987 units.
+  expect(coldResumeUnits(180_000, "claude-opus-5", "5m")).toBeCloseTo(0.987, 6);
+  expect(coldResumeUnits(180_000, "claude-opus-5", "5m")).toBeLessThan(
+    coldResumeUnits(180_000, "claude-opus-5", "1h"),
+  );
+});
+
+test("coldResumeUnits — context at or below the warm prefix prices ENTIRELY at the read rate", () => {
+  // No negative remainder, and the TTL cannot matter when nothing is rewritten.
+  expect(coldResumeUnits(WARM_PREFIX_TOKENS, "claude-opus-5", "1h")).toBeCloseTo(0.012, 6);
+  expect(coldResumeUnits(10_000, "claude-opus-5", "1h")).toBe(
+    coldResumeUnits(10_000, "claude-opus-5", "5m"),
+  );
+  expect(coldResumeUnits(10_000, "claude-opus-5", "1h")).toBeCloseTo(0.005, 6);
+});
+
+test("coldResumeUnits — zero/negative context is free, never NaN", () => {
+  expect(coldResumeUnits(0, "claude-opus-5", "1h")).toBe(0);
+  expect(coldResumeUnits(-1, "claude-opus-5", "1h")).toBe(0);
+});
+
+test("coldResumeUnits — the SAME context costs different money per model", () => {
+  // Why the marker's floor is a unit threshold, not a token count: 150k context is 1.272 units on
+  // opus but 0.2544 on haiku — a token-count floor would mean a ~5x different amount of money.
+  expect(coldResumeUnits(150_000, "claude-opus-5", "1h")).toBeCloseTo(1.272, 6);
+  expect(coldResumeUnits(150_000, "claude-haiku-4-5-20251001", "1h")).toBeCloseTo(0.2544, 6);
+  expect(coldResumeUnits(150_000, "claude-fable-5-1", "1h")).toBeCloseTo(2.526, 6);
 });

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -2515,3 +2515,86 @@ test("pruneMaintainRuns drops old completed rows but never the in-flight adoptio
       .sort(),
   ).toEqual(["new-done", "old-inflight"]);
 });
+
+// ── cold-resume reading (#2042) ────────────────────────────────────────────
+
+test("setResumeSignal round-trips the reading and a fresh session starts null", () => {
+  const s = mk();
+  const row = s.create(base);
+  expect(row.contextTokens).toBeNull();
+  expect(row.coldResumeAt).toBeNull();
+  expect(row.resumeCostUnits).toBeNull();
+  // A freshly-created row and a read-back row must agree — create() builds its return value
+  // rather than re-selecting, so the two shapes can drift silently.
+  expect(s.get(row.id)!.contextTokens).toBeNull();
+
+  s.setResumeSignal(row.id, {
+    contextTokens: 180_000,
+    coldResumeAt: 1_800_000_000_000,
+    resumeCostUnits: 1.572,
+  });
+  const parked = s.get(row.id)!;
+  expect(parked.contextTokens).toBe(180_000);
+  expect(parked.coldResumeAt).toBe(1_800_000_000_000);
+  expect(parked.resumeCostUnits).toBeCloseTo(1.572, 6);
+});
+
+// The stale-warning guard: without a full clear, a resumed session keeps a coldResumeAt that is
+// already in the past, which satisfies "now > coldResumeAt" forever and pins the HUD warning
+// across active, rewarmed work. So null must blank ALL three, not coalesce like setRuntimeIdentity.
+test("setResumeSignal(null) clears all three fields, not just some", () => {
+  const s = mk();
+  const row = s.create(base);
+  s.setResumeSignal(row.id, {
+    contextTokens: 180_000,
+    coldResumeAt: 1_800_000_000_000,
+    resumeCostUnits: 1.572,
+  });
+  s.setResumeSignal(row.id, null);
+  const resumed = s.get(row.id)!;
+  expect(resumed.contextTokens).toBeNull();
+  expect(resumed.coldResumeAt).toBeNull();
+  expect(resumed.resumeCostUnits).toBeNull();
+});
+
+test("setResumeSignal overwrites a previous park's reading outright", () => {
+  const s = mk();
+  const row = s.create(base);
+  s.setResumeSignal(row.id, {
+    contextTokens: 180_000,
+    coldResumeAt: 1_800_000_000_000,
+    resumeCostUnits: 1.572,
+  });
+  s.setResumeSignal(row.id, {
+    contextTokens: 40_000,
+    coldResumeAt: 1_900_000_000_000,
+    resumeCostUnits: 0.172,
+  });
+  const parked = s.get(row.id)!;
+  expect(parked.contextTokens).toBe(40_000);
+  expect(parked.coldResumeAt).toBe(1_900_000_000_000);
+  expect(parked.resumeCostUnits).toBeCloseTo(0.172, 6);
+});
+
+test("a sessions row predating the migration reads the new columns back as null", () => {
+  const dir = mkdtempSync(join(tmpdir(), "shep-store-resume-"));
+  const path = join(dir, "s.db");
+  try {
+    const first = new SessionStore(path);
+    const row = first.create(base);
+    // Simulate a pre-#2042 database: drop the columns the migration adds.
+    const raw = new Database(path);
+    for (const col of ["contextTokens", "coldResumeAt", "resumeCostUnits"]) {
+      raw.run(`ALTER TABLE sessions DROP COLUMN ${col}`);
+    }
+    raw.close();
+    // Re-opening runs migrateSessionColumns, which must re-add them as nullable.
+    const reopened = new SessionStore(path);
+    const migrated = reopened.get(row.id)!;
+    expect(migrated.contextTokens).toBeNull();
+    expect(migrated.coldResumeAt).toBeNull();
+    expect(migrated.resumeCostUnits).toBeNull();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -10,6 +10,7 @@ import {
   dominantModelOf,
   foldSessionBuckets,
   SessionUsageRollup,
+  resumeSignalFrom,
   type RollupSession,
 } from "../src/usage";
 import { sessionCost } from "../src/usage";
@@ -142,7 +143,7 @@ test("warm → cold main-thread sequence counts as 1 fullRecache", () => {
   expect(u.fullRecaches).toBe(1);
 });
 
-test("record with cacheRead>0 is never a fullRecache", () => {
+test("a mostly-CACHED record is not a fullRecache, even with a small write", () => {
   const u = accumulate([
     asst({ requestId: "r1", cacheRead: 5000 }), // warm
     asst({ requestId: "r2", cacheRead: 3000, w5m: 500 }), // still warm → not a recache
@@ -701,4 +702,127 @@ test("SessionUsageRollup: prune walks all records even when first record is ts=0
   const wAfterReappend = r.windowedAccum(sessionId, cutoff);
   expect(wAfterReappend).not.toBeNull();
   expect(wAfterReappend!.input).toBe(11 + 99 + 500); // 610
+});
+
+// ── resumeSignalFrom (#2042) ────────────────────────────────────────────────
+// The cold-resume marker's whole input. Every case here is about picking the right RECORD; the
+// pricing arithmetic is pinned separately in pricing.test.ts.
+
+const HOUR = 3_600_000;
+const T0 = "2026-05-30T09:00:00.000Z";
+const T1 = "2026-05-30T10:00:00.000Z";
+const T2 = "2026-05-30T11:00:00.000Z";
+
+test("resumeSignalFrom — reads the LAST main-thread record, not the largest", () => {
+  const sig = resumeSignalFrom(
+    [
+      asst({ requestId: "r1", ts: T0, cacheRead: 400_000 }), // biggest, but superseded
+      asst({ requestId: "r2", ts: T1, cacheRead: 100_000, w1h: 20_000 }),
+    ],
+    "claude-opus-5",
+    "1h",
+  );
+  expect(sig?.contextTokens).toBe(120_000);
+  expect(sig?.coldResumeAt).toBe(Date.parse(T1) + HOUR);
+});
+
+test("resumeSignalFrom — context is the record's WHOLE prompt, not the session's cumulative total", () => {
+  const sig = resumeSignalFrom(
+    [asst({ requestId: "r1", ts: T0, input: 7, cacheRead: 90_000, w5m: 1_000, w1h: 2_000 })],
+    "claude-opus-5",
+    "1h",
+  );
+  expect(sig?.contextTokens).toBe(93_007);
+});
+
+// The bug this guards: SessionUsage.lastActivity advances for EVERY accepted record, sidechains
+// included. Anchoring the TTL there lets a subagent that finished after the main conversation went
+// quiet push coldResumeAt into the future and suppress the warning exactly when it comes due — the
+// subagent never warmed the parent's prefix.
+test("resumeSignalFrom — a sidechain NEWER than the last main record moves neither field", () => {
+  const mainOnly = resumeSignalFrom(
+    [asst({ requestId: "r1", ts: T0, cacheRead: 150_000 })],
+    "claude-opus-5",
+    "1h",
+  );
+  const withLateSidechain = resumeSignalFrom(
+    [
+      asst({ requestId: "r1", ts: T0, cacheRead: 150_000 }),
+      asst({ requestId: "r2", ts: T2, cacheRead: 9_000, w5m: 500, sidechain: true }),
+    ],
+    "claude-opus-5",
+    "1h",
+  );
+  expect(withLateSidechain).toEqual(mainOnly!);
+  expect(withLateSidechain?.coldResumeAt).toBe(Date.parse(T0) + HOUR);
+});
+
+test("resumeSignalFrom — a transcript of only sidechain records yields null", () => {
+  expect(
+    resumeSignalFrom(
+      [asst({ requestId: "r1", ts: T0, cacheRead: 150_000, sidechain: true })],
+      "claude-opus-5",
+      "1h",
+    ),
+  ).toBeNull();
+});
+
+test("resumeSignalFrom — the TTL picks the expiry: 1h subscription vs 5m api-key", () => {
+  const lines = [asst({ requestId: "r1", ts: T0, cacheRead: 150_000 })];
+  expect(resumeSignalFrom(lines, "claude-opus-5", "1h")?.coldResumeAt).toBe(Date.parse(T0) + HOUR);
+  expect(resumeSignalFrom(lines, "claude-opus-5", "5m")?.coldResumeAt).toBe(
+    Date.parse(T0) + 300_000,
+  );
+});
+
+test("resumeSignalFrom — no model → null, rather than a price guessed at default weights", () => {
+  expect(
+    resumeSignalFrom([asst({ requestId: "r1", ts: T0, cacheRead: 150_000 })], null, "1h"),
+  ).toBeNull();
+});
+
+test("resumeSignalFrom — empty / context-less / timestamp-less transcripts yield null", () => {
+  expect(resumeSignalFrom([], "claude-opus-5", "1h")).toBeNull();
+  expect(resumeSignalFrom(["", "not json"], "claude-opus-5", "1h")).toBeNull();
+  expect(resumeSignalFrom([asst({ requestId: "r1", ts: T0 })], "claude-opus-5", "1h")).toBeNull();
+  expect(
+    resumeSignalFrom(
+      [asst({ requestId: "r1", ts: "", cacheRead: 150_000 })],
+      "claude-opus-5",
+      "1h",
+    ),
+  ).toBeNull();
+});
+
+test("resumeSignalFrom — a bounded TAIL gives the same answer as the whole file", () => {
+  // The poller feeds it readTranscriptTail output; only the last record matters, and it is always
+  // at the end, so a truncated head cannot change the result.
+  const whole = [
+    asst({ requestId: "r1", ts: T0, cacheRead: 400_000 }),
+    asst({ requestId: "r2", ts: T1, cacheRead: 180_000 }),
+  ];
+  expect(resumeSignalFrom(whole, "claude-opus-5", "1h")).toEqual(
+    resumeSignalFrom(whole.slice(1), "claude-opus-5", "1h")!,
+  );
+});
+
+// ── fullRecaches: the real-world cold-resume shape ──────────────────────────
+
+test("fullRecaches — a 24k surviving prefix with a 150k rebuild IS a recache", () => {
+  // Exactly the shape measured in production, and exactly what the old cacheRead===0 rule missed:
+  // it caught 3 of 168 such events.
+  const u = accumulate([
+    asst({ requestId: "r1", cacheRead: 120_000 }), // warm
+    asst({ requestId: "r2", input: 2, cacheRead: 24_000, w1h: 150_000 }), // cold resume
+  ]);
+  expect(u.fullRecaches).toBe(1);
+});
+
+test("fullRecaches — an ordinary warm turn appends a little and is NOT a recache", () => {
+  // A warm turn rewrites ~0.5-1.4% of its context; this is 2k of 152k.
+  const u = accumulate([
+    asst({ requestId: "r1", cacheRead: 120_000 }),
+    asst({ requestId: "r2", input: 2, cacheRead: 150_000, w1h: 2_000 }),
+  ]);
+  expect(u.fullRecaches).toBe(0);
 });

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3965,5 +3965,12 @@
   "settings_card_issue_ref_on": "Issue-Nummer sichtbar",
   "settings_card_issue_ref_off": "Issue-Nummer ausgeblendet",
   "feat_card_issue_ref_title": "Erkennen, an welchem Issue eine Session arbeitet",
-  "feat_card_issue_ref_body": "Eine Session-Karte nannte ihre Aufgabe, aber nicht deren Herkunft: Die Issue-Nummer steckte in der abgeschnittenen Prompt-Zeile, also musste man eine Session öffnen, um sie von der auf dem Nachbar-Issue zu unterscheiden. Karten, die aus einem Backlog-Issue gestartet wurden, tragen jetzt einen kleinen #1234-Chip neben dem PR-Badge — unter Einstellungen → Gerät lässt er sich für die ruhigere Karte abschalten."
+  "feat_card_issue_ref_body": "Eine Session-Karte nannte ihre Aufgabe, aber nicht deren Herkunft: Die Issue-Nummer steckte in der abgeschnittenen Prompt-Zeile, also musste man eine Session öffnen, um sie von der auf dem Nachbar-Issue zu unterscheiden. Karten, die aus einem Backlog-Issue gestartet wurden, tragen jetzt einen kleinen #1234-Chip neben dem PR-Badge — unter Einstellungen → Gerät lässt er sich für die ruhigere Karte abschalten.",
+  "gloss_cold_cache_term": "kalter Cache",
+  "gloss_cold_cache_def": "Der Prompt-Cache einer Session läuft nach einer Zeit ohne Aktivität ab — eine Stunde im Claude-Abonnement, fünf Minuten mit API-Schlüssel. Danach sendet der nächste Zug das gesamte Gespräch zum Cache-Schreibtarif erneut, statt es günstig zurückzulesen; dieser eine Zug kostet dadurch ein Vielfaches der Züge davor und danach.",
+  "coldresume_label": "[[cold-cache|kalt]] · ≈{units} Einheiten",
+  "coldresume_chip": "kalt · ≈{units} Einheiten",
+  "feat_cold_resume_marker_title": "Sieh vor dem Klick, was ein Fortsetzen kostet",
+  "feat_cold_resume_marker_body": "Der Prompt-Cache einer geparkten Session läuft mit der Zeit ab, und der erste Zug zurück sendet ihren gesamten Kontext zum Cache-Schreibtarif erneut — oft die teuerste Anfrage der ganzen Session. Geparkte Sessions, die kalt geworden sind, tragen jetzt einen ⚠-Chip in der Herde und eine passende Markierung in der Status-Leiste, die diese Kosten in gewichteten Einheiten schätzt — sichtbar, bevor du die Session öffnest.",
+  "coldresume_title": "Prompt-Cache abgelaufen — diese Session war länger untätig als ihre Cache-Lebensdauer. Ihre {context} Kontext müssen zum Cache-Schreibtarif erneut gesendet werden, daher kostet der nächste Zug etwa {units} gewichtete Einheiten statt eines kleinen Bruchteils davon."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3965,5 +3965,12 @@
   "settings_card_issue_ref_on": "Issue number shown",
   "settings_card_issue_ref_off": "Issue number hidden",
   "feat_card_issue_ref_title": "See which issue a session is working",
-  "feat_card_issue_ref_body": "A session card named its task but not its origin: the issue number was buried in the truncated prompt line, so telling two sessions on neighbouring issues apart meant opening one. Cards spawned from a backlog issue now carry a small #1234 chip beside the PR badge, and Settings → Device turns it off for anyone who wants the quieter card."
+  "feat_card_issue_ref_body": "A session card named its task but not its origin: the issue number was buried in the truncated prompt line, so telling two sessions on neighbouring issues apart meant opening one. Cards spawned from a backlog issue now carry a small #1234 chip beside the PR badge, and Settings → Device turns it off for anyone who wants the quieter card.",
+  "gloss_cold_cache_term": "cold cache",
+  "gloss_cold_cache_def": "A session's prompt cache expires after a stretch of inactivity — one hour on a Claude subscription, five minutes on an API key. Once it has, the next turn re-sends the whole conversation at the cache-write rate instead of reading it back cheaply, which makes that single turn many times more expensive than the turns around it.",
+  "coldresume_label": "[[cold-cache|cold]] · ≈{units} units",
+  "coldresume_chip": "cold · ≈{units} units",
+  "feat_cold_resume_marker_title": "See what a resume costs before you click",
+  "feat_cold_resume_marker_body": "A session's prompt cache expires while it sits parked, and the first turn back re-sends its whole context at the cache-write rate — often the most expensive request of the session. Parked sessions that have gone cold now carry a ⚠ chip in The Herd, and a matching marker in the session status bar, estimating that cost in weighted units so you can see it before you open the session.",
+  "coldresume_title": "Prompt cache expired — this session has been idle longer than its cache lifetime. Its {context} of context must be re-sent at the cache-write rate, so the next turn costs about {units} weighted units instead of a small fraction of that."
 }

--- a/ui/src/lib/cold-resume.ts
+++ b/ui/src/lib/cold-resume.ts
@@ -1,0 +1,45 @@
+// Cold-resume marker (#2042) — the one place that decides whether a session is expensive to
+// resume, shared by the Herd row (where the operator CHOOSES a session) and the status bar (where
+// they are already in one). Two surfaces reading two copies of this rule would eventually disagree
+// about the same session, so both call `isColdResume`.
+//
+// The server does the pricing: `ui/` has no copy of the model weight table and the two trees don't
+// share a build. What arrives is a cost in weighted units plus `coldResumeAt`, an ABSOLUTE instant.
+// The client only compares that instant against a clock it already ticks, which is why the marker
+// appears the moment the cache expires rather than on the next poll.
+
+import type { Session } from "./types";
+
+/**
+ * Estimated resume cost below which the marker stays silent.
+ *
+ * A cost floor, not a token count, because the same context is worth very different money per
+ * model: 150k tokens is 1.27 units on Opus but 0.25 on Haiku. A token threshold would nag about
+ * the cheap one and stay quiet about a genuinely expensive smaller session.
+ *
+ * At 0.5 units the marker fires from roughly 73k context on Opus, 106k on Sonnet — about half of
+ * parked sessions in the sampled corpus. Warnings that fire on everything stop being read.
+ */
+const COLD_RESUME_MIN_UNITS = 0.5;
+
+/**
+ * Is resuming this session expensive enough to warn about, as of `now`?
+ *
+ * Four conditions, all required:
+ *  - a reading exists (the session parked with a priceable transcript — never true for Codex);
+ *  - the cache has actually expired;
+ *  - the resume costs more than the floor;
+ *  - the session is PARKED. A running session is warm by definition, and its stored reading is
+ *    cleared server-side on the resume edge — this is the backstop for a reading stranded by a
+ *    crash between the park and resume edges, which would otherwise sit permanently in the past
+ *    and pin the warning across active work.
+ *
+ * Archived sessions are excluded too: `DoneRecapPanel` renders the status bar retrospectively, and
+ * a ⚠ there reads as a verdict on finished work rather than a forecast.
+ */
+export function isColdResume(session: Session, now: number): boolean {
+  if (session.status === "running" || session.status === "archived") return false;
+  const { coldResumeAt, resumeCostUnits } = session;
+  if (coldResumeAt == null || resumeCostUnits == null) return false;
+  return now > coldResumeAt && resumeCostUnits >= COLD_RESUME_MIN_UNITS;
+}

--- a/ui/src/lib/components/SessionStatusBar.browser.test.ts
+++ b/ui/src/lib/components/SessionStatusBar.browser.test.ts
@@ -304,3 +304,75 @@ describe("SessionStatusBar", () => {
     expect(document.querySelector('[role="status"]')).toBeNull();
   });
 });
+
+// ── cold-resume marker (#2042) ──────────────────────────────────────────────
+// The bar sits directly above the compose box, so this segment names money the operator is about
+// to spend by typing. It must appear exactly when the cache has expired AND the resume is worth
+// warning about — and must not linger once the session is working again.
+
+const HOUR = 3_600_000;
+
+/** A session parked with a cold, expensive reading: 180k context, ~1.6 weighted units. */
+function coldSession(partial: Partial<Session> = {}): Session {
+  return session({
+    id: "cold",
+    status: "idle",
+    contextTokens: 180_000,
+    coldResumeAt: Date.now() - HOUR,
+    resumeCostUnits: 1.572,
+    ...partial,
+  });
+}
+
+const coldEl = () => document.querySelector(".ssb-cold");
+
+describe("SessionStatusBar cold-resume marker", () => {
+  it("shows the priced marker once the cache has expired", async () => {
+    render(SessionStatusBar, { session: coldSession(), usage: usage() });
+    await expect.element(page.getByText("cold")).toBeInTheDocument();
+    expect(coldEl()?.textContent).toContain("1.6");
+    // The tooltip carries the context size the estimate is built from.
+    expect(coldEl()?.getAttribute("title")).toContain("180k");
+  });
+
+  it("stays silent while the cache is still warm", async () => {
+    render(SessionStatusBar, {
+      session: coldSession({ coldResumeAt: Date.now() + HOUR }),
+      usage: usage(),
+    });
+    expect(coldEl()).toBeNull();
+  });
+
+  it("stays silent below the cost floor, however stale the cache", async () => {
+    // 0.4 units — real, but not worth interrupting for.
+    render(SessionStatusBar, {
+      session: coldSession({ contextTokens: 60_000, resumeCostUnits: 0.4 }),
+      usage: usage(),
+    });
+    expect(coldEl()).toBeNull();
+  });
+
+  it("stays silent when the session was never parked with a reading (Codex, fresh)", async () => {
+    render(SessionStatusBar, {
+      session: coldSession({ contextTokens: null, coldResumeAt: null, resumeCostUnits: null }),
+      usage: usage(),
+    });
+    expect(coldEl()).toBeNull();
+  });
+
+  // DoneRecapPanel renders this bar retrospectively; a ⚠ there reads as a verdict on finished work.
+  it("stays silent on an archived session", async () => {
+    render(SessionStatusBar, {
+      session: coldSession({ status: "archived", archivedAt: Date.now() }),
+      usage: usage(),
+    });
+    expect(coldEl()).toBeNull();
+  });
+
+  // The stale-warning guard: a reading stranded by a crash between the park and resume edges sits
+  // permanently in the past, so "now > coldResumeAt" alone would pin the marker across live work.
+  it("stays silent on a RUNNING session even with a past coldResumeAt still on the row", async () => {
+    render(SessionStatusBar, { session: coldSession({ status: "running" }), usage: usage() });
+    expect(coldEl()).toBeNull();
+  });
+});

--- a/ui/src/lib/components/SessionStatusBar.svelte
+++ b/ui/src/lib/components/SessionStatusBar.svelte
@@ -3,8 +3,11 @@
   import { providerLabel } from "$lib/reviewer-env";
   import { sessionEnvironment } from "$lib/session-env";
   import { formatTokens, elapsedCoarse } from "$lib/format";
+  import { formatUnits } from "$lib/components/usage/format";
+  import { isColdResume } from "$lib/cold-resume";
   import { clock } from "$lib/now.svelte";
   import { m } from "$lib/paraglide/messages";
+  import GlossaryText from "./GlossaryText.svelte";
 
   // `activity` is the LIVE runtime-identity carrier: the poller persists what it observes, but that
   // write raises no session patch, so a running session's fresh model/effort reaches the client only
@@ -78,6 +81,20 @@
       ? m.statusbar_tokens_unavailable_codex_title()
       : m.statusbar_tokens_unavailable_title(),
   );
+
+  // Cold-resume marker (#2042). Priced server-side at the moment the session parked; the only
+  // client-side judgement is "has that instant passed", against the same 30s clock the elapsed
+  // segment ticks on — so the marker appears when the cache actually expires, not at the next poll.
+  const cold = $derived(isColdResume(session, clock.current));
+  const coldLabel = $derived(
+    m.coldresume_label({ units: formatUnits(session.resumeCostUnits ?? 0) }),
+  );
+  const coldTitle = $derived(
+    m.coldresume_title({
+      context: formatTokens(session.contextTokens ?? 0),
+      units: formatUnits(session.resumeCostUnits ?? 0),
+    }),
+  );
 </script>
 
 <!-- Deliberately NOT a live region (no role="status"/aria-live): the elapsed tick and the
@@ -96,6 +113,13 @@
       title={tokensUnavailableTitle}
       aria-label={tokensUnavailableTitle}>—</span
     >
+  {/if}
+  {#if cold}
+    <span class="ssb-sep" aria-hidden="true">·</span>
+    <span class="ssb-cold" title={coldTitle}>
+      <span aria-hidden="true">⚠</span>
+      <GlossaryText text={coldLabel} />
+    </span>
   {/if}
   <span class="ssb-sep" aria-hidden="true">·</span>
   <span class="ssb-elapsed" title={elapsedTitle}>{elapsedText}</span>
@@ -134,6 +158,17 @@
 
   .ssb-unavailable {
     color: var(--color-faint);
+    cursor: help;
+  }
+
+  /* Cold-resume marker (#2042): the one segment allowed to break the muted meta row, because it
+     names money the operator is about to spend by typing into the box below this bar. */
+  .ssb-cold {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+    color: var(--color-warn);
     cursor: help;
   }
 </style>

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -1560,3 +1560,66 @@ describe("UnitRow issue reference", () => {
     expect(document.querySelector(".issue-badge")).toBeNull();
   });
 });
+
+// ── cold-resume chip (#2042) ────────────────────────────────────────────────
+// The Herd is where the operator PICKS which session to resume, so the chip has to be here — the
+// status bar only ever shows the session already open. Gated on the row's own `nowMs` tick.
+
+describe("UnitRow cold-resume chip", () => {
+  const HOUR = 3_600_000;
+
+  /** A session parked with a cold, expensive reading: 180k context, ~1.6 weighted units. */
+  function coldSession(partial: Partial<Session> = {}): Session {
+    return session({
+      id: "cold",
+      status: "idle",
+      contextTokens: 180_000,
+      coldResumeAt: Date.now() - HOUR,
+      resumeCostUnits: 1.572,
+      ...partial,
+    });
+  }
+
+  function renderRow(s: Session, nowMs = Date.now()) {
+    render(UnitRow, { session: s, selected: false, nowMs, onselect: () => {} });
+    return document.querySelector(".chip-cold-resume");
+  }
+
+  it("shows the priced chip once the cache has expired", () => {
+    const chip = renderRow(coldSession());
+    expect(chip?.textContent?.replace(/\s+/g, " ").trim()).toBe("⚠ cold · ≈1.6 units");
+    expect(chip?.getAttribute("title")).toContain("180k");
+  });
+
+  // A plain <span>, never a button: the row is one big click target, and a nested interactive
+  // element (a GlossaryTerm, say) would compete with it for the tap.
+  it("does not add an interactive element to the row's click target", () => {
+    const chip = renderRow(coldSession());
+    expect(chip?.tagName).toBe("SPAN");
+    expect(chip?.querySelector("button")).toBeNull();
+  });
+
+  it("stays silent while the cache is still warm", () => {
+    expect(renderRow(coldSession({ coldResumeAt: Date.now() + HOUR }))).toBeNull();
+  });
+
+  it("stays silent below the cost floor", () => {
+    expect(renderRow(coldSession({ contextTokens: 60_000, resumeCostUnits: 0.4 }))).toBeNull();
+  });
+
+  it("stays silent when the session was never parked with a reading", () => {
+    expect(
+      renderRow(coldSession({ contextTokens: null, coldResumeAt: null, resumeCostUnits: null })),
+    ).toBeNull();
+  });
+
+  // The stale-warning guard: a reading stranded by a crash between the park and resume edges sits
+  // permanently in the past, so "now > coldResumeAt" alone would pin the chip across live work.
+  it("stays silent on a RUNNING session even with a past coldResumeAt still on the row", () => {
+    expect(renderRow(coldSession({ status: "running" }))).toBeNull();
+  });
+
+  it("appears on a blocked session — waiting on the operator goes cold like idling does", () => {
+    expect(renderRow(coldSession({ status: "blocked" }))).not.toBeNull();
+  });
+});

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -41,6 +41,9 @@
   import { toasts } from "$lib/toasts.svelte";
   import { projectIcons } from "$lib/projectIcons.svelte";
   import { m } from "$lib/paraglide/messages";
+  import { formatTokens } from "$lib/format";
+  import { formatUnits } from "$lib/components/usage/format";
+  import { isColdResume } from "$lib/cold-resume";
   import { sessionEnvironment } from "$lib/session-env";
   import { statusTip } from "$lib/actions/statusTip.svelte";
   import { onDestroy } from "svelte";
@@ -598,6 +601,23 @@
           }
         : null,
   );
+  // Cold-resume marker (#2042). The Herd is where the operator PICKS which session to resume, so
+  // the cost belongs here, before the click — not only in the status bar they reach afterwards.
+  // `nowMs` is the Herd's own tick, so the chip appears when the cache actually expires.
+  // Unlike the status bar this renders the term unmarked: a GlossaryTerm is a <button>, and nesting
+  // one inside the row's full-card click target would fight it for the tap. The title carries the
+  // explanation instead.
+  const coldResume = $derived(isColdResume(session, nowMs));
+  const coldResumeChip = $derived(
+    m.coldresume_chip({ units: formatUnits(session.resumeCostUnits ?? 0) }),
+  );
+  const coldResumeTitle = $derived(
+    m.coldresume_title({
+      context: formatTokens(session.contextTokens ?? 0),
+      units: formatUnits(session.resumeCostUnits ?? 0),
+    }),
+  );
+
   // Relaunch is offered only for an in-flight task (see canRelaunch) AND only when the
   // parent wired a handler — never on a concluded/merged record, where it would spawn a
   // duplicate and tear down the finished row.
@@ -952,6 +972,11 @@
       <span class="meta-text" use:statusTip={{ text: environment.tooltip }}
         ><TaskIdButton {session} />{environmentSuffix}</span
       >
+      {#if coldResume}
+        <span class="chip-cold-resume" title={coldResumeTitle}
+          ><span aria-hidden="true">⚠</span> {coldResumeChip}</span
+        >
+      {/if}
       {#if session.manualSteps.length > 0}
         {#if onshowowed}
           <button
@@ -1582,6 +1607,23 @@
     border-radius: 2px;
     color: var(--status-warn);
     background: color-mix(in oklab, var(--status-warn) 12%, transparent);
+  }
+  /* "cold · ≈N units" chip (#2042) — same warn recipe as .chip-manual-steps: both say "this will
+     cost you something if you act on it", and neither is an error. Stays a plain <span> so the
+     row's single click target is untouched. */
+  .chip-cold-resume {
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    font-size: var(--fs-micro);
+    letter-spacing: 0.08em;
+    padding: 1px 6px;
+    border: 1px solid var(--status-warn);
+    border-radius: 2px;
+    color: var(--status-warn);
+    background: color-mix(in oklab, var(--status-warn) 12%, transparent);
+    cursor: help;
   }
   /* chip-as-button variant (#1275) — a <button> resets font/background, so restate the base look
      and layer on the same hover/focus treatment as .manual-steps-ack for a consistent affordance.

--- a/ui/src/lib/demo/seed.ts
+++ b/ui/src/lib/demo/seed.ts
@@ -257,6 +257,12 @@ function buildSessions(): Session[] {
       lastState: "done",
       createdAt: NOW - 8 * HOUR,
       updatedAt: NOW - 70 * MIN,
+      // Cold-resume marker (#2042): an 8-hour session parked 70 minutes ago, so its 1h prompt
+      // cache lapsed ten minutes back. 214k of context re-sent at the sonnet write rate is ~1.1
+      // weighted units — the one demo session that exercises the warn chip and status-bar segment.
+      contextTokens: 214_000,
+      coldResumeAt: NOW - 10 * MIN,
+      resumeCostUnits: 1.147,
       manualSteps: [
         {
           id: "envflag-ms-1",

--- a/ui/src/lib/feature-announcements/entries/v1.48.0-cold-resume-marker.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.48.0-cold-resume-marker.ts
@@ -1,0 +1,8 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+export default {
+  id: "cold-resume-marker",
+  sinceVersion: "1.48.0",
+  titleKey: "feat_cold_resume_marker_title",
+  bodyKey: "feat_cold_resume_marker_body",
+} satisfies FeatureAnnouncement;

--- a/ui/src/lib/glossary.ts
+++ b/ui/src/lib/glossary.ts
@@ -149,6 +149,15 @@ const glossary: readonly GlossaryTerm[] = [
     bodyKey: "gloss_weighted_units_def",
   },
   {
+    // Internal rather than external: "cold cache" has no article of its own, and what the operator
+    // needs is Shepherd's specific meaning — THIS session's prompt cache has expired, so the next
+    // turn back into it is priced at the write rate.
+    id: "cold-cache",
+    kind: "internal",
+    termKey: "gloss_cold_cache_term",
+    bodyKey: "gloss_cold_cache_def",
+  },
+  {
     id: "satellite-pass",
     kind: "internal",
     termKey: "gloss_satellite_pass_term",

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1109,6 +1109,19 @@ export interface Session {
    *  Read through `sessionEnvironment()` rather than directly. */
   runtimeModel?: string | null;
   runtimeEffort?: string | null;
+  /** COLD-RESUME reading (#2042) — what the FIRST turn back into this parked session will cost,
+   *  measured server-side from the transcript when the session parked and cleared again when it
+   *  resumes. All three move together; null/absent means there is no current park to price
+   *  (running, never parked, Codex, or no usable transcript record).
+   *
+   *  Read through `isColdResume()` / `coldResumeUnits()` in `$lib/cold-resume` rather than
+   *  directly — the threshold and the parked-only rule belong in one place, so the Herd row and
+   *  the status bar cannot disagree about one session. */
+  contextTokens?: number | null;
+  /** ms epoch the prompt cache expires. Absolute rather than a server-evaluated boolean, so the
+   *  marker flips on the client's own clock tick instead of waiting for the next poll. */
+  coldResumeAt?: number | null;
+  resumeCostUnits?: number | null;
   status: SessionStatus;
   /** Operator-set "parked / done" flag, orthogonal to status. Default false. */
   readyToMerge: boolean;


### PR DESCRIPTION
Closes #2042.

A parked session's prompt cache expires while it sits — one hour on a subscription, five minutes on an api key. The first turn back re-sends its whole context at the cache-write rate (12.5–20× a cached read), routinely making it the most expensive request of the entire session. Nothing in the HUD said so; the cost only showed up afterwards in a usage report.

Parked sessions that have gone cold now carry a warn chip in **The Herd** — where the operator picks which session to resume — and a matching segment in the **session status bar**, both naming the estimated cost in weighted units.

```
claude · opus · high  ·  1.2M tok  ·  ⚠ cold · ≈1.6 units  ·  4h 12m
```

## The issue's premises didn't survive measurement

The issue flagged its thresholds as guesses and asked for them to be calibrated against real data first. I swept the author's own corpus — **211 transcripts, 13,569 consecutive main-thread turn pairs** — and three of its premises turned out to be wrong.

**1. The idle threshold needs no tuning.** Cold-vs-warm is a step function at exactly the TTL:

| idle gap | n | rebuilt >50% of context |
| --- | --- | --- |
| < 60m | 13,408 | ~0.6% |
| 60–75m | 5 | **100%** |
| 1.5–3h | 23 | **100%** |
| > 12h | 106 | **100%** |

162/162 gaps above 60 minutes were cold; essentially none below.

**2. `fullRecaches` does not detect the event it is named for.** Its `cacheRead === 0` rule fired on **3 of 168** real cold resumes, because cacheRead is never zero — a ~24k prefix survives every time (p10 20.8k / p50 23.5k / p90 28.5k), even across a 675-hour gap. Claude Code layers each request *system prompt → project context → conversation*, and a herd of parallel sessions keeps that shared leading layer warm while each conversation body expires alone. The issue proposed surfacing this metric as retrospective validation; it would have read ~0 while spend burned.

**3. Showing a number is safe.** Pricing `(context − 24k)` at the write rate predicts actual cost at **p50 0.99×, 97% within ±33%**. The issue's worry that an estimate "erodes trust faster than no number" doesn't hold.

**The prize:** those 168 cold resumes cost **367.9 units** where warm would have cost **25.9** — a **342-unit cache-miss premium, 12.9% of all spend in the sample**, at 2.04 units per resume. For scale, `docs/token-usage-analysis.md` puts TASK-295's entire authoring cost at 0.887 units.

## Design decisions

- **Captured once on the park edge, cleared on the resume edge.** `src/poller.ts` only probes *running* sessions, so a per-tick derivation would never see the parked ones this feature is about — but a parked transcript cannot change, so one bounded tail read on `running → idle/done/blocked` is enough. The clear on `→ running` is load-bearing: without it a resumed session keeps a `coldResumeAt` in the past, which satisfies `now > coldResumeAt` forever and pins the warning across active, rewarmed work.
- **Persisted on the session row, not pushed over SSE.** A transient signal would be lost on restart for exactly the long-parked sessions that matter most, since idle sessions are never re-probed.
- **The server prices; the client tells time.** `ui/` has no copy of the model weight table and the two trees don't share a build, so the server sends `coldResumeAt` as an absolute instant and the client compares it against a clock it already ticks — the marker flips when the cache expires, not at the next poll.
- **The TTL anchor is the last MAIN-THREAD record.** `SessionUsage.lastActivity` advances for sidechains too, and a subagent runs its own prefix and never rewarms the parent's — anchoring on one would postpone the warning past the moment it comes due.
- **A cost floor (0.5 weighted units), not a token count.** The same 150k context is 1.27 units on Opus and 0.25 on Haiku; a token threshold would nag about the cheap one and stay quiet about the expensive one.

Codex sessions stay silent (no cache-write premium to model), as do archived ones.

## Also in here

`fullRecaches` is corrected to count a main-thread record that cache-writes more than half its own context. Only `scripts/usage-report.ts` consumes it, and **every pre-existing test case still passes** under the new rule — one test's *name* was corrected, since a mostly-rebuilt record with a surviving prefix now legitimately counts.

`.fallowrc.jsonc` raises UnitRow's template cognitive cap 62 → 64 for the one new `{#if}` (cyclomatic unchanged at 39), in the same documented style as the entries around it.

## Verification

| Gate | Result |
| --- | --- |
| root `bun run lint` / `typecheck` | clean |
| root `bun run test` | 9623 pass, 0 fail |
| `ui/` `bun run check` | 0 errors |
| `ui/` `bun run check:i18n` | 2 locales in parity |
| `ui/` `bun run test` | 5075 pass, 0 fail |
| `check:glossary` / `check-feature-catalog` / `check:announcement-versions` | pass |
| fallow audit | pass |

New coverage: `test/poller-resume-cost.test.ts` (park/resume edges incl. park→resume→park), `resumeSignalFrom` cases in `test/usage.test.ts` (incl. sidechain-newer-than-main), `coldResumeUnits` in `test/pricing.test.ts`, store round-trip + migration in `test/store.test.ts`, and the shown/hidden matrix on both UI surfaces — including the stale-reading case (past `coldResumeAt` on a `running` session renders nothing).

## Follow-ups not taken here

- Subscription **overage** silently drops the TTL to 5m; wiring `src/usage-limits.ts` into the TTL choice is its own change. Same for an operator's own `promptCacheTtl`. Both make the marker fire *late*, never early.
- Sessions already parked when this ships carry no marker until their next park. Self-healing, no backfill.
- #1159 remains the home for the actionable api-key fix (`ENABLE_PROMPT_CACHING_1H=1`).
