### PR TITLE
feat(flock): line-art pasture for the update sheep, and a motion preference to unstick it

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3972,5 +3972,13 @@
   "coldresume_chip": "kalt · ≈{units} Einheiten",
   "feat_cold_resume_marker_title": "Sieh vor dem Klick, was ein Fortsetzen kostet",
   "feat_cold_resume_marker_body": "Der Prompt-Cache einer geparkten Session läuft mit der Zeit ab, und der erste Zug zurück sendet ihren gesamten Kontext zum Cache-Schreibtarif erneut — oft die teuerste Anfrage der ganzen Session. Geparkte Sessions, die kalt geworden sind, tragen jetzt einen ⚠-Chip in der Herde und eine passende Markierung in der Status-Leiste, die diese Kosten in gewichteten Einheiten schätzt — sichtbar, bevor du die Session öffnest.",
-  "coldresume_title": "Prompt-Cache abgelaufen — diese Session war länger untätig als ihre Cache-Lebensdauer. Ihre {context} Kontext müssen zum Cache-Schreibtarif erneut gesendet werden, daher kostet der nächste Zug etwa {units} gewichtete Einheiten statt eines kleinen Bruchteils davon."
+  "coldresume_title": "Prompt-Cache abgelaufen — diese Session war länger untätig als ihre Cache-Lebensdauer. Ihre {context} Kontext müssen zum Cache-Schreibtarif erneut gesendet werden, daher kostet der nächste Zug etwa {units} gewichtete Einheiten statt eines kleinen Bruchteils davon.",
+  "settings_motion_title": "Bewegung",
+  "settings_motion_hint": "Überstimmt die Angabe deines Systems. Animationen, die laufende Arbeit anzeigen (Spinner, Status-Pulse), laufen immer weiter.",
+  "settings_motion_hint_system": "Folgt deinem System, das gerade meldet: {resolved}. Animationen, die laufende Arbeit anzeigen, laufen immer weiter.",
+  "settings_motion_full": "Voll",
+  "settings_motion_system": "System",
+  "settings_motion_reduced": "Reduziert",
+  "feat_motion_pref_title": "Wähle, wie viel Bewegung Shepherd nutzt",
+  "feat_motion_pref_body": "Unter Einstellungen → Gerät gibt es jetzt „Bewegung“: Voll, System oder Reduziert. Manche Desktops melden „Bewegung reduzieren“, ohne dass du das je verlangt hättest — und damit stand jede Animation in Shepherd still. Stell auf Voll, und sie laufen wieder. Status-Pulse, die laufende Arbeit anzeigen, waren nie betroffen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3972,5 +3972,13 @@
   "coldresume_chip": "cold · ≈{units} units",
   "feat_cold_resume_marker_title": "See what a resume costs before you click",
   "feat_cold_resume_marker_body": "A session's prompt cache expires while it sits parked, and the first turn back re-sends its whole context at the cache-write rate — often the most expensive request of the session. Parked sessions that have gone cold now carry a ⚠ chip in The Herd, and a matching marker in the session status bar, estimating that cost in weighted units so you can see it before you open the session.",
-  "coldresume_title": "Prompt cache expired — this session has been idle longer than its cache lifetime. Its {context} of context must be re-sent at the cache-write rate, so the next turn costs about {units} weighted units instead of a small fraction of that."
+  "coldresume_title": "Prompt cache expired — this session has been idle longer than its cache lifetime. Its {context} of context must be re-sent at the cache-write rate, so the next turn costs about {units} weighted units instead of a small fraction of that.",
+  "settings_motion_title": "Motion",
+  "settings_motion_hint": "Overrides what your system reports. Animations that signal live work (spinners, status pulses) always keep running.",
+  "settings_motion_hint_system": "Following your system, which currently reports: {resolved}. Animations that signal live work always keep running.",
+  "settings_motion_full": "Full",
+  "settings_motion_system": "System",
+  "settings_motion_reduced": "Reduced",
+  "feat_motion_pref_title": "Choose how much motion Shepherd uses",
+  "feat_motion_pref_body": "Settings → Device now has a Motion control: Full, System or Reduced. Some desktops report \"reduce motion\" without you ever asking for it — which silenced every animation in Shepherd. Set it to Full to get them back. Status pulses that signal live work were never affected."
 }

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -384,13 +384,30 @@ body {
    indicators ("work happening": CI dot-pulse, pip-pulse, critic rev-pulse,
    in-progress blink) intentionally override this with `animation: ... !important`
    in their components — the pulse encodes state, not decoration, so suppressing
-   it would drop information rather than polish. */
+   it would drop information rather than polish.
+
+   Two branches, because the OS hint is a default and not a verdict: the media
+   query applies unless the operator explicitly chose "full" motion in Settings →
+   Device, and `[data-motion="reduced"]` reduces even where the OS says nothing
+   (see `motion` in theme.svelte.ts).
+
+   The `html` guard MUST stay wrapped in `:where()`. These selectors are `*` —
+   specificity 0,0,0 — and the functional indicators above beat them purely by
+   having a more specific selector of their own. `:where()` contributes nothing to
+   specificity, so the guard leaves that balance exactly as it was; an unwrapped
+   `html[data-motion=...] *` would outrank those components and silence the status
+   pulses along with the decoration. */
 @media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
+  :where(html:not([data-motion="full"])) *,
+  :where(html:not([data-motion="full"])) *::before,
+  :where(html:not([data-motion="full"])) *::after {
     animation: none !important;
   }
+}
+:where(html[data-motion="reduced"]) *,
+:where(html[data-motion="reduced"]) *::before,
+:where(html[data-motion="reduced"]) *::after {
+  animation: none !important;
 }
 
 /* touch ergonomics (mobile) */

--- a/ui/src/app.html
+++ b/ui/src/app.html
@@ -34,8 +34,15 @@
           if (meta) meta.setAttribute("content", dark ? "#0a0d0c" : "#e7ebe9");
           if (localStorage.getItem("shepherd:contrast") === "high")
             document.documentElement.dataset.contrast = "high";
+          // Motion preference before first paint too: app.css keys the
+          // decorative-motion kill switch on [data-motion], so setting it only at
+          // hydration would let a suppressed animation flash first.
+          var motion = localStorage.getItem("shepherd:motion");
+          document.documentElement.dataset.motion =
+            motion === "full" || motion === "reduced" ? motion : "system";
         } catch (e) {
           document.documentElement.dataset.theme = "dark";
+          document.documentElement.dataset.motion = "system";
         }
       })();
     </script>

--- a/ui/src/lib/components/SvgFlockOverlay.svelte
+++ b/ui/src/lib/components/SvgFlockOverlay.svelte
@@ -1,104 +1,85 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { theme } from "$lib/theme.svelte";
 
   let { placement = "backdrop" }: { placement?: "backdrop" | "sheet" } = $props();
 
-  let reducedMotion = $state(false);
-
+  // The system hint is read here rather than off the controller because the
+  // controller samples it once at module init — before a test can install its
+  // matchMedia stub. The explicit preference still wins over whatever it says.
+  let systemReduced = $state(false);
   onMount(() => {
-    reducedMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+    systemReduced = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
   });
+  const reducedMotion = $derived(
+    theme.motion === "full" ? false : theme.motion === "reduced" ? true : systemReduced,
+  );
 
