### PR TITLE
fix(ui): make statusTip's Esc dismissal reachable from the keyboard

### DIFF
--- a/ui/src/lib/components/StatusPip.browser.test.ts
+++ b/ui/src/lib/components/StatusPip.browser.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
-import { page } from "vitest/browser";
+import { page, userEvent } from "vitest/browser";
 import "../../app.css";
 import { m } from "$lib/paraglide/messages";
 import { statusLabel } from "$lib/format";
@@ -82,9 +82,41 @@ describe("StatusPip tip mode (statusTip action)", () => {
     leave(); // pinned → stays open (a real affordance, not a fleeting hover)
     await new Promise((r) => setTimeout(r, 30));
     expect(tooltipOpen()).toBe(true);
-    // Esc dismisses the pinned tooltip.
-    pipEl().dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    // Esc dismisses the pinned tooltip. Driven as a REAL keystroke, deliberately: the pip is a
+    // non-focusable <span>, so a genuine keydown targets <body> and can never reach the trigger
+    // itself. Dispatching the event on the pip (as this spec once did) models something the
+    // browser cannot produce, and passed while the feature was broken — see #2283.
+    await userEvent.keyboard("{Escape}");
     await vi.waitFor(() => expect(tooltipOpen()).toBe(false));
+  });
+
+  it("Esc is preventDefaulted, so a11yDialog (checks defaultPrevented) won't also close the host", async () => {
+    render(StatusPip, { status: "running", tip: true });
+    enter();
+    click(1); // pin it, so the tooltip is the topmost transient overlay
+    await vi.waitFor(() => expect(tooltipOpen()).toBe(true));
+
+    const ev = new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true });
+    document.body.dispatchEvent(ev);
+
+    await vi.waitFor(() => expect(tooltipOpen()).toBe(false));
+    // a11yDialog's Escape handler returns early on defaultPrevented, so an open tip inside the
+    // New Task modal dismisses itself WITHOUT discarding the operator's typed task.
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it("a HOVERED (unpinned) tip closes on Esc but does NOT swallow it", async () => {
+    render(StatusPip, { status: "running", tip: true });
+    enter(); // hover only — never pinned, so the operator never asked for this tip
+    await vi.waitFor(() => expect(tooltipOpen()).toBe(true));
+
+    const ev = new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true });
+    document.body.dispatchEvent(ev);
+
+    await vi.waitFor(() => expect(tooltipOpen()).toBe(false));
+    // Must stay reachable: consuming it here would eat the Escape that closes the slash-command
+    // menu whose description the pointer is resting on (ComposeBar handles that on the textarea).
+    expect(ev.defaultPrevented).toBe(false);
   });
 
   it("detail (tip off) keeps the native title and does not add aria-description", async () => {

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -620,11 +620,12 @@
   // `aria-description`. Raising it is also what keeps a click on the chip from selecting the row —
   // selection lives on the sibling `.unit-hit` button, which the click can no longer reach
   // (statusTip's stopPropagation is belt-and-braces; nothing between here and `.unit` listens).
-  // The chip stays a NON-FOCUSABLE <span>, like every statusTip trigger in the repo, so the
-  // keyboard reads `aria-description`, while Escape dismisses a mouse-opened panel globally.
-  // A tab stop per cold card would be a lot of noise in a long Herd. A GlossaryTerm
-  // is wrong for a different reason — its click presentation pushes content down and would
-  // reflow the card.
+  // The chip stays a NON-FOCUSABLE <span>, so the action's focus-to-open path never fires on it —
+  // a tab stop per cold card would be a lot of noise in a long Herd, and the row's own `.unit-hit`
+  // overlay is the keyboard entry point (it carries `aria-describedby`). Escape still dismisses a
+  // mouse-opened panel globally, and a PINNED one consumes the key so it can't also close a host
+  // dialog (#2283). A GlossaryTerm is wrong for a different reason — its click presentation pushes
+  // content down and would reflow the card.
   //
   // Shared structured explanation: cost first, then the choices before resuming.
   const coldResume = $derived(isColdResume(session, nowMs));

--- a/ui/src/lib/tooltips/statusTip.svelte.ts
+++ b/ui/src/lib/tooltips/statusTip.svelte.ts
@@ -37,11 +37,31 @@ let uid = 0;
  * Click propagation is stopped by default so read-only chips never select their
  * row; actionable controls can opt out while retaining the same explanation.
  *
- * The explanation is exposed to assistive tech via `aria-description` (a string —
- * always valid, no dangling IDREF, present from mount), so screen readers announce
- * it in browse mode even though the chip is not a Tab stop. The *visual* popover is
- * created lazily on first open. Pass `null` to disable (callers gate with
- * `tip ? {...} : null`).
+ * Triggers may be focusable or not, and both are supported. Most are plain `span` /
+ * `div` / `li`; BuildQueueBadge's interactive branches are real `<button>`s (its
+ * coarse-pointer branch is a read-only `<span>`), and those are what `focus`/`blur`
+ * (focus-to-open) serve. Escape dismissal does NOT depend on that — it is a
+ * window-level listener scoped to the open state, so it reaches a pinned tip on any
+ * trigger (see `onKeydown`).
+ *
+ * ON ASSISTIVE TECH — read before assuming this carries the meaning. The explanation
+ * is mirrored into `aria-description` (a string: always valid, no dangling IDREF,
+ * present from mount) and the *visual* popover is created lazily on first open, so
+ * hidden tooltip text never pollutes the DOM / text queries. But `aria-description`
+ * is **enrichment, not the carrier of meaning**: it and `aria-describedby` feed the
+ * same accessible-description property, and announcement of that property is gated by
+ * the trigger's ROLE — inconsistent on `role="img"` and on role-less generics, which
+ * is what nearly every trigger here is. Swapping the attribute would change nothing;
+ * only making the trigger interactive would, and that is deliberately not done (a tab
+ * stop per chip would be noise in a long Herd — #2269, #2283).
+ *
+ * So the invariant callers MUST honour: the trigger's accessible NAME already carries
+ * the meaning — `role="img"` + `aria-label` (StatusPip, the badges, the sandbox/quota
+ * chips) or visible text (SlashCommandMenu, PromptSources, IssueLoadAttempts, the
+ * attention/merging/ready badges) — with the Herd row's `.unit-hit` `aria-describedby`
+ * behind it. Never let this tooltip be the only place an explanation exists.
+ *
+ * Pass `null` to disable (callers gate with `tip ? {...} : null`).
  */
 export const statusTip: Action<HTMLElement, StatusTipParams | null | undefined> = (
   node,
@@ -141,7 +161,7 @@ export const statusTip: Action<HTMLElement, StatusTipParams | null | undefined> 
     open = true;
     stopAnchor = anchorPopover(node, pop, 6);
     document.addEventListener("pointerdown", onDocPointerDown, true);
-    document.addEventListener("keydown", onKeydown);
+    window.addEventListener("keydown", onKeydown, { capture: true });
     window.addEventListener("scroll", onScrollOrResize, { capture: true, passive: true });
     window.addEventListener("resize", onScrollOrResize, { passive: true });
   }
@@ -154,7 +174,7 @@ export const statusTip: Action<HTMLElement, StatusTipParams | null | undefined> 
     stopAnchor?.(); // stops autoUpdate + hidePopover()
     stopAnchor = null;
     document.removeEventListener("pointerdown", onDocPointerDown, true);
-    document.removeEventListener("keydown", onKeydown);
+    window.removeEventListener("keydown", onKeydown, { capture: true });
     window.removeEventListener("scroll", onScrollOrResize, true);
     window.removeEventListener("resize", onScrollOrResize);
   }
@@ -179,8 +199,30 @@ export const statusTip: Action<HTMLElement, StatusTipParams | null | undefined> 
     show();
     if (e.detail > 0) pinned = true; // genuine pointer click pins; keyboard (detail 0) does not
   }
