### PR TITLE
fix(plan-gate): recover turn-end edges herdr never reports as done

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2234,6 +2234,13 @@ events.subscribe((event, data) => {
     // The real turn-end edge landed → stand the backstop down for this resting episode, so a
     // healthy session never pays a redundant autopilot classify 2 minutes later.
     if (status === "done") turnEndBackstop.markDelivered(id);
+    // Arm the backstop's evidence gate + end its resting episode from the poller's 1 Hz transitions,
+    // not just its own coarse 15s sweep sample: `status` is a point-in-time level, so a working
+    // burst between two sweeps is invisible to the sample (the #1617 problem, same shape as
+    // buildQueueReminder.markRan above). Without this a short turn never arms the gate, a stale
+    // `delivered` suppresses the NEXT turn's genuinely lost edge, and a carried-over settle clock
+    // fires the backstop mid-turn against a half-written plan.
+    if (status === "running" || status === "blocked") turnEndBackstop.markActive(id);
     void sessionRouter
       .onStatus(id, status)
       .catch((err) => console.warn("[session-router] onStatus:", err));

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,6 +190,7 @@ import { RecapService, type LandedWorkEvidence } from "./recap";
 import { PostMergeStepsService } from "./post-merge-steps";
 import { DeliveryFactsService } from "./delivery";
 import { BuildQueueReminderService } from "./build-queue-reminder";
+import { TurnEndBackstopService } from "./turn-end-backstop";
 import { jsonlPathFor } from "./usage";
 import { detectPendingAuthUrl, detectLoginAuthUrl } from "./auth-url";
 import { readTranscriptTail } from "./activity";
@@ -1889,6 +1890,17 @@ onSessionGit(({ id, git }) => {
 // and write-free in the steady state, so it can ride this per-poll event.
 const deliveryFacts = new DeliveryFactsService({ store });
 onSessionGit(({ id, git }) => deliveryFacts.onGit(id, git));
+// Turn-end backstop: herdr's `done` is a "finished and unseen" notification state that VIEWING the
+// pane clears back to `idle`, so an operator watching a session as it finishes destroys the only
+// edge the plan gate's first review and autopilot's onDone key on — and nothing re-checks. This
+// recovers that edge from a settled-idle sweep. `autopilot` is declared below and referenced lazily
+// (the closure runs long after boot); both targets are idempotent/self-guarding, and the `delivered`
+// mark from the real `done` edge keeps a healthy session off this path entirely.
+const turnEndBackstop = new TurnEndBackstopService({
+  store,
+  considerPlan: (s) => planGate.consider(s),
+  autopilotDone: (id) => autopilot.onDone(id),
+});
 deferredStarts.push(() => {
   setInterval(() => {
     if (maintenance.active) return;
@@ -1920,6 +1932,10 @@ deferredStarts.push(() => {
     void buildQueueReminder
       .sweep()
       .catch((err) => console.warn("[build-queue] reminder sweep failed:", err));
+    // settled-idle recovery for a turn end herdr never reported as `done`
+    void turnEndBackstop
+      .sweep()
+      .catch((err) => console.warn("[turn-end-backstop] sweep failed:", err));
   }, 15_000);
 });
 // The standalone critic's enumeration runs on its OWN 60s timer, separate from the 15s
@@ -1952,6 +1968,7 @@ events.subscribe((event, data) => {
     recapService.onArchived(id);
     autoMergedRecapEvidence.delete(id);
     buildQueueReminder.forget(id);
+    turnEndBackstop.forget(id);
     docAgent.onArchived(id);
   }
 });
@@ -2214,6 +2231,9 @@ const sessionRouter = new SessionRouter(
 events.subscribe((event, data) => {
   if (event === "session:status") {
     const { id, status } = data as { id: string; status: string };
+    // The real turn-end edge landed → stand the backstop down for this resting episode, so a
+    // healthy session never pays a redundant autopilot classify 2 minutes later.
+    if (status === "done") turnEndBackstop.markDelivered(id);
     void sessionRouter
       .onStatus(id, status)
       .catch((err) => console.warn("[session-router] onStatus:", err));

--- a/src/turn-end-backstop.ts
+++ b/src/turn-end-backstop.ts
@@ -1,0 +1,227 @@
+// Turn-end backstop — recovers the "agent finished a turn" edge when herdr never reports `done`.
+//
+// herdr's `done` is a "finished, and nobody has looked yet" NOTIFICATION state, not a lifecycle
+// state: viewing the pane clears it back to `idle`, permanently (verified live — `herdr agent focus`
+// on a `done` pane flips it to `idle` and it stays there; `agent read` and the HUD's
+// `terminal session control` attach do NOT clear it). Shepherd keys "the agent finished a turn" on
+// `done` in exactly two places:
+//   - plan-gate.ts shouldConsiderOnSettle() — fires the FIRST plan review on `done`; on `idle` only
+//     when a prior gate already said `changes_requested`, which a first draft never has.
+//   - autopilot.ts handle() — calls onDone() only on `done`.
+// So an operator watching the pane as the agent finishes destroys the only trigger, and nothing
+// re-checks: the session hangs forever. The plan gate concentrates the failure because its directive
+// makes the agent ask questions via AskUserQuestion, so the operator is on that tab exactly when the
+// plan lands.
+//
+// This service does NOT change status semantics, mapState(), or shouldConsiderOnSettle(): the fast
+// path stays as-is and still fires instantly. The backstop only does work when the fast path already
+// failed, so its settle threshold costs latency ONLY in the broken case.
+//
+// It borrows RecapService's / BuildQueueReminderService's settled-idle debounce STRUCTURE. Both
+// dispatch targets are already fully self-guarding, which is what makes re-driving them safe:
+//   - PlanGateService.consider() short-circuits on gate-off, phase not `planning`, a review in
+//     flight or mid-spawn, an already-`approved` gate, a missing/empty plan, an unchanged plan hash,
+//     and a spawn already refused for this exact plan text. A redundant call is a free no-op.
+//   - AutopilotService.onDone() runs through eligible(), which stands down on archived, planning
+//     phase, autopilot disabled, non-isolated codex, pending MCP OAuth, paused, complete, an open PR
+//     outside full-auto, and a classify already in flight.
+
+import { isSettledIdle } from "./recap-core";
+import type { SessionStore } from "./store";
+import type { Session, SessionStatus } from "./types";
+
+/** Matches RecapService and BuildQueueReminderService — the house settled-idle dwell. */
+const DEFAULT_IDLE_THRESHOLD_MS = 120_000;
+
+/** Per-session lifetime cap on recovery ATTEMPTS (runaway guard). */
+const DEFAULT_MAX_ATTEMPTS = 3;
+
+/** The two statuses that mean "the agent is at rest": herdr's view-clearable `done` and the `idle`
+ *  it decays into. The pair {@link isSettledIdle} accepts — kept as a named predicate here because
+ *  this service needs a THREE-state view (active / resting-not-settled / resting-settled) that a
+ *  single boolean can't express. */
+function isResting(status: SessionStatus): boolean {
+  return status === "idle" || status === "done";
+}
+
+interface DebounceEntry {
+  /** epoch ms when the current resting episode began; null whenever the session isn't resting. */
+  settledSince: number | null;
+  /** true once this episode's turn end was recovered (reset when the session re-activates). */
+  firedThisEpisode: boolean;
+  /** true once the REAL `done` edge was routed for this episode — set by {@link
+   *  TurnEndBackstopService.markDelivered}. A healthy session must never pay for a redundant
+   *  autopilot classify, so a delivered episode is never backstopped. Cleared on re-activation so
+   *  the next turn's edge re-marks it. */
+  delivered: boolean;
+  /** true once we've observed this session NOT resting. The evidence gate that makes a restart
+   *  safe: a session already at rest when the process starts was never observed active, so it is
+   *  never backstopped and no restart storm of classify spawns can happen. Mirrors
+   *  BuildQueueReminderService's `sawRunning`. Deliberately NOT reset per episode — it is evidence
+   *  about the session, not about the current rest. */
+  sawActive: boolean;
+  /** lifetime recovery ATTEMPTS for this session, successful or not (runaway guard). Counting
+   *  failures too is deliberate: a rejection leaves `firedThisEpisode` unset so a TRANSIENT failure
+   *  retries on the next tick, and without a bounded attempt count a persistently throwing dispatch
+   *  would retry every sweep forever. */
+  attemptCount: number;
+}
+
+interface Deps {
+  store: Pick<SessionStore, "list">;
+  /** Re-drive the plan gate for a planning-phase session. Idempotent; see the header note. */
+  considerPlan: (s: Session) => Promise<unknown>;
+  /** Re-drive autopilot's turn-end handler. Self-guarding via eligible(); see the header note. */
+  autopilotDone: (id: string) => Promise<void>;
+  now?: () => number;
+  idleThresholdMs?: number;
+  maxAttempts?: number;
+}
+
+export class TurnEndBackstopService {
+  private now: () => number;
+  private idleThresholdMs: number;
+  private maxAttempts: number;
+  private debounce = new Map<string, DebounceEntry>();
+  /** True while a sweep is in flight. The sweep awaits each dispatch, so a slow one can still be
+   *  running when the next tick fires; without this an overlapping sweep would re-pass readyToFire
+   *  for the same session (firedThisEpisode is only set once the dispatch resolves) and deliver a
+   *  duplicate. The tick is DROPPED rather than queued — this is an idle-debounced recovery, so the
+   *  next tick re-evaluates from fresh state. Mirrors BuildQueueReminderService's guard. */
+  private sweeping = false;
+
+  constructor(private deps: Deps) {
+    this.now = deps.now ?? Date.now;
+    this.idleThresholdMs = deps.idleThresholdMs ?? DEFAULT_IDLE_THRESHOLD_MS;
+    this.maxAttempts = deps.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  }
+
+  /** Drop a session's debounce state (call on archive). */
+  forget(id: string): void {
+    this.debounce.delete(id);
+  }
+
+  /**
+   * Record that the REAL `done` status edge was routed for this session, so the backstop stands
+   * down for the current resting episode. Fed from the `session:status` subscriber in index.ts.
+   *
+   * Belt-and-braces rather than load-bearing — a redundant `considerPlan` is free — but it keeps a
+   * healthy session from paying an autopilot classify it doesn't need: onDone() can legitimately
+   * classify and then leave the session idle (e.g. an `unknown` verdict that just surfaces), which
+   * without this flag the backstop would re-drive every episode.
+   */
+  markDelivered(id: string): void {
+    this.entry(id).delivered = true;
+  }
+
+  private entry(id: string): DebounceEntry {
+    let e = this.debounce.get(id);
+    if (!e) {
+      e = {
+        settledSince: null,
+        firedThisEpisode: false,
+        delivered: false,
+        sawActive: false,
+        attemptCount: 0,
+      };
+      this.debounce.set(id, e);
+    }
+    return e;
+  }
+
+  /** End the current resting episode. `sawActive`/`attemptCount` survive — they are per-session
+   *  evidence, not per-episode state. */
+  private resetEpisode(e: DebounceEntry): void {
+    e.settledSince = null;
+    e.firedThisEpisode = false;
+    e.delivered = false;
+  }
+
+  /**
+   * Periodic recovery pass, driven by the shared 15s sweep interval in index.ts. Advances each
+   * active session's resting debounce and re-drives the turn-end consumer that missed its edge.
+   * Never throws: a dispatch rejection is logged and leaves the episode unburned so the next tick
+   * retries, bounded by the per-session attempt cap (see {@link recover}).
+   */
+  async sweep(): Promise<void> {
+    if (this.sweeping) return; // prior sweep still dispatching — skip this tick
+    this.sweeping = true;
+    try {
+      const now = this.now();
+      const live = new Set<string>();
+      for (const s of this.deps.store.list({ activeOnly: true })) {
+        live.add(s.id);
+        await this.considerSession(s, now);
+      }
+      // Forget sessions that are no longer active/listed.
+      for (const id of [...this.debounce.keys()]) {
+        if (!live.has(id)) this.debounce.delete(id);
+      }
+    } finally {
+      this.sweeping = false; // a thrown store error must not wedge the sweep off
+    }
+  }
+
+  /** Advance one session's debounce and recover its turn end if it's overdue. */
+  private async considerSession(s: Session, now: number): Promise<void> {
+    const e = this.entry(s.id);
+
+    // Active (running/blocked) → the episode is over. `blocked` counts as active: a session waiting
+    // on the operator has not finished its turn.
+    if (!isResting(s.status)) {
+      e.sawActive = true;
+      this.resetEpisode(e);
+      return;
+    }
+
+    // First tick at rest only stamps the clock — per the once-on-settled-idle house rule, since
+    // sessions go idle after every steer and firing on the first tick would run mid-work.
+    if (e.settledSince === null) {
+      e.settledSince = now;
+      return;
+    }
+
+    if (!isSettledIdle(s.status, now - e.settledSince, this.idleThresholdMs)) return;
+    if (!this.readyToFire(e)) return;
+    await this.recover(s, e);
+  }
+
+  /** Whether this resting episode is owed a recovered turn end. */
+  private readyToFire(e: DebounceEntry): boolean {
+    return (
+      !e.firedThisEpisode && // once per episode
+      !e.delivered && // the real edge already fired
+      e.sawActive && // evidence gate → restart-safe
+      e.attemptCount < this.maxAttempts // runaway guard
+    );
+  }
+
+  /**
+   * Dispatch the missed edge to the one consumer that owns this session's phase. Routing by phase
+   * (rather than calling both and leaning on autopilot's planning stand-down) keeps the intent
+   * legible: while `planning`, the plan gate owns the session and autopilot is suppressed anyway.
+   *
+   * A rejection does NOT burn the EPISODE — `firedThisEpisode` stays unset, so a transient failure
+   * retries on the next tick. The ATTEMPT is still counted, which is what bounds a persistently
+   * throwing dispatch: without that, a dependency failing every time would be re-driven every 15s
+   * forever.
+   */
+  private async recover(s: Session, e: DebounceEntry): Promise<void> {
+    const phase = s.planPhase ?? "none";
+    e.attemptCount++;
+    try {
+      if (s.planPhase === "planning") await this.deps.considerPlan(s);
+      else await this.deps.autopilotDone(s.id);
+    } catch (err) {
+      console.warn(`[turn-end-backstop] recovery failed for ${s.id} (phase=${phase}):`, err);
+      return;
+    }
+    e.firedThisEpisode = true;
+    // Logged on success only (never per tick), so the previously-invisible rate of lost turn-end
+    // edges is measurable in ~/.shepherd/shepherd.log.
+    console.log(
+      `[turn-end-backstop] recovered lost turn-end id=${s.id} phase=${phase} ` +
+        `status=${s.status} attempt=${e.attemptCount}`,
+    );
+  }
+}

--- a/src/turn-end-backstop.ts
+++ b/src/turn-end-backstop.ts
@@ -114,6 +114,28 @@ export class TurnEndBackstopService {
     this.entry(id).delivered = true;
   }
 
+  /**
+   * Record that the session is ACTIVE again — the RELIABLE arming path, fed from the poller's 1 Hz
+   * `session:status` running/blocked transitions (wired in index.ts). The sweep's own 15s sample is
+   * kept as the coarse fallback but cannot carry this alone: `status` is a point-in-time LEVEL, not
+   * a "recently-active" latch, so a working burst that starts and finishes between two sweeps is
+   * invisible to it (the same problem #1617 fixed for BuildQueueReminderService's `markRan`).
+   *
+   * All three consequences of missing a burst are real, and the third is the dangerous one:
+   *  - `sawActive` never arms, so {@link readyToFire} is false forever and the backstop silently
+   *    does nothing — for exactly the short turns a plan-gate question round produces;
+   *  - the PREVIOUS turn's `delivered` flag survives into the next episode, suppressing a genuinely
+   *    lost `done` edge so the session hangs anyway;
+   *  - `settledSince` is carried over, so a session that resumed work seconds ago already reads as
+   *    settled past the threshold and fires MID-TURN against a half-written plan — precisely what
+   *    the once-on-settled-idle house rule exists to prevent.
+   */
+  markActive(id: string): void {
+    const e = this.entry(id);
+    e.sawActive = true;
+    this.resetEpisode(e);
+  }
+
   private entry(id: string): DebounceEntry {
     let e = this.debounce.get(id);
     if (!e) {
@@ -167,10 +189,10 @@ export class TurnEndBackstopService {
     const e = this.entry(s.id);
 
     // Active (running/blocked) → the episode is over. `blocked` counts as active: a session waiting
-    // on the operator has not finished its turn.
+    // on the operator has not finished its turn. Delegates to {@link markActive} so the sweep's
+    // coarse sample and the 1 Hz event path can never diverge.
     if (!isResting(s.status)) {
-      e.sawActive = true;
-      this.resetEpisode(e);
+      this.markActive(s.id);
       return;
     }
 

--- a/test/turn-end-backstop.test.ts
+++ b/test/turn-end-backstop.test.ts
@@ -187,6 +187,52 @@ test("a rejected dispatch does not burn the episode — the next sweep retries",
   expect(calls).toBe(3); // maxAttempts
 });
 
+// ── 1 Hz markActive path: a working burst between two sweeps is invisible to the sample ──────
+
+test("markActive arms the evidence gate for a burst the sweep never samples", async () => {
+  const h = harness("planning");
+  // The session ran and finished entirely between two sweeps — every sample sees it resting.
+  h.state.status = "idle";
+  h.svc.markActive("S"); // the 1 Hz running transition
+  h.state.status = "idle";
+  await h.svc.sweep(); // first settled tick
+  h.state.t += THRESHOLD + 1;
+  await h.svc.sweep();
+  expect(h.plans).toEqual(["S"]);
+});
+
+test("markActive clears a previous turn's delivered flag", async () => {
+  const h = harness("planning");
+  h.state.status = "running";
+  await h.svc.sweep();
+  h.state.status = "done";
+  h.svc.markDelivered("S"); // turn 1 ended normally
+  await h.svc.sweep();
+  // Turn 2: the session resumes and finishes between sweeps, and THIS turn end is lost.
+  h.svc.markActive("S");
+  h.state.status = "idle";
+  await h.svc.sweep();
+  h.state.t += THRESHOLD + 1;
+  await h.svc.sweep();
+  expect(h.plans).toEqual(["S"]); // not suppressed by turn 1's delivered flag
+});
+
+test("markActive resets the settle clock so a resumed session can't fire mid-turn", async () => {
+  const h = harness("planning");
+  h.state.status = "running";
+  await h.svc.sweep();
+  h.state.status = "idle";
+  await h.svc.sweep(); // clock starts
+  h.state.t += THRESHOLD * 5; // a long rest accrues
+  h.svc.markActive("S"); // ...then the operator steers it; it's working again
+  h.state.status = "idle"; // a sample lands while it is briefly at its prompt mid-turn
+  await h.svc.sweep(); // must be treated as a FIRST settled tick, not an overdue one
+  expect(h.plans).toEqual([]);
+  h.state.t += THRESHOLD + 1; // only a fresh full settle may fire
+  await h.svc.sweep();
+  expect(h.plans).toEqual(["S"]);
+});
+
 test("sweep prunes state for sessions that are no longer listed", async () => {
   const state = { status: "running" as SessionStatus, t: 0, listed: true };
   const plans: string[] = [];

--- a/test/turn-end-backstop.test.ts
+++ b/test/turn-end-backstop.test.ts
@@ -1,0 +1,212 @@
+import { test, expect } from "bun:test";
+import { TurnEndBackstopService } from "../src/turn-end-backstop";
+import type { Session, SessionStatus } from "../src/types";
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+function session(status: SessionStatus, planPhase: Session["planPhase"]): Session {
+  // Only id + status + planPhase are read by the service; the rest is filler.
+  return { id: "S", status, planPhase } as unknown as Session;
+}
+
+const THRESHOLD = 1000;
+
+/** Build a service over a single session whose status + phase are mutable between sweeps. */
+function harness(planPhase: Session["planPhase"] = "planning") {
+  const state = { status: "running" as SessionStatus, planPhase, t: 0 };
+  const plans: string[] = [];
+  const dones: string[] = [];
+  const svc = new TurnEndBackstopService({
+    store: { list: () => [session(state.status, state.planPhase)] } as never,
+    considerPlan: async (s: Session) => {
+      plans.push(s.id);
+    },
+    autopilotDone: async (id: string) => {
+      dones.push(id);
+    },
+    now: () => state.t,
+    idleThresholdMs: THRESHOLD,
+    maxAttempts: 3,
+  });
+  return { svc, state, plans, dones };
+}
+
+/** running → idle → settle. The exact shape of the bug: a turn that ends without `done`. */
+async function restWithoutDone(h: ReturnType<typeof harness>): Promise<void> {
+  h.state.status = "running";
+  await h.svc.sweep(); // observe running → evidence gate armed
+  h.state.status = "idle";
+  await h.svc.sweep(); // first settled tick → start the clock only
+  h.state.t += THRESHOLD + 1;
+  await h.svc.sweep(); // settled → evaluate
+}
+
+// ── the regression ──────────────────────────────────────────────────────────
+
+test("planning session that rests as idle (never done) gets its plan review re-driven", async () => {
+  const h = harness("planning");
+  await restWithoutDone(h);
+  expect(h.plans).toEqual(["S"]);
+  expect(h.dones).toEqual([]);
+});
+
+test("does not fire before the settle threshold elapses", async () => {
+  const h = harness("planning");
+  h.state.status = "running";
+  await h.svc.sweep();
+  h.state.status = "idle";
+  await h.svc.sweep(); // first settled tick — never fires (house rule)
+  expect(h.plans).toEqual([]);
+  h.state.t += THRESHOLD - 1; // still short of the threshold
+  await h.svc.sweep();
+  expect(h.plans).toEqual([]);
+});
+
+// ── guards ──────────────────────────────────────────────────────────────────
+
+test("never fires for a session it did not observe running (restart safety)", async () => {
+  const h = harness("planning");
+  // Process starts with the session already at rest — no running was ever observed.
+  h.state.status = "idle";
+  await h.svc.sweep();
+  h.state.t += THRESHOLD * 10;
+  await h.svc.sweep();
+  expect(h.plans).toEqual([]);
+});
+
+test("a delivered done edge suppresses the backstop for that resting episode", async () => {
+  const h = harness("planning");
+  h.state.status = "running";
+  await h.svc.sweep();
+  h.state.status = "done"; // herdr reported done → the real edge fired
+  h.svc.markDelivered("S");
+  await h.svc.sweep();
+  h.state.t += THRESHOLD + 1;
+  await h.svc.sweep();
+  expect(h.plans).toEqual([]);
+});
+
+test("done that decays to idle stays one episode — still suppressed", async () => {
+  const h = harness("planning");
+  h.state.status = "running";
+  await h.svc.sweep();
+  h.state.status = "done";
+  h.svc.markDelivered("S");
+  await h.svc.sweep();
+  h.state.status = "idle"; // operator viewed the pane; herdr cleared `done`
+  h.state.t += THRESHOLD + 1;
+  await h.svc.sweep();
+  expect(h.plans).toEqual([]);
+});
+
+test("fires at most once per resting episode", async () => {
+  const h = harness("planning");
+  await restWithoutDone(h);
+  h.state.t += THRESHOLD * 5;
+  await h.svc.sweep();
+  await h.svc.sweep();
+  expect(h.plans).toEqual(["S"]);
+});
+
+test("re-arms after the session goes back to work and rests again", async () => {
+  const h = harness("planning");
+  await restWithoutDone(h);
+  expect(h.plans).toEqual(["S"]);
+  await restWithoutDone(h); // running resets the episode; a fresh rest fires again
+  expect(h.plans).toEqual(["S", "S"]);
+});
+
+test("stops firing at the lifetime cap", async () => {
+  const h = harness("planning");
+  for (let i = 0; i < 5; i++) await restWithoutDone(h);
+  expect(h.plans).toHaveLength(3); // maxAttempts
+});
+
+test("an executing session routes to autopilot, not the plan gate", async () => {
+  const h = harness("executing");
+  await restWithoutDone(h);
+  expect(h.dones).toEqual(["S"]);
+  expect(h.plans).toEqual([]);
+});
+
+test("a session with the plan gate off still gets its autopilot turn-end", async () => {
+  const h = harness(null);
+  await restWithoutDone(h);
+  expect(h.dones).toEqual(["S"]);
+  expect(h.plans).toEqual([]);
+});
+
+test("blocked is not a resting state — it never accrues settle time", async () => {
+  const h = harness("planning");
+  h.state.status = "running";
+  await h.svc.sweep();
+  h.state.status = "blocked"; // waiting on the operator, not finished
+  await h.svc.sweep();
+  h.state.t += THRESHOLD * 10;
+  await h.svc.sweep();
+  expect(h.plans).toEqual([]);
+});
+
+test("forget() drops a session's state so a stale episode can't fire after archive", async () => {
+  const h = harness("planning");
+  h.state.status = "running";
+  await h.svc.sweep();
+  h.state.status = "idle";
+  await h.svc.sweep();
+  h.svc.forget("S");
+  h.state.t += THRESHOLD + 1;
+  await h.svc.sweep(); // forget cleared the evidence gate → this is a first sighting again
+  expect(h.plans).toEqual([]);
+});
+
+test("a rejected dispatch does not burn the episode — the next sweep retries", async () => {
+  const state = { status: "running" as SessionStatus, t: 0 };
+  let calls = 0;
+  const svc = new TurnEndBackstopService({
+    store: { list: () => [session(state.status, "planning")] } as never,
+    considerPlan: async () => {
+      calls++;
+      throw new Error("spawn failed");
+    },
+    autopilotDone: async () => {},
+    now: () => state.t,
+    idleThresholdMs: THRESHOLD,
+    maxAttempts: 3,
+  });
+  await svc.sweep();
+  state.status = "idle";
+  await svc.sweep();
+  state.t += THRESHOLD + 1;
+  await svc.sweep(); // throws internally, must not escape the sweep
+  expect(calls).toBe(1);
+  await svc.sweep(); // episode not burned → retried
+  expect(calls).toBe(2);
+  // ...but the retry is BOUNDED: a dependency that throws every time must not be re-driven
+  // every 15s forever, so failed attempts count toward the cap too.
+  for (let i = 0; i < 10; i++) await svc.sweep();
+  expect(calls).toBe(3); // maxAttempts
+});
+
+test("sweep prunes state for sessions that are no longer listed", async () => {
+  const state = { status: "running" as SessionStatus, t: 0, listed: true };
+  const plans: string[] = [];
+  const svc = new TurnEndBackstopService({
+    store: { list: () => (state.listed ? [session(state.status, "planning")] : []) } as never,
+    considerPlan: async (s: Session) => {
+      plans.push(s.id);
+    },
+    autopilotDone: async () => {},
+    now: () => state.t,
+    idleThresholdMs: THRESHOLD,
+    maxAttempts: 3,
+  });
+  await svc.sweep(); // observe running
+  state.listed = false;
+  await svc.sweep(); // gone → pruned
+  state.listed = true;
+  state.status = "idle";
+  await svc.sweep(); // first sighting again, no running observed since the prune
+  state.t += THRESHOLD + 1;
+  await svc.sweep();
+  expect(plans).toEqual([]);
+});


### PR DESCRIPTION
## The bug

Roughly one session in five hung after plan creation: the plan was written, the agent went quiet,
and the adversarial plan reviewer never started — with autopilot on.

## Root cause (confirmed live, not inferred)

**herdr's `done` is a "finished, and nobody has looked yet" notification state, not a lifecycle
state.** Viewing the pane clears it back to `idle`, permanently.

Verified on the live instance:

| Probe | Result |
| --- | --- |
| `herdr agent focus` on a `done` pane | flips to `idle` **instantly**, stays `idle` after unfocus |
| `herdr agent read` | stays `done` |
| `herdr terminal session control` (the HUD's PTY attach) | stays `done` |
| `herdr agent explain` on a `done` and an `idle` pane | both `state: idle`, rule `live_prompt_box` — so `done` is an overlay, not terminal-derived |

Shepherd keyed "the agent finished a turn" on `done` alone in exactly two places:

- `src/plan-gate.ts` → `shouldConsiderOnSettle()` returns true on `done`; on `idle` only when a
  prior gate already decided `changes_requested`. A **first** draft has no prior gate, so it
  returns false.
- `src/autopilot.ts` → `handle()` calls `onDone()` only when `change.status === "done"`.

`src/poller.ts` → `reconcileAgent()` maps herdr state through `mapState()`: only herdr `done`
becomes Shepherd `done`.

So an operator **watching the pane as the planner finishes** destroys the only trigger, and nothing
re-checks — the session hangs forever. Autopilot is silenced by the same lost edge, which is why
"autopilot is on" did not rescue it. The plan gate concentrates the failure because its directive
makes the agent ask questions via `AskUserQuestion`, so the operator is on that tab exactly when the
plan lands.

Caught in the act: session `26017f67` was sitting in `planPhase=planning` with `.shepherd-plan.md`
written, herdr `agent_status: idle`, zero `plan_gates` rows, zero `reviewer_spawns` rows and no
`[plan-gate]` log line. Its hook trail showed two `AskUserQuestion` rounds.

Most of the codebase already treats the two as equivalent — `recap-core.ts` → `isSettledIdle()`,
`recap.ts` → `sweep()`, and `plan-gate.ts` → `shouldCheckPlanDrift()` all accept `idle || done`.
The first-review trigger and `onDone()` were the outliers.

## The fix

`TurnEndBackstopService` (`src/turn-end-backstop.ts`) — a settled-idle sweep that recovers the
missed edge, borrowing the debounce structure `RecapService` and `BuildQueueReminderService` already
use. It rides the existing 15s sweep interval; no new timer.

**Status semantics, `mapState()` and `shouldConsiderOnSettle()` are untouched.** The fast path still
fires instantly; the backstop only does work when the fast path already failed, so its settle
threshold costs latency *only* in the broken case.

Safe to re-drive because both targets already self-guard: `PlanGateService.consider()` short-circuits
on gate-off, wrong phase, in-flight/mid-spawn, approved, missing plan, unchanged plan hash and an
already-refused spawn; `AutopilotService.onDone()` runs through `eligible()`, which stands down on
archived, planning phase, autopilot off, non-isolated codex, pending MCP OAuth, paused, complete, an
open PR outside full-auto, and an in-flight classify.

Guards, each with precedent in `BuildQueueReminderService`:

- **Observed-active evidence gate** — only backstop a session seen non-resting at least once. This
  is what makes a restart safe: a session already at rest when the process starts is never
  backstopped, so there is no restart storm of classify spawns.
- **Never the first settled tick** — per the once-on-settled-idle house rule.
- **`markDelivered()` on the real `done` edge** — a healthy session never pays a redundant autopilot
  classify.
- **Once per episode, plus a per-session attempt cap** — failed attempts count too, so a
  persistently throwing dispatch can't be re-driven every 15s forever.
- **Re-entrancy guard** on the sweep; the tick is dropped, not queued.

Recoveries log one line each, so the previously-invisible rate of lost turn-end edges is now
measurable.

## Verification

`bun run lint` clean · `bun run test` 9700 pass / 0 fail · `bunx tsc --noEmit` clean ·
`bunx fallow audit --base origin/main --fail-on-issues` exit 0.

14 new unit tests cover the regression and every guard, over an injected clock and store — no herdr,
no spawns, no LLM.

## Notes for the reviewer

- **Known duplication (warn-only).** `fallow` flags a 28-line clone between this sweep and
  `build-queue-reminder.ts`'s — the generic "iterate active sessions, consider each, prune dead
  entries" loop. Left as-is deliberately: extracting it would mean editing working code in the
  sibling service for no behavioural gain. Happy to extract as a follow-up if preferred.
- **`push.ts` has the same bug** and was deliberately scoped out — filed as #2267.
- ⚠️ **Unrelated but worth knowing:** `herdr integration status` reports `claude: outdated (v5 < v9)`.
  The installed v5 hook reports session *identity* only, never state, which is why herdr still falls
  back to terminal classification and can produce `done` at all. herdr's docs say an
  actively-reporting integration is authoritative for `idle`/`working`/`blocked` — **a list with no
  `done` in it.** If v9 reports state, `herdr integration install claude` could take this from a
  1-in-5 failure to 100%. This PR would absorb that rather than hang, but every turn end would then
  pay the settle latency. Verify before upgrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
