### PR TITLE
fix(blocked): match the two real spinner frames SPINNER_RE missed (#2282)

### DIFF
--- a/src/blocked.ts
+++ b/src/blocked.ts
@@ -42,7 +42,8 @@ const YES_NO_RE = /\(\s*y\s*\/\s*n\s*\)|\[\s*y\s*\/\s*n\s*\]/i;
 //
 // Selected-option caret. `*` is deliberately NOT in the caret set even though OPTION_RE accepts
 // it as an option marker: it is also the markdown bullet leader (same reasoning that keeps `+`
-// out of SPINNER_RE), and a bulleted numbered list is exactly the prose this guards against.
+// out of the spinner patterns below), and a bulleted numbered list is exactly the prose this
+// guards against.
 const CARET_OPTION_RE = /^[\s│|]*[❯>]\s*\d+[.)]/;
 // Key-hint footer, as a substring of the (·-separated, often word-wrapped) hint line. Matched on
 // the stable fragments rather than a whole wording: the live corpus carries at least a dozen
@@ -62,25 +63,54 @@ export function tailLines(text: string, n = TAIL_LINES): string[] {
     .slice(-n);
 }
 
-// Active-turn spinner line, anchored: the line must START with a spinner/tool
-// glyph (·✢✳✶✻✽*⎿), then carry an ellipsis directly followed by "(" + either an
-// elapsed-time counter or the legacy "esc to interrupt" hint, e.g.
-// "✶ Bunning… (1m 13s · ↑ 1.3k tokens)" / "⎿  Running… (4s)" /
-// "✻ Imagining… (esc to interrupt)". The glyph anchor rejects prose quoting a
-// time mid-text ("the build finished… (3m 12s)"), queued-input lines
-// ("❯ retry… (2m 30s)"), and a bare "esc to interrupt" on a non-spinner line;
-// the `…(` adjacency rejects "… +5 lines (ctrl+o to expand)" and "(1M context)"
-// (no elapsed time). `+` is excluded: zero occurrences as a spinner frame in
-// 889 production-captured tails, and a common markdown/diff line leader. `*`
-// IS a genuine production spinner frame and stays — its residual
-// markdown-bullet risk is covered by the poller's freshness gate (continued
-// suppression requires the buffer to advance between classify reads).
-const SPINNER_RE = /^\s*[·✢✳✶✻✽*⎿].*?…\s*\((?:(?:\d+h\s*)?(?:\d+m\s*)?\d+s\b|esc to interrupt)/i;
+// Active-turn spinner frames, in two anchored shapes. Both require a line that
+// STARTS with a spinner/tool glyph, which is what rejects prose quoting a time
+// mid-text ("the build finished… (3m 12s)"), queued-input lines
+// ("❯ retry… (2m 30s)"), and a bare "esc to interrupt" on a non-spinner line.
+// `+` is excluded from both: zero occurrences as a spinner frame across the
+// production-captured tails, and a common markdown/diff line leader. `*` IS a
+// genuine production spinner frame and stays — its residual markdown-bullet risk
+// is covered by the poller's freshness gate (continued suppression requires the
+// buffer to advance between classify reads).
+//
+// Both shapes were measured for #2282 against a live install's block corpus
+// (snapshot: 3911 unique tails, 27087 unique lines): each one matches exactly one
+// line the other misses, and nothing else in the corpus. Line-level by
+// construction, so #2281's shape gate does not move these numbers — but it does
+// feed them more panes, since a chrome-less numbered run it demotes to
+// `awaiting-input` now reaches the suppression path this evidence supports.
+
+// (1) Timed — glyph + ellipsis + a parenthetical carrying an elapsed-time counter
+// or the legacy "esc to interrupt" hint: "✶ Bunning… (1m 13s · ↑ 1.3k tokens)" /
+// "⎿  Running… (4s)" / "✻ Imagining… (esc to interrupt)". The counter need NOT be
+// adjacent to "…(" — it may sit behind leading text in the SAME parenthetical
+// ("· Julienning… (running stop hooks… 1/2 · 2m 31s · ↓ 8.7k tokens", #2282).
+// `[^)]` keeps the counter from being borrowed out of a LATER parenthetical, and
+// the length bound keeps it near this one's start even when the paren is truncated
+// unclosed at pane width (that frame's exact shape). Requiring a counter at all is
+// what rejects "… +5 lines (ctrl+o to expand)" and "(1M context)" — neither
+// carries an elapsed time — so relaxing the adjacency does not re-open them.
+const SPINNER_TIMED_RE =
+  /^\s*[·✢✳✶✻✽*⎿].*?…\s*\([^)\n]{0,40}?(?:(?:\d+h\s*)?(?:\d+m\s*)?\d+s\b|esc to interrupt)/i;
+
+// (2) Untimed — the frame BEFORE the counter appears: glyph + one capitalized word
+// + ellipsis at end of line ("✽ Mulling…", #2282). Deliberately the tightest shape
+// that covers it, because an ellipsis with no parenthetical is otherwise close to
+// unconstrained prose: the single capitalized alpha word is what stops a `·` bullet
+// truncated to an ellipsis at pane width from forging a spinner, and `⎿` is
+// excluded here because "⎿  Running…" is a tool-result leader RETAINED in
+// scrollback beside the tool's own output — it outlives the turn it belongs to.
+// Not gerund-gated: requiring "-ing" would assume Claude Code's spinner vocabulary
+// stays all-gerund forever, for no measured gain. Multi-word status lines
+// ("✽ Adding i18n + final review…") stay unmatched until their counter lands and
+// shape (1) takes over — an accepted miss, roughly a second wide.
+const SPINNER_UNTIMED_RE = /^\s*[·✢✳✶✻✽*]\s+[A-Z][a-z]+…\s*$/;
 
 /**
  * True when the terminal tail shows an actively-working Claude Code turn — a
- * glyph-anchored spinner line with an elapsed-time counter or the legacy
- * "esc to interrupt" hint. Scans the same last-15-non-empty-lines window as
+ * glyph-anchored spinner line, either carrying an elapsed-time counter / the
+ * legacy "esc to interrupt" hint or in the untimed frame that precedes the
+ * counter. Scans the same last-15-non-empty-lines window as
  * `classifyBlocked` (the spinner always sits just above the input box; this
  * avoids matching stale scrollback).
  *
@@ -91,7 +121,7 @@ const SPINNER_RE = /^\s*[·✢✳✶✻✽*⎿].*?…\s*\((?:(?:\d+h\s*)?(?:\d+m
  * against that upstream herdr bug.
  */
 export function hasActiveSpinner(text: string): boolean {
-  return tailLines(text).some((l) => SPINNER_RE.test(l));
+  return tailLines(text).some((l) => SPINNER_TIMED_RE.test(l) || SPINNER_UNTIMED_RE.test(l));
 }
 
 // The at-rest input box's queued-input hint. Claude Code 2.1.266 ships three

--- a/test/blocked.test.ts
+++ b/test/blocked.test.ts
@@ -89,6 +89,35 @@ test("hasActiveSpinner rejects idle/blocked buffers", () => {
   expect(hasActiveSpinner("❯\n⏵⏵ bypass permissions on (shift+tab to cycle)")).toBe(false);
 });
 
+test("hasActiveSpinner detects the two real frames it used to miss (#2282)", () => {
+  // the untimed frame, before the elapsed counter appears
+  expect(hasActiveSpinner("✽ Mulling…")).toBe(true);
+  // a counter that is present but not adjacent to "…(" — leading text in the same parenthetical,
+  // truncated unclosed at pane width
+  expect(hasActiveSpinner("· Julienning… (running stop hooks… 1/2 · 2m 31s · ↓ 8.7k tokens")).toBe(
+    true,
+  );
+});
+
+test("hasActiveSpinner rejects the retained '⎿ Running…' tool-result leader (#2282)", () => {
+  // Untimed shape excludes ⎿ on purpose: this leader stays in scrollback beside the tool's own
+  // output, so it outlives the turn it belongs to and is no evidence of a live one. Its TIMED
+  // form ("⎿  Running… (4s)") does count, and is asserted above.
+  expect(hasActiveSpinner("  ⎿  Running…")).toBe(false);
+});
+
+test("hasActiveSpinner's untimed shape stays tight around the spinner-word form", () => {
+  // a `·` bullet truncated to an ellipsis at pane width must not forge a spinner
+  expect(hasActiveSpinner("· This is ~11 pages incl. a story-template rebuild, index…")).toBe(
+    false,
+  );
+  // lowercase / multi-word / trailing-text variants are prose, not a spinner frame
+  expect(hasActiveSpinner("· mulling…")).toBe(false);
+  expect(hasActiveSpinner("✽ Mulling… and then some")).toBe(false);
+  // the relaxed timed shape must not borrow a counter out of a LATER parenthetical
+  expect(hasActiveSpinner("⎿  Read… (ctrl+o to expand) and it took (3s)")).toBe(false);
+});
+
 test("hasQueuedInput detects every queued-hint wording Claude Code ships", () => {
   expect(hasQueuedInput("❯ Press up to edit queued messages")).toBe(true);
   expect(hasQueuedInput("❯ Press up to select a queued message")).toBe(true);
@@ -382,4 +411,16 @@ test("looksLikeDemotedMenu marks exactly what classifyBlocked demoted", () => {
 
   // no numbered run at all → nothing was demoted
   expect(looksLikeDemotedMenu(classifyBlocked("What should I name it?\n❯").tail)).toBe(false);
+});
+
+test("real #2282 panes: both were mid-turn and now read as working", () => {
+  for (const name of ["spinner-untimed.txt", "spinner-inline-parenthetical.txt"]) {
+    const pane = readFileSync(join(fixturesDir, name), "utf8");
+    // each pane is the no-evidence fallback the poller would otherwise announce…
+    expect(classifyBlocked(pane).shape).toBe("awaiting-input");
+    // …and carries no queued input, so #2272's branch cannot cover it
+    expect(hasQueuedInput(pane)).toBe(false);
+    // …but the agent was demonstrably working, so suppression must engage
+    expect(hasActiveSpinner(pane)).toBe(true);
+  }
 });

--- a/test/fixtures/fullscreen/spinner-inline-parenthetical.txt
+++ b/test/fixtures/fullscreen/spinner-inline-parenthetical.txt
@@ -1,0 +1,15 @@
+     + full-bleed media, Card chrome). Implement them here? →
+     Implement here (Recommended)
+     · This is ~11 pages incl. a story-template rebuild, index
+     rebuild, 3 resource pages and über-uns. Ship as one PR or
+     promote to an epic? → Single PR (Recommended)
+· Julienning… (running stop hooks… 1/2 · 2m 31s · ↓ 8.7k tokens
+ · thinking)
+  ⎿  Tip: Share Claude Code and earn €10 in usage credits ·
+     /passes
+─────────────────────────────────────────────────────────────────
+❯
+─────────────────────────────────────────────────────────────────
+  …/.shepherd-worktrees/topmedia-website-visual-gap-audit-simi…
+  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents
+                                               ● high · /effort

--- a/test/fixtures/fullscreen/spinner-untimed.txt
+++ b/test/fixtures/fullscreen/spinner-untimed.txt
@@ -1,0 +1,15 @@
+  Two alternatives, for completeness:
+● User declined to answer questions
+  ⎿  · How should we resolve the jarring height step between passive readouts and tall buttons? (De-box the readouts / Equalize
+     heights, recede readouts / Shrink the delta + seam)
+● What would you like to clarify? Happy to reframe — whether it's the options themselves, a constraint I'm missing, or something
+  about how these controls behave that I should factor in first.
+✻ Crunched for 1m 33s
+❯ You need to show me this as a design in HTML/CSS and make it available over tailscale. Then send me a link I can click.
+✽ Mulling…
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  …/.shepherd-worktrees/shepherd-two-different-shape-heights shepherd/two-different-shape-heights   ⣿⠀⠀⠀⠀⠀⠀⠀⠀⠀ 9% ctx Opus 4.…
+  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents
+                                                                                                              ● high · /effort


### PR DESCRIPTION
Closes #2282.

`hasActiveSpinner` is the poller's "this agent is actually working" evidence, used to suppress the no-evidence `awaiting-input` fallback. Two real production spinner frames slipped past `SPINNER_RE`, so suppression never engaged and a false "needs you" nudge fired.

## What the corpus actually says

I measured the live install's block corpus first (`signals` where `kind='block'` — the same corpus #2272 was measured on) rather than guessing at the widening. Snapshot: 3911 unique tails, **1290 of them classifying `awaiting-input`**, 27 087 unique lines. (Those shape counts predate #2281, which landed while this was in review — see the rebase note at the bottom. The per-line measurements below are shape-independent and unchanged.)

The headline is worse than the issue implies: **the old pattern matched 0 of those 1290 tails.** Spinner suppression effectively never engaged in production.

The whole corpus holds exactly three glyph+ellipsis near-misses — the two frames the issue names, plus `⎿  Running…`, which is a *retained tool-result leader*, not a spinner frame (it sits in scrollback beside the tool's own output, outliving the turn it belongs to). That third one is why this could not be a loose "glyph + ellipsis" widen.

| variant | all 27 087 lines | `awaiting-input` lines |
| --- | --- | --- |
| old `SPINNER_RE` | 3 | **0** |
| timed, gap allowed inside the same `(…)` | 4 | 1 — the case-2 true positive |
| untimed `glyph + Word + …$`, `⎿` excluded | 1 | 1 — the case-1 true positive |
| untimed, same but `⎿` allowed | 2 | 2 — drags in `⎿ Running…` |

## The change

`SPINNER_RE` splits into two anchored, separately-justified shapes; `hasActiveSpinner` keeps its signature and its window, and scans both:

- **Timed** — today's pattern with the `…(` adjacency relaxed to a bounded run of non-`)` characters, so the counter may sit behind leading text in the **same** parenthetical (`· Julienning… (running stop hooks… 1/2 · 2m 31s · ↓ 8.7k tokens`). `[^)]` stops the counter being borrowed out of a *later* parenthetical; the length bound keeps it near this one's start even when the paren is truncated unclosed at pane width, which is exactly that frame's shape. Requiring a counter at all is what rejects `… +5 lines (ctrl+o to expand)` and `(1M context)` — neither carries an elapsed time — so relaxing adjacency does not re-open them.
- **Untimed** — new, for the frame before the counter appears (`✽ Mulling…`): glyph + one capitalized word + ellipsis at EOL, with `⎿` excluded. Deliberately the tightest shape that covers it, since an ellipsis with no parenthetical is otherwise close to unconstrained prose; the single capitalized word is what stops a `·` bullet truncated at pane width from forging a spinner.

## Decisions worth flagging to a reviewer

- **No poller change.** The freshness gate in `trySuppressSpinner()` stays the residual-risk absorber: a false match over a static buffer falls through and re-arms the block after one reclassify cadence (3 s).
- **Rejected the issue's alternative** of corroborating with `lastActiveTurnAt` / hook activity. `isActiveTurnFresh()`'s window is `2 × probeCheckMs` = 14 s, and a *genuine* `awaiting-input` block also follows fresh activity (the agent works, then asks) — so it is non-discriminative for ~14 s. As the primary signal it would delay every real block that long; as an extra AND-gate it buys nothing measurable while forcing `hasActiveSpinner` to stop being a pure one-argument predicate.
- **Not gerund-gated.** Requiring `-ing` scores identically on the corpus but would assume Claude Code's spinner vocabulary stays all-gerund forever.
- **Accepted miss:** multi-word untimed status lines (`✽ Adding i18n + final review…`) stay unmatched until their counter lands and the timed shape takes over — roughly a second wide.

## Verification

- Both #2282 panes added as fixtures, captured verbatim from the corpus (the `queued-messages.txt` convention from #2272). Each is asserted to classify `awaiting-input`, to carry no queued input (so #2272's branch cannot cover it), and to now read as working.
- Negative tests pin the deliberate exclusions: `⎿ Running…`, a truncated `·` bullet, lowercase/multi-word variants, and a counter in a later parenthetical.
- Every positive and negative already asserted in `test/blocked.test.ts` still holds, `fullscreen-spinner.txt` included.
- Re-measured with the shipped code: exactly **2** `awaiting-input` tails now match, and they are the two intended frames.
- Root `bun run lint`, `bunx tsc --noEmit` and `bun run test` (9753 pass / 0 fail) green; `fallow audit --base origin/main` clean on all 4 changed files.

## Rebase note — composition with #2281

Rebased onto `main` after #2287 (#2281, dialog-chrome gate for menus) landed in the same file. `src/blocked.ts` auto-merged; `test/blocked.test.ts` was a pure additive tail collision (both sides appended tests), resolved by keeping both.

Two things I checked rather than assumed, because #2281 measured its own corpus with the *old* spinner regex:

- **#2281's "NO row carries chrome AND a live spinner" invariant still holds** under the widened regex — re-measured: 0 of 2550 menus. Its comment stays accurate.
- **The two changes compose, and the result is better than either alone.** #2281 demotes chrome-less numbered runs to `awaiting-input`, which is exactly where this suppression lives. Of its 13 demoted prose-menus, 2 carry a live spinner (`· Bootstrapping… (1m 28s …)`, `✽ Gallivanting… (35s …)`) that was previously never consulted, because those panes classified `menu`. Combined, **4 of 1300 `awaiting-input` tails now suppress, where before either change it was 0.**

One line outside the planned diff: #2281's new comment cross-referenced `SPINNER_RE`, a symbol this PR's split removes, so that reference now points at the spinner patterns generally. The corpus comment also dropped its `awaiting-input` count, which #2281 legitimately moves — the line-level evidence it cites does not depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

