### PR TITLE
fix(poller): don't raise awaiting-input on a queued-input pane (#2272)

### DIFF
--- a/src/blocked.ts
+++ b/src/blocked.ts
@@ -74,6 +74,31 @@ export function hasActiveSpinner(text: string): boolean {
   return tailLines(text).some((l) => SPINNER_RE.test(l));
 }
 
+// The at-rest input box's queued-input hint. Claude Code 2.1.266 ships three
+// wordings — "Press up to edit queued messages", "Press up to select a queued
+// message" and "…select a queued message to edit" — so the match is anchored on
+// the stable "press up to <verb> … queued message" spine rather than one string.
+const QUEUED_INPUT_RE = /press up to \w+\s+(?:a\s+)?queued message/i;
+
+/**
+ * True when the terminal tail shows the agent's at-rest input box carrying
+ * QUEUED operator input. A session holding input it has not consumed yet cannot
+ * be waiting for more, so an `awaiting-input` fallback over such a buffer is a
+ * false "needs you" (issue #2272). Scans the same last-15-non-empty-lines window
+ * as `classifyBlocked` (the hint sits just above the footer), so the phrase
+ * appearing in older scrollback cannot forge it.
+ *
+ * Why this exists: herdr latches `agent_status=blocked` after an answered dialog
+ * — the same upstream bug `hasActiveSpinner` guards against — but the spinner is
+ * not on screen yet, so the latch falls through to the no-evidence
+ * `awaiting-input` fallback. Measured on a live install: of 1432 captured
+ * `awaiting-input` block rows NONE carried a spinner, while every full-screen
+ * capture of the false positive carried this hint.
+ */
+export function hasQueuedInput(text: string): boolean {
+  return tailLines(text).some((l) => QUEUED_INPUT_RE.test(l));
+}
+
 /** Classify a blocked agent's terminal tail into an actionable shape. Never throws. */
 export function classifyBlocked(text: string): BlockReason {
   const tail = tailLines(text);

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -18,6 +18,7 @@ import { herdrUsesExternalRegistrationSpawn } from "./herdr-capabilities";
 import {
   classifyBlocked,
   hasActiveSpinner,
+  hasQueuedInput,
   quotaBlockReason,
   tailLines,
   type BlockReason,
@@ -1730,11 +1731,17 @@ export class StatusPoller {
    * a wedged turn (or a static tail merely quoting a spinner-like line) and falls
    * through to the normal emit, re-arming the block instead of suppressing forever.
    * The first sighting of an episode gets a one-cadence grace (nothing to compare
-   * yet; the common case is a genuinely working spinner). The suppression episode
-   * is surfaced as the working-while-blocked display flag: `onWorkingBlocked(id, true)`
-   * once on entry; on re-arm (any block that will be emitted) `onWorkingBlocked(id,
-   * false)` fires first, then `onBlock`, in the same tick — clients see the flag drop
-   * and the block land together.
+   * yet; the common case is a genuinely working spinner).
+   *
+   * A second, unconditional suppression covers the same herdr latch BEFORE the spinner
+   * appears: a pane carrying QUEUED operator input (issue #2272). That one has no
+   * freshness gate — queued input is an observed state, not a liveness inference — and is
+   * vetoed by a detected `authUrl`, which can share the pane with it.
+   *
+   * Either suppression episode is surfaced as the working-while-blocked display flag:
+   * `onWorkingBlocked(id, true)` once on entry; on re-arm (any block that will be
+   * emitted) `onWorkingBlocked(id, false)` fires first, then `onBlock`, in the same
+   * tick — clients see the flag drop and the block land together.
    */
   private maybeClassify(s: Session, term: string): boolean {
     const id = s.id;
@@ -1751,42 +1758,12 @@ export class StatusPoller {
       console.warn(`[poller] classify failed for ${id}:`, err);
       return false; // best-effort; retry next cadence (didn't classify → didn't look)
     }
-    if (reason.shape === "awaiting-input" && hasActiveSpinner(visible)) {
-      // herdr can latch "blocked" after an answered dialog; a live spinner means the
-      // agent resumed working — clear any announced block instead of emitting the
-      // no-evidence fallback. (suppression scoped to awaiting-input only: a genuine
-      // menu/y-n dialog must always surface, spinner or not)
-      if (this.trySuppressSpinner(id, visible)) return true; // looked this tick (suppressed emit)
-      // Freshness gate tripped: the buffer did NOT advance since the last classify
-      // read — a wedged turn or a static buffer quoting a spinner-like line, not a
-      // live spinner. Fall through to the normal emit so the block re-arms (flag-off
-      // before the block, below). `lastSuppressVisible` is deliberately KEPT: while
-      // the buffer stays frozen, every subsequent read lands here and dedupes on
-      // `lastSig` — deleting it would re-grant first-sighting grace each cadence
-      // (suppress/re-arm oscillation).
-    } else {
-      // Suppression context over (spinner gone, or a genuine menu/y-n dialog) →
-      // drop the episode memory so the next spinner sighting gets a fresh grace.
-      this.lastSuppressVisible.delete(id);
-    }
-    // Awaiting-input blocks may be an MCP OAuth prompt: attach the full authorize URL from
-    // the transcript (Claude word-wraps it un-clickably in the PTY). Gated to awaiting-input
-    // so a menu/y-n block never triggers the read; the read is bounded + throttled by the
-    // reclassifyMs gate above. `authUrl` is part of `reason`, so it rides the lastSig dedup
-    // and the block snapshot for free; null ⇒ field omitted (not an auth prompt).
     if (reason.shape === "awaiting-input") {
-      // Transcript first (MCP OAuth). If none, fall back to reconstructing a `/login` account URL
-      // from the visible buffer we already read — covers a login modal herdr happens to classify
-      // as `blocked`. Run it through the SAME two-read stability gate as the resting path
-      // (`confirmLoginUrl`) so a mid-paint truncated authorize URL never surfaces for a cadence.
-      // Cache the REAL tail (`reason.tail`, i.e. `tailLines(visible)`), not a placeholder: the
-      // confirmed cache is shared with the resting path, and a `blocked → idle` transition (not a
-      // leave-resting edge, so caches persist) inherits this entry — an empty tail would surface a
-      // context-less banner that the URL-keyed re-emit gate never corrects.
-      const authUrl =
-        this.detectAuth(s) ??
-        this.confirmLoginUrl(id, { url: detectLoginAuthUrl(visible), tail: reason.tail })?.url;
-      if (authUrl) reason.authUrl = authUrl;
+      if (this.suppressAwaitingInput(s, visible, reason)) return true; // looked, suppressed emit
+    } else {
+      // A genuine menu/y-n dialog ends any suppression context → drop the episode memory
+      // so the next spinner sighting gets a fresh grace.
+      this.lastSuppressVisible.delete(id);
     }
     const sig = JSON.stringify(reason);
     if (sig === this.lastSig.get(id)) return true; // looked this tick (dedup short-circuit)
@@ -1799,7 +1776,70 @@ export class StatusPoller {
   }
 
   /**
-   * Freshness-gated spinner suppression for `maybeClassify`. Records `visible`
+   * The `awaiting-input` half of `maybeClassify`: attach an `authUrl` when one is pending
+   * and decide whether this no-evidence fallback should be SUPPRESSED rather than emitted.
+   * Returns true when suppressed (announced block cleared once, working-while-blocked flag
+   * raised, nothing emitted); false to fall through to the normal emit. Mutates `reason`
+   * only by setting `authUrl`. Never runs for a menu/y-n dialog — those always surface.
+   */
+  private suppressAwaitingInput(s: Session, visible: string, reason: BlockReason): boolean {
+    const id = s.id;
+    // #2272: the pane carries QUEUED operator input — the agent has input it has not
+    // consumed, so it cannot be waiting for more. Computed first (pure, no I/O) because it
+    // also takes precedence over the spinner branch: a queued buffer must never be handed
+    // to the freshness gate, which re-armed this exact false block every cadence.
+    const queued = hasQueuedInput(visible);
+    if (!queued && hasActiveSpinner(visible)) {
+      // herdr can latch "blocked" after an answered dialog; a live spinner means the
+      // agent resumed working — clear any announced block instead of emitting the
+      // no-evidence fallback.
+      if (this.trySuppressSpinner(id, visible)) return true;
+      // Freshness gate tripped: the buffer did NOT advance since the last classify
+      // read — a wedged turn or a static buffer quoting a spinner-like line, not a
+      // live spinner. Fall through to the normal emit so the block re-arms (flag-off
+      // before the block, in the caller). `lastSuppressVisible` is deliberately KEPT:
+      // while the buffer stays frozen, every subsequent read lands here and dedupes on
+      // `lastSig` — deleting it would re-grant first-sighting grace each cadence
+      // (suppress/re-arm oscillation).
+    } else {
+      // Suppression context over (spinner gone), or the queued-input branch below owns
+      // this read → drop the episode memory so the next spinner sighting gets a fresh
+      // grace.
+      this.lastSuppressVisible.delete(id);
+    }
+    // Awaiting-input blocks may be an MCP OAuth prompt: attach the full authorize URL from
+    // the transcript (Claude word-wraps it un-clickably in the PTY). Gated to awaiting-input
+    // so a menu/y-n block never triggers the read; the read is bounded + throttled by the
+    // reclassifyMs gate in the caller. `authUrl` is part of `reason`, so it rides the lastSig
+    // dedup and the block snapshot for free; null ⇒ field omitted (not an auth prompt).
+    //
+    // Transcript first (MCP OAuth). If none, fall back to reconstructing a `/login` account URL
+    // from the visible buffer we already read — covers a login modal herdr happens to classify
+    // as `blocked`. Run it through the SAME two-read stability gate as the resting path
+    // (`confirmLoginUrl`) so a mid-paint truncated authorize URL never surfaces for a cadence.
+    // Cache the REAL tail (`reason.tail`, i.e. `tailLines(visible)`), not a placeholder: the
+    // confirmed cache is shared with the resting path, and a `blocked → idle` transition (not a
+    // leave-resting edge, so caches persist) inherits this entry — an empty tail would surface a
+    // context-less banner that the URL-keyed re-emit gate never corrects.
+    const authUrl =
+      this.detectAuth(s) ??
+      this.confirmLoginUrl(id, { url: detectLoginAuthUrl(visible), tail: reason.tail })?.url;
+    if (authUrl) reason.authUrl = authUrl;
+    // #2272: suppress the no-evidence fallback over a queued-input pane. An auth prompt
+    // VETOES it: the prompt renders above the at-rest input box and classifies as
+    // awaiting-input, so it can share a pane with queued input, and `maybeAuthAtRest` only
+    // covers idle/done — suppressing one would strand the operator with no re-arm path.
+    // Unlike the spinner branch there is no freshness gate: queued input is an observed
+    // state, not a liveness inference, so a frozen pane must keep suppressing.
+    if (queued && !authUrl) {
+      this.enterSuppression(id);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Freshness-gated spinner suppression for `suppressAwaitingInput`. Records `visible`
    * as the episode baseline and returns true when the buffer is FRESH — first
    * sighting (one-cadence grace; nothing to compare yet) or advanced since the
    * previous read (a live spinner ticking its counters) — having suppressed the
@@ -1813,15 +1853,22 @@ export class StatusPoller {
     const prev = this.lastSuppressVisible.get(id);
     this.lastSuppressVisible.set(id, visible);
     if (prev !== undefined && prev === visible) return false; // frozen → re-arm
+    this.enterSuppression(id);
+    return true;
+  }
+
+  /** Shared body of both suppression branches (spinner + queued input): clear any
+   *  announced block exactly once and raise the working-while-blocked display flag once
+   *  per episode, not per cadence. */
+  private enterSuppression(id: string): void {
     if (this.lastSig.has(id)) {
       this.lastSig.delete(id);
       this.emitBlock(id, null);
     }
     if (!this.workingWhileBlocked.has(id)) {
       this.workingWhileBlocked.add(id);
-      this.onWorkingBlocked(id, true); // once per episode, not per cadence
+      this.onWorkingBlocked(id, true);
     }
-    return true;
   }
 
   /**

--- a/test/blocked.test.ts
+++ b/test/blocked.test.ts
@@ -1,7 +1,12 @@
 import { test, expect } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { classifyBlocked, hasActiveSpinner, quotaBlockReason } from "../src/blocked";
+import {
+  classifyBlocked,
+  hasActiveSpinner,
+  hasQueuedInput,
+  quotaBlockReason,
+} from "../src/blocked";
 import type { Session, PlanGate } from "../src/types";
 
 test("classifies a numbered permission menu", () => {
@@ -81,6 +86,36 @@ test("hasActiveSpinner rejects idle/blocked buffers", () => {
   expect(hasActiveSpinner("❯ 1. Yes\n  2. No")).toBe(false);
   expect(hasActiveSpinner("Enter to select · ↑/↓ to navigate · Esc to cancel")).toBe(false);
   expect(hasActiveSpinner("❯\n⏵⏵ bypass permissions on (shift+tab to cycle)")).toBe(false);
+});
+
+test("hasQueuedInput detects every queued-hint wording Claude Code ships", () => {
+  expect(hasQueuedInput("❯ Press up to edit queued messages")).toBe(true);
+  expect(hasQueuedInput("❯ Press up to select a queued message")).toBe(true);
+  expect(hasQueuedInput("❯ Press up to select a queued message to edit")).toBe(true);
+});
+
+test("hasQueuedInput detects the real captured pane from issue #2272", () => {
+  const pane = readFileSync(
+    join(import.meta.dir, "fixtures/fullscreen/queued-messages.txt"),
+    "utf8",
+  );
+  expect(hasQueuedInput(pane)).toBe(true);
+  // the same pane is exactly the no-evidence fallback, with no spinner to suppress on
+  expect(classifyBlocked(pane).shape).toBe("awaiting-input");
+  expect(hasActiveSpinner(pane)).toBe(false);
+});
+
+test("hasQueuedInput rejects idle/blocked buffers and scrollback mentions", () => {
+  expect(hasQueuedInput("❯\n⏵⏵ bypass permissions on (shift+tab to cycle)")).toBe(false);
+  expect(hasQueuedInput("❯ 1. Yes\n  2. No")).toBe(false);
+  // prose about the feature is not the hint
+  expect(hasQueuedInput("The queued message was dropped when the pane died.")).toBe(false);
+  // …and the hint scrolled out of the last-15-non-empty-lines window no longer counts
+  const scrolledOut = [
+    "❯ Press up to edit queued messages",
+    ...Array.from({ length: 15 }, (_, i) => `output line ${i + 1}`),
+  ].join("\n");
+  expect(hasQueuedInput(scrolledOut)).toBe(false);
 });
 
 test("hasActiveSpinner rejects spinner-shaped text on non-glyph-anchored lines", () => {

--- a/test/fixtures/fullscreen/queued-messages.txt
+++ b/test/fixtures/fullscreen/queued-messages.txt
@@ -1,0 +1,15 @@
+    the mention reaches nobody, so if you ask a question, say
+    so. Such a reply can arrive
+    mid-turn, interrupting what you are doing: weave it into
+    the work in progress rather than
+    starting over, unless it tells you to stop.
+    If $BUZZ_BIN is unset, publishing is switched off for this
+    session: skip it entirely and
+    do not retry.
+─────────────────────────────────────────────────────────────────
+❯ Press up to edit queued messages
+─────────────────────────────────────────────────────────────────
+  …/.shepherd-worktrees/shepherd-plan-gate-cannot-re shepherd/…
+  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents
+                     Update available! Run: mise upgrade claude
+                                               ● high · /effort

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -565,6 +565,92 @@ test("static buffer quoting a spinner-like markdown bullet ultimately surfaces t
   expect(h.poller.workingBlockedSnapshot()).toEqual({});
 });
 
+/** Issue #2272: herdr latches "blocked" after an answered dialog while the pane shows
+ *  the at-rest input box carrying QUEUED operator input — no dialog, no spinner. The
+ *  real captured pane from the issue's session; the hint reads "Press up to edit queued
+ *  messages" a few lines above the footer. */
+const QUEUED_TAIL = readFileSync(
+  join(import.meta.dir, "fixtures/fullscreen/queued-messages.txt"),
+  "utf8",
+);
+
+test("suppresses the awaiting-input fallback when the pane carries queued operator input", async () => {
+  const h = spinnerHarness(QUEUED_TAIL);
+  await h.poller.tick();
+  expect(h.blocks).toHaveLength(0);
+  expect(h.working).toEqual([{ id: h.id, working: true }]);
+  expect(h.poller.workingBlockedSnapshot()).toEqual({ [h.id]: true });
+});
+
+test("frozen queued-input buffer never re-arms: no block across cadences (#2272)", async () => {
+  const h = spinnerHarness(QUEUED_TAIL);
+  await h.poller.tick();
+  // The buffer stays byte-identical — the shape that made the spinner freshness gate
+  // re-arm every cadence. Queued input is a STATE, not a liveness inference, so it must
+  // keep suppressing however long the pane sits still.
+  for (let i = 0; i < 4; i++) {
+    h.advance(3001);
+    await h.poller.tick();
+  }
+  expect(h.blocks).toHaveLength(0);
+  expect(h.events).toEqual(["working:true"]); // one flag-on for the whole episode
+});
+
+test("clears an announced block exactly once when queued input replaces the dialog", async () => {
+  const h = spinnerHarness("❯ 1. Yes\n  2. No");
+  await h.poller.tick();
+  expect(h.blocks).toHaveLength(1);
+  expect((h.blocks[0]!.block as any).shape).toBe("menu");
+
+  // operator answers; herdr keeps latching blocked while the TUI drops back to the
+  // at-rest box with the reply still queued
+  h.setText(QUEUED_TAIL);
+  h.advance(3001);
+  await h.poller.tick();
+  h.advance(3001);
+  await h.poller.tick();
+  expect(h.events).toEqual(["block:menu", "block:null", "working:true"]);
+});
+
+test("still emits a menu block when queued input is also on screen", async () => {
+  const h = spinnerHarness(`${QUEUED_TAIL}\n❯ 1. Yes\n  2. No`);
+  await h.poller.tick();
+  expect(h.blocks).toHaveLength(1);
+  expect((h.blocks[0]!.block as any).shape).toBe("menu");
+  expect(h.working).toHaveLength(0); // a genuine dialog never enters the display state
+});
+
+test("re-arms once the queued-input hint leaves the pane", async () => {
+  const h = spinnerHarness(QUEUED_TAIL);
+  await h.poller.tick();
+  expect(h.blocks).toHaveLength(0);
+
+  h.setText("I need your input on the API design.\n❯");
+  h.advance(3001);
+  await h.poller.tick();
+  expect(h.events).toEqual(["working:true", "working:false", "block:awaiting-input"]);
+  expect(h.poller.workingBlockedSnapshot()).toEqual({});
+});
+
+test("an auth prompt on screen wins over queued input", async () => {
+  // An MCP OAuth / `/login` prompt renders ABOVE the at-rest input box and classifies as
+  // awaiting-input, so it can share a pane with queued input. Suppressing it would strand
+  // the operator — maybeAuthAtRest only covers idle/done.
+  const url = "https://claude.ai/oauth/authorize?code=1&client_id=abc";
+  const h = spinnerHarness(`Login\n\n${url}\n\nPaste code here if prompted >\n${QUEUED_TAIL}`);
+  // confirmLoginUrl needs two identical reads before it trusts a PTY-reconstructed URL,
+  // so the first cadence suppresses and the second surfaces the block with the URL.
+  await h.poller.tick();
+  expect(h.blocks).toHaveLength(0);
+
+  h.advance(3001);
+  await h.poller.tick();
+  expect(h.blocks).toHaveLength(1);
+  const block = h.blocks[0]!.block as any;
+  expect(block.shape).toBe("awaiting-input");
+  expect(block.authUrl).toBe(url);
+});
+
 // route mirror of GET /api/claude-alive (see poller-liveness.test.ts)
 test("GET /api/working-blocked returns the snapshot; {} when unwired", async () => {
   const baseDeps = {


### PR DESCRIPTION
Closes #2272.

`StatusPoller` raised an `awaiting-input` "needs you" block on a pane that was not asking anything: Claude Code's ordinary at-rest input box with the operator's reply still queued.

## What the live data said

I measured a read-only copy of the live DB (4217 `block` signal rows) before planning, because the issue flags its own mechanism as unverified — and it is wrong.

**The freshness gate is not involved.** Of **1432** rows that `classifyBlocked` shapes as `awaiting-input`, **0** carry an active spinner. `trySuppressSpinner` — and the freshness gate the issue suspects — is never reached on this path. The emit comes straight from `classifyBlocked`'s no-evidence fallback, which requires no dialog affordance at all.

**The real shape.** Reconstructing the three byte-identical payloads the issue cites: the pane is the at-rest input box with stale scrollback above it and `❯ Press up to edit queued messages`. Of the 45 rows that captured a full screen, **33** have that shape — no spinner, no dialog, every one from the last 10 days. Each lands 3–5 s after an answered dialog, i.e. herdr's documented `blocked` latch, in the window before the spinner paints.

## The fix

Suppress the `awaiting-input` fallback when the pane carries queued operator input. That is positive, content-independent evidence: the agent has input it has not consumed, so it cannot be waiting for more. No semantic reading of the scrollback — separating "the last thing on screen is a question to me" from "the last thing on screen is old boilerplate" is not a regex problem.

- `hasQueuedInput()` (`src/blocked.ts`) scans the same last-15-non-empty-lines window as `hasActiveSpinner`, so a scrollback mention cannot forge it. Covers all three wordings Claude Code 2.1.266 ships.
- Suppression mechanics reuse the spinner path (clear any announced block once, raise the working-while-blocked flag once), which `displayStatus()` already renders as `running` rather than "needs you".
- **No freshness gate** — that gate is exactly what let this re-fire ten minutes later. Queued input is an observed state, not a liveness inference.
- **A detected `authUrl` vetoes the suppression.** An MCP OAuth / `/login` prompt renders *above* the at-rest input box and also classifies as `awaiting-input`, so it can share a pane with queued input; `maybeAuthAtRest` only covers idle/done, so a suppressed auth block would have no re-arm path. Corpus overlap is 0 (35 queued-hint rows, 36 auth-prompt rows, none both), but the failure mode is severe and the guard is an ordering change, so it ships anyway. Ordered so the auth read still never runs on a spinner-suppressed tick — no new I/O on the single loop.
- `menu` / `yes-no` dialogs always surface, queued input or not — unchanged.

`maybeClassify`'s `awaiting-input` half moved into `suppressAwaitingInput()` to keep the function under the fallow cognitive-complexity gate.

## Rejected on evidence

The issue's other suggestion — refuse `awaiting-input` without a dialog affordance — would suppress 257/1432 rows, and reviewing that set found genuine blocks it swallows: a real MCP OAuth prompt and an AskUserQuestion wizard bar (`←  ☐ Deliverable … ✔ Submit  →`).

## Accepted trade-off

The stall detector only runs via `maybeProbe` on `status === "running"`, so a session that genuinely wedges while herdr holds `blocked` *and* queued input is on screen surfaces nothing until herdr flips. Every observed instance resolved in seconds; the alternative (a frozen-dwell escape hatch) adds tunable state for a case the corpus never shows.

## Tests

`test/fixtures/fullscreen/queued-messages.txt` is the real captured pane from the issue's session, asserted against rather than a hand-written approximation. New cases cover: suppression, the frozen buffer never re-arming across cadences (#2272's exact re-fire), clearing an announced block exactly once when the dialog is answered, `menu` still surfacing, re-arming once the hint leaves, and an auth prompt winning over queued input.

`bun run lint`, `bun run test` (9749 pass) and `bunx fallow audit --base origin/main --fail-on-issues` all pass.

## Follow-ups, not fixed here

Two adjacent false positives found while measuring, filed separately: #2281 (prose numbered lists emitting false `menu` blocks while a turn is live) and #2282 (`SPINNER_RE` missing real working frames).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
