### PR TITLE
fix(demo): answer /api/repos + the New Task GETs (#1800)

### DIFF
--- a/ui/src/lib/demo/router.test.ts
+++ b/ui/src/lib/demo/router.test.ts
@@ -455,3 +455,211 @@ describe("PUT /api/settings echoes the field the real server echoes", () => {
     expect(body.ok).toBeUndefined();
   });
 });
+
+// #1800: `/api/repos` had no handler, so `listRepos()` saw the permissive `{}` tail and
+// `ReposStore.load()` put `undefined` into `entries` (typed `RepoEntry[]`). The `pathIndex`
+// $derived then threw `undefined.flatMap` INSIDE Svelte's flush, aborting the whole batch —
+// which is what logged an error on every session open, left the mobile detail screen
+// unmounted, and stranded the terminal pane at 0x0 after a tab roundtrip.
+//
+// The same trap sits behind the two other GETs the New Task composer fires (`/api/branches`,
+// `/api/issues`): both assign a response array straight into a non-optional `$state` array.
+describe("New Task flow GETs never fall back to {} (#1800)", () => {
+  it("GET /api/repos returns {repos, recentWindowDays} — an ARRAY, never {}", async () => {
+    const { status, body } = await get("/api/repos");
+    expect(status).toBe(200);
+    expect(Array.isArray(body.repos)).toBe(true);
+    expect(body.repos.length).toBeGreaterThan(0);
+    expect(typeof body.recentWindowDays).toBe("number");
+  });
+
+  it("every repo entry resolves the repoPath its seeded sessions carry", async () => {
+    const { body } = await get("/api/repos");
+    // repos.nameFor() indexes on BOTH path and realPath; every seeded session's repoPath
+    // must land in that index, or steer scoping and the command bar silently see no repo.
+    const known = new Set<string>(
+      (body.repos as { path: string; realPath: string }[]).flatMap((r) => [r.path, r.realPath]),
+    );
+    for (const s of demoState.sessions()) expect(known.has(s.repoPath)).toBe(true);
+  });
+
+  it("GET /api/branches returns {branches, current, default} per repo", async () => {
+    const { status, body } = await get(`/api/branches?repo=${encodeURIComponent(REPO)}`);
+    expect(status).toBe(200);
+    expect(Array.isArray(body.branches)).toBe(true);
+    expect(body.branches).toContain("main");
+    expect(body.default).toBe("main");
+    // An unrecognized repo still gets a valid list, so pickBaseBranch() falls back to "main".
+    const unknown = (await get("/api/branches?repo=/nope")).body;
+    expect(unknown).toEqual({ branches: [], current: null, default: null });
+  });
+
+  it("GET /api/branch-status reports a clean, in-sync seeded base", async () => {
+    const { status, body } = await get(
+      `/api/branch-status?repo=${encodeURIComponent(REPO)}&branch=main`,
+    );
+    expect(status).toBe(200);
+    expect(body).toEqual({
+      behind: 0,
+      ahead: 0,
+      diverged: false,
+      hasUpstream: true,
+      localExists: true,
+    });
+    // An unseeded branch reads as neither local nor upstream — what the real server says
+    // about a branch it cannot find.
+    const missing = (await get(`/api/branch-status?repo=${encodeURIComponent(REPO)}&branch=nope`))
+      .body;
+    expect(missing.localExists).toBe(false);
+    expect(missing.hasUpstream).toBe(false);
+  });
+
+  it("GET /api/issues returns the listIssues() shape with a real issue array", async () => {
+    const { status, body } = await get(`/api/issues?repo=${encodeURIComponent(REPO)}`);
+    expect(status).toBe(200);
+    expect(Array.isArray(body.issues)).toBe(true);
+    expect(body.issues.length).toBeGreaterThan(0);
+    expect(body.slug).toBe("acme/storefront");
+    expect(body.webUrl).toBe("https://github.com/acme/storefront");
+    expect(typeof body.viewer).toBe("string");
+    // `error: null` matters: an empty-but-errored list makes the UI blame the forge.
+    expect(body.error).toBeNull();
+    expect(body.lightweight).toBe(false);
+    expect(Array.isArray(body.attempts)).toBe(true);
+    for (const i of body.issues) {
+      expect(typeof i.number).toBe("number");
+      expect(typeof i.title).toBe("string");
+      expect(Array.isArray(i.labels)).toBe(true);
+      expect(Array.isArray(i.assignees)).toBe(true);
+    }
+  });
+
+  it("issue counts match the Backlog lens' openIssues, so the demo never contradicts itself", async () => {
+    const backlog = (await get("/api/backlog")).body as {
+      projects: { path: string; openIssues: number }[];
+      totals: { openIssues: number };
+    };
+    let sum = 0;
+    for (const p of backlog.projects) {
+      const { issues } = (await get(`/api/issues?repo=${encodeURIComponent(p.path)}`)).body;
+      expect(issues.length).toBe(p.openIssues);
+      sum += issues.length;
+    }
+    expect(sum).toBe(backlog.totals.openIssues);
+  });
+
+  it("every epic child issue is listed, so picking one in New Task finds a real issue", async () => {
+    const { issues } = (await get(`/api/issues?repo=${encodeURIComponent(REPO)}`)).body;
+    const numbers = new Set((issues as { number: number }[]).map((i) => i.number));
+    const { subIssues } = (await get(`/api/epics?repo=${encodeURIComponent(REPO)}`)).body;
+    for (const n of subIssues as number[]) expect(numbers.has(n)).toBe(true);
+  });
+
+  it("an unrecognized repo yields an empty-but-successful issue list, not a failure", async () => {
+    const { body } = await get("/api/issues?repo=/nope");
+    expect(body.issues).toEqual([]);
+    expect(body.slug).toBeNull();
+    expect(body.error).toBeNull();
+  });
+});
+
+describe("POST /api/sessions (#1800) creates a real session instead of {ok:true}", () => {
+  it("returns a Session and pushes it into the live herd", async () => {
+    const before = demoState.sessions().length;
+    const r = await handleApi("POST", u("/api/sessions"), {
+      repoPath: REPO,
+      baseBranch: "main",
+      prompt: "Add a gift-wrap option to the checkout summary",
+      model: "opus",
+    });
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    // The page calls selectNewSession(r.id) — a missing id selected `undefined`.
+    expect(typeof body.id).toBe("string");
+    expect(body.id.length).toBeGreaterThan(0);
+    expect(body.repoPath).toBe(REPO);
+    expect(body.prompt).toBe("Add a gift-wrap option to the checkout summary");
+    expect(body.branch).toBe("shepherd/add-a-gift");
+    expect(body.status).toBe("running");
+    expect(demoState.sessions().length).toBe(before + 1);
+    expect(demoState.sessions().find((s) => s.id === body.id)).toBeDefined();
+  });
+
+  it("emits session:new so the herd rail picks the row up over the socket", async () => {
+    const seen: string[] = [];
+    const off = bus.subscribe((ev) => {
+      if (ev.event === "session:new") seen.push(ev.data.id);
+    });
+    const r = await handleApi("POST", u("/api/sessions"), {
+      repoPath: REPO,
+      baseBranch: "main",
+      prompt: "Tidy the footer",
+      model: "opus",
+    });
+    off();
+    expect(seen).toEqual([(await r.json()).id]);
+  });
+
+  it("takes a fresh TASK designation that collides with no live or archived session", async () => {
+    const taken = new Set(
+      [...demoState.sessions(), ...demoState.doneSessions()].map((s) => s.desig),
+    );
+    const r = await handleApi("POST", u("/api/sessions"), {
+      repoPath: REPO,
+      baseBranch: "main",
+      prompt: "Tweak the header",
+      model: "opus",
+    });
+    expect(taken.has((await r.json()).desig)).toBe(false);
+  });
+
+  it("carries the operator's plan-gate choice into the planning phase", async () => {
+    const r = await handleApi("POST", u("/api/sessions"), {
+      repoPath: REPO,
+      baseBranch: "main",
+      prompt: "Rework the cart",
+      model: "opus",
+      planGateEnabled: true,
+    });
+    const body = await r.json();
+    expect(body.planGateEnabled).toBe(true);
+    expect(body.planPhase).toBe("planning");
+  });
+
+  it("the terminal arm creates a bare, non-isolated shell in the repo's main checkout", async () => {
+    const r = await handleApi("POST", u("/api/sessions"), { terminal: true, repoPath: REPO });
+    const body = await r.json();
+    expect(body.terminal).toBe(true);
+    expect(body.branch).toBeNull();
+    expect(body.isolated).toBe(false);
+    expect(body.worktreePath).toBe(REPO);
+    expect(body.prompt).toBe("");
+  });
+
+  it("rejects a body with no repoPath rather than inventing a session", async () => {
+    const before = demoState.sessions().length;
+    const r = await handleApi("POST", u("/api/sessions"), { prompt: "no repo" });
+    expect(r.status).toBe(400);
+    expect(demoState.sessions().length).toBe(before);
+  });
+
+  it("a created session's detail tabs all answer with valid empty records", async () => {
+    const id = (
+      await (
+        await handleApi("POST", u("/api/sessions"), {
+          repoPath: REPO,
+          baseBranch: "main",
+          prompt: "Check the tabs",
+          model: "opus",
+        })
+      ).json()
+    ).id;
+    expect((await get(`/api/sessions/${id}/activity`)).body).toEqual([]);
+    expect(Array.isArray((await get(`/api/sessions/${id}/diff`)).body.files)).toBe(true);
+    expect((await get(`/api/sessions/${id}/usage`)).body.total).toBe(0);
+    expect((await get(`/api/sessions/${id}/queue`)).body.steps).toEqual([]);
+    // No seeded git state — the real server 404s for a session with no PR yet. Read via
+    // handleApi, not get(): a 404 carries no body, so get()'s r.json() would throw.
+    expect((await handleApi("GET", u(`/api/sessions/${id}/git`), undefined)).status).toBe(404);
+  });
+});

