### PR TITLE
fix(blocked): require dialog chrome before shaping a buffer as a menu (#2281)

### DIFF
--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -1,6 +1,6 @@
 import type { SessionStore } from "./store";
 import type { Session, AutopilotVerdict, ReviewVerdict } from "./types";
-import type { BlockReason } from "./blocked";
+import { looksLikeDemotedMenu, type BlockReason } from "./blocked";
 import type { GitState } from "./forge/types";
 import type { SessionStateChange } from "./session-snapshot";
 import { effectiveAutopilot } from "./effective-autopilot";
@@ -454,7 +454,15 @@ export class AutopilotService {
 
   /** session:block handler. Only steerable shapes are eligible; menu/stall surface as-is.
    *  The auth set/clear runs BEFORE the shape guard so a null block from the poller's clearBlock
-   *  actually reaches `authPending.delete` (a null would otherwise early-return). */
+   *  actually reaches `authPending.delete` (a null would otherwise early-return).
+   *
+   *  A DEMOTED menu is surfaced too (#2281): `classifyBlocked` shapes a numbered run without
+   *  dialog chrome as `awaiting-input`, which is steerable — and steering types text + Enter into
+   *  the pane. If that buffer is a real dialog caught mid-paint, the Enter answers its highlighted
+   *  option; `consider()` cannot catch it either, since it never re-reads the shape after its
+   *  (multi-second) classify spawn. So these stand down and wait for a human, exactly as the
+   *  `menu` shape they came from does. Only this edge is guarded — `onDone` classifies a tail
+   *  regardless of shape and is unchanged. */
   async onBlock(id: string, block: BlockReason | null): Promise<void> {
     if (block?.authUrl) {
       this.authPending.add(id); // human-only MCP OAuth prompt — stand down, never steer it
@@ -462,6 +470,9 @@ export class AutopilotService {
     }
     this.authPending.delete(id); // null / non-auth block ⇒ no OAuth pending
     if (!block || !STEERABLE_SHAPES.has(block.shape)) return;
+    // Only the demoted shape: a genuine `yes-no` carries its own evidence, and its tail may hold
+    // an unrelated numbered list.
+    if (block.shape === "awaiting-input" && looksLikeDemotedMenu(block.tail)) return;
     await this.consider(id, block.tail, `${AUTOPILOT_LABEL}${id}`);
   }
 

--- a/src/blocked.ts
+++ b/src/blocked.ts
@@ -26,10 +26,30 @@ const TAIL_LINES = 15;
 // Matches "1. Yes", "❯ 2. No", "│  3) Foo", AND the fullscreen renderer's zero-space packing
 // of the long option ("2.Yes, allow all edits…"). Group 2 captures the delimiter spacing
 // (undefined when packed with no space); group 3 is the label. The zero-space form is gated
-// in classifyBlocked (see below) so a decimal ("2.5 GB") or a bare-token run ("1.tsx"/"2.x")
+// in captureOptionRun (see below) so a decimal ("2.5 GB") or a bare-token run ("1.tsx"/"2.x")
 // can't forge a menu.
 const OPTION_RE = /^[\s│|]*[❯>*]?\s*(\d+)[.)](\s+)?(\S.*?)\s*$/;
 const YES_NO_RE = /\(\s*y\s*\/\s*n\s*\)|\[\s*y\s*\/\s*n\s*\]/i;
+// ── Dialog chrome: the two marks a RENDERED menu carries and PRINTED prose does not (#2281) ──
+// A numbered run alone is not evidence of a dialog — an agent writing a recap as "1. … 2. …"
+// produces the same shape, so a menu must additionally carry one of these.
+//
+// Measured over the live corpus (4226 captured block tails, 2791 of them classified `menu` before
+// this gate): 2708 carry the caret, 2554 the footer, 2776 at least one — so both halves are
+// load-bearing (222 caret-only, 68 footer-only). Of the 15 chrome-less rows, 13 are prose
+// forgeries and 2 are real dialogs caught mid-paint. NO row carries chrome AND a live spinner,
+// which is why a genuine dialog still surfaces spinner or not.
+//
+// Selected-option caret. `*` is deliberately NOT in the caret set even though OPTION_RE accepts
+// it as an option marker: it is also the markdown bullet leader (same reasoning that keeps `+`
+// out of SPINNER_RE), and a bulleted numbered list is exactly the prose this guards against.
+const CARET_OPTION_RE = /^[\s│|]*[❯>]\s*\d+[.)]/;
+// Key-hint footer, as a substring of the (·-separated, often word-wrapped) hint line. Matched on
+// the stable fragments rather than a whole wording: the live corpus carries at least a dozen
+// variants, most of them truncated mid-line by the pane width ("Enter to select · ↑/↓ to
+// navigate · n to add notes · Tab to").
+const DIALOG_FOOTER_RE =
+  /enter to (?:select|confirm)|esc to cancel|(?:↑\/↓|arrow keys) to navigate/i;
 // eslint-disable-next-line no-control-regex
 const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]/g;
 
@@ -99,11 +119,8 @@ export function hasQueuedInput(text: string): boolean {
   return tailLines(text).some((l) => QUEUED_INPUT_RE.test(l));
 }
 
-/** Classify a blocked agent's terminal tail into an actionable shape. Never throws. */
-export function classifyBlocked(text: string): BlockReason {
-  const tail = tailLines(text);
-
-  // Capture the last contiguous 1..n run of numbered options.
+/** The last contiguous 1..n run of numbered options in `tail` (empty when there is none). */
+function captureOptionRun(tail: string[]): BlockOption[] {
   let run: BlockOption[] = [];
   for (const line of tail) {
     const m = OPTION_RE.exec(line);
@@ -118,7 +135,49 @@ export function classifyBlocked(text: string): BlockReason {
     if (n === run.length + 1) run.push({ label: label!, send: num! });
     else if (n === 1) run = [{ label: label!, send: num! }];
   }
-  if (run.length >= 2) return { shape: "menu", options: run, tail };
+  return run;
+}
+
+/** True when `tail` carries a mark only a RENDERED dialog has: a caret on one of its numbered
+ *  options, or the key-hint footer. Scans the same window as the option run it qualifies. */
+function hasDialogChrome(tail: string[]): boolean {
+  return tail.some((l) => CARET_OPTION_RE.test(l) || DIALOG_FOOTER_RE.test(l));
+}
+
+/**
+ * True when `tail` is the shape `classifyBlocked` DEMOTED: a numbered option run with no dialog
+ * chrome, classified `awaiting-input` rather than `menu` (#2281).
+ *
+ * Consumed by `AutopilotService.onBlock` (src/autopilot.ts), whose `STEERABLE_SHAPES` includes
+ * `awaiting-input`: steering types text + Enter into the pane, and if the buffer is a real dialog
+ * caught mid-paint that Enter answers its highlighted option. Autopilot therefore stands these
+ * down and lets them surface, exactly as it does a `menu`.
+ *
+ * Re-derived over the same `tail` array the block carries (`BlockReason.tail`, i.e. what
+ * `classifyBlocked` classified), so it agrees with the demotion by construction.
+ */
+export function looksLikeDemotedMenu(tail: string[]): boolean {
+  return captureOptionRun(tail).length >= 2 && !hasDialogChrome(tail);
+}
+
+/**
+ * Classify a blocked agent's terminal tail into an actionable shape. Never throws.
+ *
+ * A `menu` needs BOTH a contiguous 1..n option run AND dialog chrome (#2281). The run alone is
+ * prose an agent printed as often as a dialog the CLI rendered, and a forged menu is worse than a
+ * stale card: its options are clickable and type `1`/`2` into a PTY that may be mid-turn. A
+ * chrome-less run degrades to `awaiting-input`, where the poller's spinner / queued-input
+ * suppression (src/poller.ts → `suppressAwaitingInput`) applies.
+ *
+ * The cost is bounded and self-correcting: a real dialog read MID-PAINT, before its caret or
+ * footer has landed, shows as `awaiting-input` for one `reclassifyMs` cadence and upgrades to a
+ * `menu` with its options on the next read.
+ */
+export function classifyBlocked(text: string): BlockReason {
+  const tail = tailLines(text);
+
+  const run = captureOptionRun(tail);
+  if (run.length >= 2 && hasDialogChrome(tail)) return { shape: "menu", options: run, tail };
 
   if (tail.some((l) => YES_NO_RE.test(l))) {
     return {

--- a/src/critic-stuck.ts
+++ b/src/critic-stuck.ts
@@ -13,9 +13,16 @@ import { classifyBlocked, type BlockShape } from "./blocked";
  *   2. the pane buffer is BYTE-IDENTICAL to the previous read.
  *
  * (2) is what makes this safe to act on. Critics routinely PRINT numbered lists — findings are
- * written as "1. … 2. …" — and `classifyBlocked` cannot tell a rendered menu from prose that looks
- * like one. The discriminator is motion, not shape: a working agent's buffer advances between
- * reads, a wedged one's cannot. Same freshness idea the poller applies to spinner suppression.
+ * written as "1. … 2. …" — so motion, not shape, is the discriminator: a working agent's buffer
+ * advances between reads, a wedged one's cannot. Same freshness idea the poller applies to
+ * spinner suppression.
+ *
+ * Since #2281 shape carries weight too: `classifyBlocked` reports `menu` only for a numbered run
+ * that also renders dialog chrome (a caret on an option, or the key-hint footer), which a printed
+ * findings list never has. Real prompts — the captured upsell pane in this module's tests
+ * included — all carry it, so every wedge this exists for is still caught; what it no longer
+ * reports is a critic frozen on its own findings render, previously an accepted false positive
+ * costing an early finalize.
  *
  * `awaiting-input` / `stall` / `quota` shapes are deliberately NOT treated as stuck: they are
  * either legitimately mid-turn or already have their own dedicated handling, and killing a run on

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -391,6 +391,38 @@ test("menu shape never classifies or steers (always surfaces as-is)", async () =
   expect(h.state().autopilotStepCount).toBe(0);
 });
 
+test("a demoted menu never classifies or steers (#2281)", async () => {
+  // classifyBlocked shapes a chrome-less numbered run as awaiting-input, which IS steerable —
+  // but steering types text + Enter, and a real dialog caught mid-paint would take that Enter as
+  // an answer to its highlighted option. Stands down and surfaces, like the menu it came from.
+  const h = harness({ session: sess(), verdict: { kind: "gate", summary: "x" } });
+  await h.svc.onBlock(
+    "s1",
+    block(["Both parts are covered:", "1. Backlog counter — …", "2. Circuit-breaker — …"]),
+  );
+  expect(h.classified).toHaveLength(0);
+  expect(h.events.length).toBe(0);
+  expect(h.state().autopilotStepCount).toBe(0);
+});
+
+test("an awaiting-input tail with no numbered run still steers (#2281 guard is narrow)", async () => {
+  const h = harness({ session: sess(), verdict: { kind: "gate", summary: "asking to start" } });
+  await h.svc.onBlock("s1", block(["Shall I start?", "❯"]));
+  expect(h.classified).toHaveLength(1);
+  expect(h.events).toContainEqual({ steer: PROCEED_STEER });
+});
+
+test("a yes-no prompt is still steered when its tail holds a numbered list (#2281)", async () => {
+  const h = harness({ session: sess(), verdict: { kind: "gate", summary: "asking to start" } });
+  await h.svc.onBlock("s1", {
+    shape: "yes-no",
+    options: [],
+    tail: ["1. rebase onto main", "2. re-run CI", "Continue? (y/n)"],
+  });
+  expect(h.classified).toHaveLength(1);
+  expect(h.events).toContainEqual({ steer: PROCEED_STEER });
+});
+
 test("disabled (repo off, no override) → no-op", async () => {
   const h = harness({
     session: sess({ autopilotEnabled: null }),

--- a/test/blocked.test.ts
+++ b/test/blocked.test.ts
@@ -5,6 +5,7 @@ import {
   classifyBlocked,
   hasActiveSpinner,
   hasQueuedInput,
+  looksLikeDemotedMenu,
   quotaBlockReason,
 } from "../src/blocked";
 import type { Session, PlanGate } from "../src/types";
@@ -326,4 +327,59 @@ test("bare-token-run false-positive guard: '1.tsx'/'2.tsx' does not classify as 
 test("fullscreen-spinner.txt hasActiveSpinner returns true", () => {
   const text = readFileSync(join(fixturesDir, "fullscreen-spinner.txt"), "utf8");
   expect(hasActiveSpinner(text)).toBe(true);
+});
+
+// ── #2281: a menu needs dialog chrome, not just a numbered run ────────────────
+
+test("prose numbered run with no dialog chrome is not a menu (real captured pane)", () => {
+  const pane = readFileSync(join(fixturesDir, "prose-menu.txt"), "utf8");
+  const r = classifyBlocked(pane);
+  expect(r.shape).toBe("awaiting-input");
+  expect(r.options).toEqual([]);
+  // …and the pane is a working agent, so the poller suppresses it rather than raising a card
+  expect(hasActiveSpinner(pane)).toBe(true);
+});
+
+test("the at-rest input box's own caret does not qualify a numbered run", () => {
+  // "❯" sits on its own prompt line in every at-rest pane; only a caret ON an option counts.
+  const tail = ["1. First finding", "2. Second finding", "❯"].join("\n");
+  expect(classifyBlocked(tail).shape).toBe("awaiting-input");
+});
+
+test("either chrome half alone admits a menu", () => {
+  const caretOnly = ["Do you want to proceed?", "❯ 1. Yes", "  2. No"].join("\n");
+  expect(classifyBlocked(caretOnly).shape).toBe("menu");
+
+  // AskUserQuestion frames can scroll their caret out of the tail window but keep the footer
+  const footerOnly = [
+    "Which ruleset should I apply?",
+    " 1. strict",
+    " 2. recommended",
+    "Enter to select · ↑/↓ to navigate · Esc to cancel",
+  ].join("\n");
+  const r = classifyBlocked(footerOnly);
+  expect(r.shape).toBe("menu");
+  expect(r.options.map((o) => o.send)).toEqual(["1", "2"]);
+});
+
+test("chrome alone does not forge a menu without a numbered run", () => {
+  expect(classifyBlocked("Paste the code here\nEsc to cancel").shape).toBe("awaiting-input");
+});
+
+test("a mid-paint dialog upgrades to a menu on the next read", () => {
+  const painting = [" 1. Yes", " 2. No"].join("\n");
+  expect(classifyBlocked(painting).shape).toBe("awaiting-input");
+  expect(classifyBlocked(`${painting}\nEnter to confirm · Esc to cancel`).shape).toBe("menu");
+});
+
+test("looksLikeDemotedMenu marks exactly what classifyBlocked demoted", () => {
+  const demoted = classifyBlocked(readFileSync(join(fixturesDir, "prose-menu.txt"), "utf8"));
+  expect(looksLikeDemotedMenu(demoted.tail)).toBe(true);
+
+  const real = classifyBlocked(readFileSync(join(fixturesDir, "classic-menu.txt"), "utf8"));
+  expect(real.shape).toBe("menu");
+  expect(looksLikeDemotedMenu(real.tail)).toBe(false);
+
+  // no numbered run at all → nothing was demoted
+  expect(looksLikeDemotedMenu(classifyBlocked("What should I name it?\n❯").tail)).toBe(false);
 });

--- a/test/critic-stuck.test.ts
+++ b/test/critic-stuck.test.ts
@@ -42,15 +42,13 @@ test("does NOT fire on a critic's numbered findings list while output advances",
   expect(stuckOnPrompt(FINDINGS_PANE + "\n4. more", FINDINGS_PANE)).toBeNull();
 });
 
-// …but a run that has genuinely stopped dead on that same text IS reported. Documenting the
-// residual: the guard is motion, not content, so a critic idling on its final findings render is
-// indistinguishable from a wedged one. This is safe WITHOUT relying on the detector being skipped
-// — an unrepaired verdict never reaches `wait` at all, and for a repaired one ReviewService
-// re-decides the wedge through decideVerdictAction(spawnFinished=true), which finalizes the
-// verdict's VALUE rather than discarding it. A false positive here costs an early finalize, never
-// the critic's findings.
-test("an idle pane whose last paint happens to be a numbered list still reports stuck", () => {
-  expect(stuckOnPrompt(FINDINGS_PANE, FINDINGS_PANE)).toBe("menu");
+// …and since #2281 a frozen findings list is no longer reported either: `classifyBlocked` needs
+// dialog chrome (a caret on an option, or the key-hint footer) to call something a menu, and a
+// printed list has none. That closes the residual this test used to document — a critic idling on
+// its final findings render was indistinguishable from a wedged one and cost an early finalize.
+// A REAL prompt is unaffected: every one carries chrome (see UPSELL_PANE above).
+test("an idle pane whose last paint happens to be a numbered list is not stuck", () => {
+  expect(stuckOnPrompt(FINDINGS_PANE, FINDINGS_PANE)).toBeNull();
 });
 
 test("fires on a y/n confirm", () => {

--- a/test/fixtures/fullscreen/prose-menu.txt
+++ b/test/fixtures/fullscreen/prose-menu.txt
@@ -1,0 +1,15 @@
+  $ gh pr view 276  →  MERGED  2026-07-20T19:42:46Z
+  Both parts of the issue are covered in the current source:
+  1. Backlog counter — ai-judge.ts:893 sets result.skippedByBudget = toJudge.length - (judgedCount + failures) at the budgetExhausted break, kept distinct from skippedByCap; surfaced in persist.ts:324 and the worker log (time-review-detect.ts:20,
+  aiBacklog=cap+budget).
+  2. Circuit-breaker — AI_JUDGE_MAX_FAILURES = 3 (ai-judge.ts:98) plus the time_review_ai_judge_failures ledger (migration 0071); entries park after 3 consecutive entry-specific failures on the same inputHash, self-heal on input change/success, with a
+  storm guard so a rate-limit outage can't park healthy entries. Degraded report gates on newlyParked > 0 (persist.ts:132).
+  The issue just was never closed after #276 merged.
+● User answered Claude's questions:
+  ⎿  · #274 is already shipped by merged PR #276. How do you want to proceed? → Close #274 (Recommended)
+✽ Gallivanting… (35s · ↓ 2.2k tokens)
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  …/.shepherd-worktrees/pulse-time-review-judge-skippedbycap shepherd/time-review-circuit-breaker   ⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀ 6% ctx Opus 4.8 (1M context) operator@example.com · example.org                                                                     ● high · /effort
+  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -620,6 +620,28 @@ test("still emits a menu block when queued input is also on screen", async () =>
   expect(h.working).toHaveLength(0); // a genuine dialog never enters the display state
 });
 
+/** Issue #2281: the real captured pane of a session that was WORKING — a recap written as a
+ *  numbered list, the at-rest footer, and a live spinner. Before the chrome gate this shaped as
+ *  a `menu` whose clickable options typed `1`/`2` into a mid-turn PTY. */
+const PROSE_MENU_TAIL = readFileSync(
+  join(import.meta.dir, "fixtures/fullscreen/prose-menu.txt"),
+  "utf8",
+);
+
+test("a prose-forged menu on a working pane suppresses instead of raising a card (#2281)", async () => {
+  const h = spinnerHarness(PROSE_MENU_TAIL);
+  await h.poller.tick();
+  expect(h.blocks).toHaveLength(0);
+  expect(h.working).toEqual([{ id: h.id, working: true }]);
+
+  // the spinner keeps ticking, so the buffer advances and suppression holds
+  h.setText(PROSE_MENU_TAIL.replace("(35s ·", "(41s ·"));
+  h.advance(3001);
+  await h.poller.tick();
+  expect(h.blocks).toHaveLength(0);
+  expect(h.events).toEqual(["working:true"]);
+});
+
 test("re-arms once the queued-input hint leaves the pane", async () => {
   const h = spinnerHarness(QUEUED_TAIL);
   await h.poller.tick();


### PR DESCRIPTION
Closes #2281.

`classifyBlocked` shaped a buffer as `menu` on any contiguous `1. … 2. …` run in the last 15 non-empty lines. A recap written as a numbered list satisfies that, so a session that was actively working raised a false "needs you" card — with clickable options that send `1`/`2` into a PTY mid-turn.

A `menu` now needs a second mark: **dialog chrome** a rendered dialog carries and printed prose does not — a `❯`/`>` caret on one of the numbered options, or the key-hint footer (`Enter to select` / `Enter to confirm` / `Esc to cancel` / `↑/↓`/`arrow keys to navigate`). A chrome-less run degrades to `awaiting-input`.

## Why chrome, and not "a spinner vetoes a menu"

Measured against the live corpus — 4226 captured `block` tails, the exact window `classifyBlocked` scans:

| | rows |
| --- | --- |
| classified `menu` | 2791 |
| carry chrome | 2776 (99.46%) |
| chrome **and** a live spinner | **0** |
| no chrome + live spinner (the rows the issue reports) | 3 |
| no chrome, no spinner (same forgery, at rest) | 12 |

Both chrome halves are load-bearing: 222 rows carry only the caret, 68 only the footer.

Hand-inspecting the 15 chrome-less rows: 13 are prose forgeries, 2 are real `AskUserQuestion` dialogs captured **mid-paint** (`attachSignalCapture` keeps only the first emit of a 60s episode, so half-painted frames are over-represented — their next 3s repaint carries chrome).

So the spinner veto the issue floated would have fixed 3 of 15 and been blind to the 12 at-rest forgeries. And because no row carries chrome *and* a spinner, the "a genuine dialog always surfaces, spinner or not" rule is untouched — `test/poller.test.ts` → "still emits a menu block when a spinner line is also visible" passes unchanged.

Cost: a real dialog read mid-paint shows as `awaiting-input` for one `reclassifyMs` cadence (3s), then upgrades to a `menu` with its options.

Re-measured after the change on today's snapshot: 2720 buffers would have shaped as `menu` under the old rule, 2706 do now; the 14 demoted are the forgeries, and 0 surviving menus carry a live spinner.

## Autopilot

`STEERABLE_SHAPES` contains `awaiting-input`, so the demotion would newly route these into `consider()` → `steer()`, which types text + Enter into the pane — and `consider()` never re-reads the shape after its multi-second classify spawn, so a dialog that finished painting meanwhile would take that Enter as an answer to its highlighted option. `onBlock` therefore stands a demoted buffer down and lets it surface, exactly as it does a `menu`. The guard is scoped to `awaiting-input` only: a genuine `yes-no` carries its own evidence and its tail may hold an unrelated numbered list.

## Inherited change in `stuckOnPrompt`

`src/critic-stuck.ts` shares the classifier. Every real wedge it exists for carries chrome (its own captured upsell-pane fixture has both halves), so wedge detection is intact; what it no longer reports is a critic frozen on its own findings render — an accepted false positive its comments already flagged, costing an early finalize. Its one test flips accordingly.

## Verification

- `bun run lint`, `bunx tsc --noEmit`, `bun run test` (9759 pass / 0 fail), `bunx fallow audit --base origin/main --fail-on-issues` — all clean.
- New: the verbatim failing pane from the issue committed as `test/fixtures/fullscreen/prose-menu.txt` (operator e-mail in the status line redacted), asserted both at the classifier and through the poller (suppressed, no card, one working-while-blocked flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
