### PR TITLE
fix(diagnostics): re-verify the tailscale serve denial on every check

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -125,9 +125,12 @@ export interface DiagnosticsDeps {
    *  Service mapping are detected. Reject ⇒ treated as "not serving". */
   runServeStatus?: () => Promise<string>;
   /** True when `tailscale serve` refused a preview registration for lack of
-   *  operator/root rights (`TailscaleServeService.permissionDenied`). Default
+   *  operator/root rights. Asked fresh on every run and may answer asynchronously: the
+   *  wired implementation (`TailscaleServeService.revalidatePermission`) re-verifies its
+   *  latched verdict against tailscaled, so a denial the operator has since fixed clears
+   *  on a re-check instead of persisting until someone opens a preview. Default
    *  `() => false` so an unwired service keeps today's behavior. */
-  previewServeDenied?: () => boolean;
+  previewServeDenied?: () => boolean | Promise<boolean>;
   /** Run a verbatim remediation command (a shell pipeline like `curl … | bash`).
    *  Resolves on exit 0; rejects on non-zero exit or timeout. Default spawns a
    *  detached process group and SIGKILLs the whole group on timeout. Injected in tests. */
@@ -435,7 +438,7 @@ function resolveClaudeTrustDeps(deps: DiagnosticsDeps): {
  *  rather than inline in the constructor for the same reason `resolveClaudeTrustDeps` exists —
  *  the ctor sits at the repo's complexity ceiling, and one more inline `??` trips the health
  *  gate. */
-function resolvePreviewServeDenied(deps: DiagnosticsDeps): () => boolean {
+function resolvePreviewServeDenied(deps: DiagnosticsDeps): () => boolean | Promise<boolean> {
   return deps.previewServeDenied ?? (() => false);
 }
 
@@ -1103,7 +1106,7 @@ export class DiagnosticsService {
   private ghProbeRetryDelayMs: number;
   private resolveHost: () => Promise<string | null>;
   private runServeStatus: () => Promise<string>;
-  private previewServeDenied: () => boolean;
+  private previewServeDenied: () => boolean | Promise<boolean>;
   private runRemediation: (cmd: string) => Promise<void>;
   private anyForgeRepo: () => boolean;
   private anyLightweightRepo: () => boolean;
@@ -1462,7 +1465,7 @@ export class DiagnosticsService {
     // working HUD mapping (written earlier with root, or by another user), so `findServedPort`
     // succeeds and the row would report `ok` while every preview registration is refused.
     // That green-over-broken reading is the blind spot this check exists to close.
-    if (this.previewServeDenied()) {
+    if (await this.previewServeDenied()) {
       return {
         id: "tailscale",
         state: "warning",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2811,10 +2811,12 @@ const diagnostics = new DiagnosticsService({
   // Diagnose row reflects the same cell the sweeps read (a fresh ProcessReaper
   // would carry an always-cold cell). Pure read, no spawn.
   probeHealth: () => reaper.health(),
-  // Pure read of the serve service's latched permission verdict — no extra spawn. Lets the
-  // `tailscale` row report a host that refuses our serve-config writes, which the
-  // HUD-port-only serve-status check cannot see.
-  previewServeDenied: () => tailscaleServe.permissionDenied(),
+  // Lets the `tailscale` row report a host that refuses our serve-config writes, which the
+  // HUD-port-only serve-status check cannot see. Re-verifies rather than reading the latch:
+  // the latch clears only on a successful register, so without this a re-check kept showing
+  // the denial after the operator ran `tailscale set --operator=$USER`. Costs one read-only
+  // `tailscale debug prefs` and only while a denial actually stands.
+  previewServeDenied: () => tailscaleServe.revalidatePermission(),
   anyForgeRepo: () =>
     listRepos(config.repoRoot).some((r) => store.getRepoConfig(r.path).repoMode === "forge"),
   anyLightweightRepo: () =>

--- a/src/tailscale.ts
+++ b/src/tailscale.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { userInfo } from "node:os";
 import { promisify } from "node:util";
 import { execFileSync, timedAsync } from "./instrument";
 
@@ -88,6 +89,22 @@ const defaultRunSync: TailscaleRunnerSync = (args) => {
   execFileSync("tailscale", args, { timeout: SYNC_TIMEOUT_MS, stdio: "ignore" });
 };
 
+/** The OS identity a serve-config write would be attributed to. */
+export type ServeIdentity = { uid: number; username: string };
+
+/** Real identity of this process. `getuid` is absent on Windows (-1 ⇒ "not root", which
+ *  falls through to the operator comparison); `userInfo` throws when the uid has no passwd
+ *  entry, which we report as an empty name so it can never match an OperatorUser. */
+const defaultIdentity = (): ServeIdentity => {
+  let username = "";
+  try {
+    username = userInfo().username;
+  } catch {
+    /* no passwd entry — leave the name empty */
+  }
+  return { uid: process.getuid?.() ?? -1, username };
+};
+
 export interface TailscaleServeOpts {
   base: number;
   count: number;
@@ -100,6 +117,9 @@ export interface TailscaleServeOpts {
   run?: TailscaleRunner;
   /** Sync shutdown path; default defaultRunSync */
   runSync?: TailscaleRunnerSync;
+  /** OS identity this process runs as, read by {@link TailscaleServeService.revalidatePermission}
+   *  to compare against tailscaled's `--operator`. Injectable for tests; default defaultIdentity. */
+  identity?: () => ServeIdentity;
 }
 
 /**
@@ -114,17 +134,20 @@ export class TailscaleServeService {
   /** Latched by ANY async mutation refused for lack of operator/root rights — `register`,
    *  `unregister` and `reconcileStartup` alike, since all three write serve config (only the
    *  sync `stopAll` skips it: the process is exiting and nothing reads this afterwards).
-   *  Cleared only by a subsequent SUCCESSFUL `register` — not by a successful
-   *  unregister or reconcile, neither of which clears it. That asymmetry is deliberate and
-   *  matches the hint the operator is given ("run `tailscale set --operator=…`, then reopen
-   *  the preview"): reopening a preview is a register, so the row goes green exactly when
-   *  the fix is proven on the path that was broken. Surfaced via {@link permissionDenied}. */
+   *  Cleared on exactly two paths: a subsequent SUCCESSFUL `register` (the fix proven on the
+   *  path that was broken), and {@link revalidatePermission} (the host re-examined on demand).
+   *  A successful unregister or reconcile clears nothing — neither proves we may write.
+   *  Surfaced via {@link permissionDenied}. */
   private denied = false;
 
   constructor(private opts: TailscaleServeOpts) {}
 
   private get run() {
     return this.opts.run ?? defaultRun;
+  }
+
+  private get identity() {
+    return this.opts.identity ?? defaultIdentity;
   }
 
   private enqueue(op: () => Promise<void>): Promise<void> {
@@ -237,8 +260,12 @@ export class TailscaleServeService {
 
   /**
    * True when a serve mutation was refused for lack of operator/root rights (see
-   * {@link isServeConfigDenied}) and no later `register` has since succeeded — i.e. the
+   * {@link isServeConfigDenied}) and nothing has since cleared that verdict — i.e. the
    * host needs `tailscale set --operator=<user>` before any preview can be published.
+   *
+   * Pure read of the latch. Callers that want the verdict re-examined against the daemon
+   * first — Diagnostics, whose re-check must reflect a fix the operator just applied —
+   * should await {@link revalidatePermission} instead.
    *
    * Reports OBSERVED failures only: a boot that has neither reconciled nor registered
    * anything yet reads `false`, and so does a disabled service. `reconcileStartup`
@@ -246,6 +273,57 @@ export class TailscaleServeService {
    * the first preview opens.
    */
   permissionDenied(): boolean {
+    return this.denied;
+  }
+
+  /**
+   * Re-verify a latched denial against the daemon: clear it when the host has since granted
+   * us serve-config rights, and return the (possibly updated) verdict.
+   *
+   * WHY this exists: {@link permissionDenied} is cleared only by a successful `register`, so
+   * after the operator runs the documented `sudo tailscale set --operator=$USER` the latch
+   * stays true until someone opens a preview. Diagnostics re-checks read the latch, so the
+   * `tailscale` row could not go green from the settings panel however often the checks were
+   * re-run — the applied fix looked like it had not worked.
+   *
+   * READ-ONLY: `tailscale debug prefs` is a LocalAPI GET, permitted for any local user — which
+   * is exactly why it still answers on a denied host — and nothing here writes serve config.
+   * tailscaled gates serve-config writes on `PermitWrite`, granted to root or the configured
+   * `OperatorUser`; those are the two conditions checked here.
+   *
+   * Fail-safe in both directions: an unreadable or unexpected prefs answer KEEPS the latch, so
+   * an observed denial is never downgraded to green on a guess; and clearing it is not a
+   * standing verdict — the next refused mutation latches it again.
+   */
+  async revalidatePermission(): Promise<boolean> {
+    if (!this.denied) return false;
+    const { uid, username } = this.identity();
+    // root is granted PermitWrite unconditionally, so its rights never depend on --operator
+    // and there is nothing for the prefs read to add.
+    if (uid === 0) {
+      this.denied = false;
+      return false;
+    }
+    try {
+      const { stdout } = await this.run(["debug", "prefs"]);
+      const parsed: unknown = JSON.parse(stdout);
+      const operator =
+        parsed !== null && typeof parsed === "object" && "OperatorUser" in parsed
+          ? parsed.OperatorUser
+          : null;
+      // An empty OperatorUser means "root only"; an empty username means we could not read
+      // our own — neither may be allowed to match the other into a false clearance.
+      if (
+        typeof operator === "string" &&
+        operator !== "" &&
+        username !== "" &&
+        operator === username
+      ) {
+        this.denied = false;
+      }
+    } catch {
+      /* prefs unreadable — keep the observed denial rather than guess */
+    }
     return this.denied;
   }
 }

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -723,6 +723,25 @@ describe("DiagnosticsService probes", () => {
     expect(c.state).toBe("ok");
     expect(c.hintKey).toBe("diagnostics_hint_tailscale_ok");
   });
+  // The dep is asked fresh on every run and may answer asynchronously (the wired
+  // implementation re-verifies a latched denial against tailscaled). Without this, a
+  // re-check after `tailscale set --operator=$USER` kept reporting the stale verdict and
+  // the row could never go green from the settings panel.
+  it("tailscale: an async dep that clears the denial lets the row go green on a re-check", async () => {
+    let denied = true;
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      previewServeDenied: async () => denied,
+    });
+    const first = byId((await svc.check(0)).checks, "tailscale");
+    expect(first.state).toBe("warning");
+    expect(first.hintKey).toBe("diagnostics_hint_tailscale_serve_denied");
+
+    denied = false;
+    const second = byId((await svc.check(0)).checks, "tailscale");
+    expect(second.state).toBe("ok");
+    expect(second.hintKey).toBe("diagnostics_hint_tailscale_ok");
+  });
   it("tailscale: never forwards raw serve-status text", async () => {
     const secret = "SECRET-SERVE-LINE-127.0.0.1";
     const svc = new DiagnosticsService({

--- a/test/tailscale.test.ts
+++ b/test/tailscale.test.ts
@@ -503,3 +503,155 @@ describe("TailscaleServeService.permissionDenied", () => {
     expect(svc.permissionDenied()).toBe(false);
   });
 });
+
+// ── revalidatePermission ──────────────────────────────────────────────────────
+// The latch alone cannot answer "is the host still denying us?" after the operator
+// runs the documented fix: only a successful `register` clears it, so a Diagnostics
+// re-check reads stale memory and the row can never go green from the panel (#2272).
+
+/** `tailscale debug prefs` output, trimmed to the field the revalidation reads.
+ *  Shaped like the real thing (top-level JSON object, `OperatorUser` a username string). */
+function prefsStdout(operatorUser: string): string {
+  return JSON.stringify({
+    ControlURL: "https://controlplane.tailscale.com",
+    WantRunning: true,
+    OperatorUser: operatorUser,
+  });
+}
+
+/** Runner that refuses every serve mutation but answers `debug prefs` with `operatorUser`. */
+function deniedThenPrefs(operatorUser: string): { calls: string[][]; run: TailscaleRunner } {
+  const calls: string[][] = [];
+  const run: TailscaleRunner = async (args) => {
+    calls.push(args);
+    if (args[0] === "debug") return { stdout: prefsStdout(operatorUser) };
+    throw deniedError();
+  };
+  return { calls, run };
+}
+
+describe("TailscaleServeService.revalidatePermission", () => {
+  test("clears a latched denial once the host names us --operator", async () => {
+    const { calls, run } = deniedThenPrefs("moe");
+    const svc = new TailscaleServeService({
+      base: 8001,
+      count: 5,
+      enabled: true,
+      run,
+      identity: () => ({ uid: 1000, username: "moe" }),
+    });
+
+    await svc.register("s1", 8001);
+    expect(svc.permissionDenied()).toBe(true);
+
+    expect(await svc.revalidatePermission()).toBe(false);
+    // Cleared on the service itself, not just for the caller: every consumer of
+    // permissionDenied must stop believing preview is dark.
+    expect(svc.permissionDenied()).toBe(false);
+    expect(calls.at(-1)).toEqual(["debug", "prefs"]);
+  });
+
+  test("keeps the denial when the host names a different --operator", async () => {
+    const { run } = deniedThenPrefs("someone-else");
+    const svc = new TailscaleServeService({
+      base: 8001,
+      count: 5,
+      enabled: true,
+      run,
+      identity: () => ({ uid: 1000, username: "moe" }),
+    });
+
+    await svc.register("s1", 8001);
+
+    expect(await svc.revalidatePermission()).toBe(true);
+    expect(svc.permissionDenied()).toBe(true);
+  });
+
+  test("clears a latched denial when running as root (rights never depend on --operator)", async () => {
+    const { run } = deniedThenPrefs("");
+    const svc = new TailscaleServeService({
+      base: 8001,
+      count: 5,
+      enabled: true,
+      run,
+      identity: () => ({ uid: 0, username: "root" }),
+    });
+
+    await svc.register("s1", 8001);
+
+    expect(await svc.revalidatePermission()).toBe(false);
+    expect(svc.permissionDenied()).toBe(false);
+  });
+
+  test("does not probe at all when nothing was ever denied", async () => {
+    const { calls, run } = makeRun();
+    const svc = new TailscaleServeService({ base: 8001, count: 5, enabled: true, run });
+
+    expect(await svc.revalidatePermission()).toBe(false);
+    expect(calls).toEqual([]);
+  });
+
+  // Fail-safe: an unreadable prefs answer must never downgrade an observed denial to green.
+  test("keeps the denial when the prefs probe rejects", async () => {
+    const run: TailscaleRunner = async (args) => {
+      if (args[0] === "debug") throw new Error("spawn tailscale ENOENT");
+      throw deniedError();
+    };
+    const svc = new TailscaleServeService({
+      base: 8001,
+      count: 5,
+      enabled: true,
+      run,
+      identity: () => ({ uid: 1000, username: "moe" }),
+    });
+
+    await svc.register("s1", 8001);
+
+    expect(await svc.revalidatePermission()).toBe(true);
+    expect(svc.permissionDenied()).toBe(true);
+  });
+
+  test("keeps the denial when prefs output is not the JSON we expect", async () => {
+    const run: TailscaleRunner = async (args) => {
+      if (args[0] === "debug") return { stdout: "not json" };
+      throw deniedError();
+    };
+    const svc = new TailscaleServeService({
+      base: 8001,
+      count: 5,
+      enabled: true,
+      run,
+      identity: () => ({ uid: 1000, username: "moe" }),
+    });
+
+    await svc.register("s1", 8001);
+
+    expect(await svc.revalidatePermission()).toBe(true);
+    expect(svc.permissionDenied()).toBe(true);
+  });
+
+  // A cleared latch is not a permanent verdict: the next real refusal re-latches, so the
+  // row reports the host as it is rather than as it was at the moment of the re-check.
+  test("re-latches when a later mutation is refused again", async () => {
+    let operator = "moe";
+    const run: TailscaleRunner = async (args) => {
+      if (args[0] === "debug") return { stdout: prefsStdout(operator) };
+      throw deniedError();
+    };
+    const svc = new TailscaleServeService({
+      base: 8001,
+      count: 5,
+      enabled: true,
+      run,
+      identity: () => ({ uid: 1000, username: "moe" }),
+    });
+
+    await svc.register("s1", 8001);
+    expect(await svc.revalidatePermission()).toBe(false);
+
+    operator = "";
+    await svc.register("s2", 8002);
+
+    expect(await svc.revalidatePermission()).toBe(true);
+  });
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3535,7 +3535,7 @@
   "keymap_mode_research_short": "RECH.",
   "feat_newtask_keymap_title": "⌘ halten zeigt alle Tastenkürzel",
   "feat_newtask_keymap_body": "Halte in „Neue Aufgabe\" kurz ⌘ (Strg unter Windows/Linux) — jedes Bedienelement zeigt sein Kürzel direkt an seinem Platz, Loslassen blendet wieder aus. ? öffnet die vollständige Tastenkarte.",
-  "diagnostics_hint_tailscale_serve_denied": "Tailscale verweigert Shepherd die serve-Konfiguration, dadurch lässt sich keine Live-Vorschau veröffentlichen — führe einmalig sudo tailscale set --operator=$USER aus und öffne die Vorschau erneut.",
+  "diagnostics_hint_tailscale_serve_denied": "Tailscale verweigert Shepherd die serve-Konfiguration, dadurch lässt sich keine Live-Vorschau veröffentlichen — führe einmalig sudo tailscale set --operator=$USER aus und prüfe die Checks erneut.",
   "feat_fast_repo_switch_title": "Repo wechseln, ohne die Tastatur zu verlassen",
   "feat_fast_repo_switch_body": "Tippe auf dem Handy beim Schreiben auf den Repo-Namen in der Kopfzeile von „Neue Aufgabe“ — die Repo-Liste öffnet sich sofort, und nach der Auswahl landest du direkt wieder in deiner Beschreibung, die Tastatur bleibt oben. Zwei Tipps statt fünf.",
   "cardmenu_stop": "Agent stoppen",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3535,7 +3535,7 @@
   "keymap_mode_research_short": "RSCH.",
   "feat_newtask_keymap_title": "Hold ⌘ to see every shortcut",
   "feat_newtask_keymap_body": "In New Task, hold ⌘ (Ctrl on Windows/Linux) for a moment and every control shows its shortcut right where it sits — release to dismiss. Press ? for the full key card.",
-  "diagnostics_hint_tailscale_serve_denied": "Tailscale refuses Shepherd's serve config, so no live preview can be published — run sudo tailscale set --operator=$USER once, then reopen the preview.",
+  "diagnostics_hint_tailscale_serve_denied": "Tailscale refuses Shepherd's serve config, so no live preview can be published — run sudo tailscale set --operator=$USER once, then re-run the checks.",
   "feat_fast_repo_switch_title": "Switch repo without leaving the keyboard",
   "feat_fast_repo_switch_body": "On a phone, tap the repo name in the New Task header while you're typing — the repo list opens straight away, and picking one drops you right back into your description with the keyboard still up. Two taps instead of five.",
   "cardmenu_stop": "Stop agent",


### PR DESCRIPTION
## Das Problem

Der `tailscale`-Check bleibt auf **Warnung**, auch nachdem man den Befehl ausgeführt hat, den der Hinweis selbst nennt (`sudo tailscale set --operator=$USER`). „CHECKS NEU PRÜFEN" ändert nichts — der Knopf kann die Zeile, die er anzeigt, strukturell nicht grün bekommen.

## Wurzelursache

`TailscaleServeService.denied` ist ein **Einweg-Latch**. Er wird gesetzt, wenn eine serve-config-Schreiboperation abgewiesen wird, und ausschließlich durch ein später **erfolgreiches `register()`** wieder geräumt.

`tailscaleProbe` liest genau diesen Latch (`src/diagnostics.ts:1465`) und kehrt mit `warning` zurück, **bevor** tailscaled überhaupt gefragt wird. Ein Re-Check misst also nie neu — er liest veralteten Speicher. Die Zeile wird erst grün, wenn zufällig jemand eine Vorschau öffnet.

Auf dem Host verifiziert: nach dem Befehl funktionieren die Rechte tatsächlich (`tailscale serve --bg --https=59999 …` und `… off`, beide exit 0), während der Check weiter Warnung meldete.

## Die Änderung

`revalidatePermission()` prüft eine stehende Verweigerung neu, statt dem Latch zu glauben:

- tailscaled gated serve-config-Schreibzugriffe über `PermitWrite` — gewährt an **root** oder den konfigurierten **`OperatorUser`**. Genau diese beiden Bedingungen werden geprüft.
- Der Probe ist **rein lesend**: `tailscale debug prefs` ist ein LocalAPI-GET, der auch auf einem verweigernden Host antwortet. Es wird nichts an der serve-config geschrieben, und die Ausgabe wird nie weitergereicht — nur ein Boolean entsteht daraus.
- Geräumt wird am Service selbst, nicht nur für den Aufrufer, damit alle Konsumenten aufhören, die Vorschau für tot zu halten.
- Kosten: ein zusätzlicher Aufruf, und nur solange eine Verweigerung überhaupt ansteht.

**Fail-safe in beide Richtungen:** eine unlesbare oder unerwartete prefs-Antwort **behält** die beobachtete Verweigerung (nie grün auf Verdacht), und ein geräumter Latch ist kein Dauerurteil — die nächste abgewiesene Mutation setzt ihn wieder.

Der Hinweistext schickte bisher zur Vorschau; er nennt jetzt den Weg, der funktioniert (EN + DE).

## Verifikation

- `bun run lint` — sauber
- `bun run test` — 9729 pass, 0 fail
- `cd ui && bun run check` — 0 errors · `check:i18n` — 2 Locales in Parität · `bun run test` — 5140 pass
- **Gegen das echte tailscaled dieser Maschine (1.98.4)**: Latch künstlich gesetzt → `revalidatePermission()` räumt ihn anhand der echten `debug prefs`-Ausgabe.

8 neue Tests decken ab: Räumen bei passendem Operator, Behalten bei fremdem Operator, root-Kurzschluss, kein Probe ohne Verweigerung, Fail-safe bei Exec- und Parse-Fehlern, erneutes Latchen nach späterer Abweisung, und der asynchrone Diagnose-Pfad, der die Zeile beim Re-Check grün werden lässt.