--- a/ui/src/lib/demo/router.ts
+++ b/ui/src/lib/demo/router.ts
@@ -11,6 +11,7 @@
 // instead of one long branchy switch.
 
 import { demoState } from "./state";
+import type { AgentProvider, CreateInput, IssueRef, SandboxProfile } from "$lib/types";
 
 function json(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
@@ -25,6 +26,36 @@ function field<T>(body: unknown, key: string): T | undefined {
     return (body as Record<string, T>)[key];
   }
   return undefined;
+}
+
+/** Read a body field that is string-manipulated downstream (interpolated into a branch
+ *  or worktree path, or slugified into a session name). `field()` casts without checking,
+ *  so a non-string here would reach `.toLowerCase()` and throw. */
+function str(body: unknown, key: string, fallback = ""): string {
+  const v = field<unknown>(body, key);
+  return typeof v === "string" ? v : fallback;
+}
+
+/** Shape the untyped `POST /api/sessions` body into a typed `CreateInput`, picking the
+ *  union arm off the `terminal` discriminant. Every absent field falls back to the same
+ *  default the real server applies, so the demo never invents a stronger choice than the
+ *  operator made. */
+function createInputFrom(body: unknown, repoPath: string): CreateInput {
+  if (field<boolean>(body, "terminal") === true) return { terminal: true, repoPath };
+  return {
+    repoPath,
+    baseBranch: str(body, "baseBranch", "main"),
+    prompt: str(body, "prompt"),
+    agentProvider: field<AgentProvider>(body, "agentProvider"),
+    model: field<string | null>(body, "model") ?? null,
+    effort: field<string | null>(body, "effort") ?? null,
+    planGateEnabled: field<boolean | null>(body, "planGateEnabled") ?? null,
+    autopilotEnabled: field<boolean | null>(body, "autopilotEnabled") ?? null,
+    sandboxProfile: field<SandboxProfile | null>(body, "sandboxProfile") ?? null,
+    research: field<boolean>(body, "research") === true,
+    epicAuthoring: field<boolean>(body, "epicAuthoring") === true,
+    issueRef: field<IssueRef>(body, "issueRef"),
+  };
 }
 
 /** Extract the `:id` from `/api/sessions/:id/<tail>` (or `/api/held/:id/<tail>`). */
