### PR TITLE
fix(maintain): dedupe block signals per episode, drop block from incident band

### DIFF
--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -258,7 +258,7 @@ disposable worktree and nothing else. **Tier 3** skips the issue and opens a **p
 | Band | Measures | Window | Tier 1 | Tier 2 |
 | --- | --- | --- | --- | --- |
 | `critic_error_rate` | Share of outcome-bearing review spawns that errored (produced no verdict) | 7 days, min sample 10 | ≥ `0.15` | ≥ `0.30` |
-| `incident_spike` | `signals` per kind — needs **both** an occurrence count and a distinct-session count, so one thrashing task can't trip it. The `reply` kind is excluded (operator corrections are high-volume by design) | 7 days | ≥ 10 occurrences **and** ≥ 3 sessions | ≥ 25 occurrences **and** ≥ 5 sessions |
+| `incident_spike` | `signals` per kind — needs **both** an occurrence count and a distinct-session count, so one thrashing task can't trip it. The `reply` and `block` kinds are excluded — operator corrections and an agent asking the operator a question are both high-volume by design, not fault classes | 7 days | ≥ 10 occurrences **and** ≥ 3 sessions | ≥ 25 occurrences **and** ≥ 5 sessions |
 | `first_pass_collapse` | Per-repo first-pass review rate — direction is **inverted**, a lower rate is worse | 30 days, min sample 8 | ≤ `0.60` | ≤ `0.40` |
 | `dead_code_drift` | Auto-fixable dead-code findings in Shepherd's own checkout (`fallow dead-code`). Point-in-time, no window and no minimum sample. Declares a tier-3 fix class, so its tier-2 breach is **promoted to tier 3** | now | ≥ 1 finding | ≥ 3 findings |
 

--- a/src/maintain-core.ts
+++ b/src/maintain-core.ts
@@ -46,11 +46,18 @@ export const FIRST_PASS_RANGE = "30d" as const;
 const FIRST_PASS_WINDOW_DAYS = 30;
 
 /**
- * `incident_spike` evaluates every SignalKind EXCEPT this one. `reply` is the learnings flywheel's
- * operator-correction stream — high-volume by design and not an incident class, so including it
- * would put the band permanently in breach on a healthy install.
+ * `incident_spike` evaluates every SignalKind EXCEPT these. Both are high-volume BY DESIGN rather
+ * than fault streams, so including them puts the band permanently in breach on a healthy install:
+ *
+ * - `reply` is the learnings flywheel's operator-correction stream.
+ * - `block` is an agent asking the operator a question (#2242). Every payload in the breach that
+ *   filed that issue was a healthy planning dialog — which ruleset to use, how far a fix should go.
+ *   Deduping the repaint noise alone does NOT rescue this band: measured on a live install, one
+ *   row per episode still left 52–78 occurrences across 32 sessions against a 25/5 tier-2
+ *   threshold, so the band would simply re-file. Genuine faults stay covered by `stall`, `critic`
+ *   and `injection_detected`.
  */
-const INCIDENT_KIND_EXCLUDED: SignalKind = "reply";
+const INCIDENT_KINDS_EXCLUDED: ReadonlySet<SignalKind> = new Set<SignalKind>(["reply", "block"]);
 
 /** How long a band is suppressed after a run COMPLETES, whatever its outcome or tier. */
 export const DEFAULT_COOLDOWN_MS = 14 * 24 * 60 * 60 * 1000;