-  const actors = [
-    {
-      id: "sheep-1",
-      type: "sheep",
-      kind: "light small",
-      lane: 18,
-      width: 92,
-      start: 108,
-      distance: -136,
-      delay: "-1s",
-      duration: "11s",
-    },
-    {
-      id: "sheep-2",
-      type: "sheep",
-      kind: "dark small flip",
-      lane: 72,
-      width: 94,
-      start: 93,
-      distance: -124,
-      delay: "-6s",
-      duration: "13s",
-    },
-    {
-      id: "sheep-3",
-      type: "sheep",
-      kind: "light big",
-      lane: 108,
-      width: 150,
-      start: 116,
-      distance: -150,
-      delay: "-4s",
-      duration: "16s",
-    },
-    {
-      id: "sheep-4",
-      type: "sheep",
-      kind: "dark big flip",
-      lane: 30,
-      width: 144,
-      start: 70,
-      distance: -100,
-      delay: "-11s",
-      duration: "18s",
-    },
-    {
-      id: "sheep-5",
-      type: "sheep",
-      kind: "light tiny reverse",
-      lane: 150,
-      width: 76,
-      start: -18,
-      distance: 118,
-      delay: "-9s",
-      duration: "12s",
-    },
-    {
-      id: "sheep-6",
-      type: "sheep",
-      kind: "light small",
-      lane: 86,
-      width: 90,
-      start: 42,
-      distance: -74,
-      delay: "-7s",
-      duration: "10s",
-    },
-    {
-      id: "sheep-7",
-      type: "sheep",
-      kind: "dark small",
-      lane: 166,
-      width: 96,
-      start: 118,
-      distance: -148,
-      delay: "-14s",
-      duration: "15s",
-    },
-    {
-      id: "dog",
-      type: "dog",
-      kind: "dog",
-      lane: 10,
-      width: 92,
-      start: 122,
-      distance: -150,
-      delay: "-4s",
-      duration: "8s",
-    },
+  /** Ground-plane depth. Everything visual hangs off this, so an actor can't end
+   *  up small-but-fast or near-but-high: far is smaller, higher (closer to the
+   *  horizon), fainter and slower; near is bigger, lower, stronger and quicker. */
+  type Depth = "far" | "mid" | "near";
+
+  type Actor = {
+    id: string;
+    type: "sheep" | "dog";
+    depth: Depth;
+    /** Travel direction along the ground: -1 leftwards, +1 rightwards. */
+    dir: -1 | 1;
+    /** Where it sits at t=0, in vw — expressed as a delay against the crossing. */
+    at: number;
+    /** Composed resting spot (vw) for the static, reduced-motion tableau. */
+    rest: number;
+    tone?: "slate";
+  };
+
+  /** Seconds for one full crossing, per depth. Near is fastest — that is the
+   *  parallax. The dog gets its own, quicker pace so it gains on the flock
+   *  instead of drifting along with it. */
+  const PACE: Record<Depth, number> = { far: 19, mid: 14, near: 10 };
+  const DOG_PACE = 8.5;
+  /** Gait period per depth: a nearer animal visibly steps faster. */
+  const STEP: Record<Depth, number> = { far: 0.9, mid: 0.72, near: 0.58 };
+
+  /** The crossing spans START → START + TRAVEL, both well outside the viewport. */
+  const START = 120;
+  const TRAVEL = 140;
+
+  // The whole flock moves one way and the dog works it from behind — that is the
+  // premise, so there is no counter-walking straggler. Facing is derived from
+  // `dir` below, never listed per actor: hand-kept flip flags are exactly how
+  // four of the seven sheep ended up moon-walking.
+  const actors: Actor[] = [
+    { id: "sheep-far-1", type: "sheep", depth: "far", dir: -1, at: 70, rest: 20 },
+    { id: "sheep-far-2", type: "sheep", depth: "far", dir: -1, at: 18, rest: 58, tone: "slate" },
+    { id: "sheep-mid-1", type: "sheep", depth: "mid", dir: -1, at: 92, rest: 8 },
+    { id: "sheep-mid-2", type: "sheep", depth: "mid", dir: -1, at: 46, rest: 40, tone: "slate" },
+    { id: "sheep-mid-3", type: "sheep", depth: "mid", dir: -1, at: 5, rest: 72 },
+    { id: "sheep-near-1", type: "sheep", depth: "near", dir: -1, at: 78, rest: 26 },
+    { id: "sheep-near-2", type: "sheep", depth: "near", dir: -1, at: 30, rest: 62, tone: "slate" },
+    { id: "dog", type: "dog", depth: "near", dir: -1, at: 100, rest: 88 },
   ];
+
+  /** Static grass, sitting on the same ground lines the animals walk. */
+  const tufts: { id: string; depth: Depth; x: number }[] = [
+    { id: "t1", depth: "far", x: 12 },
+    { id: "t2", depth: "far", x: 47 },
+    { id: "t3", depth: "far", x: 81 },
+    { id: "t4", depth: "mid", x: 28 },
+    { id: "t5", depth: "mid", x: 66 },
+    { id: "t6", depth: "near", x: 15 },
+    { id: "t7", depth: "near", x: 71 },
+  ];
+
+  const VIEWBOX = { sheep: { w: 160, h: 100 }, dog: { w: 120, h: 76 } };
+
+  /** The sprites are drawn facing right; anything travelling left is mirrored. */
+  const facing = (a: Actor) => (a.dir < 0 ? "left" : "right");
+  const pace = (a: Actor) => (a.type === "dog" ? DOG_PACE : PACE[a.depth]);
+  /** Off-screen entry edge: right for a leftward walk, left for a rightward one. */
+  const origin = (a: Actor) => -START * a.dir;
+  /** Negative delay = start the crossing mid-flight, so `at` is the t=0 spot. */
+  const delay = (a: Actor) => -(pace(a) * Math.abs(a.at - origin(a))) / TRAVEL;
 </script>
 
 <div
@@ -108,72 +89,88 @@
   data-reduced={reducedMotion ? "true" : "false"}
   aria-hidden="true"
 >
-  {#each actors as actor (actor.id)}
-    <svg
-      class="actor {actor.kind}"
-      data-flock-actor={actor.type}
-      viewBox={actor.type === "dog" ? "0 0 96 58" : "0 0 150 96"}
-      style:--lane={`${actor.lane}px`}
-      style:--start={`${actor.start}vw`}
-      style:--distance={`${actor.distance}vw`}
-      style:--delay={actor.delay}
-      style:--duration={actor.duration}
-      style:--actor-width={`${actor.width}px`}
-      role="img"
-    >
-      {#if actor.type === "dog"}
-        <g class="sprite dog-sprite">
-          <path
-            class="dog-line body"
-            data-dog-body
-            d="M19 37 C24 23 39 20 51 28 L70 26 C78 25 84 31 84 39"
-          />
-          <path class="dog-line head" d="M20 37 L11 27 L20 19 L33 29" />
-          <path class="dog-line ear" d="M17 24 L13 12 L27 21" />
-          <path class="dog-line tail" d="M81 31 C91 24 94 16 91 8" />
-          <path class="dog-line legs" d="M38 35 L32 50 M60 34 L65 50" />
-          <circle class="dog-eye" cx="22" cy="27" r="2.4" />
-        </g>
-      {:else}
-        <g class="sprite sheep-sprite">
-          <path
-            class="sheep-leg rear"
-            d="M42 61 L38 88 M64 63 L62 88 M92 62 L95 88 M110 60 L115 86"
-          />
-          <path
-            class="wool base"
-            data-sheep-body
-            d="M35 59
-               C20 58 14 45 22 34
-               C17 22 30 12 43 18
-               C50 4 71 6 77 20
-               C89 8 107 17 106 32
-               C121 30 130 43 124 56
-               C130 68 115 78 101 71
-               C91 83 72 80 68 68
-               C56 80 37 75 35 59Z"
-          />
-          <circle class="wool puff" cx="34" cy="39" r="16" />
-          <circle class="wool puff" cx="52" cy="24" r="18" />
-          <circle class="wool puff" cx="76" cy="25" r="20" />
-          <circle class="wool puff" cx="99" cy="37" r="18" />
-          <circle class="wool puff" cx="54" cy="58" r="20" />
-          <circle class="wool puff" cx="84" cy="60" r="19" />
-          <path
-            class="face"
-            d="M112 40
-               C128 35 141 45 140 60
-               C139 76 122 81 112 69
-               C105 61 104 46 112 40Z"
-          />
-          <path class="ear" d="M117 43 C116 30 130 28 132 40 C127 41 122 43 117 43Z" />
-          <path class="snout" d="M127 62 C131 64 135 63 137 60" />
-          <circle class="eye" cx="127" cy="53" r="3" />
-          <path class="tail" d="M22 48 C11 46 9 56 18 60" />
-        </g>
-      {/if}
-    </svg>
-  {/each}
+  <div class="pasture">
+    <div class="ground"></div>
+    <div class="horizon"></div>
+
+    {#each tufts as tuft (tuft.id)}
+      <svg
+        class="tuft {tuft.depth}"
+        viewBox="0 0 24 14"
+        style:--x={`${tuft.x}vw`}
+        aria-hidden="true"
+        ><path d="M4 14 C4 8 3 5 1 2 M12 14 C12 6 12 4 12 1 M20 14 C20 8 21 5 23 3" /></svg
+      >
+    {/each}
+
+    {#each actors as actor (actor.id)}
+      <svg
+        class="actor {actor.depth} {actor.type}"
+        class:slate={actor.tone === "slate"}
+        data-flock-actor={actor.type}
+        data-facing={facing(actor)}
+        viewBox="0 0 {VIEWBOX[actor.type].w} {VIEWBOX[actor.type].h}"
+        style:--vb={VIEWBOX[actor.type].w}
+        style:--start={`${origin(actor)}vw`}
+        style:--distance={`${TRAVEL * actor.dir}vw`}
+        style:--rest={`${actor.rest}vw`}
+        style:--delay={`${delay(actor).toFixed(2)}s`}
+        style:--pace={`${pace(actor)}s`}
+        style:--step={`${STEP[actor.depth]}s`}
+        role="img"
+      >
+        {#if actor.type === "dog"}
+          <g class="facing">
+            <!-- far pair first: drawn under the body, so it reads as the off side -->
+            <g class="legs far"><path d="M25 42 L22 65 M68 44 L72 65" /></g>
+            <path class="tail" d="M16 34 C7 36 2 32 1 25" />
+            <!-- Collie proportions: long lean barrel, tucked waist, deep chest. -->
+            <path
+              class="silhouette"
+              data-dog-body
+              d="M16 34 C14 26 22 21 32 23 C44 20 56 21 64 25 C72 26 76 30 76 36
+                 C74 43 68 47 60 46 C52 47 46 41 40 41 C30 42 17 41 16 34Z"
+            />
+            <g class="legs near"><path d="M32 43 L28 67 M60 45 L64 67" /></g>
+            <g class="head">
+              <path
+                class="silhouette"
+                d="M70 26 C72 18 80 14 88 17 C96 19 100 24 104 26 C110 27 112 30 108 32
+                   C102 34 94 34 88 32 C80 32 72 31 70 26Z"
+              />
+              <path class="ear" d="M76 19 L75 7 C79 5 83 9 87 14Z" />
+              <circle class="eye" cx="88" cy="24" r="2" />
+            </g>
+          </g>
+        {:else}
+          <g class="facing">
+            <g class="legs far"><path d="M40 60 L38 88 M92 60 L94 88" /></g>
+            <path class="tail" d="M20 44 C10 40 6 50 14 55" />
+            <path
+              class="silhouette"
+              data-sheep-body
+              d="M22 54 C10 50 10 34 24 31 C22 18 38 12 48 20 C54 6 76 6 82 19
+                 C94 8 112 15 111 30 C124 30 126 46 114 52 C116 62 104 68 96 63
+                 C88 72 70 71 64 63 C52 70 30 66 22 54Z"
+            />
+            <path class="curl" d="M40 34 C46 28 54 30 56 36 M66 28 C72 22 82 24 84 30" />
+            <path class="curl" d="M50 50 C56 44 66 46 68 52" />
+            <g class="legs near"><path d="M54 62 L52 90 M104 60 L108 90" /></g>
+            <g class="head">
+              <path
+                class="silhouette"
+                d="M110 38 C122 31 142 33 149 43 C155 51 150 62 140 64 C128 66 112 56 110 38Z"
+              />
+              <!-- after the head, or its own silhouette fill swallows the ear -->
+              <path class="ear" d="M121 39 C112 31 116 21 126 25 C127 31 125 36 121 39Z" />
+              <path class="snout" d="M141 58 C145 59 148 57 149 54" />
+              <circle class="eye" cx="130" cy="45" r="2.6" />
+            </g>
+          </g>
+        {/if}
+      </svg>
+    {/each}
+  </div>
 </div>
 
 <style>
@@ -182,135 +179,115 @@
     overflow: hidden;
     user-select: none;
     contain: paint;
+    /* Sprite sizes scale as one, so the composition holds when the band shrinks. */
+    --scale: 1;
   }
   .flock.backdrop {
     position: absolute;
     inset: auto 0 0;
-    height: min(36dvh, 310px);
+    height: min(42dvh, 340px);
     z-index: 0;
   }
   .flock.sheet {
     display: none;
   }
-  .actor {
+
+  /* The pasture is the scene: the animals' lanes and the horizon are percentages
+     of THIS box, so the band can change height without anything clipping. */
+  .pasture {
     position: absolute;
-    bottom: var(--lane);
+    inset: auto 0 0;
+    height: 100%;
+  }
+  /* Ground below the horizon — a barely-there lift, not a fill. */
+  .ground {
+    position: absolute;
+    inset: auto 0 0;
+    height: 44%;
+    background: linear-gradient(
+      to bottom,
+      color-mix(in srgb, var(--color-ink-bright) 4%, transparent),
+      transparent
+    );
+  }
+  .horizon {
+    position: absolute;
     left: 0;
-    width: var(--actor-width);
-    height: auto;
-    color: var(--color-ink-bright);
-    opacity: 0.62;
-    overflow: visible;
-    transform: translate3d(var(--start), 0, 0);
-    animation:
-      flock-cross var(--duration) linear var(--delay) infinite,
-      flock-wiggle 0.58s ease-in-out var(--delay) infinite alternate;
-  }
-  .actor.big {
-    opacity: 0.56;
-  }
-  .actor.tiny {
-    opacity: 0.54;
-  }
-  .actor.dark {
-    color: var(--color-slate);
-    opacity: 0.66;
-  }
-  .actor.dog {
-    color: var(--color-amber);
-    opacity: 0.82;
-    animation:
-      flock-cross var(--duration) linear var(--delay) infinite,
-      dog-loop 0.46s ease-in-out var(--delay) infinite alternate;
-  }
-  .sprite {
-    transform-origin: center;
-  }
-  .actor.flip .sprite {
-    transform: translateX(150px) scaleX(-1);
-  }
-  .actor.dog.flip .sprite {
-    transform: translateX(96px) scaleX(-1);
-  }
-  .wool {
-    fill: currentColor;
-    stroke: color-mix(in srgb, currentColor 64%, var(--color-bg));
-    stroke-width: 3;
-    stroke-linejoin: round;
-  }
-  .wool.base {
-    opacity: 0.82;
-  }
-  .wool.puff {
-    opacity: 0.96;
-  }
-  .face,
-  .ear {
-    fill: var(--color-bg);
-    stroke: currentColor;
-    stroke-width: 4;
-    stroke-linejoin: round;
-  }
-  .tail,
-  .snout,
-  .eye {
-    fill: none;
-    stroke: currentColor;
-    stroke-width: 3;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-  }
-  .eye {
-    fill: currentColor;
-    stroke: none;
-  }
-  .sheep-leg {
-    fill: none;
-    stroke: currentColor;
-    stroke-width: 5;
-    stroke-linecap: round;
-  }
-  .sheep-leg.rear {
-    opacity: 0.82;
-  }
-  .dog-line {
-    fill: none;
-    stroke: currentColor;
-    stroke-width: 4;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-  }
-  .dog-eye {
-    fill: currentColor;
-  }
-  .flock.reduced .actor {
-    animation: none;
-  }
-  .flock.reduced .actor:nth-child(1) {
-    transform: translate3d(10vw, 0, 0);
-  }
-  .flock.reduced .actor:nth-child(2) {
-    transform: translate3d(24vw, 0, 0);
-  }
-  .flock.reduced .actor:nth-child(3) {
-    transform: translate3d(42vw, 0, 0);
-  }
-  .flock.reduced .actor:nth-child(4) {
-    transform: translate3d(62vw, 0, 0);
-  }
-  .flock.reduced .actor:nth-child(5) {
-    transform: translate3d(76vw, 0, 0);
-  }
-  .flock.reduced .actor:nth-child(6) {
-    transform: translate3d(33vw, 0, 0);
-  }
-  .flock.reduced .actor:nth-child(7) {
-    transform: translate3d(88vw, 0, 0);
-  }
-  .flock.reduced .actor:nth-child(8) {
-    transform: translate3d(54vw, 0, 0);
+    right: 0;
+    bottom: 44%;
+    height: 1px;
+    background: var(--color-line-bright);
+    /* Faded ends so it reads as distance, not as a rule drawn across the screen. */
+    -webkit-mask-image: linear-gradient(90deg, transparent, #000 14%, #000 86%, transparent);
+    mask-image: linear-gradient(90deg, transparent, #000 14%, #000 86%, transparent);
   }
 
+  .tuft,
+  .actor {
+    position: absolute;
+    left: 0;
+    height: auto;
+    overflow: visible;
+    color: var(--color-ink-bright);
+  }
+  /* Depth drives size, lane, opacity and pace together — see the Depth type. */
+  .far {
+    bottom: 28%;
+    opacity: 0.3;
+  }
+  .mid {
+    bottom: 16%;
+    opacity: 0.44;
+  }
+  .near {
+    bottom: 4%;
+    opacity: 0.6;
+  }
+  .actor.far {
+    width: calc(72px * var(--scale));
+  }
+  .actor.mid {
+    width: calc(106px * var(--scale));
+  }
+  .actor.near {
+    width: calc(152px * var(--scale));
+  }
+  .actor.slate {
+    color: var(--color-slate);
+  }
+  .actor.dog {
+    width: calc(130px * var(--scale));
+    color: var(--color-amber);
+    opacity: 0.78;
+  }
+  .tuft {
+    color: var(--color-line-bright);
+    transform: translate3d(var(--x), 0, 0);
+  }
+  .tuft.far {
+    width: calc(16px * var(--scale));
+  }
+  .tuft.mid {
+    width: calc(24px * var(--scale));
+  }
+  .tuft.near {
+    width: calc(34px * var(--scale));
+  }
+  .tuft path {
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.6;
+    stroke-linecap: round;
+  }
+
+  .actor {
+    transform: translate3d(var(--start), 0, 0);
+    animation:
+      flock-cross var(--pace) linear var(--delay) infinite,
+      flock-bob var(--step) ease-in-out var(--delay) infinite alternate;
+  }
+  /* `translate`/`rotate` are independent of `transform`, so the bob and the gait
+     compose with the crossing instead of overwriting it. */
   @keyframes flock-cross {
     from {
       transform: translate3d(var(--start), 0, 0);
@@ -319,25 +296,115 @@
       transform: translate3d(calc(var(--start) + var(--distance)), 0, 0);
     }
   }
-  @keyframes flock-wiggle {
+  @keyframes flock-bob {
     from {
-      translate: 0 -3px;
-      rotate: -2deg;
+      translate: 0 -1.5px;
     }
     to {
-      translate: 0 4px;
-      rotate: 2deg;
+      translate: 0 1.5px;
     }
   }
-  @keyframes dog-loop {
+
+  .actor[data-facing="left"] .facing {
+    transform: translateX(calc(var(--vb) * 1px)) scaleX(-1);
+  }
+
+  .legs {
+    transform-box: fill-box;
+    transform-origin: top center;
+    animation: step var(--step) ease-in-out var(--delay) infinite alternate;
+  }
+  /* The two pairs swing in opposite phase — that is what makes it a walk. */
+  .legs.near {
+    animation-direction: alternate-reverse;
+  }
+  @keyframes step {
     from {
-      translate: 0 -6px;
-      rotate: 3deg;
+      rotate: -8deg;
     }
     to {
-      translate: 0 5px;
-      rotate: -3deg;
+      rotate: 8deg;
     }
+  }
+
+  /* The dog works the flank: it pendulums across the ground plane (toward and
+     away from the camera) while it gains on the flock, and its tail wags. */
+  .actor.dog .facing {
+    animation: dog-weave 2.6s ease-in-out var(--delay) infinite alternate;
+  }
+  @keyframes dog-weave {
+    from {
+      translate: 0 -5px;
+    }
+    to {
+      translate: 0 6px;
+    }
+  }
+  .actor.dog .tail {
+    transform-box: fill-box;
+    transform-origin: bottom left;
+    animation: wag 0.3s ease-in-out var(--delay) infinite alternate;
+  }
+  @keyframes wag {
+    from {
+      rotate: -16deg;
+    }
+    to {
+      rotate: 16deg;
+    }
+  }
+
+  /* Line art throughout. The silhouettes carry the page ground as their fill so
+     overlapping animals occlude each other cleanly instead of blending into a
+     muddle of half-transparent shapes. */
+  .silhouette {
+    fill: var(--color-bg);
+    stroke: currentColor;
+    stroke-width: 3;
+    stroke-linejoin: round;
+  }
+  .ear {
+    fill: var(--color-bg);
+    stroke: currentColor;
+    stroke-width: 2.6;
+    stroke-linejoin: round;
+  }
+  .curl,
+  .snout,
+  .tail {
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2.4;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+  .legs path {
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 3.4;
+    stroke-linecap: round;
+  }
+  .eye {
+    fill: currentColor;
+  }
+
+  /* Resting state. Positions come from the actor data, not from an nth-child
+     ladder that silently drifts the moment the list is reordered. */
+  .flock.reduced .actor,
+  .flock.reduced .actor .facing,
+  .flock.reduced .legs,
+  .flock.reduced .tail {
+    animation: none;
+  }
+  .flock.reduced .actor {
+    transform: translate3d(var(--rest), 0, 0);
+    translate: none;
+  }
+  /* Heads down: a flock at rest is a flock grazing. */
+  .flock.reduced .actor:not(.dog) .head {
+    transform-box: fill-box;
+    transform-origin: left center;
+    rotate: 24deg;
   }
 
   @media (max-width: 768px) {
@@ -351,20 +418,42 @@
       height: 100dvh;
       margin-bottom: -100dvh;
       z-index: 0;
+      --scale: 0.62;
     }
-    .actor {
+    /* No ground band on a phone. The sheet's commit list carries `flex-grow: 1`
+       and an opaque `--color-inset` background, so it eats the screen and the
+       only strip left at the bottom is the action row — a pasture there lands
+       the whole herd across the "Updating…" button. The animals spread over the
+       full sheet instead and show through the gaps between the opaque boxes:
+       same sprites, same gait, same derived facing, framed as a backdrop rather
+       than a scene. The horizon and tufts only make sense on real ground. */
+    .flock.sheet .ground,
+    .flock.sheet .horizon,
+    .flock.sheet .tuft {
+      display: none;
+    }
+    .flock.sheet .far {
+      bottom: 62%;
+    }
+    .flock.sheet .mid {
+      bottom: 38%;
+    }
+    .flock.sheet .near {
+      bottom: 14%;
+    }
+    .flock.sheet .actor {
       opacity: 0.26;
     }
-    .actor.big {
-      opacity: 0.24;
-    }
-    .actor.dog {
-      opacity: 0.38;
+    .flock.sheet .actor.dog {
+      opacity: 0.34;
     }
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .actor {
+    .actor,
+    .actor .facing,
+    .legs,
+    .tail {
       animation: none;
     }
   }

--- a/ui/src/lib/components/UpdateModal.browser.test.ts
+++ b/ui/src/lib/components/UpdateModal.browser.test.ts
@@ -11,6 +11,7 @@ vi.mock("$lib/api", async (orig) => ({
 }));
 
 import UpdateModal from "./UpdateModal.svelte";
+import { theme } from "$lib/theme.svelte";
 import { applyUpdate, getUpdateDirty } from "$lib/api";
 
 const mockApply = applyUpdate as unknown as ReturnType<typeof vi.fn>;
@@ -52,6 +53,7 @@ afterEach(async () => {
   mockApply.mockImplementation(() => new Promise(() => {}));
   mockDirty.mockReset();
   mockDirty.mockResolvedValue({ dirty: false, dirtyFiles: [], dirtyCount: 0, sig: null });
+  theme.setMotion("system");
   await page.viewport(1280, 900);
 });
 
@@ -200,6 +202,90 @@ describe("UpdateModal", () => {
     expect(sheet!.querySelector('[data-flock-actor="dog"]')).not.toBeNull();
     expect(sheet!.querySelector("pre")).toBeNull();
     expect(sheet!.querySelector("[data-sheep-body]")).not.toBeNull();
+  });
+
+  it("faces every actor the way it actually travels", async () => {
+    await page.viewport(1280, 900);
+
+    render(UpdateModal, { props: { update, updating: true, deploy } });
+
+    const actors = [...document.querySelectorAll<SVGElement>('[data-flock="backdrop"] .actor')];
+    expect(actors.length).toBeGreaterThan(4);
+    for (const a of actors) {
+      // `--distance` is the signed ground travel; the sprites are drawn facing
+      // right. A mismatch here is an animal moon-walking across the pasture.
+      const travel = parseFloat(a.style.getPropertyValue("--distance"));
+      expect(travel, `${a.className.baseVal} has no travel`).not.toBe(0);
+      expect(a.dataset.facing, `${a.className.baseVal} travels ${travel}vw`).toBe(
+        travel < 0 ? "left" : "right",
+      );
+    }
+  });
+
+  it("keeps every actor inside the pasture band — nothing clipped at the edges", async () => {
+    for (const [w, h] of [
+      [1280, 900],
+      [1440, 900],
+    ] as const) {
+      await page.viewport(w, h);
+      render(UpdateModal, { props: { update, updating: true, deploy } });
+
+      const flock = document.querySelector<HTMLElement>('[data-flock="backdrop"]')!;
+      const band = flock.querySelector<HTMLElement>(".pasture")!.getBoundingClientRect();
+      const actors = [...flock.querySelectorAll<SVGElement>(".actor")];
+      expect(actors.length).toBeGreaterThan(4);
+      for (const a of actors) {
+        const r = a.getBoundingClientRect();
+        expect(
+          r.bottom,
+          `${a.className.baseVal} at ${w}x${h} sinks below the band`,
+        ).toBeLessThanOrEqual(band.bottom + 0.5);
+        expect(
+          r.top,
+          `${a.className.baseVal} at ${w}x${h} rises above the band`,
+        ).toBeGreaterThanOrEqual(band.top - 0.5);
+      }
+      document.body.innerHTML = "";
+    }
+  });
+
+  it("stands the flock on a horizon rather than letting it float", async () => {
+    await page.viewport(1280, 900);
+
+    render(UpdateModal, { props: { update, updating: true, deploy } });
+
+    const flock = document.querySelector<HTMLElement>('[data-flock="backdrop"]')!;
+    const horizon = flock.querySelector<HTMLElement>(".horizon")!;
+    expect(horizon).not.toBeNull();
+    const hr = horizon.getBoundingClientRect();
+    // Far animals stand beyond the horizon line, near ones in front of it.
+    const far = flock.querySelector<SVGElement>(".actor.far")!.getBoundingClientRect();
+    const near = flock.querySelector<SVGElement>(".actor.near")!.getBoundingClientRect();
+    expect(far.bottom).toBeGreaterThan(hr.bottom);
+    expect(near.bottom).toBeGreaterThan(far.bottom);
+    expect(far.height).toBeLessThan(near.height);
+  });
+
+  it('keeps the flock moving when the operator picked "full" motion', async () => {
+    mockReducedMotion(true); // the system says reduce…
+    theme.setMotion("full"); // …and the operator overruled it
+
+    render(UpdateModal, { props: { update, updating: true, deploy } });
+
+    const flock = document.querySelector<HTMLElement>('[data-flock="backdrop"]')!;
+    expect(flock.dataset.reduced).toBe("false");
+    expect(getComputedStyle(flock.querySelector(".actor")!).animationName).not.toBe("none");
+  });
+
+  it('stills the flock when the operator picked "reduced" motion', async () => {
+    mockReducedMotion(false); // the system says nothing…
+    theme.setMotion("reduced"); // …and the operator asked for calm
+
+    render(UpdateModal, { props: { update, updating: true, deploy } });
+
+    const flock = document.querySelector<HTMLElement>('[data-flock="backdrop"]')!;
+    await vi.waitFor(() => expect(flock.dataset.reduced).toBe("true"));
+    expect(getComputedStyle(flock.querySelector(".actor")!).animationName).toBe("none");
   });
 
   it("uses a testable static flock state when reduced motion is requested", async () => {

--- a/ui/src/lib/components/settings/SettingsDevicePanel.browser.test.ts
+++ b/ui/src/lib/components/settings/SettingsDevicePanel.browser.test.ts
@@ -4,6 +4,7 @@ import { page } from "vitest/browser";
 import "../../../app.css";
 import { m } from "$lib/paraglide/messages";
 import { infoTips } from "$lib/info-tips.svelte";
+import { theme } from "$lib/theme.svelte";
 
 // Stub $lib/push so pushState resolves to unsupported — avoids navigator.
 vi.mock("$lib/push", async (importOriginal) => {
@@ -107,5 +108,68 @@ describe("SettingsDevicePanel hide-info-tips switch", () => {
 
     expect(infoTips.hidden).toBe(true);
     await expect.element(tipsSwitchOn()).toHaveAttribute("aria-checked", "true");
+  });
+});
+
+// The motion picker is a device pref like theme/contrast — the panel drives the
+// controller directly. It exists so an operator can overrule a system that reports
+// `prefers-reduced-motion: reduce` without being asked to (see app.css).
+const motionOpt = (label: string) => page.getByRole("button", { name: label, exact: true });
+
+describe("SettingsDevicePanel motion picker", () => {
+  afterEach(() => {
+    theme.setMotion("system");
+    localStorage.removeItem("shepherd:motion");
+    delete document.documentElement.dataset.motion;
+  });
+
+  // The attribute is written by the controller's #apply() — from the pre-paint
+  // script in app.html and theme.init() in the real app, and on every pick. A bare
+  // panel render runs neither, so this only asserts the control's own state.
+  it("defaults to system", async () => {
+    render(SettingsDevicePanel, {});
+
+    await expect
+      .element(motionOpt(m.settings_motion_system()))
+      .toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("picking Full persists the choice and flips the attribute", async () => {
+    render(SettingsDevicePanel, {});
+
+    await motionOpt(m.settings_motion_full()).click();
+
+    expect(theme.motion).toBe("full");
+    expect(document.documentElement.dataset.motion).toBe("full");
+    expect(localStorage.getItem("shepherd:motion")).toBe("full");
+    await expect
+      .element(motionOpt(m.settings_motion_full()))
+      .toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("picking Reduced stills decorative motion via the app.css guard", async () => {
+    render(SettingsDevicePanel, {});
+    const probe = document.createElement("div");
+    const css = document.createElement("style");
+    css.textContent = `@keyframes dp { to { opacity: 0 } } .dp { animation: dp 1s linear infinite }`;
+    probe.className = "dp";
+    document.head.appendChild(css);
+    document.body.appendChild(probe);
+
+    await motionOpt(m.settings_motion_reduced()).click();
+    expect(getComputedStyle(probe).animationName).toBe("none");
+
+    css.remove();
+    probe.remove();
+  });
+
+  it("names the resolved system value while on System", async () => {
+    render(SettingsDevicePanel, {});
+
+    const resolved =
+      theme.motionResolved === "reduced" ? m.settings_motion_reduced() : m.settings_motion_full();
+    await expect
+      .element(page.getByText(m.settings_motion_hint_system({ resolved })))
+      .toBeInTheDocument();
   });
 });

--- a/ui/src/lib/components/settings/SettingsDevicePanel.svelte
+++ b/ui/src/lib/components/settings/SettingsDevicePanel.svelte
@@ -9,7 +9,7 @@
     type PushStatus,
     type PushCategories,
   } from "$lib/push";
-  import { theme, type ThemePref } from "$lib/theme.svelte";
+  import { theme, type ThemePref, type MotionPref } from "$lib/theme.svelte";
   import { tabTicker } from "$lib/tab-ticker.svelte";
   import { infoTips } from "$lib/info-tips.svelte";
   import { issueRef } from "$lib/issue-ref.svelte";
@@ -46,6 +46,27 @@
     { pref: "light", icon: "sun", label: m.theme_light },
     { pref: "system", icon: "auto", label: m.theme_system },
   ];
+
+  // Motion picker. The OS hint is the default, but it is not always trustworthy —
+  // a bare Wayland session can report `prefers-reduced-motion: reduce` with nothing
+  // in the desktop actually asking for it, and app.css then stills every animation
+  // in Shepherd. This is the escape hatch, and the hint line below names what the
+  // system is currently reporting so the diagnosis doesn't need a browser console.
+  const MOTIONS: { pref: MotionPref; label: () => string }[] = [
+    { pref: "full", label: m.settings_motion_full },
+    { pref: "system", label: m.settings_motion_system },
+    { pref: "reduced", label: m.settings_motion_reduced },
+  ];
+  const motionHint = $derived(
+    theme.motion === "system"
+      ? m.settings_motion_hint_system({
+          resolved:
+            theme.motionResolved === "reduced"
+              ? m.settings_motion_reduced()
+              : m.settings_motion_full(),
+        })
+      : m.settings_motion_hint(),
+  );
 
   let push = $state<PushStatus>({ supported: false, permission: "unsupported", subscribed: false });
   let pushBusy = $state(false);
@@ -98,6 +119,21 @@
         aria-pressed={theme.pref === t.pref}
         aria-label={m.actionbar_theme_option({ label: t.label() })}
         onclick={() => theme.setPref(t.pref)}><ThemeIcon icon={t.icon} /></button
+      >
+    {/each}
+  </div>
+</div>
+<div class="motion-row">
+  <span class="micro"><HighlightText text={m.settings_motion_title()} {query} /></span>
+  <p class="hint"><HighlightText text={motionHint} {query} /></p>
+  <div class="theme-seg" role="group" aria-label={m.settings_motion_title()}>
+    {#each MOTIONS as mo (mo.pref)}
+      <button
+        type="button"
+        class="t-opt wide"
+        class:on={theme.motion === mo.pref}
+        aria-pressed={theme.motion === mo.pref}
+        onclick={() => theme.setMotion(mo.pref)}>{mo.label()}</button
       >
     {/each}
   </div>
@@ -451,11 +487,13 @@
      every viewport so the menu reads identically on mobile and desktop — desktop
      additionally mirrors the theme switcher in the ActionBar for quick access. */
   .theme-row,
+  .motion-row,
   .contrast-row {
     display: flex;
     flex-direction: column;
     gap: 6px;
   }
+  .motion-row .hint,
   .contrast-row .hint {
     color: var(--color-faint);
     font-size: var(--fs-meta);
@@ -485,6 +523,14 @@
   .t-opt.on {
     color: var(--color-amber);
     background: var(--color-inset);
+  }
+  /* Text options rather than glyphs, so they need the smaller label type and
+     room to wrap on a narrow phone instead of overflowing the segment. */
+  .t-opt.wide {
+    font-size: var(--fs-meta);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 0 12px;
   }
   .feedback {
     display: flex;

--- a/ui/src/lib/feature-announcements/entries/v1.48.0-motion-pref.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.48.0-motion-pref.ts
@@ -1,0 +1,8 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+export default {
+  id: "motion-pref",
+  sinceVersion: "1.48.0",
+  titleKey: "feat_motion_pref_title",
+  bodyKey: "feat_motion_pref_body",
+} satisfies FeatureAnnouncement;

--- a/ui/src/lib/motion-preference.browser.test.ts
+++ b/ui/src/lib/motion-preference.browser.test.ts
@@ -1,0 +1,77 @@
+// Guards the motion kill switch in app.css. Two things must hold at once, and
+// they pull against each other:
+//
+//   1. `[data-motion="reduced"]` stills decorative animation everywhere.
+//   2. Functional status indicators (CI dot-pulse, pip-pulse, critic rev-pulse)
+//      keep animating — they encode "work is happening", not decoration, and
+//      they earn that by carrying their own `animation: … !important` on a more
+//      specific selector.
+//
+// #2 only survives because the guard sits inside `:where()` (zero specificity).
+// Drop the `:where()` and this file goes red — which is the entire point of it.
+import { describe, it, expect, afterEach } from "vitest";
+import "../app.css";
+
+let style: HTMLStyleElement | null = null;
+
+function mount(html: string, css: string) {
+  style = document.createElement("style");
+  style.textContent = css;
+  document.head.appendChild(style);
+  document.body.innerHTML = html;
+}
+
+afterEach(() => {
+  style?.remove();
+  style = null;
+  document.body.innerHTML = "";
+  delete document.documentElement.dataset.motion;
+});
+
+// The indicator selector is a SINGLE class on purpose — specificity (0,1,0),
+// exactly like the real `.dot-pending` / `.cb-cog` / `.pip-pulse` rules. A
+// two-class selector would be (0,2,0) and would survive even an unguarded
+// `html[data-motion="reduced"] *` (0,1,1), i.e. it would not catch the
+// regression this file exists to catch.
+const FIXTURE = `
+  @keyframes mp-spin { from { rotate: 0deg } to { rotate: 360deg } }
+  .decor { animation: mp-spin 1s linear infinite; }
+  .indicator { animation: mp-spin 1s linear infinite !important; }
+`;
+
+const nameOf = (sel: string) =>
+  getComputedStyle(document.querySelector(sel) as Element).animationName;
+
+describe("motion preference", () => {
+  it("leaves both animations running when no preference is set", () => {
+    mount(`<div class="decor"></div><div class="indicator"></div>`, FIXTURE);
+
+    expect(nameOf(".decor")).toBe("mp-spin");
+    expect(nameOf(".indicator")).toBe("mp-spin");
+  });
+
+  it('stills decorative motion under [data-motion="reduced"]', () => {
+    document.documentElement.dataset.motion = "reduced";
+    mount(`<div class="decor"></div>`, FIXTURE);
+
+    expect(nameOf(".decor")).toBe("none");
+  });
+
+  it('keeps functional status animation alive under [data-motion="reduced"]', () => {
+    document.documentElement.dataset.motion = "reduced";
+    mount(`<div class="indicator"></div>`, FIXTURE);
+
+    // If this fails, the guard in app.css outranks the component's !important —
+    // check that `html[data-motion=…]` is still wrapped in :where().
+    expect(nameOf(".indicator")).toBe("mp-spin");
+  });
+
+  it('does not still anything under [data-motion="full"] or "system"', () => {
+    for (const pref of ["full", "system"] as const) {
+      document.documentElement.dataset.motion = pref;
+      mount(`<div class="decor"></div>`, FIXTURE);
+      expect(nameOf(".decor"), `data-motion="${pref}"`).toBe("mp-spin");
+      style?.remove();
+    }
+  });
+});

--- a/ui/src/lib/settings-search.ts
+++ b/ui/src/lib/settings-search.ts
@@ -217,6 +217,7 @@ export function sectionSearchRows(ctx: {
     device: [
       [m.settings_tab_device()],
       [m.actionbar_theme_group_aria()],
+      [m.settings_motion_title(), m.settings_motion_hint()],
       [m.settings_contrast_title(), m.settings_contrast_hint()],
       [m.settings_colorblind_title(), m.settings_colorblind_hint()],
       [m.settings_tab_ticker_title(), m.settings_tab_ticker_hint()],

--- a/ui/src/lib/theme.svelte.ts
+++ b/ui/src/lib/theme.svelte.ts
@@ -6,11 +6,14 @@
 
 export type ThemePref = "dark" | "light" | "system";
 export type Resolved = "dark" | "light";
+export type MotionPref = "system" | "full" | "reduced";
 
 const STORAGE_KEY = "shepherd:theme";
 const CONTRAST_KEY = "shepherd:contrast";
 const COLORBLIND_KEY = "shepherd:colorblind";
+const MOTION_KEY = "shepherd:motion";
 const DARK_QUERY = "(prefers-color-scheme: dark)";
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
 
 function readPref(): ThemePref {
   try {
@@ -40,8 +43,22 @@ function readColorblind(): boolean {
   }
 }
 
+function readMotion(): MotionPref {
+  try {
+    const v = localStorage.getItem(MOTION_KEY);
+    if (v === "system" || v === "full" || v === "reduced") return v;
+  } catch {
+    /* localStorage unavailable (SSR / privacy mode) */
+  }
+  return "system";
+}
+
 function systemPrefersDark(): boolean {
   return typeof matchMedia !== "undefined" ? matchMedia(DARK_QUERY).matches : true;
+}
+
+function systemReducesMotion(): boolean {
+  return typeof matchMedia !== "undefined" ? matchMedia(REDUCED_MOTION_QUERY).matches : false;
 }
 
 class ThemeController {
@@ -59,8 +76,20 @@ class ThemeController {
   // normal-sighted users, but a rotgrün-confused operator can switch it on.
   colorblind = $state<boolean>(readColorblind());
 
+  // Motion is a third independent layer. The OS hint (prefers-reduced-motion) is
+  // the default, but it is not always trustworthy — a bare Wayland session can
+  // report `reduce` with nothing in the DE actually asking for it, which silently
+  // kills every animation in the app. "full" / "reduced" let the operator say so
+  // explicitly; an in-app choice is more specific than a system-wide hint.
+  motion = $state<MotionPref>(readMotion());
+  systemReducedMotion = $state<boolean>(systemReducesMotion());
+
   resolved = $derived<Resolved>(
     this.pref === "system" ? (this.systemDark ? "dark" : "light") : this.pref,
+  );
+
+  motionResolved = $derived<"full" | "reduced">(
+    this.motion === "system" ? (this.systemReducedMotion ? "reduced" : "full") : this.motion,
   );
 
   /** Persist + apply a new preference. */
@@ -108,6 +137,17 @@ class ThemeController {
     this.setColorblind(!this.colorblind);
   }
 
+  /** Persist + apply the motion preference (drives [data-motion] in app.css). */
+  setMotion(p: MotionPref) {
+    this.motion = p;
+    try {
+      localStorage.setItem(MOTION_KEY, p);
+    } catch {
+      /* ignore — preference just won't survive reload */
+    }
+    this.#apply();
+  }
+
   #apply() {
     if (typeof document !== "undefined") {
       const root = document.documentElement;
@@ -119,20 +159,31 @@ class ThemeController {
       if (meta) meta.setAttribute("content", this.resolved === "dark" ? "#0a0d0c" : "#e7ebe9");
       if (this.contrast) root.dataset.contrast = "high";
       else delete root.dataset.contrast;
+      // The *preference* lands on the attribute, not the resolved value: app.css
+      // needs to tell "system (follow the media query)" apart from "full"/"reduced".
+      root.dataset.motion = this.motion;
     }
   }
 
-  /** Wire OS-theme changes. Call once on mount; returns a disposer. */
+  /** Wire OS-theme + OS-motion changes. Call once on mount; returns a disposer. */
   init(): () => void {
     this.#apply();
     if (typeof matchMedia === "undefined") return () => {};
-    const mq = matchMedia(DARK_QUERY);
-    const onChange = () => {
-      this.systemDark = mq.matches;
+    const dark = matchMedia(DARK_QUERY);
+    const onDark = () => {
+      this.systemDark = dark.matches;
       this.#apply();
     };
-    mq.addEventListener("change", onChange);
-    return () => mq.removeEventListener("change", onChange);
+    dark.addEventListener("change", onDark);
+    const motion = matchMedia(REDUCED_MOTION_QUERY);
+    const onMotion = () => {
+      this.systemReducedMotion = motion.matches;
+    };
+    motion.addEventListener("change", onMotion);
+    return () => {
+      dark.removeEventListener("change", onDark);
+      motion.removeEventListener("change", onMotion);
+    };
   }
 }
 


### PR DESCRIPTION
Die Update-Schafe standen auf dem Desktop still, und die Szene hatte ein paar Fehler, die man einmal gesehen nicht mehr übersieht.

## Die Diagnose ging anders aus als erwartet

Naheliegend war `prefers-reduced-motion` — `ui/src/app.css` schaltet darunter pauschal jede Animation ab (`*, *::before, *::after { animation: none !important }`). Die Messung sagt aber: das System meldet **kein** reduced-motion (echtes Chromium auf der Wayland-Session, Playwright-Emulation per `reducedMotion: null` zurückgesetzt → `reduce: false`, `dark: true`). Die Ursache des Stillstands ist damit nicht bewiesen.

Beide Arbeiten hier decken den Fall trotzdem ab: greift die Einstellung, löst sie es; greift sie nicht, löst die Kompositionsarbeit das Symptom, weil die Herde jetzt groß, auf sichtbarem Boden und im Blickfeld läuft.

## Bewegungs-Einstellung

Geräte-lokale Präferenz (System / Voll / Reduziert) im Theme-Controller, als `data-motion` aufs `<html>` — schon im Vor-Paint-Skript, sonst blitzt eine unterdrückte Animation vor der Hydration auf. Im Settings-Tab „Gerät" als Segmentleiste neben dem Theme-Schalter; bei „System" nennt der Hinweis den aktuell gemeldeten Wert, damit die nächste „bei mir bewegt sich nichts"-Frage ohne Browserkonsole beantwortbar ist.

**Die heikle Stelle:** Die Pauschalregel hat den Selektor `*`, Spezifität 0,0,0. Die funktionalen Statusanzeigen (CI-Punkt-Puls, Pip-Puls, Critic-Rev-Puls) überstimmen sie mit eigenem `animation: … !important` und gewinnen **nur, weil ihr Selektor spezifischer ist**. Ein naives `:root:not([data-motion="full"]) *` (0,2,0) hätte die Balance gekippt und die Statuspulse mit stillgestellt. Der Wächter steht deshalb in `:where()`, das nichts zur Spezifität beiträgt. `ui/src/lib/motion-preference.browser.test.ts` pinnt genau das — Fixture-Selektor ist bewusst **eine** Klasse, wie die echten `.dot-pending`/`.cb-cog`, weil zwei Klassen die Regression durchgelassen hätten.

## Die Weide

- **Vier von sieben Schafen liefen rückwärts.** `flip` war ein handgepflegtes Flag pro Akteur, das Sprite schaut nach rechts — `sheep-1/-3/-6/-7` hatten negative Laufstrecke ohne Flag. Blickrichtung wird jetzt aus dem Vorzeichen der Strecke **abgeleitet**, kann also nicht wieder abdriften.
- **Stilbruch behoben.** Der Hund war Strichzeichnung, die Schafe gefüllte Blobs aus Basispfad plus sechs halbtransparenten Kreisen, deren Kanten durchschienen. Beide sind jetzt Linienkunst mit Grundfüllung, sodass sich überlappende Tiere sauber verdecken.
- **Boden und Tiefe.** Horizont mit ausgeblendeten Enden, drei Tiefenebenen — fern kleiner, höher, blasser, langsamer; nah größer, tiefer, kräftiger, schneller. Das dreht die bisherige Inversion um (die großen, nahen Schafe waren die langsamsten).
- **Gangart.** Zwei gegenläufige Beinpaare statt eines Auf-Ab-Wackelns, Schrittfrequenz nach Tiefe.
- **Der Hund hütet.** Eigenes, schnelleres Tempo, sodass er auf die Herde aufläuft, Pendeln quer zur Laufrichtung, wedelnde Rute. Neu als Collie gezeichnet — die erste Fassung las sich wie ein Ferkel.
- **Kein Beschnitt mehr.** Der Hund auf Spur 10 wurde von der Bandunterkante angeschnitten; Spuren sind jetzt Prozente des Bandes.
- **Standbild aus Daten** statt aus einer `nth-child`-Kette, die beim Umsortieren der Akteursliste still abdriftet: gleichmäßig verteilte Herde mit gesenkten Köpfen, Hund an der Flanke.
- Tote Klasse `reverse` entfernt.

## Abweichung von der abgestimmten Entscheidung: das Handy

Abgestimmt war „gleiche Weide wie Desktop, nur anders gerahmt". Gebaut, gemessen, verworfen: die Commit-Liste im Sheet hat `flex-grow: 1` und einen opaken `--color-inset`-Hintergrund, frisst also den Schirm — der einzige freie Bodenstreifen unten ist die Aktionszeile, und die komplette Herde landete quer über dem „Updating…"-Knopf.

Auf dem Handy verteilen sich die Tiere deshalb weiter über das ganze Sheet und scheinen durch die Lücken, mit allen neuen Sprites, der Gangart und der korrekten Laufrichtung. Horizont und Grasbüschel entfallen dort — ohne echten Boden ergeben sie keinen Sinn.

## Verifikation

- `ui`: `bun run check` 0 Fehler, `check:i18n` in Parität, 5155 Tests grün
- Wurzel: `bun run lint` sauber, 9728 Tests grün
- Feature-Katalog- und Announcement-Gate grün
- Die zwei neuen Flock-Tests mutiert gegengeprüft: Blickrichtung verdreht → rot, Spur unter den Bandrand geschoben → rot
- Sichtprüfung per Screenshot bei 1440×900, 1920×1080 und 390×844, plus das Standbild
