### PR TITLE
test(ui): await the rejection event, not a 50ms timer (#2028)

### DIFF
--- a/ui/src/lib/components/EpicPanel.browser.test.ts
+++ b/ui/src/lib/components/EpicPanel.browser.test.ts
@@ -192,19 +192,28 @@ describe("EpicPanel duplicate-child guard", () => {
     // The each block's effect throws asynchronously (Svelte schedules it), surfacing as an
     // unhandled rejection rather than a synchronous throw from render() — capture it here and
     // preventDefault so it's asserted, not leaked into the run as a false failure.
+    //
+    // Wait on the event, never on a timer (#2028). A fixed sleep is a deadline, not a guarantee:
+    // under a loaded full-suite run the listener came off before the rejection was dispatched, so
+    // it escaped to vitest — every test green, process exit 1. `landed` holds the listener in
+    // place until the rejection actually arrives. vitest's per-test timeout bounds the wait, so a
+    // Svelte that stops validating keys fails this case rather than hanging the run.
     let captured: string | null = null;
+    let onLanded!: () => void;
+    const landed = new Promise<void>((resolve) => (onLanded = resolve));
     const onRejection = (ev: PromiseRejectionEvent) => {
       const msg = String((ev.reason as Error)?.message ?? ev.reason ?? "");
       if (msg.includes("each_key_duplicate")) {
         captured = msg;
         ev.preventDefault();
+        onLanded();
       }
     };
     window.addEventListener("unhandledrejection", onRejection);
     try {
       const e: Epic = { ...epic(), children: [child({ number: 709 }), child({ number: 709 })] };
       render(EpicPanel, { repoPath: "/repo", parent: 327, epic: e });
-      await new Promise((r) => setTimeout(r, 50));
+      await landed;
       expect(captured).toMatch(/each_key_duplicate/);
     } finally {
       window.removeEventListener("unhandledrejection", onRejection);


### PR DESCRIPTION
Fixes #2028.

The `ui` lane intermittently exits **1 with every test passing**, alongside an unhandled `each_key_duplicate` rejection blamed on `EpicPanel.svelte` — on PRs that never touch it.

### Not a product bug

The duplicate key is constructed by the test itself. `EpicPanel`'s keyed `{#each epic.children as c (c.number)}` and the data-layer dedup (parser + `assembleEpic`) are correct; the `EpicPanel duplicate-child guard` case deliberately renders two children numbered `709` and asserts Svelte complains.

### The race, reproduced

Svelte schedules the each-block effect's throw asynchronously, so it surfaces as an unhandled rejection rather than a synchronous throw from `render()`. The test caught it with a temporary `unhandledrejection` listener torn down in a `finally` after a fixed **50 ms** sleep — a deadline, not a guarantee.

Confirmed locally with a throwaway spec rather than left as a hypothesis:

| Wait strategy | Handler fires in window | Escapes to vitest | Exit |
| --- | --- | --- | --- |
| fixed sleep, 0 ms (forced repro) | no | yes | 1 |
| fixed sleep, 50 ms (before this PR, loaded run) | sometimes | sometimes | 1 intermittently |
| await the event (this PR) | always (~8.6 ms) | no | 0 |

The 0 ms repro produced the reported signature exactly — `Tests 1 passed (1)` + `Errors 1 error`, exit 1. So under a loaded 289-file parallel run the listener comes off before the rejection is dispatched: the assertion has already passed, and the rejection escapes to vitest.

### Fix

Wait on the **event**, not a timer: a promise resolved from inside `onRejection` keeps the listener installed until the rejection actually lands. `vitest`'s per-test timeout bounds the wait, so a Svelte that stops validating keys fails this named case rather than hanging the run.

`render(...)` stays un-awaited — bare `render(` is the dominant convention in this suite (1375 call sites vs 341 awaited), it is synchronous in `vitest-browser-svelte`, and awaiting it would not have closed this race.

### Deliberately not done

- **A `beforeAll`/`afterAll` listener.** Verified only one rejection is emitted per crashed render — nothing leaked through `vitest-browser-svelte`'s cleanup or end of file — so test scope suffices. Promoting it is a two-line escape hatch if that ever changes.
- **A shared rejection-capture helper.** This is the only such site in the repo.
- **A global unhandled-rejection swallow in vitest setup.** It would mask genuine regressions.
- **Retuning the browser project's worker caps.** Load is the trigger, not the defect.

### Verification

- `EpicPanel.browser.test.ts` alone: 11/11 green, exit 0, no `Unhandled Errors` section.
- Full `ui` suite twice: **318 files / 5192 tests passed**, exit 0, no `Errors` line, both runs.
- `bun run check` clean (0 errors, 0 warnings); prettier + eslint clean; pre-push `fallow audit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
