### PR TITLE
fix(push): recover session-finished push for panes the operator watched

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ import {
   attachMergePush,
   attachUsagePush,
   attachCreditsPush,
+  notifySessionDone,
 } from "./push";
 import { ReadyNotifier } from "./ready-notify";
 import { Presence } from "./presence";
@@ -1892,14 +1893,18 @@ const deliveryFacts = new DeliveryFactsService({ store });
 onSessionGit(({ id, git }) => deliveryFacts.onGit(id, git));
 // Turn-end backstop: herdr's `done` is a "finished and unseen" notification state that VIEWING the
 // pane clears back to `idle`, so an operator watching a session as it finishes destroys the only
-// edge the plan gate's first review and autopilot's onDone key on — and nothing re-checks. This
-// recovers that edge from a settled-idle sweep. `autopilot` is declared below and referenced lazily
-// (the closure runs long after boot); both targets are idempotent/self-guarding, and the `delivered`
-// mark from the real `done` edge keeps a healthy session off this path entirely.
+// edge the plan gate's first review, autopilot's onDone and the "agent finished its turn" push
+// (#2267) key on — and nothing re-checks. This recovers that edge from a settled-idle sweep.
+// `autopilot` is declared below and referenced lazily (the closure runs long after boot); all
+// targets are idempotent/self-guarding, and the `delivered` mark from the real `done` edge keeps a
+// healthy session off this path entirely — which is also what stops a duplicate finish push.
 const turnEndBackstop = new TurnEndBackstopService({
   store,
   considerPlan: (s) => planGate.consider(s),
   autopilotDone: (id) => autopilot.onDone(id),
+  // Same helper attachPush() uses on the real edge, so the recovered push is the one the operator
+  // missed (same kind/tag/cooldown key) rather than a second, separate notification.
+  notifyDone: (id) => notifySessionDone(push, store, id),
 });
 deferredStarts.push(() => {
   setInterval(() => {

--- a/src/push.ts
+++ b/src/push.ts
@@ -545,14 +545,34 @@ export function attachReviewPush(events: EventHub, store: SessionStore, push: Pu
   });
 }
 
+/**
+ * Send the "agent finished its turn" push for one session.
+ *
+ * Two callers reach the same turn end by different routes and MUST produce the same payload —
+ * same kind, same tag, same cooldown key — or a recovered push would land as a second, separate
+ * notification instead of the one the operator missed:
+ *   - {@link attachPush}, on the real `session:status` = `done` edge (the fast path), and
+ *   - TurnEndBackstopService, when herdr never reported `done` because the operator had the pane
+ *     open as the turn ended (#2267).
+ *
+ * Returns the notify promise so the backstop can see a rejection; {@link attachPush} voids it.
+ */
+export function notifySessionDone(
+  push: PushService,
+  store: Pick<SessionStore, "get">,
+  id: string,
+): Promise<boolean> {
+  const name = store.get(id)?.name ?? id;
+  return push.notify({ kind: "done", sessionId: id, tag: id, name });
+}
+
 /** Bridge F3 state events to push notifications. Both events are already edge-triggered. */
 export function attachPush(events: EventHub, store: SessionStore, push: PushService): void {
   events.subscribe((event, data) => {
     if (event === "session:status") {
       const { id, status } = data as { id: string; status: string };
       if (status !== "done") return;
-      const name = store.get(id)?.name ?? id;
-      void push.notify({ kind: "done", sessionId: id, tag: id, name });
+      void notifySessionDone(push, store, id);
     } else if (event === "session:block") {
       const { id, block } = data as { id: string; block: BlockReason | null };
       if (!block) return;

--- a/src/turn-end-backstop.ts
+++ b/src/turn-end-backstop.ts
@@ -4,20 +4,21 @@
 // state: viewing the pane clears it back to `idle`, permanently (verified live — `herdr agent focus`
 // on a `done` pane flips it to `idle` and it stays there; `agent read` and the HUD's
 // `terminal session control` attach do NOT clear it). Shepherd keys "the agent finished a turn" on
-// `done` in exactly two places:
+// `done` in exactly three places:
 //   - plan-gate.ts shouldConsiderOnSettle() — fires the FIRST plan review on `done`; on `idle` only
 //     when a prior gate already said `changes_requested`, which a first draft never has.
 //   - autopilot.ts handle() — calls onDone() only on `done`.
+//   - push.ts attachPush() — the "agent finished its turn" notification, gated on `status === "done"`.
 // So an operator watching the pane as the agent finishes destroys the only trigger, and nothing
-// re-checks: the session hangs forever. The plan gate concentrates the failure because its directive
-// makes the agent ask questions via AskUserQuestion, so the operator is on that tab exactly when the
-// plan lands.
+// re-checks: the session hangs forever and its finish push is silently dropped (#2267). The plan
+// gate concentrates the failure because its directive makes the agent ask questions via
+// AskUserQuestion, so the operator is on that tab exactly when the plan lands.
 //
 // This service does NOT change status semantics, mapState(), or shouldConsiderOnSettle(): the fast
 // path stays as-is and still fires instantly. The backstop only does work when the fast path already
 // failed, so its settle threshold costs latency ONLY in the broken case.
 //
-// It borrows RecapService's / BuildQueueReminderService's settled-idle debounce STRUCTURE. Both
+// It borrows RecapService's / BuildQueueReminderService's settled-idle debounce STRUCTURE. All
 // dispatch targets are already fully self-guarding, which is what makes re-driving them safe:
 //   - PlanGateService.consider() short-circuits on gate-off, phase not `planning`, a review in
 //     flight or mid-spawn, an already-`approved` gate, a missing/empty plan, an unchanged plan hash,
@@ -25,6 +26,8 @@
 //   - AutopilotService.onDone() runs through eligible(), which stands down on archived, planning
 //     phase, autopilot disabled, non-isolated codex, pending MCP OAuth, paused, complete, an open PR
 //     outside full-auto, and a classify already in flight.
+//   - push.notify() drops a send inside its own cooldown window and honors each device's category
+//     selection, on top of the `delivered` stand-down below.
 
 import { isSettledIdle } from "./recap-core";
 import type { SessionStore } from "./store";
@@ -33,8 +36,15 @@ import type { Session, SessionStatus } from "./types";
 /** Matches RecapService and BuildQueueReminderService — the house settled-idle dwell. */
 const DEFAULT_IDLE_THRESHOLD_MS = 120_000;
 
-/** Per-session lifetime cap on recovery ATTEMPTS (runaway guard). */
-const DEFAULT_MAX_ATTEMPTS = 3;
+/** Per-session, PER-CONSUMER cap on consecutive failed dispatches (runaway guard). Deliberately not
+ *  a lifetime cap on recoveries: a session whose pane the operator keeps open loses its turn-end
+ *  edge on EVERY turn, so a lifetime cap would let it hang (or go un-notified) again after the third
+ *  turn. Re-driving once per resting episode is exactly what a healthy `done` edge already does
+ *  every turn — the thing that actually needs bounding is a dispatch that throws every time. */
+const DEFAULT_MAX_CONSECUTIVE_FAILURES = 3;
+
+/** The turn-end consumers this service re-drives, each tracked separately per resting episode. */
+type Consumer = "push" | "phase";
 
 /** The two statuses that mean "the agent is at rest": herdr's view-clearable `done` and the `idle`
  *  it decays into. The pair {@link isSettledIdle} accepts — kept as a named predicate here because
@@ -47,12 +57,18 @@ function isResting(status: SessionStatus): boolean {
 interface DebounceEntry {
   /** epoch ms when the current resting episode began; null whenever the session isn't resting. */
   settledSince: number | null;
-  /** true once this episode's turn end was recovered (reset when the session re-activates). */
-  firedThisEpisode: boolean;
+  /** the consumers whose recovery has landed for THIS episode (reset when the session re-activates).
+   *  Tracked per consumer, not as one flag: a pass dispatches both, so a single flag would mean a
+   *  failing plan-gate/autopilot spawn replays an ALREADY-SENT push on the next 15s tick. */
+  fired: Record<Consumer, boolean>;
   /** true once the REAL `done` edge was routed for this episode — set by {@link
    *  TurnEndBackstopService.markDelivered}. A healthy session must never pay for a redundant
-   *  autopilot classify, so a delivered episode is never backstopped. Cleared on re-activation so
-   *  the next turn's edge re-marks it. */
+   *  autopilot classify or a DUPLICATE finish notification, so a delivered episode is never
+   *  backstopped. Cleared on re-activation so the next turn's edge re-marks it.
+   *
+   *  Deliberately keyed on the status EDGE, not on the push having actually reached a device: a
+   *  send suppressed by push.notify()'s cooldown or by a device muting the `agent` category is the
+   *  existing intended behavior, and re-driving it here would defeat both. */
   delivered: boolean;
   /** true once we've observed this session NOT resting. The evidence gate that makes a restart
    *  safe: a session already at rest when the process starts was never observed active, so it is
@@ -60,11 +76,17 @@ interface DebounceEntry {
    *  BuildQueueReminderService's `sawRunning`. Deliberately NOT reset per episode — it is evidence
    *  about the session, not about the current rest. */
   sawActive: boolean;
-  /** lifetime recovery ATTEMPTS for this session, successful or not (runaway guard). Counting
-   *  failures too is deliberate: a rejection leaves `firedThisEpisode` unset so a TRANSIENT failure
-   *  retries on the next tick, and without a bounded attempt count a persistently throwing dispatch
-   *  would retry every sweep forever. */
-  attemptCount: number;
+  /** consecutive REJECTED dispatches per consumer, reset to 0 by that consumer's next success. A
+   *  rejection leaves the consumer's `fired` flag unset so a TRANSIENT failure retries on the next
+   *  tick; this streak is what stops a persistently throwing dispatch from being re-driven every
+   *  15s forever.
+   *
+   *  Counted per consumer, like `fired`: a plan-gate spawn that throws every time must not also
+   *  silence the finish push, which is a different dependency that is working fine.
+   *
+   *  Like `sawActive` these survive re-activation — a dependency that has failed every pass does
+   *  not become healthy because the agent started another turn, and only a success clears it. */
+  failStreak: Record<Consumer, number>;
 }
 
 interface Deps {
@@ -73,27 +95,31 @@ interface Deps {
   considerPlan: (s: Session) => Promise<unknown>;
   /** Re-drive autopilot's turn-end handler. Self-guarding via eligible(); see the header note. */
   autopilotDone: (id: string) => Promise<void>;
+  /** Send the "agent finished its turn" push the lost `done` edge never triggered (#2267).
+   *  Phase-agnostic, because the real edge in attachPush() is too. */
+  notifyDone: (id: string) => Promise<unknown>;
   now?: () => number;
   idleThresholdMs?: number;
-  maxAttempts?: number;
+  maxConsecutiveFailures?: number;
 }
 
 export class TurnEndBackstopService {
   private now: () => number;
   private idleThresholdMs: number;
-  private maxAttempts: number;
+  private maxConsecutiveFailures: number;
   private debounce = new Map<string, DebounceEntry>();
   /** True while a sweep is in flight. The sweep awaits each dispatch, so a slow one can still be
    *  running when the next tick fires; without this an overlapping sweep would re-pass readyToFire
-   *  for the same session (firedThisEpisode is only set once the dispatch resolves) and deliver a
-   *  duplicate. The tick is DROPPED rather than queued — this is an idle-debounced recovery, so the
-   *  next tick re-evaluates from fresh state. Mirrors BuildQueueReminderService's guard. */
+   *  for the same session (a consumer's `fired` flag is only set once its dispatch resolves) and
+   *  deliver a duplicate. The tick is DROPPED rather than queued — this is an idle-debounced
+   *  recovery, so the next tick re-evaluates from fresh state. Mirrors
+   *  BuildQueueReminderService's guard. */
   private sweeping = false;
 
   constructor(private deps: Deps) {
     this.now = deps.now ?? Date.now;
     this.idleThresholdMs = deps.idleThresholdMs ?? DEFAULT_IDLE_THRESHOLD_MS;
-    this.maxAttempts = deps.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+    this.maxConsecutiveFailures = deps.maxConsecutiveFailures ?? DEFAULT_MAX_CONSECUTIVE_FAILURES;
   }
 
   /** Drop a session's debounce state (call on archive). */
@@ -105,10 +131,11 @@ export class TurnEndBackstopService {
    * Record that the REAL `done` status edge was routed for this session, so the backstop stands
    * down for the current resting episode. Fed from the `session:status` subscriber in index.ts.
    *
-   * Belt-and-braces rather than load-bearing — a redundant `considerPlan` is free — but it keeps a
-   * healthy session from paying an autopilot classify it doesn't need: onDone() can legitimately
-   * classify and then leave the session idle (e.g. an `unknown` verdict that just surfaces), which
-   * without this flag the backstop would re-drive every episode.
+   * Load-bearing for the push consumer — without it a healthy session would be notified twice, by
+   * attachPush() on the edge and again by this sweep two minutes later. For the other two it also
+   * keeps a healthy session from paying an autopilot classify it doesn't need: onDone() can
+   * legitimately classify and then leave the session idle (e.g. an `unknown` verdict that just
+   * surfaces), which without this flag the backstop would re-drive every episode.
    */
   markDelivered(id: string): void {
     this.entry(id).delivered = true;
@@ -141,21 +168,21 @@ export class TurnEndBackstopService {
     if (!e) {
       e = {
         settledSince: null,
-        firedThisEpisode: false,
+        fired: { push: false, phase: false },
         delivered: false,
         sawActive: false,
-        attemptCount: 0,
+        failStreak: { push: 0, phase: 0 },
       };
       this.debounce.set(id, e);
     }
     return e;
   }
 
-  /** End the current resting episode. `sawActive`/`attemptCount` survive — they are per-session
+  /** End the current resting episode. `sawActive`/`failStreak` survive — they are per-session
    *  evidence, not per-episode state. */
   private resetEpisode(e: DebounceEntry): void {
     e.settledSince = null;
-    e.firedThisEpisode = false;
+    e.fired = { push: false, phase: false };
     e.delivered = false;
   }
 
@@ -208,42 +235,83 @@ export class TurnEndBackstopService {
     await this.recover(s, e);
   }
 
-  /** Whether this resting episode is owed a recovered turn end. */
+  /** Whether this resting episode still owes at least one consumer a recovered turn end. */
   private readyToFire(e: DebounceEntry): boolean {
     return (
-      !e.firedThisEpisode && // once per episode
       !e.delivered && // the real edge already fired
       e.sawActive && // evidence gate → restart-safe
-      e.attemptCount < this.maxAttempts // runaway guard
+      (this.owes(e, "push") || this.owes(e, "phase"))
     );
   }
 
+  /** Whether one consumer still owes this episode a dispatch: not yet fired (once per consumer per
+   *  episode) and not written off by its own runaway guard. */
+  private owes(e: DebounceEntry, c: Consumer): boolean {
+    return !e.fired[c] && e.failStreak[c] < this.maxConsecutiveFailures;
+  }
+
   /**
-   * Dispatch the missed edge to the one consumer that owns this session's phase. Routing by phase
-   * (rather than calling both and leaning on autopilot's planning stand-down) keeps the intent
-   * legible: while `planning`, the plan gate owns the session and autopilot is suppressed anyway.
+   * Dispatch the missed edge to every consumer this episode still owes.
    *
-   * A rejection does NOT burn the EPISODE — `firedThisEpisode` stays unset, so a transient failure
-   * retries on the next tick. The ATTEMPT is still counted, which is what bounds a persistently
-   * throwing dispatch: without that, a dependency failing every time would be re-driven every 15s
-   * forever.
+   * The push is phase-agnostic (attachPush() does not look at the phase either) and goes FIRST: it
+   * is the cheapest and the most time-sensitive of the three, and a plan-gate or autopilot spawn
+   * failure must not swallow the operator's notification.
+   *
+   * The other dispatch is routed BY PHASE rather than calling both and leaning on autopilot's
+   * planning stand-down, which keeps the intent legible: while `planning`, the plan gate owns the
+   * session and autopilot is suppressed anyway.
+   *
+   * A rejection does NOT burn that consumer's episode flag, so a transient failure retries on the
+   * next tick — and neither the flag nor the failure streak is shared, so one consumer can neither
+   * replay the other's success nor silence it by failing. What bounds a persistently throwing
+   * dispatch is its own `failStreak` against `maxConsecutiveFailures`.
    */
   private async recover(s: Session, e: DebounceEntry): Promise<void> {
     const phase = s.planPhase ?? "none";
-    e.attemptCount++;
-    try {
-      if (s.planPhase === "planning") await this.deps.considerPlan(s);
-      else await this.deps.autopilotDone(s.id);
-    } catch (err) {
-      console.warn(`[turn-end-backstop] recovery failed for ${s.id} (phase=${phase}):`, err);
-      return;
+    const fired: Consumer[] = [];
+
+    if (this.owes(e, "push")) {
+      if (await this.run(s.id, phase, e, "push", () => this.deps.notifyDone(s.id)))
+        fired.push("push");
     }
-    e.firedThisEpisode = true;
+
+    if (this.owes(e, "phase")) {
+      const dispatch = () =>
+        s.planPhase === "planning" ? this.deps.considerPlan(s) : this.deps.autopilotDone(s.id);
+      if (await this.run(s.id, phase, e, "phase", dispatch)) fired.push("phase");
+    }
+
+    if (fired.length === 0) return;
     // Logged on success only (never per tick), so the previously-invisible rate of lost turn-end
     // edges is measurable in ~/.shepherd/shepherd.log.
     console.log(
       `[turn-end-backstop] recovered lost turn-end id=${s.id} phase=${phase} ` +
-        `status=${s.status} attempt=${e.attemptCount}`,
+        `status=${s.status} consumers=${fired.join(",")}`,
     );
+  }
+
+  /** Run one consumer's dispatch and record the outcome against that consumer alone. Returns
+   *  whether it landed; never throws, so the sweep goes on to the next consumer and next session. */
+  private async run(
+    id: string,
+    phase: string,
+    e: DebounceEntry,
+    c: Consumer,
+    dispatch: () => Promise<unknown>,
+  ): Promise<boolean> {
+    try {
+      await dispatch();
+    } catch (err) {
+      e.failStreak[c]++;
+      console.warn(
+        `[turn-end-backstop] ${c} recovery failed for ${id} ` +
+          `(phase=${phase}, consecutive=${e.failStreak[c]}):`,
+        err,
+      );
+      return false;
+    }
+    e.fired[c] = true;
+    e.failStreak[c] = 0;
+    return true;
   }
 }

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -11,6 +11,7 @@ import {
   attachCreditsPush,
   blockSummary,
   buildPayload,
+  notifySessionDone,
   USAGE_WARN_PCT,
   type NotifyInput,
   type SendFn,
@@ -176,6 +177,30 @@ test("attachPush pushes on session:status=done", async () => {
   await Promise.resolve();
   expect(calls.length).toBe(1);
   expect(calls[0]).toMatchObject({ kind: "done", sessionId: "abc", tag: "abc" });
+});
+
+test("notifySessionDone builds the same payload attachPush sends on the real edge", async () => {
+  // The turn-end backstop recovers a finish push herdr's lost `done` edge never triggered (#2267).
+  // It must reproduce the fast path's payload exactly — a different kind/tag/cooldown key would
+  // land as a SECOND notification instead of the one the operator missed.
+  const calls: any[] = [];
+  const { store, push } = svc(async () => ({}));
+  (push as any).notify = async (p: any) => calls.push(p);
+  const events = new EventHub();
+  attachPush(events, store, push);
+  events.emit("session:status", { id: "abc", status: "done" });
+  await Promise.resolve();
+  await notifySessionDone(push, store, "abc");
+  expect(calls.length).toBe(2);
+  expect(calls[1]).toEqual(calls[0]);
+});
+
+test("notifySessionDone falls back to the id when the session is unknown", async () => {
+  const calls: any[] = [];
+  const { store, push } = svc(async () => ({}));
+  (push as any).notify = async (p: any) => calls.push(p);
+  await notifySessionDone(push, store, "gone");
+  expect(calls[0]).toMatchObject({ kind: "done", sessionId: "gone", tag: "gone", name: "gone" });
 });
 
 test("attachPush ignores non-done statuses", async () => {

--- a/test/turn-end-backstop.test.ts
+++ b/test/turn-end-backstop.test.ts
@@ -16,6 +16,7 @@ function harness(planPhase: Session["planPhase"] = "planning") {
   const state = { status: "running" as SessionStatus, planPhase, t: 0 };
   const plans: string[] = [];
   const dones: string[] = [];
+  const pushes: string[] = [];
   const svc = new TurnEndBackstopService({
     store: { list: () => [session(state.status, state.planPhase)] } as never,
     considerPlan: async (s: Session) => {
@@ -24,11 +25,14 @@ function harness(planPhase: Session["planPhase"] = "planning") {
     autopilotDone: async (id: string) => {
       dones.push(id);
     },
+    notifyDone: async (id: string) => {
+      pushes.push(id);
+    },
     now: () => state.t,
     idleThresholdMs: THRESHOLD,
-    maxAttempts: 3,
+    maxConsecutiveFailures: 3,
   });
-  return { svc, state, plans, dones };
+  return { svc, state, plans, dones, pushes };
 }
 
 /** running → idle → settle. The exact shape of the bug: a turn that ends without `done`. */
@@ -116,10 +120,13 @@ test("re-arms after the session goes back to work and rests again", async () => 
   expect(h.plans).toEqual(["S", "S"]);
 });
 
-test("stops firing at the lifetime cap", async () => {
+test("successful recoveries are NOT capped — every lost turn end is recovered", async () => {
+  // The bug this service exists for repeats on EVERY turn of a watched session, so a lifetime cap
+  // on successes would let it hang (and go un-notified) again from the 4th turn on.
   const h = harness("planning");
   for (let i = 0; i < 5; i++) await restWithoutDone(h);
-  expect(h.plans).toHaveLength(3); // maxAttempts
+  expect(h.plans).toHaveLength(5);
+  expect(h.pushes).toHaveLength(5);
 });
 
 test("an executing session routes to autopilot, not the plan gate", async () => {
@@ -162,6 +169,7 @@ test("forget() drops a session's state so a stale episode can't fire after archi
 test("a rejected dispatch does not burn the episode — the next sweep retries", async () => {
   const state = { status: "running" as SessionStatus, t: 0 };
   let calls = 0;
+  const pushes: string[] = [];
   const svc = new TurnEndBackstopService({
     store: { list: () => [session(state.status, "planning")] } as never,
     considerPlan: async () => {
@@ -169,9 +177,12 @@ test("a rejected dispatch does not burn the episode — the next sweep retries",
       throw new Error("spawn failed");
     },
     autopilotDone: async () => {},
+    notifyDone: async (id: string) => {
+      pushes.push(id);
+    },
     now: () => state.t,
     idleThresholdMs: THRESHOLD,
-    maxAttempts: 3,
+    maxConsecutiveFailures: 3,
   });
   await svc.sweep();
   state.status = "idle";
@@ -182,9 +193,52 @@ test("a rejected dispatch does not burn the episode — the next sweep retries",
   await svc.sweep(); // episode not burned → retried
   expect(calls).toBe(2);
   // ...but the retry is BOUNDED: a dependency that throws every time must not be re-driven
-  // every 15s forever, so failed attempts count toward the cap too.
+  // every 15s forever, so consecutive failed passes stop it.
   for (let i = 0; i < 10; i++) await svc.sweep();
-  expect(calls).toBe(3); // maxAttempts
+  expect(calls).toBe(3); // maxConsecutiveFailures
+  // The push consumer succeeded on the first pass and must NOT be replayed by the retries of the
+  // one that failed — the whole reason the episode flags are per consumer.
+  expect(pushes).toEqual(["S"]);
+});
+
+test("a clean pass resets the failure streak", async () => {
+  const state = { status: "running" as SessionStatus, t: 0, fail: true };
+  let calls = 0;
+  const svc = new TurnEndBackstopService({
+    store: { list: () => [session(state.status, "planning")] } as never,
+    considerPlan: async () => {
+      calls++;
+      if (state.fail) throw new Error("spawn failed");
+    },
+    autopilotDone: async () => {},
+    notifyDone: async () => {},
+    now: () => state.t,
+    idleThresholdMs: THRESHOLD,
+    maxConsecutiveFailures: 3,
+  });
+  const rest = async () => {
+    state.status = "running";
+    await svc.sweep();
+    state.status = "idle";
+    await svc.sweep();
+    state.t += THRESHOLD + 1;
+    await svc.sweep();
+  };
+  await rest(); // fail #1
+  await rest(); // fail #2
+  expect(calls).toBe(2);
+  state.fail = false;
+  await rest(); // succeeds → streak back to 0
+  expect(calls).toBe(3);
+  state.fail = true;
+  // A fresh run of failures gets the full budget again, rather than the session being permanently
+  // written off by two failures that a healthy pass has since disproved.
+  await rest();
+  await rest();
+  await rest();
+  expect(calls).toBe(6);
+  await rest(); // streak exhausted again
+  expect(calls).toBe(6);
 });
 
 // ── 1 Hz markActive path: a working burst between two sweeps is invisible to the sample ──────
@@ -242,9 +296,10 @@ test("sweep prunes state for sessions that are no longer listed", async () => {
       plans.push(s.id);
     },
     autopilotDone: async () => {},
+    notifyDone: async () => {},
     now: () => state.t,
     idleThresholdMs: THRESHOLD,
-    maxAttempts: 3,
+    maxConsecutiveFailures: 3,
   });
   await svc.sweep(); // observe running
   state.listed = false;
@@ -255,4 +310,121 @@ test("sweep prunes state for sessions that are no longer listed", async () => {
   state.t += THRESHOLD + 1;
   await svc.sweep();
   expect(plans).toEqual([]);
+});
+
+// ── the finish push (#2267): a third consumer of the same lost edge ──────────
+
+test("recovers the finish push for a session that rests as idle (never done)", async () => {
+  const h = harness("planning");
+  await restWithoutDone(h);
+  expect(h.pushes).toEqual(["S"]);
+});
+
+test("recovers the finish push regardless of plan phase", async () => {
+  // attachPush() does not look at planPhase, so neither may the recovery: an executing session
+  // that loses its `done` edge must still notify.
+  for (const phase of ["executing", null] as const) {
+    const h = harness(phase);
+    await restWithoutDone(h);
+    expect(h.pushes).toEqual(["S"]);
+  }
+});
+
+test("a delivered done edge suppresses the recovered push — no duplicate notification", async () => {
+  const h = harness("planning");
+  h.state.status = "running";
+  await h.svc.sweep();
+  h.state.status = "done"; // attachPush() already notified off this edge
+  h.svc.markDelivered("S");
+  await h.svc.sweep();
+  h.state.status = "idle"; // operator views the pane; herdr clears `done`
+  h.state.t += THRESHOLD * 10;
+  await h.svc.sweep();
+  expect(h.pushes).toEqual([]);
+});
+
+test("does not push before the settle threshold, or without observed activity", async () => {
+  const early = harness("planning");
+  early.state.status = "running";
+  await early.svc.sweep();
+  early.state.status = "idle";
+  await early.svc.sweep();
+  early.state.t += THRESHOLD - 1;
+  await early.svc.sweep();
+  expect(early.pushes).toEqual([]);
+
+  // Restart safety: a session already at rest when the process started was never observed active.
+  const restarted = harness("planning");
+  restarted.state.status = "idle";
+  await restarted.svc.sweep();
+  restarted.state.t += THRESHOLD * 10;
+  await restarted.svc.sweep();
+  expect(restarted.pushes).toEqual([]);
+});
+
+test("pushes at most once per resting episode, and again on the next lost turn end", async () => {
+  const h = harness("planning");
+  await restWithoutDone(h);
+  h.state.t += THRESHOLD * 5;
+  await h.svc.sweep();
+  await h.svc.sweep();
+  expect(h.pushes).toEqual(["S"]);
+  await restWithoutDone(h); // next turn, edge lost again
+  expect(h.pushes).toEqual(["S", "S"]);
+});
+
+test("a failing push does not suppress the phase-routed recovery", async () => {
+  const state = { status: "running" as SessionStatus, t: 0 };
+  const plans: string[] = [];
+  const svc = new TurnEndBackstopService({
+    store: { list: () => [session(state.status, "planning")] } as never,
+    considerPlan: async (s: Session) => {
+      plans.push(s.id);
+    },
+    autopilotDone: async () => {},
+    notifyDone: async () => {
+      throw new Error("no subscriptions");
+    },
+    now: () => state.t,
+    idleThresholdMs: THRESHOLD,
+    maxConsecutiveFailures: 3,
+  });
+  await svc.sweep();
+  state.status = "idle";
+  await svc.sweep();
+  state.t += THRESHOLD + 1;
+  await svc.sweep();
+  expect(plans).toEqual(["S"]); // the hang fix must not depend on the notification succeeding
+});
+
+test("a permanently failing phase consumer does not silence the finish push", async () => {
+  // The runaway guard is per consumer for this reason: a plan-gate spawn that throws every time is
+  // a different dependency from web-push, and must not write the session off for both.
+  const state = { status: "running" as SessionStatus, t: 0 };
+  let plans = 0;
+  const pushes: string[] = [];
+  const svc = new TurnEndBackstopService({
+    store: { list: () => [session(state.status, "planning")] } as never,
+    considerPlan: async () => {
+      plans++;
+      throw new Error("spawn failed");
+    },
+    autopilotDone: async () => {},
+    notifyDone: async (id: string) => {
+      pushes.push(id);
+    },
+    now: () => state.t,
+    idleThresholdMs: THRESHOLD,
+    maxConsecutiveFailures: 3,
+  });
+  for (let i = 0; i < 6; i++) {
+    state.status = "running";
+    await svc.sweep();
+    state.status = "idle";
+    await svc.sweep();
+    state.t += THRESHOLD + 1;
+    await svc.sweep();
+  }
+  expect(plans).toBe(3); // written off by its own streak
+  expect(pushes).toHaveLength(6); // every lost turn end still notified
 });


### PR DESCRIPTION
`src/push.ts` → `attachPush()` gates the "session finished" push on `status !== "done"`. herdr's
`done` is a *"finished, and nobody has looked yet"* notification state, not a lifecycle state —
viewing the pane clears it back to `idle` — so any session the operator had open when it finished
never reports `done` and its finish push is silently dropped.

Same lost edge #2268 fixed for the plan gate and autopilot with `TurnEndBackstopService`; push.ts
was deliberately left out of that PR's scope.

## What this does

Routes the finish push through that backstop as a **third consumer**, next to the plan gate and
autopilot. The other candidate — accepting `idle` at the push site — was rejected: `idle` is a
point-in-time level and sessions go idle after every steer, so that site would need its own
settled-idle debounce, evidence gate and per-episode dedupe, i.e. a second copy of the backstop
living in `push.ts`.

The backstop already owns every guard this push needs and `push.ts` owns none of them: the 120s
settled-idle dwell (an `idle` blip after a steer must not fire "agent finished"), the `sawActive`
evidence gate (a restart cannot emit a burst of finish pushes), once per resting episode, and the
`delivered` stand-down fed from the real `done` edge — which is what stops a healthy session being
notified twice. `attachPush()`'s `status !== "done"` gate is untouched, so the fast path still
fires instantly; the dwell costs latency only in the already-broken case.

Both callers now build the payload through one exported `notifySessionDone()`, so the recovered
push is the one the operator missed (same kind/tag/cooldown key) rather than a second, separate
notification.

## Two state-model changes this forced

**Per-consumer episode flags.** A recovery pass now dispatches two things, so the single
`firedThisEpisode` flag would let a failing plan-gate spawn replay an already-sent push on the next
15s tick.

**The runaway guard moves from a lifetime cap to consecutive failures, counted per consumer.** It
was a lifetime cap of 3 recovery *attempts* per session, counting successes. That doesn't survive a
third consumer: the lost edge repeats on **every** turn of a watched session, so a lifetime cap
means the session hangs (and goes un-notified) again from the fourth turn on. Resetting on success
keeps the guard's actual purpose — bounding a dispatch that throws every time — and re-driving once
per resting episode is exactly what a healthy `done` edge already does every turn. Counting per
consumer matters too: a plan-gate spawn that throws every time must not also silence the finish
push, which is a different dependency that is working fine.

Stated plainly: this also lifts the lifetime-3 ceiling for the existing plan-gate and autopilot
consumers, so autopilot's classify can now be re-driven once per resting episode indefinitely. That
is deliberate and is parity with the healthy path's per-turn cost; both targets remain fully
self-guarding.

## Verification

Root `bun run lint`, `bunx tsc --noEmit` and `bun run test` (9713 pass / 0 fail) are green, as is
the pre-push fallow delta audit. No UI/extension change and no new user-facing string — the `done`
push kind already has EN+DE catalog entries.

New tests cover: the recovered push for a session that rests as `idle`, phase-agnostic recovery,
the `delivered` stand-down (no duplicate), the dwell and restart-safety gates, once per episode and
re-arming on the next lost turn end, a failing push not suppressing the phase-routed recovery, a
failing phase consumer not silencing the push, and the streak resetting on a clean pass.

Closes #2267

🤖 Generated with [Claude Code](https://claude.com/claude-code)
