### PR TITLE
feat(hooks): default SHEPHERD_HOOKS_SIGNALS on; unify the signal gate

### DIFF
--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -157,13 +157,19 @@ Two independent stages, each an env override on a code default:
   sub-agent roster fan-out. Observe-only: it never mutates session status. **Default on** as of the
   post-soak flip; set `SHEPHERD_HOOKS_INGEST=0` to disable (the kill switch).
 - **Signals** (`SHEPHERD_HOOKS_SIGNALS`) — feed matched hook events into the poller's signal
-  pipeline. Still **opt-in**; meaningful only when ingest is also on (with ingest off, no events
-  arrive to feed, and Shepherd warns and treats signals as off).
+  pipeline. **Default on** as of the post-soak flip; meaningful only when ingest is also on (with
+  ingest off, no events arrive to feed, and Shepherd warns and treats signals as off).
+
+  The signals kill switch is deliberately **partial**: on herdr **0.7.5 and newer**, agents are
+  spawned through external registration, so herdr never advances `agent_status` itself and the
+  `Notification` hook is the *only* source of awaiting-input edges. Signals are therefore forced on
+  there regardless of the flag, and `SHEPHERD_HOOKS_SIGNALS=0` takes effect only on herdr **0.7.4
+  and older** — where herdr's own detection plus the transcript probe still cover the gap.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `SHEPHERD_HOOKS_INGEST` | `1` (on) | Inject observe-only lifecycle hooks into spawned agents (ingest route, ring buffer/logging, sub-agent roster fan-out). No status consumption; additive + fail-open. Set `0` to disable entirely (kill switch) |
-| `SHEPHERD_HOOKS_SIGNALS` | `0` (off) | Set `1` to forward matched hook events into the poller's signal pipeline. Meaningful only when `SHEPHERD_HOOKS_INGEST` is also on |
+| `SHEPHERD_HOOKS_SIGNALS` | `1` (on) | Forward matched hook events into the poller's signal pipeline. Meaningful only when `SHEPHERD_HOOKS_INGEST` is also on. Set `0` to disable — but see the caveat above: that only bites on herdr ≤ 0.7.4 |
 
 ## Tool guard (PreToolUse deny)
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -692,9 +692,14 @@ export const config = {
   toolGuard: parseKillSwitch(process.env.SHEPHERD_TOOL_GUARD),
   // Phase 1: feed received hook events into the poller (the single owner of signal state).
   // Meaningful only when `hooksIngest` is also on — with ingest off no events arrive to feed.
-  // Still OPT-IN (=== "1"): #740 flipped only ingest on. Promoting signals to default awaits
-  // confirmed soak of the #711 netns transport (autonomous/egress) it would consume events over.
-  hooksSignals: process.env.SHEPHERD_HOOKS_SIGNALS === "1",
+  // DEFAULT ON as of #740, completing the flip #1686 started on `hooksIngest`. The soak gate this
+  // waited on was overtaken by #1890: on herdr ≥0.7.5 (external-registration spawn) the poller's
+  // `hookSignalsActive()` forces signals on regardless of this flag, because the
+  // `Notification(permission_prompt)` hook is then the ONLY awaiting-input source (#1891). So the
+  // flag's remaining reach is herdr ≤0.7.4 — which is exactly the configuration the operator box
+  // soaked under with SHEPHERD_HOOKS_SIGNALS=1 from 2026-06-15 on. Additive + fail-open either way.
+  // SHEPHERD_HOOKS_SIGNALS=0 is the kill switch, and it only takes effect on herdr ≤0.7.4.
+  hooksSignals: parseKillSwitch(process.env.SHEPHERD_HOOKS_SIGNALS),
   // PR-gated AI doc agent (issue #882, epic #875 Phase 3). Opt-in soak flag, mirroring
   // SHEPHERD_HOOKS_INGEST→HOOKS_SIGNALS: default-off and reversible. This is now Phase-0
   // OBSERVE — when on, the trigger spawns a scoped, dontAsk doc agent that edits stale prose

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -156,9 +156,14 @@ export interface LivenessWiring {
  *  herdr can't advance `agent_status` for us. On the 0.7.5 external-registration path it never does
  *  (sandboxed agents it can't observe; trusted agents defer to the client-pinned state), AND claude's
  *  real session id is unknown there (#1889) so the transcript-based activity probe can't run either.
- *  The hooks are then the ONLY source of working/idle/blocked edges Shepherd pushes back. ≤0.7.4
- *  keeps herdr's own detection + the transcript probe, so this stays behind the opt-in `hooksSignals`
- *  flag there (no behaviour change). */
+ *  The hooks are then the ONLY source of working/idle/blocked edges Shepherd pushes back, so the
+ *  `hooksSignals` kill switch cannot turn them off there. ≤0.7.4 keeps herdr's own detection + the
+ *  transcript probe, so the flag still governs on those versions — it just defaults ON now (#740).
+ *
+ *  THE single gate for every push-signal consumer in this file. Read it rather than
+ *  `config.hooksSignals` directly: the raw flag misses the ≥0.7.5 override, which used to leave the
+ *  feature half-on (events ingested, but the #713 stop-window measurement and the probe's
+ *  redundant-emit suppression silently inert). */
 function hookSignalsActive(): boolean {
   return config.hooksSignals || herdrUsesExternalRegistrationSpawn();
 }
@@ -378,7 +383,7 @@ export class StatusPoller {
    *  herdr-blocked, `clearBlock`, reap, prune). */
   private lastSuppressVisible = new Map<string, string>();
 
-  /** Phase-1/2 push-hook state (issue #704), all gated by `config.hooksSignals`.
+  /** Phase-1/2 push-hook state (issue #704), all gated by `hookSignalsActive()`.
    *  Fed via HookIngest.onSignal → ingestActivity / ingestNotification / ingestSessionStart;
    *  the poller stays the single owner of per-session signal dedup + the working-while-blocked
    *  state machine, so push events funnel through `emitActivity`/`maybeClassify`
@@ -402,7 +407,7 @@ export class StatusPoller {
    *  `pendingStopAt` holds a Stop seen before its done-flip (stop-wins side); `pendingDoneAt`
    *  holds a done-flip seen before its Stop (herdr-wins side). Whichever arrives first parks
    *  here; the other side pairs it (emitting the signed window) or it expires unpaired. Both
-   *  are reaped on gone/prune and inert when `config.hooksSignals` is off. */
+   *  are reaped on gone/prune and inert when `hookSignalsActive()` is false. */
   private pendingStopAt = new Map<string, number>();
   private pendingDoneAt = new Map<string, number>();
 
@@ -722,7 +727,7 @@ export class StatusPoller {
       this.pruneInactive(activeIds);
       // Observe-only Stop↔herdr-done window (issue #713): expire markers that never paired
       // within the horizon (no-stop emit / silent stale-Stop drop). Gated; no behaviour change.
-      if (config.hooksSignals) this.expireStaleStopWindows();
+      if (hookSignalsActive()) this.expireStaleStopWindows();
       // Refresh the probe snapshot cell (darwin; no-op on Linux/fakes) before the
       // sweeps read it. Driven here — not from a sweep — because the liveness sweep
       // has no wiring of its own and the preview sweep short-circuits when no
@@ -1087,7 +1092,7 @@ export class StatusPoller {
    * a usage-limit halt. Extracted to keep reconcileAgent under the complexity gate.
    */
   private handleDoneEdge(s: Session): void {
-    if (config.hooksSignals) this.measureStopWindow(s.id, this.now());
+    if (hookSignalsActive()) this.measureStopWindow(s.id, this.now());
     this.detectUsageHalt(s);
   }
 
@@ -1315,7 +1320,7 @@ export class StatusPoller {
    * REAL tool summary (vs. the interim heartbeat's `summary:null`), so it beats the
    * interim emit on the freshness guard below.
    *
-   * No-op when `config.hooksSignals` is off (the sink is never wired in that case, so
+   * No-op when `hookSignalsActive()` is false (the sink is never wired in that case, so
    * this is belt-and-suspenders for direct callers/tests). Records `lastHookActivityAt`
    * so `maybeProbe` knows the push path is fresh.
    */
@@ -1363,7 +1368,7 @@ export class StatusPoller {
    * and an awaiting-input edge we haven't confirmed simply stays on the existing
    * `herdr-blocked → classifyBlocked` fallback (no regression).
    *
-   * No-op when `config.hooksSignals` is off.
+   * No-op when `hookSignalsActive()` is false.
    */
   ingestNotification(id: string, type: string): void {
     if (!hookSignalsActive()) return;
@@ -1378,7 +1383,7 @@ export class StatusPoller {
    * reusing the sweep's own map + flip-dedup so push + poll never double-emit. Boot
    * liveness is monotonic (true until exit), so this cannot oscillate with the sweep,
    * which will agree (the process is alive — the hook fired from inside it). No-op when
-   * `config.hooksSignals` is off.
+   * `hookSignalsActive()` is false.
    * (Stop/SessionEnd consumption is deferred to #713 — observe-only this phase.)
    */
   ingestSessionStart(id: string): void {
@@ -1401,10 +1406,10 @@ export class StatusPoller {
    * is silently overwritten — Stop is a per-turn edge, only the latest matters).
    *
    * Pure measurement: never touches status, routing, or any block/activity state — polling
-   * stays authoritative. No-op when `config.hooksSignals` is off.
+   * stays authoritative. No-op when `hookSignalsActive()` is false.
    */
   ingestStopMeasure(id: string, stopAt: number): void {
-    if (!config.hooksSignals) return;
+    if (!hookSignalsActive()) return;
     const d = this.pendingDoneAt.get(id);
     if (d !== undefined && stopAt - d <= STOP_WINDOW_MAX_MS) {
       // herdr-wins: the done-flip preceded this Stop (window ≤ 0).
@@ -1443,7 +1448,7 @@ export class StatusPoller {
    * Per-tick expiry sweep for the observe-only Stop↔done markers (issue #713). A pending
    * done that aged past the horizon never paired with a Stop → emit `null` (no-stop) and
    * drop it. A pending Stop that aged out is dropped SILENTLY — a Stop with no done-flip is
-   * not a done-flip and emits nothing. Inert when `config.hooksSignals` is off (callers gate).
+   * not a done-flip and emits nothing. Inert when `hookSignalsActive()` is false (callers gate).
    */
   private expireStaleStopWindows(): void {
     const now = this.now();
@@ -1558,11 +1563,11 @@ export class StatusPoller {
    * enough that the transcript/interim probe should defer its redundant activity emit?
    * Fresh = a push landed within `2 × probeCheckMs` (two probe cadences — long enough
    * to bridge the gap between two pushes, short enough that a gone-quiet push hands the
-   * active path back to the probe). Always false when `hooksSignals` is off (the map
+   * active path back to the probe). Always false when `hookSignalsActive()` is false (the map
    * stays empty), so the probe emits exactly as today — the fallback.
    */
   private hookActivityFresh(id: string, now: number): boolean {
-    if (!config.hooksSignals) return false;
+    if (!hookSignalsActive()) return false;
     const at = this.lastHookActivityAt.get(id);
     return at !== undefined && now - at < 2 * this.probeCheckMs;
   }

--- a/test/poller-stop-window.test.ts
+++ b/test/poller-stop-window.test.ts
@@ -16,11 +16,13 @@ function withListAsync<T extends { list: () => HerdrAgent[] }>(
 }
 import { classifyBlocked } from "../src/blocked";
 import { config } from "../src/config";
+import { setDetectedHerdrVersion } from "../src/herdr-capabilities";
 
 // Observe-only Stop↔herdr-done window measurement (issue #713). Polling stays authoritative;
 // these tests assert the SIGNED window emission + marker bookkeeping only, never any routing
-// change. `config.hooksSignals` gates the whole feature — save/restore it per-test so the
-// flag never leaks across the suite.
+// change. `hookSignalsActive()` gates the whole feature (the `config.hooksSignals` flag OR the
+// ≥0.7.5 external-registration path) — save/restore both inputs per-test so neither leaks
+// across the suite.
 
 const baseSession = {
   name: "x",
@@ -93,7 +95,7 @@ function stopHarness() {
   };
 }
 
-test("stop-window: inert when config.hooksSignals is off", async () => {
+test("stop-window: inert when hook signals are inactive", async () => {
   const orig = config.hooksSignals;
   config.hooksSignals = false;
   try {
@@ -104,6 +106,30 @@ test("stop-window: inert when config.hooksSignals is off", async () => {
     expect(h.windows).toHaveLength(0);
   } finally {
     config.hooksSignals = orig;
+  }
+});
+
+// #740: the gate is `hookSignalsActive()` — the flag OR the ≥0.7.5 external-registration path —
+// not the raw flag. Measurement used to read `config.hooksSignals` directly, so on herdr ≥0.7.5
+// with the kill switch set the sink was wired and Stop events arrived, yet every window was
+// silently dropped. Pins the override so that split state can't come back.
+test("stop-window: active on herdr >=0.7.5 even with the hooksSignals kill switch set", async () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = false;
+  setDetectedHerdrVersion("0.7.5");
+  try {
+    const h = stopHarness();
+    const t1 = h.now();
+    h.poller.ingestStopMeasure(h.id, t1);
+    h.advance(2000);
+    const t2 = h.now();
+    h.setStatus("done");
+    await h.poller.tick();
+    expect(h.windows).toEqual([{ id: h.id, windowMs: t2 - t1 }]);
+  } finally {
+    config.hooksSignals = orig;
+    // Module-level state shared across the whole run — always hand it back.
+    setDetectedHerdrVersion(null);
   }
 });
 

--- a/test/setup-test-env.ts
+++ b/test/setup-test-env.ts
@@ -32,11 +32,11 @@ for (const key of Object.keys(process.env)) {
   if (key.startsWith("SHEPHERD_") && !KEEP.has(key)) delete process.env[key];
 }
 
-// #740 flipped SHEPHERD_HOOKS_INGEST to default-ON (kill-switch `!== "0"` form). The strip above
-// removes the ambient var, so config would otherwise read the *code* default (on) and
-// spawnSettingsOverlay would bake a `hooks` blob into every spawn/resume argv — breaking the
-// snapshot tests this preload exists to keep deterministic. Pin both hook flags OFF so the suite
-// keeps CI-equivalent, hooks-off isolation. The on-path stays covered by the tests that set
-// `config.hooksIngest` / `config.hooksSignals` directly (service.test.ts, poller*.test.ts).
+// #740 flipped BOTH hook flags to default-ON (kill-switch `!== "0"` form) — ingest first, then
+// signals. The strip above removes the ambient vars, so config would otherwise read the *code*
+// defaults (on) and spawnSettingsOverlay would bake a `hooks` blob into every spawn/resume argv —
+// breaking the snapshot tests this preload exists to keep deterministic. Pin both hook flags OFF
+// so the suite keeps CI-equivalent, hooks-off isolation. The on-path stays covered by the tests
+// that set `config.hooksIngest` / `config.hooksSignals` directly (service.test.ts, poller*.test.ts).
 process.env.SHEPHERD_HOOKS_INGEST = "0";
 process.env.SHEPHERD_HOOKS_SIGNALS = "0";


### PR DESCRIPTION
Completes the #740 flip that PR #1686 started on `hooksIngest`. Closes #740.

## What changed

1. **`hooksSignals` → default-on** (`parseKillSwitch`, `0` disables), matching `hooksIngest`.
2. **Unified the signal gate**: four sites in `src/poller.ts` read `config.hooksSignals` raw instead of going through `hookSignalsActive()` — now fixed.

## Why flip now, with criterion (a) still unmet

#740 wanted a week-plus soak *including real autonomous netns sessions*. Honest status:

- **(b) #713 turn-window data — MET.** Current log window: 47,416 `match=ok` vs 64 `match=mismatch`, 373 sessions, 2,071 stop-window pairings, zero transport failures or fallbacks.
- **(a) autonomous/netns — still unmet, and it cannot accrue by waiting.** `egressApplies()` is `profile === "autonomous"` and `sandboxDefaultProfile` defaults to `trusted`; the live DB holds **152/152 sessions `trusted` / `egressApplied=0`** across the full six-week retention window — unchanged from the 2026-06-22 re-check.

**The premise the gate was written under has been overtaken.** PR #1890 moved herdr ≥ 0.7.5 onto external-registration spawn, and `hookSignalsActive()` / `hookSignalsWanted` are both `config.hooksSignals || herdrUsesExternalRegistrationSpawn()`. herdr 0.9.0 is what ships — so **signals are already force-on for every fresh install, flag or not**, because the `Notification(permission_prompt)` hook is then the only awaiting-input source (#1891).

So the flag's remaining reach is herdr ≤ 0.7.4 — which is exactly the configuration the operator box soaked under with `SHEPHERD_HOOKS_SIGNALS=1` from 2026-06-15 on. The flip ratifies a soaked state rather than introducing an unproven one.

**Stated plainly for the record:** this ships the #711 netns transport default-on still without netns-specific evidence. That is a deliberate acceptance, not a resolved criterion. It is defensible — the path is fail-open by construction (5 s hook budget, poller stays authoritative) and `hooksIngest` already reaches it, shipped default-on by #1686 on the same footing — but a reviewer who wants the evidence first should say so, and the honest answer is that it requires deliberately running an autonomous-profile session, not more waiting.

## The gate fix is a live bug, not tidying

On a fresh install with herdr 0.9.0 and no env override, the split gate broke the feature in half:

- `ingestActivity()` **writes** `lastHookActivityAt` (correct predicate) while `hookActivityFresh()` **read** `false` — so `maybeProbe`'s redundant-emit suppression never engaged and the transcript probe double-emitted activity alongside the push path.
- The #713 stop-window measurement — the instrument that produced criterion (b) — was silently off despite the sink being wired and `Stop` events arriving.

Flipping the default hides this; it does not fix it (setting `SHEPHERD_HOOKS_SIGNALS=0` on ≥ 0.7.5 lands right back in the split state). All four now read `hookSignalsActive()`.

## Kill-switch semantics

`SHEPHERD_HOOKS_SIGNALS=0` stays a deliberately **partial** kill switch: on herdr ≥ 0.7.5 signals cannot be turned off, because letting them be would regress blocked-state detection to nothing (#1891). After this PR it is *coherently* partial rather than half-on/half-off, and the docs say so explicitly.

## Testing

New regression test pins the override: with `config.hooksSignals = false` and `setDetectedHerdrVersion("0.7.5")`, a stop-window **is** emitted. Verified it fails against the old gating and passes with the fix.

The test preload keeps both flags pinned off — it exists to hold spawn-argv snapshots deterministic; only its comment changed.

Verified: `bun run lint`, `bun run test` (9,750 pass / 0 fail), `bunx tsc --noEmit`, `bunx fallow audit`, and a full `docs-site` build. All 7 pre-push lanes green.

## Manual operator steps

**None.** `~/.shepherd/env` already carries `SHEPHERD_HOOKS_INGEST=1` and `SHEPHERD_HOOKS_SIGNALS=1`; both become redundant no-ops that match the new defaults. Per #740's own guidance they can stay as explicit documentation — nothing to set, unset, restart, or backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