+  // Escape lives on the WINDOW, in capture phase, only while a tip is open — not on the
+  // trigger. Most triggers are non-focusable, so a real keystroke targets <body> and would
+  // never reach a node listener (#2283); a pinned tip would then have no keyboard exit at
+  // all, failing WCAG 2.2 SC 1.4.13 (Dismissible).
+  //
+  // Whether the key is CONSUMED follows intent, because these two states differ:
+  //  - PINNED (a deliberate pointer click): the tip is an overlay the operator opened, so it
+  //    owns this Escape. Capture + preventDefault, because `a11yDialog` closes its host dialog
+  //    unless `defaultPrevented` and its listener sits on the dialog NODE — whose bubble phase
+  //    runs before any bubble-phase window listener. Without this, a pinned tip in the New Task
+  //    modal (InstrumentToggle's ON/OFF suffix) would dismiss itself only after the modal had
+  //    already closed, discarding the operator's typed task. Protocol per IssueDetailsPopover.
+  //  - HOVERED (incidental): the operator never asked for this tip, so it must NOT steal a
+  //    keystroke aimed elsewhere. Hide it, but let the event run on — otherwise hovering a
+  //    command description in SlashCommandMenu would swallow the Escape that closes the menu.
+  // `stopPropagation` (not `stopImmediatePropagation`) so several open tips close on one Esc.
   function onKeydown(e: KeyboardEvent) {
-    if (e.key === "Escape") hide();
+    if (e.key !== "Escape") return;
+    const owned = pinned; // hide() clears it — read first
+    if (owned) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+    hide();
   }
 
   function enable(next: StatusTipParams) {
@@ -207,7 +249,6 @@ export const statusTip: Action<HTMLElement, StatusTipParams | null | undefined> 
       node.addEventListener("focus", onFocus);
       node.addEventListener("blur", onBlur);
       node.addEventListener("click", onClick);
-      node.addEventListener("keydown", onKeydown);
     }
   }
 