@@ -49,6 +80,10 @@ const bootstrapGetRoutes: Record<string, GetHandler> = {
   // Done lens (#Task 8): archived sessions, distinct from the live `sessions` list.
   "/api/sessions/done": () => json(demoState.doneSessions()),
   "/api/repo-config": (url) => json(demoState.repoConfig(repoParam(url))),
+  // The repo index. Fired on mount by `repos.load()`; without it `listRepos()` saw the
+  // permissive `{}` tail and `entries` became undefined, which threw inside Svelte's
+  // flush and aborted the whole batch (#1800).
+  "/api/repos": () => json(demoState.repos()),
   "/api/commands": (url) => {
     const provider = url.searchParams.get("provider");
     if (provider && provider !== "claude" && provider !== "codex")
@@ -110,10 +145,24 @@ const epicsGetRoutes: Record<string, GetHandler> = {
   },
 };
 
+// ── New Task dialog (#1800) ──────────────────────────────────────────────
+// The GETs the composer fires as it opens, once a repo is selected. Each answers the
+// exact shape its `api.ts` caller consumes: `listBranches()` and `listIssues()` both
+// assign a response array straight into a `$state` array typed non-optional, so the
+// `{}` tail would put `undefined` there and the next `$derived` over it would throw
+// inside Svelte's flush — the same crash `/api/repos` caused.
+const newTaskGetRoutes: Record<string, GetHandler> = {
+  "/api/branches": (url) => json(demoState.branches(repoParam(url))),
+  "/api/branch-status": (url) =>
+    json(demoState.branchStatus(repoParam(url), url.searchParams.get("branch") ?? "")),
+  "/api/issues": (url) => json(demoState.issues(repoParam(url))),
+};
+
 const exactGetRoutes: Record<string, GetHandler> = {
   ...bootstrapGetRoutes,
   ...lensGetRoutes,
   ...epicsGetRoutes,
+  ...newTaskGetRoutes,
 };
 
 // ── session-detail tabs (Task 8 sibling audit) ─────────────────────────────
@@ -270,6 +319,15 @@ function handleSessionMutation(
   // below — "clear-merged" isn't a session id.
   if (method === "POST" && path === "/api/sessions/clear-merged") {
     return json(demoState.clearMerged(field<string[]>(body, "ids") ?? []));
+  }
+  // POST /api/sessions — New Task create + clean-terminal create. Handled before the
+  // /:id/<tail> table (there is no id segment). Without it the `{ok:true}` tail let
+  // `createSession()` resolve to a body with no `id`, and the page then selected
+  // `undefined` instead of the new session.
+  if (method === "POST" && path === "/api/sessions") {
+    const repoPath = str(body, "repoPath");
+    if (!repoPath) return json({ error: "repoPath required" }, 400);
+    return json(demoState.createSession(createInputFrom(body, repoPath)));
   }
   // POST /api/epic/approve-next needs the URL query, so it's handled here alongside
   // the other epic-shaped mutations rather than inline in handleApi.

--- a/ui/src/lib/demo/seed.ts
+++ b/ui/src/lib/demo/seed.ts
@@ -55,8 +55,10 @@ import type {
   SessionUsage,
   SlashCommand,
   PostMergeSteps,
+  RepoEntry,
+  Issue,
 } from "$lib/types";
-import type { DemoWorld, DemoRepoConfig } from "./types-world";
+import type { DemoWorld, DemoRepoConfig, DemoBranchList } from "./types-world";
 
 const STOREFRONT = "/demo/acme/storefront";
 const API = "/demo/acme/api";
@@ -70,8 +72,11 @@ const MIN = 60_000;
 const HOUR = 60 * MIN;
 const DAY = 24 * HOUR;
 
-/** Fill a full Session from a partial, defaulting every required field. */
-function mkSession(
+/** Fill a full Session from a partial, defaulting every required field. Exported so the
+ *  `POST /api/sessions` mutator in `state.ts` builds a created session from the SAME
+ *  defaults as a seeded one — a hand-rolled spread would silently inherit whatever the
+ *  session it copied happens to carry. */
+export function mkSession(
   partial: Partial<Session> & Pick<Session, "id" | "desig" | "name" | "repoPath">,
 ): Session {
   return {
@@ -863,6 +868,152 @@ function buildUpNext(): UpNextSnapshot {
           ),
         ],
       },
+    ],
+  };
+}
+
+/** The demo operator's own forge login — `listIssues`' `viewer`, which drives the
+ *  "mine & unassigned" issue filter and the "assigned to someone else" notice.
+ *  Exported so `state.ts` answers `/api/issues` with the same login the seeded
+ *  issues are authored by. */
+export const DEMO_VIEWER = "acme-dev";
+
+/** GET /api/repos — the repo index. `path` and `realPath` are BOTH the seeded
+ *  `repoPath`: `repos.nameFor()` resolves either form, and every seeded session's
+ *  repoPath is this same string, so a demo repo always resolves to its name. */
+function buildRepos(): RepoEntry[] {
+  return [
+    {
+      name: "storefront",
+      remoteSlug: "acme/storefront",
+      path: STOREFRONT,
+      realPath: STOREFRONT,
+      display: "~/acme/storefront",
+      lastUsedAt: NOW - 20 * SEC,
+      recentAgentCount: 5,
+    },
+    {
+      name: "api",
+      remoteSlug: "acme/api",
+      path: API,
+      realPath: API,
+      display: "~/acme/api",
+      lastUsedAt: NOW - 4 * MIN,
+      recentAgentCount: 2,
+    },
+  ];
+}
+
+/** GET /api/branches?repo= — the New Task base-branch picker. Deliberately only the
+ *  long-lived branches: a real checkout would also list every `shepherd/*` worktree
+ *  branch, but those are never a sensible BASE and would bury `main` in the dropdown. */
+function buildBranches(): Record<string, DemoBranchList> {
+  return {
+    [STOREFRONT]: {
+      branches: ["main", "release/2026-06"],
+      current: "main",
+      default: "main",
+    },
+    [API]: {
+      branches: ["main"],
+      current: "main",
+      default: "main",
+    },
+  };
+}
+
+/** GET /api/issues?repo= — open forge issues. Numbers deliberately reuse the ones the
+ *  rest of the world already references, so nothing contradicts: storefront gets the
+ *  epic parent + its five children (`buildEpics`) and the two Up Next items
+ *  (`buildUpNext`); api gets the two issues its running sessions claim plus its Up Next
+ *  item. The counts (8 + 3) are exactly `buildBacklog`'s per-repo `openIssues` and their
+ *  `totals.openIssues` of 11 — keep the three in step when editing either. */
+function buildIssues(): Record<string, Issue[]> {
+  const mk =
+    (repo: string) =>
+    (number: number, title: string, body: string, extra: Partial<Issue> = {}): Issue => ({
+      number,
+      title,
+      body,
+      url: `${gh(repo)}/issues/${number}`,
+      labels: [],
+      createdAt: NOW - 3 * DAY,
+      assignees: [],
+      author: DEMO_VIEWER,
+      ...extra,
+    });
+  const sf = mk(STOREFRONT);
+  const api = mk(API);
+  return {
+    [STOREFRONT]: [
+      sf(EPIC_PARENT, "Checkout v2", "Umbrella issue for the checkout rework.", {
+        labels: ["epic"],
+        createdAt: NOW - 9 * DAY,
+      }),
+      sf(
+        101,
+        "Coupon-code field at checkout",
+        "Add a coupon-code field to the summary and apply the discount to the total.",
+      ),
+      sf(
+        102,
+        "Shipping-cost estimator",
+        "Estimate shipping cost from the cart weight + destination and show it in the summary.",
+      ),
+      sf(
+        103,
+        "Cart-total rounding fix",
+        "Fix the rounding bug that drops a cent on 3-for-2 offers.",
+        {
+          labels: ["bug"],
+        },
+      ),
+      sf(104, "Saved payment methods", "Let returning customers pick a stored card at checkout.", {
+        blockedBy: [101],
+        assignees: ["acme-dana"],
+      }),
+      sf(
+        105,
+        "Guest checkout",
+        "Allow checkout without an account, upgrading to one on confirmation.",
+        { blockedBy: [101, 102] },
+      ),
+      sf(
+        121,
+        "Wishlist button on product cards",
+        "Let shoppers save items to a wishlist from the grid.",
+        {
+          createdAt: NOW - 26 * HOUR,
+        },
+      ),
+      sf(
+        122,
+        "Empty-cart illustration",
+        "Show a friendly empty state when the cart has no items.",
+        {
+          createdAt: NOW - 26 * HOUR,
+        },
+      ),
+    ],
+    [API]: [
+      api(
+        220,
+        "Rotating refresh-token session store",
+        "Rework the auth session store to a rotating refresh-token scheme.",
+      ),
+      api(
+        221,
+        "Migrate the database layer to Neon serverless Postgres",
+        "Move the API's database layer onto Neon serverless Postgres.",
+      ),
+      api(
+        222,
+        "Add request-id correlation header",
+        "Thread a request id through logs for tracing.",
+        {
+          createdAt: NOW - 30 * HOUR,
+        },
+      ),
     ],
   };
 }
