### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs-site/src/content/docs/reference/glossary.md
+++ b/docs-site/src/content/docs/reference/glossary.md
@@ -141,6 +141,18 @@ A model-weighted measure of token spend that counts what actually draws down you
 subscription limits — output tokens cost far more than cached reads, so weighted
 units, not raw token counts, reflect true usage.
 
+### Cold cache
+
+A session's prompt cache expires after a stretch of inactivity — one hour on a
+Claude subscription, five minutes on an API key. Once it has, the next turn
+re-sends the whole conversation at the cache-write rate instead of reading it
+back cheaply, which makes that single turn many times more expensive than the
+turns around it. A parked session that has gone cold carries a warn chip in The
+Herd and a matching marker in its status bar, estimating that first turn's cost
+in [weighted units](#weighted-units) so you can see it before you resume.
+Codex sessions and archived ones stay silent, as does anything below a small
+cost floor.
+
 ### Reasoning effort
 
 A cost/quality dial (`low`, `medium`, `high`, `xhigh`, `max`, `ultra`) that sets

--- a/docs/external-task-api.md
+++ b/docs/external-task-api.md
@@ -174,11 +174,21 @@ usage is already high, so an automated submitter doesn't push you over a cap. Th
 gate is **on by default** and governed by two env vars (`SHEPHERD_USAGE_HOLD_ENABLED`,
 default on; `SHEPHERD_USAGE_HOLD_PCT`, default `80`).
 
-A submission is held only when **both** of these hold (`src/usage-hold.ts`):
+A submission is held only when **all** of these hold (`src/usage-hold.ts`,
+`src/server.ts`):
 
+- the resolved coding CLI is **Claude** — the request's `agentProvider` if it set
+  one, else the operator's default provider. A Codex submission is never held,
+  because the hold gate reads Claude's usage windows; and
 - the gate is enabled, and the request did not set `force: true`; and
 - the higher of the 5-hour and weekly usage windows is at or above
   `SHEPHERD_USAGE_HOLD_PCT`.
+
+That first condition interacts with **capacity failover**
+(`src/provider-failover.ts`): when the default CLI's weekly window runs low the
+operator can switch the default to the other CLI from the usage popover, and
+Shepherd switches back on its own once capacity returns. While the default is
+Codex, submissions that don't name a provider are spawned rather than held.
 
 When usage can't be measured (api-key auth, or caps not yet calibrated) the windows
 read `0`, so a task is **never** held — Shepherd won't freeze work it can't measure.

--- a/ui/src/lib/docs-manifest.ts
+++ b/ui/src/lib/docs-manifest.ts
@@ -81,7 +81,7 @@ export const DOCS_PAGES: readonly DocsPage[] = [
     title: "Concepts & glossary",
     path: "/reference/glossary/",
     keywords:
-      "the shepherd-specific and industry terms used throughout the app and these docs. shepherd concepts epic plan gate autopilot task amendment critic merge train rework first-pass rate first-push ci green plan drift maintain loop band inferred lightweight repo trial weighted units reasoning effort satellite pass host capacity herdr runtime hygiene sandbox membrane spawn prompt access token token scope industry terms pr ci telemetry lead time inode",
+      "the shepherd-specific and industry terms used throughout the app and these docs. shepherd concepts epic plan gate autopilot task amendment critic merge train rework first-pass rate first-push ci green plan drift maintain loop band inferred lightweight repo trial weighted units cold cache reasoning effort satellite pass host capacity herdr runtime hygiene sandbox membrane spawn prompt access token token scope industry terms pr ci telemetry lead time inode",
   },
   {
     title: "Project house rules",


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc update summary

## Changes

- **`docs-site/src/content/docs/reference/glossary.md`** — added a **Cold cache**
  concept entry (between _Weighted units_ and _Reasoning effort_, matching the
  registry's own ordering). The page states that its definitions are the ones
  driving the in-app term tooltips from `ui/src/lib/glossary.ts`; commit
  `f08cd6285` ("feat(usage): mark sessions that are expensive to resume") added a
  `cold-cache` term to that registry (`gloss_cold_cache_term` /
  `gloss_cold_cache_def` in `ui/messages/en.json`) with no counterpart here. The
  wording follows the shipped definition plus the operator-visible surface from
  the same commit: the warn chip in The Herd and the session-status-bar marker,
  the estimate in weighted units, and the Codex / archived / below-cost-floor
  cases that stay silent.

- **`docs/external-task-api.md`** — the "Usage-aware hold gate" section listed
  two conditions and said a submission is held when **both** hold. The gate has a
  third, earlier condition in `src/server.ts`: `tryHoldNewTask` (and
  `usageHoldApplies` for the Up Next path) resolve the provider from the
  request's `agentProvider` else `config.defaultAgentProvider` and return
  immediately unless it is `claude`, so a Codex submission is never held.
  Rewrote the list as "all of these" with that condition first, and added a note
  on its interaction with capacity failover (`src/provider-failover.ts`,
  `config.providerFailoverFrom`, commit `8a2f532a8`): while the default CLI has
  been switched to Codex, provider-less submissions spawn rather than hold.

Nothing else in the in-scope set was changed. Spot-checks that came back current:
`docs-site/src/content/docs/reference/configuration.md` already carries the
`incident_spike` band's `block` exclusion from `4cbd752f5`; `getting-started.md`'s
"herdr 0.9.0 is the last supported version" still matches
`HERDR_LAST_SUPPORTED_VERSION` in `src/herdr-capabilities.ts`;
`docs/sandbox-security.md` was refreshed by the previous sync (`82b7d2856`) and no
source change since then touches the membrane; `docs/token-usage-analysis.md` is a
dated report of a fixed sample, not a live description.

## Uncertain / needs human judgement

- **`configuration.md` does not document `SHEPHERD_DEFAULT_AGENT_PROVIDER`**, even
  though the page's description promises "every environment variable". It is read
  in `src/config.ts:912`, and commit `8a2f532a8` made it something Shepherd now
  writes itself (capacity failover, plus the non-env `providerFailoverFrom` runtime
  field). I did not add a row: a scan of `src/config.ts` shows a whole family of
  vars the page deliberately omits (`SHEPHERD_DEFAULT_MODEL`,
  `SHEPHERD_DEFAULT_EFFORT`, `SHEPHERD_CRITIC_*` / `SHEPHERD_PLANNER_*` /
  `SHEPHERD_RECAP_*` / `SHEPHERD_NAMER_*`, `SHEPHERD_AUTH_MODE`,
  `SHEPHERD_FABLE_AVAILABLE`, `SHEPHERD_AUTOPILOT_*`, `SHEPHERD_REVIEW_CYCLES_CAP`,
  …), so the page looks curated rather than exhaustive and I could not tell whether
  a single new row is wanted or whether the whole section needs a decision.

- **Where capacity failover belongs in the docs site** is unclear to me. It is a
  visible operator behaviour (the usage popover's switch, the automatic restore on
  the 30 s tick, the "picking a CLI by hand ends the substitution" rule) but it has
  no env var, so it fits neither the env-var tables in `configuration.md` nor
  `operating.md`'s host/systemd scope, and the glossary mirrors a UI registry that
  has no term for it. I documented only the part that changes already-documented
  behaviour (the hold gate, above) and left the feature itself undocumented.

- **The cold-resume correction to `fullRecaches`** (same commit `f08cd6285`: the
  metric now counts a main-thread record that cache-writes more than half its own
  context, instead of the old `cacheRead === 0` test).
  `docs/token-usage-analysis.md` describes and uses a `FullRecache` column under
  the old rule. I left it alone because that document is an explicitly historical
  report of a fixed five-task sample with figures that are "unchanged" by design —
  rewriting the column's definition in place would misdescribe how those numbers
  were actually produced. A human may still want a dated footnote saying the metric
  has since been redefined, so a re-run of `scripts/usage-report.ts` will not
  reproduce the `FullRecache` column.