@@ -440,7 +447,7 @@ export function evaluateBands(
 
   // ── incident_spike (global, one row per signal kind) ────────────────────────
   for (const row of input.incidents) {
-    if (row.kind === INCIDENT_KIND_EXCLUDED) continue;
+    if (INCIDENT_KINDS_EXCLUDED.has(row.kind)) continue;
     out.push({
       key: bandKey("incident_spike", row.kind),
       bandId: "incident_spike",

--- a/src/maintain.ts
+++ b/src/maintain.ts
@@ -222,6 +222,7 @@ export type MaintainStore = Pick<
   | "countSignalsByKind"
   | "listSignalsByKind"
   | "upsertMaintainReading"
+  | "pruneMaintainReadings"
   | "listMaintainReadings"
   | "insertMaintainRun"
   | "finishMaintainRun"
@@ -407,6 +408,10 @@ export class MaintainService {
 
     const readings = evaluateBands(await this.gather(now), this.thresholds, now);
     for (const r of readings) this.deps.store.upsertMaintainReading(r);
+    // Retire readings this sweep did not produce, so a band that stopped being evaluated (an
+    // excluded signal kind, a repo that no longer exists) can't sit on the Delivery lens forever
+    // at its last tier. See `pruneMaintainReadings` for why an empty set is a no-op.
+    this.deps.store.pruneMaintainReadings(readings.map((r) => r.key));
 
     // Tier 1 IS this log line plus the persisted reading — deliberately not a `signals` row.
     const breached = breaches(readings);

--- a/src/signals.ts
+++ b/src/signals.ts
@@ -1,27 +1,71 @@
 import type { EventHub } from "./events";
 import type { SessionStore } from "./store";
 import type { BlockReason } from "./blocked";
+import type { SignalKind } from "./types";
+
+/**
+ * How long after an observed block event the same session+kind stays inside one EPISODE (#2242).
+ *
+ * The poller re-emits `session:block` on every terminal repaint of a waiting dialog: its dedup key
+ * is `JSON.stringify(reason)` and `reason.tail` is the last 15 visible lines, so a scrolled
+ * context, an advancing checkbox row or a live counter yields a different signature and a fresh
+ * emit every `reclassifyMs` (default 3s). Measured on a live install: 181 `block` rows across 32
+ * sessions in 7 days, of which 103 landed within 30s of the previous row in the same session and
+ * 40 within 5s. Deduping on the payload is near-useless (181 → 169) precisely because the repaints
+ * DIFFER; time adjacency is the signature that separates repaints from distinct episodes.
+ */
+const EPISODE_DEBOUNCE_MS = 60_000;
 
 /**
  * Capture `block` and `stall` learning signals off the `session:block` event.
  * Reply signals are captured in SessionService.reply; critic signals in ReviewService.
  * A `stall`-shaped block becomes a "stall" signal; every other shape a "block" signal.
  * Cleared blocks (block: null) and unknown sessions are ignored.
+ *
+ * DEDUPED PER EPISODE (#2242): repeated block events for the same session+kind collapse into one
+ * signal row. The dedup lives HERE and not in the poller on purpose — `session:block` also drives
+ * the UI block card's tail, the herdr state push and the working-while-blocked flag, all of which
+ * want per-repaint accuracy; the `signals` table is the only consumer that over-counts. Keyed by
+ * kind as well as session so a `stall` and a `block` in the same session never share a window
+ * (`stall` is already once-per-episode via the poller's fixed `STALL_SIG`, so the window is inert
+ * there — it is applied uniformly rather than special-cased).
+ *
+ * The window SLIDES: every observed event re-stamps the key, so an episode that keeps repainting
+ * stays one episode however long it runs, and a new row needs a real `debounceMs` lull in the
+ * event stream. A `block: null` clear deliberately does NOT reset it — the poller drops `lastSig`
+ * in both `trySuppressSpinner` and `clearBlock`, so an episode keyed on clear events would still
+ * write a fresh row on every spinner-suppression or leave-blocked flap, which is the amplifier
+ * this is here to neutralise.
  */
 export function attachSignalCapture(
   events: Pick<EventHub, "subscribe">,
   store: Pick<SessionStore, "get" | "addSignal">,
+  opts?: { now?: () => number; debounceMs?: number },
 ): () => void {
+  const now = opts?.now ?? (() => Date.now());
+  const debounceMs = opts?.debounceMs ?? EPISODE_DEBOUNCE_MS;
+  /** session+kind → when that key was last OBSERVED (not last written). */
+  const lastSeenAt = new Map<string, number>();
   return events.subscribe((event, data) => {
     if (event !== "session:block") return;
     const { id, block } = data as { id: string; block: BlockReason | null };
     if (!block) return;
     const s = store.get(id);
     if (!s) return;
+    const kind: SignalKind = block.shape === "stall" ? "stall" : "block";
+    const t = now();
+    // Bound the map by the sessions currently blocking: anything past the window can no longer
+    // suppress a write, so it is dead weight. Cheap — the map only ever holds blocked sessions.
+    for (const [k, at] of lastSeenAt) if (t - at >= debounceMs) lastSeenAt.delete(k);
+    // NUL-joined so no session id / kind pair can collide into another key.
+    const key = `${s.id}\u0000${kind}`;
+    const seen = lastSeenAt.has(key);
+    lastSeenAt.set(key, t); // slide the window on every event, written or not
+    if (seen) return; // still inside the episode → a repaint, not a new incident
     store.addSignal({
       repoPath: s.repoPath,
       sessionId: s.id,
-      kind: block.shape === "stall" ? "stall" : "block",
+      kind,
       payload: block.tail.join("\n"),
     });
   });

--- a/src/store.ts
+++ b/src/store.ts
@@ -4615,6 +4615,28 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     );
   }
 
+  /**
+   * Drop every reading whose band key the latest sweep did NOT produce, and return how many went
+   * (#2242).
+   *
+   * `upsertMaintainReading` only ever writes, so a band that stops being evaluated — a kind added
+   * to the incident-band exclusion, a repo that no longer exists — would otherwise leave its last
+   * reading in the table forever. That is not merely untidy: `listMaintainReadings` orders
+   * `tier DESC`, so a retired tier-2 row pins itself to the top of the Delivery lens band card at
+   * a frozen `evaluatedAt`, and the exclusion that retired it looks inert to the operator.
+   *
+   * An EMPTY `keepKeys` deletes nothing. A sweep always produces at least the global bands, so an
+   * empty set means the caller has no measurement rather than a measurement of nothing — wiping
+   * the table on it would turn a degraded gather into data loss.
+   */
+  pruneMaintainReadings(keepKeys: readonly string[]): number {
+    if (keepKeys.length === 0) return 0;
+    const placeholders = keepKeys.map(() => "?").join(",");
+    return this.db.run(`DELETE FROM maintain_readings WHERE bandKey NOT IN (${placeholders})`, [
+      ...keepKeys,
+    ]).changes;
+  }
+
   /** Every band's latest reading, most severe first then most recent. */
   listMaintainReadings(): BandReading[] {
     const rows = this.db

--- a/test/maintain-core.test.ts
+++ b/test/maintain-core.test.ts
@@ -128,14 +128,19 @@ describe("critic_error_rate band", () => {
 });
 
 describe("incident_spike band", () => {
-  it("excludes the `reply` kind — the correction stream is not an incident class", () => {
+  it("excludes the high-volume-by-design kinds, whatever their counts", () => {
     const readings = evaluate({
       incidents: [
+        // The operator-correction stream...
         { kind: "reply", occurrences: 500, sessions: 40 },
+        // ...and an agent asking the operator a question (#2242). Neither is a fault class, so
+        // neither may produce a reading however far past the tier-2 counts it runs.
+        { kind: "block", occurrences: 500, sessions: 40 },
         { kind: "stall", occurrences: 1, sessions: 1 },
       ],
     });
     expect(readings.some((r) => r.key === "incident_spike:reply")).toBe(false);
+    expect(readings.some((r) => r.key === "incident_spike:block")).toBe(false);
     expect(readings.some((r) => r.key === "incident_spike:stall")).toBe(true);
   });
 
@@ -149,21 +154,21 @@ describe("incident_spike band", () => {
 
   it("logs when both tier-1 counts are met", () => {
     const r = readingFor(
-      evaluate({ incidents: [{ kind: "block", occurrences: 10, sessions: 3 }] }),
-      "incident_spike:block",
+      evaluate({ incidents: [{ kind: "critic", occurrences: 10, sessions: 3 }] }),
+      "incident_spike:critic",
     );
     expect(r.tier).toBe(1);
   });
 
   it("diagnoses only when both tier-2 counts are met", () => {
     const nearMiss = readingFor(
-      evaluate({ incidents: [{ kind: "block", occurrences: 25, sessions: 4 }] }),
-      "incident_spike:block",
+      evaluate({ incidents: [{ kind: "critic", occurrences: 25, sessions: 4 }] }),
+      "incident_spike:critic",
     );
     expect(nearMiss.tier).toBe(1);
     const hit = readingFor(
-      evaluate({ incidents: [{ kind: "block", occurrences: 25, sessions: 5 }] }),
-      "incident_spike:block",
+      evaluate({ incidents: [{ kind: "critic", occurrences: 25, sessions: 5 }] }),
+      "incident_spike:critic",
     );
     expect(hit.tier).toBe(2);
   });
@@ -247,11 +252,11 @@ describe("breaches", () => {
     const readings = evaluate({
       incidents: [
         { kind: "stall", occurrences: 30, sessions: 9 },
-        { kind: "block", occurrences: 30, sessions: 9 },
+        { kind: "critic", occurrences: 30, sessions: 9 },
       ],
     });
     expect(breaches(readings).map((r) => r.key)).toEqual([
-      "incident_spike:block",
+      "incident_spike:critic",
       "incident_spike:stall",
     ]);
   });

--- a/test/maintain.test.ts
+++ b/test/maintain.test.ts
@@ -301,6 +301,42 @@ describe("sweep gating", () => {
     expect(keys).toContain("first_pass_collapse:/repos/b");
   });
 
+  it("retires a reading the sweep no longer produces", async () => {
+    const h = harness({ repoDelivery: () => [repoRow(SELF, 1, 20)] });
+    // A band that WAS evaluated once and never will be again: an excluded signal kind (#2242), a
+    // repo that has since been removed. Readings are upserted and never overwritten by absence, so
+    // without the prune this row sits at the top of the Delivery lens (ordered tier DESC) forever.
+    h.store.upsertMaintainReading({
+      key: "incident_spike:block",
+      bandId: "incident_spike",
+      repoPath: null,
+      subject: "block",
+      tier: 2,
+      value: 125,
+      sampleN: 21,
+      belowMinSample: false,
+      evaluatedAt: NOW - 86_400_000,
+    });
+    await h.svc.sweep();
+    const keys = h.store.listMaintainReadings().map((r) => r.key);
+    expect(keys).not.toContain("incident_spike:block");
+    expect(keys).toContain("first_pass_collapse:/repos/shepherd"); // this sweep's own survive
+  });
+
+  it("keeps every reading when a sweep produces none, rather than wiping the table", async () => {
+    const h = harness({ repoDelivery: () => [repoRow(SELF, 1, 20)] });
+    await h.svc.sweep();
+    const before = h.store.listMaintainReadings().length;
+    expect(before).toBeGreaterThan(0);
+    // An empty produce-set is "no measurement", not "a measurement of nothing" — a degraded
+    // gather must not read as data loss.
+    expect(h.store.pruneMaintainReadings([])).toBe(0);
+    expect(h.store.listMaintainReadings()).toHaveLength(before);
+    // ...and it reports what it actually removed, so a caller can log the retirement.
+    const keys = h.store.listMaintainReadings().map((r) => r.key);
+    expect(h.store.pruneMaintainReadings(keys.slice(0, 1))).toBe(before - 1);
+  });
+
   it("evaluates once per local day", async () => {
     const h = harness({ repoDelivery: collapsing });
     await h.svc.sweep();

--- a/test/signals-attach.test.ts
+++ b/test/signals-attach.test.ts
@@ -3,7 +3,7 @@ import { EventHub } from "../src/events";
 import { SessionStore } from "../src/store";
 import { attachSignalCapture } from "../src/signals";
 
-function mk() {
+function mk(opts?: { now?: () => number; debounceMs?: number }) {
   const store = new SessionStore(":memory:");
   const s = store.create({
     name: "n",
@@ -17,9 +17,26 @@ function mk() {
     herdrAgentId: "t1",
   });
   const events = new EventHub();
-  attachSignalCapture(events, store);
+  attachSignalCapture(events, store, opts);
   return { store, s, events };
 }
+
+/** A second session in the SAME repo, so a per-session assertion can't pass by repo scoping. */
+function addSession(store: SessionStore, name: string) {
+  return store.create({
+    name,
+    prompt: "p",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: `b-${name}`,
+    worktreePath: `/wt-${name}`,
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: `t-${name}`,
+  });
+}
+
+const menu = (tail: string[]) => ({ shape: "menu" as const, options: [], tail });
 
 test("session:block with a menu shape records a 'block' signal", () => {
   const { store, s, events } = mk();
@@ -52,4 +69,95 @@ test("block for an unknown session records nothing", () => {
   const { store, events } = mk();
   events.emit("session:block", { id: "nope", block: { shape: "menu", options: [], tail: [] } });
   expect(store.listSignals("/r").length).toBe(0);
+});
+
+// ── per-episode dedup (#2242) ────────────────────────────────────────────────
+// The poller re-emits `session:block` on every terminal repaint of a waiting dialog, so the
+// capture layer collapses an episode into one row. The window SLIDES on every observed event.
+
+test("repaints of the same dialog inside the window record ONE signal", () => {
+  let t = 1_000;
+  const { store, s, events } = mk({ now: () => t, debounceMs: 60_000 });
+  // Same dialog, three different tails — a repaint changes the tail, which is exactly why
+  // payload-equality dedup does not work and this window exists.
+  events.emit("session:block", { id: s.id, block: menu(["Which ruleset?", "❯ 1. strict"]) });
+  t += 3_000; // the poller's reclassify cadence
+  events.emit("session:block", { id: s.id, block: menu(["Which ruleset?", "  1. strict", "x"]) });
+  t += 25_000;
+  events.emit("session:block", { id: s.id, block: menu(["Which ruleset?", "❯ 2. loose"]) });
+  const sigs = store.listSignals("/r");
+  expect(sigs.length).toBe(1);
+  expect(sigs[0]!.payload).toContain("❯ 1. strict"); // the FIRST sighting is the one kept
+});
+
+test("a block past the window opens a new episode", () => {
+  let t = 1_000;
+  const { store, s, events } = mk({ now: () => t, debounceMs: 60_000 });
+  events.emit("session:block", { id: s.id, block: menu(["first"]) });
+  t += 60_000; // exactly at the boundary — the window has elapsed
+  events.emit("session:block", { id: s.id, block: menu(["second"]) });
+  expect(store.listSignals("/r").length).toBe(2);
+});
+
+test("the window SLIDES: a repaint stream never ages out mid-episode", () => {
+  let t = 1_000;
+  const { store, s, events } = mk({ now: () => t, debounceMs: 60_000 });
+  // 10 minutes of repaints at the 3s cadence stays ONE episode, because each event re-stamps the
+  // key. A fixed (non-sliding) window would emit a fresh row every 60s of the same dialog.
+  for (let i = 0; i < 200; i++) {
+    events.emit("session:block", { id: s.id, block: menu([`repaint ${i}`]) });
+    t += 3_000;
+  }
+  expect(store.listSignals("/r").length).toBe(1);
+});
+
+test("the window is per session — a concurrent block elsewhere is its own episode", () => {
+  const t = 1_000;
+  const { store, s, events } = mk({ now: () => t, debounceMs: 60_000 });
+  const other = addSession(store, "other");
+  events.emit("session:block", { id: s.id, block: menu(["mine"]) });
+  events.emit("session:block", { id: other.id, block: menu(["theirs"]) });
+  expect(store.listSignals("/r").length).toBe(2);
+});
+
+test("the window is per kind — a stall and a block never share one", () => {
+  const t = 1_000;
+  const { store, s, events } = mk({ now: () => t, debounceMs: 60_000 });
+  events.emit("session:block", { id: s.id, block: menu(["a question"]) });
+  events.emit("session:block", {
+    id: s.id,
+    block: { shape: "stall", options: [], tail: ["quiet"] },
+  });
+  expect(
+    store
+      .listSignals("/r")
+      .map((x) => x.kind)
+      .sort(),
+  ).toEqual(["block", "stall"]);
+});
+
+test("a clear does NOT reopen the window — the leave-blocked flap is the amplifier", () => {
+  let t = 1_000;
+  const { store, s, events } = mk({ now: () => t, debounceMs: 60_000 });
+  events.emit("session:block", { id: s.id, block: menu(["a question"]) });
+  // The poller drops `lastSig` in both trySuppressSpinner and clearBlock, emitting a clear and
+  // then re-arming on the next cadence. Treating that as an episode boundary would restore the
+  // duplication this dedup exists to remove.
+  t += 3_000;
+  events.emit("session:block", { id: s.id, block: null });
+  t += 3_000;
+  events.emit("session:block", { id: s.id, block: menu(["a question", "(repainted)"]) });
+  expect(store.listSignals("/r").length).toBe(1);
+});
+
+test("an idle session's key is not retained once its episode has aged out", () => {
+  let t = 1_000;
+  const { store, s, events } = mk({ now: () => t, debounceMs: 60_000 });
+  events.emit("session:block", { id: s.id, block: menu(["old"]) });
+  t += 120_000;
+  // A block for ANOTHER session sweeps the stale key; the original then behaves as unseen.
+  const other = addSession(store, "other");
+  events.emit("session:block", { id: other.id, block: menu(["theirs"]) });
+  events.emit("session:block", { id: s.id, block: menu(["new episode"]) });
+  expect(store.listSignals("/r").length).toBe(3);
 });


### PR DESCRIPTION
Closes #2242.

`incident_spike:block` was scoring normal interactive use as an incident. Two independent causes, both fixed here.

## What the live data said

I measured a read-only copy of the live DB before planning, because the issue's own first open question asks for it — and the answer reshaped the fix.

| Dedup rule | occurrences | sessions | tier (25/5 = T2) |
| --- | --- | --- | --- |
| none (today) | 181 | 32 | **2** |
| exact `(sessionId, payload)` | 169 | 32 | **2** |
| episode = 30s gap | 78 | 32 | **2** |
| episode = 60s gap | 71 | 32 | **2** |
| episode = 120s gap | 62 | 32 | **2** |
| episode = 300s gap | 52 | 32 | **2** |

Two results drove the design:

- **The issue's proposed measurement under-reports.** `GROUP BY sessionId, payload` removes only 12 of 181 rows — the repaints genuinely *differ*, which is exactly why payload dedup fails. The real signature is time adjacency: 103/181 rows land within 30s of the previous row in the same session, 40 within 5s (the 3s reclassify cadence).
- **Dedup alone cannot clear the band at any plausible window.** Even 5 minutes leaves 52 occurrences across 32 sessions. So the issue's second open question ("does it still breach?") answers *yes*, not even downgraded — a dedup-only fix would have the maintain loop re-file this same issue on its next sweep.

## Changes

**1. Per-episode dedup at the capture layer** (`src/signals.ts`)

A 60s sliding per-`(session, kind)` window. Deliberately **not** in the poller, which is what the issue title proposes: `session:block` also drives the UI block card's tail, the herdr state push and the working-while-blocked flag, all of which want per-repaint accuracy. The `signals` table is the only consumer that over-counts, so that is where the dedup goes.

The window slides on every observed event, so a long repaint stream stays one episode. A `block: null` clear deliberately does **not** reset it — `trySuppressSpinner` and `clearBlock` both drop `lastSig` and re-arm, so clear-keyed episodes would still write a row per flap. Those are the two amplifiers the issue names.

**2. `block` joins `reply` in the incident-band exclusion** (`src/maintain-core.ts`)

An agent asking the operator a question is high-volume by design, not a fault class — every payload in the breach that filed #2242 was a healthy planning dialog. Genuine faults stay covered by `stall`, `critic` and `injection_detected`.

**3. Retire readings a sweep no longer produces** (`src/store.ts`, `src/maintain.ts`)

Not in the issue; found while implementing. `upsertMaintainReading` only ever writes, and the live DB holds `incident_spike:block | tier 2 | value 125`. Excluding the kind stops it being re-evaluated, so that row would freeze at tier 2 forever — and `listMaintainReadings` orders `tier DESC`, pinning it to the top of the Delivery lens band card. **Without this, change 2 is invisible to the operator.** An empty produce-set is a no-op, so a degraded gather can't read as data loss.

## Blast radius

The two other consumers of block-signal counts are unaffected, verified rather than assumed:

- `isGoodOutcome` (learnings reward attribution) tests `blockingSignalCount === 0` — an episode still writes ≥1 row, so zero-ness never flips.
- The auto-trial gate reads `distinctKinds` / `distinctSessions`, which deduping within one session+kind cannot change.

The one real consequence: the distiller's corpus shrinks, so its `minSignals` gate (default 5) trips less often. Judged correct rather than regressive — five repaints of one dialog should not trigger a distill run — and `minSignals` is left alone rather than retuned speculatively.

## Not in scope

- **No `src/poller.ts` change at all.** The amplifiers are neutralised at the capture layer instead.
- **The frozen-buffer false positive** from the issue's fourth open question is **real** — session `1ab3d5c0…` carries three rows of identical *static* Shepherd prompt text about `$BUZZ_BIN`, an awaiting-input fallback firing on a frozen buffer rather than a live dialog. It is a distinct poller classification defect on a path this PR does not touch, so it is filed as #2272.
- Splitting quota-shaped blocks into their own `SignalKind` (offered to the operator, not chosen); retuning `minSignals`; any env knob for the window.

## Verification

`bun run lint`, `bun run test` (9722 pass / 0 fail), `bunx tsc --noEmit`, and the fallow delta gate (`No issues in 8 changed files`) all pass.

Three existing `maintain-core` fixtures used `block` merely as their example kind; they move to a non-excluded kind so they keep asserting the 10/3 and 25/5 tier boundaries they were written for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)