@@ -1684,6 +1835,9 @@ export function buildSeed(): DemoWorld {
     slashCommands: buildSlashCommands(),
     todo: buildTodo(),
     postMergeSteps: buildPostMergeSteps(),
+    repos: buildRepos(),
+    branches: buildBranches(),
+    issues: buildIssues(),
     gitStates: buildGitStates(),
     activityStates: buildActivityStates(),
     claudeAliveStates: {

--- a/ui/src/lib/demo/state.ts
+++ b/ui/src/lib/demo/state.ts
@@ -41,10 +41,15 @@ import type {
   SlashCommand,
   Leftover,
   PostMergeSteps,
+  RepoEntry,
+  Issue,
+  IssueFetchAttempt,
+  CreateInput,
+  StandardCreateInput,
 } from "$lib/types";
 import { bus } from "./bus";
-import { buildSeed } from "./seed";
-import type { DemoWorld, DemoRepoConfig } from "./types-world";
+import { buildSeed, mkSession, DEMO_VIEWER } from "./seed";
+import type { DemoWorld, DemoRepoConfig, DemoBranchList } from "./types-world";
 
 // A canonical, never-mutated seed. Every `reset()` `structuredClone`s from THIS, so
 // live mutations can never leak back into the seed and a reset always restores clean.
@@ -65,6 +70,86 @@ function emit(ev: WsEvent): void {
 
 function find(id: string): Session | undefined {
   return world.sessions.find((s) => s.id === id);
+}
+
+/** The server's recent-agent window, which the New Task picker names on its
+ *  "recently worked on" group. Matches the seeded `recentAgentCount`s. */
+const RECENT_REPO_WINDOW_DAYS = 14;
+
+/** Next free `TASK-<n>` designation across live AND archived sessions, so a created
+ *  session can never collide with a Done-lens row. */
+function nextTaskNumber(): number {
+  const used = [...world.sessions, ...world.doneSessions].map((s) =>
+    Number(/^TASK-(\d+)$/.exec(s.desig)?.[1] ?? 0),
+  );
+  return Math.max(0, ...used) + 1;
+}
+
+/** A kebab session name from the prompt's first few words — the shape the real server's
+ *  namer produces, without the LLM round-trip. */
+function nameFromPrompt(prompt: string): string {
+  const slug = prompt
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .split("-")
+    .filter(Boolean)
+    .slice(0, 3)
+    .join("-");
+  return slug || "new-task";
+}
+
+/** A clean-terminal create: a bare operator shell in the repo's MAIN checkout — no
+ *  branch, no worktree, no agent, no prompt. */
+function terminalSession(num: number, repoPath: string): Session {
+  return mkSession({
+    id: `new-${num}`,
+    desig: `TASK-${num}`,
+    name: "terminal",
+    repoPath,
+    prompt: "",
+    branch: null,
+    worktreePath: repoPath,
+    isolated: false,
+    terminal: true,
+    model: null,
+    sandboxApplied: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+}
+
+/** A normal agent session, carrying every choice the composer actually submitted —
+ *  an absent field stays null/false rather than inventing a stronger choice. */
+function agentSession(num: number, input: StandardCreateInput): Session {
+  const name = nameFromPrompt(input.prompt);
+  const id = `new-${num}`;
+  return mkSession({
+    id,
+    desig: `TASK-${num}`,
+    name,
+    repoPath: input.repoPath,
+    prompt: input.prompt,
+    baseBranch: input.baseBranch,
+    branch: `shepherd/${name}`,
+    worktreePath: `${input.repoPath}/.worktrees/${id}`,
+    agentProvider: input.agentProvider ?? "claude",
+    model: input.model,
+    effort: input.effort ?? null,
+    planGateEnabled: input.planGateEnabled ?? null,
+    // The server opens a plan-gated task in its planning phase; the gate's Go releases it.
+    planPhase: input.planGateEnabled === true ? "planning" : null,
+    autopilotEnabled: input.autopilotEnabled ?? null,
+    research: input.research === true,
+    epicAuthoring: input.epicAuthoring === true,
+    sandboxApplied: input.sandboxProfile ?? "standard",
+    issueNumber: input.issueRef?.number ?? null,
+    issueUrl: input.issueRef?.url,
+    status: "running",
+    lastState: "working",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
 }
 
 export const demoState = {
@@ -158,6 +243,64 @@ export const demoState = {
   /** GET /api/manual-steps/outstanding (Owed lens) — only still-outstanding records. */
   outstandingManualSteps: (): PostMergeSteps[] =>
     world.postMergeSteps.filter((r) => r.clearedAt == null),
+
+  // ── New Task flow (#1800) ───────────────────────────────────────────────
+  /** GET /api/repos — the repo index behind `repos.svelte.ts` and the New Task picker. */
+  repos: (): { repos: RepoEntry[]; recentWindowDays: number } => ({
+    repos: world.repos,
+    recentWindowDays: RECENT_REPO_WINDOW_DAYS,
+  }),
+
+  /** GET /api/branches?repo= — a valid empty list (never `{}`) for an unrecognized
+   *  repoPath; `pickBaseBranch` then falls back to "main" exactly as it does against a
+   *  server that can't read the repo. */
+  branches: (repoPath: string): DemoBranchList =>
+    world.branches[repoPath] ?? { branches: [], current: null, default: null },
+
+  /** GET /api/branch-status?repo=&branch= — the demo's seeded bases are clean and in
+   *  sync. An unseeded branch reports as neither local nor upstream, which is what the
+   *  real server says about a branch it can't find. */
+  branchStatus: (
+    repoPath: string,
+    branch: string,
+  ): {
+    behind: number;
+    ahead: number;
+    diverged: boolean;
+    hasUpstream: boolean;
+    localExists: boolean;
+  } => {
+    const known = world.branches[repoPath]?.branches.includes(branch) ?? false;
+    return { behind: 0, ahead: 0, diverged: false, hasUpstream: known, localExists: known };
+  },
+
+  /** GET /api/issues?repo= — open issues, and a genuine zero (`error: null`, not a
+   *  failure) for an unrecognized repoPath. `slug`/`webUrl` are derived from the repo
+   *  index, so this can never disagree with `/api/repos`. */
+  issues: (
+    repoPath: string,
+  ): {
+    slug: string | null;
+    webUrl: string | null;
+    issues: Issue[];
+    viewer: string | null;
+    error: string | null;
+    lightweight: boolean;
+    attempts: IssueFetchAttempt[];
+  } => {
+    // Keyed on `path` exactly like `world.issues` below (and like every other
+    // repo-scoped map here), so slug and issues can never disagree about one repo.
+    const slug = world.repos.find((r) => r.path === repoPath)?.remoteSlug ?? null;
+    return {
+      slug,
+      webUrl: slug ? `https://github.com/${slug}` : null,
+      issues: world.issues[repoPath] ?? [],
+      viewer: DEMO_VIEWER,
+      error: null,
+      lightweight: false,
+      attempts: [],
+    };
+  },
 
   usageLimits: (): UsageLimitsResponse => world.usage,
   update: (): UpdateStatus => world.update,
@@ -453,6 +596,21 @@ export const demoState = {
     world.sessions = [...world.sessions, session];
     emit({ event: "session:new", data: session });
     emit({ event: "held:changed", data: { count: world.held.length } });
+    return session;
+  },
+
+  /** POST /api/sessions — the New Task create, and the clean-terminal create (the two
+   *  arms of `CreateInput`). Mirrors `spawnHeld`: append a fully-defaulted Session and
+   *  push it over the socket, so the herd rail and the Viewport pick it up exactly as
+   *  they would from the real server. The session is deliberately thin — no seeded git
+   *  state, diff or transcript — and every per-session GET already answers an unknown id
+   *  with a valid empty record, so each tab renders its empty state instead of erroring. */
+  createSession(input: CreateInput): Session {
+    const num = nextTaskNumber();
+    const session =
+      input.terminal === true ? terminalSession(num, input.repoPath) : agentSession(num, input);
+    world.sessions = [...world.sessions, session];
+    emit({ event: "session:new", data: session });
     return session;
   },
 

--- a/ui/src/lib/demo/types-world.ts
+++ b/ui/src/lib/demo/types-world.ts
@@ -38,6 +38,8 @@ import type {
   SlashCommand,
   RepoConfig,
   PostMergeSteps,
+  RepoEntry,
+  Issue,
 } from "$lib/types";
 
 /** Mirrors `RepoConfigResponse` from `$lib/api` (`RepoConfig` + optimistic-automation
@@ -46,6 +48,14 @@ export type DemoRepoConfig = RepoConfig & {
   automationConfirmed?: boolean;
   automationRowExists?: boolean;
 };
+
+/** Mirrors `BranchList` from `$lib/api` for the same reason `DemoRepoConfig` mirrors
+ *  `RepoConfigResponse`: the seed layer stays import-clean of api.ts. */
+export interface DemoBranchList {
+  branches: string[];
+  current: string | null;
+  default: string | null;
+}
 
 /** The complete seeded demo world — one dataset per bootstrap/lens GET. */
 export interface DemoWorld {
@@ -78,6 +88,19 @@ export interface DemoWorld {
   todo: Record<string, { exists: boolean; content: string }>;
   /** GET /api/manual-steps/outstanding (Owed lens) — durable post-merge step records. */
   postMergeSteps: PostMergeSteps[];
+
+  // ── New Task flow (#1800) ───────────────────────────────────────────────
+  // Every GET the New Task dialog fires as it opens. These are NOT optional polish:
+  // `api.ts` types each response's array field as non-optional, so a `{}` fallthrough
+  // assigns `undefined` into a `$state` array and the next `$derived` over it throws
+  // INSIDE Svelte's flush — which aborts the whole batch and silently kills unrelated
+  // DOM and effects elsewhere in the app. That is the #1800 crash; see repos.svelte.ts.
+  /** GET /api/repos — the repo index behind `repos.svelte.ts` and the New Task picker. */
+  repos: RepoEntry[];
+  /** GET /api/branches?repo= — local branches + current/default, per repo path. */
+  branches: Record<string, DemoBranchList>;
+  /** GET /api/issues?repo= — open forge issues, per repo path. */
+  issues: Record<string, Issue[]>;
 
   // ── ambient status ─────────────────────────────────────────────────────
   usage: UsageLimitsResponse;

--- a/ui/src/lib/repos.svelte.test.ts
+++ b/ui/src/lib/repos.svelte.test.ts
@@ -33,6 +33,32 @@ describe("repos store", () => {
     expect(repos.loaded).toBe(true);
   });
 
+  // #1800: demo mode answered GET /api/repos with `{}` (no handler, permissive fallback),
+  // so `entries` became `undefined` and the `pathIndex` $derived threw
+  // `undefined.flatMap` INSIDE Svelte's flush — aborting the whole batch and silently
+  // dropping unrelated DOM/effects app-wide. A shapeless body must degrade to "no repos".
+  it("load() keeps entries an array when the body carries no repos", async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response(JSON.stringify({}), { status: 200 }),
+    ) as unknown as typeof fetch;
+    await repos.load();
+    expect(repos.entries).toEqual([]);
+    expect(repos.loaded).toBe(true);
+    // The $derived over entries must still be readable — this is what used to throw.
+    expect(repos.nameFor("/root/alpha")).toBeNull();
+    expect(repos.knownNames).toEqual([]);
+  });
+
+  it("load() keeps entries an array when repos is not an array at all", async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ repos: null, recentWindowDays: 14 }), { status: 200 }),
+    ) as unknown as typeof fetch;
+    await repos.load();
+    expect(repos.entries).toEqual([]);
+    expect(repos.nameFor("/root/alpha")).toBeNull();
+  });
+
   it("nameFor resolves both the raw path and the realPath to the same name", () => {
     repos.entries = [
       { name: "beta", path: "/root/beta", display: "/root/beta", realPath: "/elsewhere/beta-real" },

--- a/ui/src/lib/repos.svelte.ts
+++ b/ui/src/lib/repos.svelte.ts
@@ -12,7 +12,14 @@ class ReposStore {
 
   async load() {
     try {
-      this.entries = (await listRepos()).repos;
+      // Never let a shapeless body put a non-array here (#1800). `entries` feeds the
+      // `pathIndex` $derived below, and a throw inside a $derived aborts the Svelte
+      // flush batch it lands in — so one malformed bootstrap response silently drops
+      // unrelated DOM and effects app-wide (the session detail never mounting on
+      // mobile, a terminal pane never re-fitting) with only a boundary log to show
+      // for it. Degrade to "no repos known" instead: every reader already handles it.
+      const repos = (await listRepos()).repos;
+      this.entries = Array.isArray(repos) ? repos : [];
     } catch (e) {
       this.error = e instanceof Error ? e.message : "failed to load repos";
     } finally {


### PR DESCRIPTION
Closes #1800.

## One root cause, not two bugs

`/api/repos` had no handler in the demo router, so it fell through to the permissive
`json({})` tail. `listRepos()` then resolved to `{}`, and `ReposStore.load()` assigned
`undefined` into `entries` — a field typed `RepoEntry[]`. The `pathIndex` `$derived` in
`ui/src/lib/repos.svelte.ts` evaluated `undefined.flatMap(...)` and threw.

The throw lands **inside `Batch.flush`**, so Svelte aborts the entire flush batch. That single
abort is every symptom the issue reported:

| Symptom                                            | Mechanism                                                                        |
| -------------------------------------------------- | -------------------------------------------------------------------------------- |
| Desktop: error logged on every session open        | `Viewport` reaches `repos.nameFor()` via `SteerBar` / `ComposeBar`               |
| Mobile (≤768px): detail screen never opens         | the aborted batch drops the DOM work that would mount it                         |
| Terminal empty after Terminal→Activity→Terminal    | same aborted batch — **not** a separate fake-PTY reattach bug                    |

The issue guessed the terminal death was independent. It isn't. Measured across the roundtrip
with the fix stubbed in, `.xterm-screen` goes `840×136 → 0×0 → 840×136` (recovers); without it,
`840×136 → 0×0 → 0×0`.

A fourth casualty of the same cause, not in the issue: the demo's **New Task dialog was dead** —
empty repo picker, "pick a repository to start", Create disabled. `NewTask.svelte`'s `onMount`
destructures `listRepos()` and its trailing `.catch(() => {})` swallowed the identical throw.

## What this changes

**The demo transport** gains the five endpoints the bootstrap and the composer actually fire:
`GET /api/repos`, `/api/branches`, `/api/branch-status`, `/api/issues`, and a
`POST /api/sessions` mutator (which previously hit the `{ok:true}` tail, so the page selected
`undefined` instead of the new session).

Wiring the composer was **not optional polish**. Answering `/api/repos` alone un-blocks the
dialog and thereby relocates the identical crash twice over: `/api/branches` → `{}` →
`branches` (typed `string[]`) → `.includes()` in the `baseOptions` `$derived`; `/api/issues` →
`{}` → `IssueData.issues` (typed `Issue[]`) → filtered in `PromptSources.svelte`.

**Seed data** is internally consistent with the world that already existed: repo entries whose
`path`/`realPath` are the seeded sessions' `repoPath` (so `nameFor()` resolves), and issue
numbers reused from `buildEpics()` (#100 + #101–#105) and `buildUpNext()` (#121, #122, #222)
rather than invented. The per-repo counts are exactly `buildBacklog()`'s existing
`openIssues` 8 / 3 — a test asserts the two never drift apart.

**One guard layer**: `ReposStore.load()` now refuses a non-array `repos`. It earns its line
because a `$derived` throw takes out unrelated DOM and effects app-wide, so one malformed
bootstrap body must not be able to do that again.

## Verified

In the live demo (`SHEPHERD_DEMO=1 vite dev`), driven through CDP:

- 1280×800: opening **all eight** seeded sessions → **0** page errors (was 1 per open)
- 390×844: the detail screen opens, `.xterm-screen` present (was absent entirely)
- Terminal→Activity→Terminal: `.xterm-screen` returns to `840×136` (was stuck at `0×0`)
- New Task: `storefront` preselected, upstream check resolves, issue panel lists **8 open**
  with real issues, and Create & Run creates `TASK-51 · add-a-gift`, which lands in the herd
  and opens in the Viewport — 0 errors throughout

Gates: `ui` check 0 errors · `ui` 5252 tests pass · root 9775 tests pass · root `tsc` clean ·
`check:i18n` in parity · `fallow audit` clean on all 7 changed files.

## Out of scope

The audit behind this fix found 29 further `api.ts` endpoints still on the permissive tail —
plus the New Task "Shape" and "Attach" buttons. None fires at bootstrap or in the composer, and
all degrade without aborting a flush. Recorded with the full list and a suggested shape in
**#2295**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