@@ -220,7 +261,6 @@ export const statusTip: Action<HTMLElement, StatusTipParams | null | undefined> 
       node.removeEventListener("focus", onFocus);
       node.removeEventListener("blur", onBlur);
       node.removeEventListener("click", onClick);
-      node.removeEventListener("keydown", onKeydown);
     }
     if (body) {
       void unmount(body);


### PR DESCRIPTION
Closes #2283.

> **Rebased onto #2290**, which independently added a partial fix for the same bug. This PR is now the *delta* over it — see "Relationship to #2290" below. The action also moved to `ui/src/lib/tooltips/` in that PR; this change follows it there.

`statusTip`'s `keydown` listener sat on the trigger node, but nearly every trigger is a non-focusable `span` / `div` / `li` — a real Escape targets `<body>` and never reached it. A pointer click **pins** a tip, so a pinned tip had **no keyboard exit at all**: only outside-click and scroll dismissed it. That's a WCAG 2.2 SC 1.4.13 (*Content on Hover or Focus → Dismissible*) failure.

## Relationship to #2290

#2290 added `document.addEventListener("keydown", onKeydown)` in `show()`, **bubble phase, no `preventDefault`**, while keeping the node listener. That makes Escape *reachable* — the important half — but leaves two defects:

1. **It still loses to `a11yDialog`.** `a11yDialog` closes its host dialog on Escape unless `defaultPrevented`, and its listener sits on the dialog **node**, whose bubble phase runs *before* any listener on `document`/`window`. `statusTip` lives inside the New Task modal (`InstrumentToggle`'s ON/OFF suffix), so dismissing a pinned tip there still closes the modal first and **discards the operator's typed task**.
2. **The node `keydown` listener is now genuinely redundant** — it was kept alongside the new one.

This PR moves the listener to **window, capture phase**, which is what actually wins that race (the protocol `IssueDetailsPopover.svelte` already documents), drops the redundant node listener, and makes consumption intent-scoped.

## Consumption follows intent

- **Pinned** (deliberate pointer click) → `preventDefault()` + `stopPropagation()`. The tip is an overlay the operator opened, so it owns this Escape — and this is what protects the New Task modal.
- **Hovered** (incidental) → hide, but let the key run on. Found in self-review: consuming here would swallow the Escape that closes `SlashCommandMenu` when the pointer merely rests on a command description.

`stopPropagation`, not `stopImmediatePropagation`, so several open tips still close on one Escape.

## Three corrections to the issue as filed

Both of #2283's proposed options lead somewhere unhelpful:

1. **"Every trigger is non-focusable" is false.** `BuildQueueBadge`'s interactive branches are real `<button>`s (its coarse-pointer branch is a read-only `<span>`). `focus`/`blur` fire there today — deleting them would have been a regression, so they stay.
2. **The Herd row already has the keyboard path the issue asks for.** `UnitRow`'s `.unit-hit` overlay is a focusable `<button>` carrying `aria-describedby`. Card badges are enrichment on top of it, not the only route.
3. **Swapping `aria-description` → `aria-describedby` buys nothing.** Both feed the *same* accessible-description property; announcement is gated by the trigger's **role**, not by which attribute supplied the string. The only real lever is making triggers interactive — the tab-stop noise #2269 deliberately rejected.

So: **no new tab stops, no `focusable` param, no call-site markup changes.** The doc block now states the invariant callers must honour — the trigger's accessible *name* already carries the meaning (`role="img"` + `aria-label`, or visible text), and this tooltip must never be the only place an explanation exists. `UnitRow`'s cold-resume comment is reconciled with #2290's wording too.

## The old test was the bug in miniature

The original Esc spec dispatched a synthetic `keydown` **on the pip element** — something a browser can never do to a non-focusable span. It was green while the feature was broken. It now drives a real `userEvent.keyboard("{Escape}")`, plus two specs pinning the pinned-consumes / hovered-passes-through split.

## Verification

`bun run lint` clean · `cd ui && bun run check` 0 errors (6296 files) · `cd ui && bun run test` 319 files / 5199 tests · root `bun run test` 9783 tests, 0 fail · `bunx fallow audit --base origin/main --fail-on-issues` → *No issues in 3 changed files* · pre-push green. #2290's own new `tooltips/statusTip.browser.test.ts` passes unchanged against the capture-phase listener.

No new user-facing strings, so no i18n or feature-catalog entry. 3 files, `ui/` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
