### PR TITLE
fix(demo): close the remaining shape-blind API stubs (#1821)

### DIFF
--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -611,12 +611,18 @@
     isMac = /mac|iphone|ipad|ipod/i.test(navigator.platform || navigator.userAgent);
     listRepos()
       .then(({ repos: r, recentWindowDays }) => {
-        repos = r;
+        // The second `listRepos()` consumer, guarded the same way as `ReposStore.load()`
+        // (#1800): a shapeless body would put a non-array in `repos`, and `selectedRepo`'s
+        // `$derived` would then throw inside Svelte's flush — aborting the batch and freezing
+        // every user `$effect` in the app (#1821). Bind it ONCE, because the three reads below
+        // need the same normalised value; guarding only the assignment still throws on `.length`.
+        const list = Array.isArray(r) ? r : [];
+        repos = list;
         recentRepoWindowDays = recentWindowDays;
         // Prefer the most-recently-used NON-hidden repo; if every repo is hidden,
         // fall back to the full list so repoPath is never left empty.
-        if (!repoPath && r.length > 0)
-          repoPath = defaultRepoPath(r.filter((repo) => !repo.hidden)) || r[0]!.path;
+        if (!repoPath && list.length > 0)
+          repoPath = defaultRepoPath(list.filter((repo) => !repo.hidden)) || list[0]!.path;
       })
       .catch(() => {});
     // Focus the prompt so the user can type immediately when the dialog opens.

--- a/ui/src/lib/demo/router.test.ts
+++ b/ui/src/lib/demo/router.test.ts
@@ -663,3 +663,60 @@ describe("POST /api/sessions (#1800) creates a real session instead of {ok:true}
     expect((await handleApi("GET", u(`/api/sessions/${id}/git`), undefined)).status).toBe(404);
   });
 });
+
+// #1821: these four all reached the permissive `{}` tail with a shape their api.ts caller
+// cannot survive. The throw that follows lands inside a `$derived` during Svelte's flush and
+// ABORTS THE BATCH, so every queued user `$effect` in the app stops re-running until a reload.
+// The assertions below are on the shape CONTRACT each caller is typed against — not on
+// incidental seeded values — because that contract is what keeps the flush alive.
+describe("GETs whose {} fallback threw in the caller (#1821)", () => {
+  it("GET /api/fs/dirs returns a DirListing — DirPicker reads entries.length", async () => {
+    const { status, body } = await get("/api/fs/dirs?path=/demo/acme");
+    expect(status).toBe(200);
+    expect(Array.isArray(body.entries)).toBe(true);
+    expect(body.entries.map((e: { name: string }) => e.name)).toEqual(["api", "storefront"]);
+    // `display` matches settings.repoRootDisplay, so the panel's "already your root" check resolves.
+    expect(body.display).toBe((await get("/api/settings")).body.repoRootDisplay);
+    expect(body.parent).toBe("/demo");
+  });
+
+  it("GET /api/fs/dirs browses the chain above the repo root, and bottoms out at null", async () => {
+    expect((await get("/api/fs/dirs?path=/demo")).body.parent).toBe("/");
+    expect((await get("/api/fs/dirs?path=/")).body.parent).toBeNull();
+  });
+
+  it("GET /api/fs/dirs with no path browses the configured repo root", async () => {
+    const { body } = await get("/api/fs/dirs");
+    expect(body.path).toBe((await get("/api/settings")).body.repoRoot);
+    expect(Array.isArray(body.entries)).toBe(true);
+  });
+
+  it("GET /api/fs/dirs gives an unseeded directory a valid listing with a working up-crumb", async () => {
+    const { status, body } = await get("/api/fs/dirs?path=/demo/acme/storefront");
+    expect(status).toBe(200);
+    expect(body.entries).toEqual([]); // empty, but never {}
+    expect(body.parent).toBe("/demo/acme"); // "up" still walks back into the seeded chain
+  });
+
+  it("GET /api/access-tokens wraps an array under {tokens} — the panel reads tokens.length", async () => {
+    const { status, body } = await get("/api/access-tokens");
+    expect(status).toBe(200);
+    expect(Array.isArray(body.tokens)).toBe(true);
+  });
+
+  it("GET /api/plugin-update always carries `plugins` — {} is truthy, so `?.` would not save it", async () => {
+    const { status, body } = await get("/api/plugin-update");
+    expect(status).toBe(200);
+    expect(Array.isArray(body.plugins)).toBe(true);
+    expect(body.updateAvailable).toBe(false);
+    expect(typeof body.checkedAt).toBe("number");
+  });
+
+  it("GET /api/stranded is an ARRAY — setClaudeAlive iterates it with for…of", async () => {
+    const { status, body } = await get("/api/stranded");
+    expect(status).toBe(200);
+    expect(Array.isArray(body)).toBe(true);
+    // No session in the scenario is a restart-strand; the `false` liveness entries are plain husks.
+    expect(body).toEqual([]);
+  });
+});

--- a/ui/src/lib/demo/router.ts
+++ b/ui/src/lib/demo/router.ts
@@ -101,10 +101,20 @@ const bootstrapGetRoutes: Record<string, GetHandler> = {
   "/api/update/log": () => json({ phase: "idle", exitCode: null, log: "" }),
   "/api/herdr-update": () => json(demoState.herdrUpdate()),
   "/api/codex-update": () => json(demoState.codexUpdate()),
+  // Fetched at mount alongside the other update GETs, and again by Settings → Plugins.
+  // The `{}` tail landed in `store.pluginUpdates`, where Settings' `$derived` reads
+  // `pluginUpdates?.plugins.filter(...)` — `{}` is truthy, so the optional chain did not
+  // save it and the throw aborted Svelte's flush (#1821).
+  "/api/plugin-update": () => json(demoState.pluginUpdate()),
   "/api/star-prompt": () => json(demoState.starPrompt()),
   "/api/git": () => json(demoState.gitStates()),
   "/api/activity": () => json(demoState.activityStates()),
   "/api/claude-alive": () => json(demoState.claudeAliveStates()),
+  // Paired with /api/claude-alive: the client folds the boolean snapshot, then upgrades these
+  // ids to `stranded`. `setClaudeAlive` does `for…of` over the value, so the permissive `{}`
+  // tail threw there — BEFORE the folded liveness map was assigned, silently dropping the
+  // whole claude-alive bootstrap (#1821).
+  "/api/stranded": () => json(demoState.stranded()),
   "/api/working-blocked": () => json(demoState.workingBlockedStates()),
   "/api/holds": () => json(demoState.holdStates()),
   "/api/subagents": () => json(demoState.subagentStates()),
@@ -158,11 +168,24 @@ const newTaskGetRoutes: Record<string, GetHandler> = {
   "/api/issues": (url) => json(demoState.issues(repoParam(url))),
 };
 
+// ── settings dialog (#1821) ──────────────────────────────────────────────────
+// The GETs only the Settings panels fire, on mount. Both were reaching the permissive `{}`
+// tail with a shape their caller cannot survive: DirPicker reads `listing.entries.length`
+// and SettingsAccessPanel reads `tokens.length`. A throw from either lands inside Svelte's
+// flush and ABORTS THE BATCH, which stops every queued user `$effect` in the app — the whole
+// UI goes stale until a reload, with no visible error. Same failure as `/api/repos` (#1800)
+// and `PUT /api/settings` (#2240): the fix is always a correctly-shaped response.
+const settingsGetRoutes: Record<string, GetHandler> = {
+  "/api/fs/dirs": (url) => json(demoState.dirs(url.searchParams.get("path") ?? "")),
+  "/api/access-tokens": () => json(demoState.accessTokens()),
+};
+
 const exactGetRoutes: Record<string, GetHandler> = {
   ...bootstrapGetRoutes,
   ...lensGetRoutes,
   ...epicsGetRoutes,
   ...newTaskGetRoutes,
+  ...settingsGetRoutes,
 };
 
 // ── session-detail tabs (Task 8 sibling audit) ─────────────────────────────
@@ -405,6 +428,15 @@ export async function handleApi(method: string, url: URL, body: unknown): Promis
     // Permissive fallback for off-screen endpoints: unmatched read → benign empty
     // object; unmatched mutation → a generic success. Keeps the demo UI from
     // erroring on endpoints no showcased screen touches.
+    //
+    // It is shape-BLIND, though, so it is only benign for a caller whose type tolerates
+    // `{}` (a `Record<string, …>` map). Hand it to a caller expecting an array or a
+    // required field and the `undefined` that lands downstream throws inside a `$derived`
+    // during Svelte's flush, which aborts the batch and freezes every user `$effect` in the
+    // app — a stale UI with no visible error (#1821, #1800, #2240). Dev-only warn so the
+    // next such gap announces itself in `bun run dev:demo` instead of presenting as a
+    // mysteriously frozen page; silent in the built public demo.
+    if (import.meta.env.DEV) console.warn("[demo-unmatched]", m, path);
     return json(m === "GET" ? {} : { ok: true });
   } catch {
     // Never throw out of the transport — a malformed request degrades to a stub.

--- a/ui/src/lib/demo/seed.ts
+++ b/ui/src/lib/demo/seed.ts
@@ -57,6 +57,7 @@ import type {
   PostMergeSteps,
   RepoEntry,
   Issue,
+  DirListing,
 } from "$lib/types";
 import type { DemoWorld, DemoRepoConfig, DemoBranchList } from "./types-world";
 
@@ -1769,6 +1770,39 @@ function buildTodo(): Record<string, { exists: boolean; content: string }> {
   };
 }
 
+/** GET /api/fs/dirs?path= (Settings → Workspace repo-root picker, and the onboarding gate).
+ *  Both call sites browse into `settings.repoRoot` first, so `/demo/acme` and every node above
+ *  it is seeded — the picker's "up" crumb then walks a real chain instead of dead-ending.
+ *  `display` mirrors the server's tilde abbreviation, matching `settings.repoRootDisplay`
+ *  (`~/acme`), so the panel's "this is already your root" check resolves.
+ *
+ *  Unlike the `{#each}`-shaped gaps, the permissive `{}` fallback genuinely THREW here:
+ *  DirPicker reads `listing.entries.length`, and an undefined `entries` inside Svelte's
+ *  flush aborted the batch — freezing every user `$effect` in the app (#1821). */
+function buildDirs(): Record<string, DirListing> {
+  return {
+    "/": { path: "/", display: "/", parent: null, entries: [{ name: "demo", path: "/demo" }] },
+    "/demo": {
+      path: "/demo",
+      display: "~",
+      parent: "/",
+      entries: [{ name: "acme", path: "/demo/acme" }],
+    },
+    "/demo/acme": {
+      path: "/demo/acme",
+      display: "~/acme",
+      parent: "/demo",
+      // Derived from the repo index rather than re-listed: the real `/api/fs/dirs` is
+      // enumerating the very directories `listRepos()` reports under repoRoot, so a
+      // hand-written copy here could drift out of agreement with `/api/repos`.
+      // Sorted by name — the order a real directory listing arrives in.
+      entries: buildRepos()
+        .map((r) => ({ name: r.name, path: r.path }))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    },
+  };
+}
+
 /** GET /api/manual-steps/outstanding (Owed lens) — durable post-merge step records.
  *  Two rows: `deps`'s single owed (post-merge) step (mirrors its `holdStates` entry +
  *  `manualSteps` above), and `envflag`'s un-acked PRE-merge step (#1478 merged-card
@@ -1834,6 +1868,7 @@ export function buildSeed(): DemoWorld {
     repoConfig: buildRepoConfig(),
     slashCommands: buildSlashCommands(),
     todo: buildTodo(),
+    dirs: buildDirs(),
     postMergeSteps: buildPostMergeSteps(),
     repos: buildRepos(),
     branches: buildBranches(),

--- a/ui/src/lib/demo/state.ts
+++ b/ui/src/lib/demo/state.ts
@@ -46,6 +46,9 @@ import type {
   IssueFetchAttempt,
   CreateInput,
   StandardCreateInput,
+  DirListing,
+  AccessToken,
+  PluginUpdatesStatus,
 } from "$lib/types";
 import { bus } from "./bus";
 import { buildSeed, mkSession, DEMO_VIEWER } from "./seed";
@@ -150,6 +153,14 @@ function agentSession(num: number, input: StandardCreateInput): Session {
     createdAt: Date.now(),
     updatedAt: Date.now(),
   });
+}
+
+/** Parent of an absolute path, or null at the root — so an unseeded directory listing still
+ *  offers a working "up" crumb in the picker. */
+function parentDir(path: string): string | null {
+  const cut = path.replace(/\/+$/, "").lastIndexOf("/");
+  if (cut < 0) return null;
+  return cut === 0 ? "/" : path.slice(0, cut);
 }
 
 export const demoState = {
@@ -301,6 +312,32 @@ export const demoState = {
       attempts: [],
     };
   },
+
+  /** GET /api/fs/dirs?path= — the Settings → Workspace repo-root picker. An unseeded path
+   *  answers an empty-but-valid listing (never `{}`: DirPicker reads `entries.length`) with a
+   *  computed `parent`, so browsing into an unseeded directory still has a working "up". */
+  dirs: (path: string): DirListing => {
+    const p = path === "" ? world.settings.repoRoot : path;
+    return world.dirs[p] ?? { path: p, display: p, parent: parentDir(p), entries: [] };
+  },
+
+  /** GET /api/access-tokens — the demo mints no machine tokens, so the empty list is a true
+   *  zero. `{ tokens: [] }`, never `{}`: SettingsAccessPanel reads `tokens.length`. */
+  accessTokens: (): { tokens: AccessToken[] } => ({ tokens: [] }),
+
+  /** GET /api/plugin-update — the demo's seeded plugins are all current, so no update is
+   *  offered. The `plugins` array must be present: Settings' `$derived` reads
+   *  `pluginUpdates?.plugins.filter(...)`, and `{}` is truthy, so a missing field threw. */
+  pluginUpdate: (): PluginUpdatesStatus => ({
+    plugins: [],
+    updateAvailable: false,
+    checkedAt: Date.now(),
+  }),
+
+  /** GET /api/stranded — no session in the scenario is a restart-strand (the `false` entries in
+   *  `claudeAliveStates` are plain husks). Must be an ARRAY: `setClaudeAlive` does `for…of` over
+   *  it, and `{}` threw there before the liveness map was ever assigned. */
+  stranded: (): string[] => [],
 
   usageLimits: (): UsageLimitsResponse => world.usage,
   update: (): UpdateStatus => world.update,

--- a/ui/src/lib/demo/types-world.ts
+++ b/ui/src/lib/demo/types-world.ts
@@ -40,6 +40,7 @@ import type {
   PostMergeSteps,
   RepoEntry,
   Issue,
+  DirListing,
 } from "$lib/types";
 
 /** Mirrors `RepoConfigResponse` from `$lib/api` (`RepoConfig` + optimistic-automation
@@ -88,6 +89,10 @@ export interface DemoWorld {
   todo: Record<string, { exists: boolean; content: string }>;
   /** GET /api/manual-steps/outstanding (Owed lens) — durable post-merge step records. */
   postMergeSteps: PostMergeSteps[];
+  /** GET /api/fs/dirs?path= (Settings → Workspace repo-root picker), keyed by the browsed
+   *  path. Only the nodes on the way to `settings.repoRoot` are seeded; anything else gets an
+   *  empty-but-valid listing from the getter. */
+  dirs: Record<string, DirListing>;
 
   // ── New Task flow (#1800) ───────────────────────────────────────────────
   // Every GET the New Task dialog fires as it opens. These are NOT optional polish:


### PR DESCRIPTION
Closes #1821.

> **Rebased onto #2296.** That PR (for #1800) landed while this was open and fixed the
> `/api/repos` instance of this bug — which also resolves #1821's visible symptom. It also
> guarded `ReposStore.load()`, so my equivalent guard there is gone: I took main's
> `Array.isArray` version, which is strictly stronger than the `?? []` I had. What remains here
> is the rest of the same bug class, which #2296 did not cover.

## The bug class

The demo router's permissive tail answers `{}` for any unmatched GET. That is benign for a
`Record`-typed caller and fatal for every other one: the `undefined` that lands downstream throws
inside a `$derived` during Svelte's `Batch.flush`, and **the throw aborts the batch**. Render
effects that already ran keep the DOM fresh — which is why in #1821 the header, prompt and card
highlight switched — but every queued *user* `$effect` stops re-running **app-wide** until a
reload, so the usage poll and the PTY stayed keyed to the previous session.

Verified with a browser A/B rather than inferred: a probe `$effect` in `+page.svelte` reading
`selected?.id` also stopped firing, which ruled out any `Viewport`-scoping explanation. Third
instance of this class after #2240 (`PUT /api/settings`) and #1800 (`/api/repos`).

## What this PR adds

**Four more shape-invalid stubs.** Each now answers the shape its caller is typed against. The
first three froze the whole app the moment Settings opened:

| Route | Why `{}` was a defect |
| --- | --- |
| `/api/fs/dirs` | `DirPicker` reads `listing.entries.length` |
| `/api/access-tokens` | `SettingsAccessPanel` reads `tokens.length` |
| `/api/plugin-update` | Settings' `$derived` reads `pluginUpdates?.plugins.filter(...)` — `{}` is truthy, so `?.` did not save it |
| `/api/stranded` | `setClaudeAlive` does `for…of` over it, throwing *before* `this.claudeAlive = folded` — silently dropping the whole claude-alive bootstrap |

The seeded `/demo/acme` listing derives from #2296's `buildRepos()` rather than re-listing the
repos by hand, so `/api/fs/dirs` cannot drift out of agreement with `/api/repos`.

**The second `listRepos()` consumer.** #2296 guarded `ReposStore.load()`; `NewTask` reads the same
response into a `$state` array that `selectedRepo`'s `$derived` calls `.find` on, so it could throw
the same way. Guarded identically, bound once because the three reads below it (`.length`,
`.filter`, `[0]!`) would otherwise still throw.

**A dev-only `[demo-unmatched]` warn** on the permissive tail, so the next gap in this class
announces itself in `bun run dev:demo` instead of presenting as a mysteriously frozen page. Silent
in the built public demo. This is how the four routes above were found.

## Still unmatched, deliberately

`/api/blocks`, `/api/amendments` and `/api/spawn-notices` are typed `Record<string, …>`, so `{}` is
a valid empty map — the dev warn lists them and that is correct, not a to-do.
`/api/plugins/manage/installed` is also safe: `getInstalledPlugins()` already does
`body.installed ?? []`; it only leaves the manager list empty.

`Viewport.svelte` is untouched — the existing vitest browser test that rerenders session A → B
already proves the component re-keys correctly.

## Verification (re-run after the rebase, on the merged code)

Switching sessions re-keys the usage poll every time (`coupon → neon → authstore`, each fetching
its own `/api/sessions/<id>/usage`) and the terminal follows, with zero page errors. Settings →
Workspace lists `api` + `storefront` under `~/acme` and resolves "already the current root";
Settings → Access renders "No tokens yet." The only `[demo-unmatched]` warnings left are the three
`Record`-shaped ones above.

One behaviour change worth a look: with `/api/stranded` no longer throwing, the claude-alive
bootstrap actually applies, so the seeded `false` entries (`rounding`, `deps`) now fold to `husk`
and show the Resume affordance. That is the seed's own intent — confirmed in the browser, and no
"revive stranded" banner appears, since the list is correctly empty.

`ui`: `bun run check` clean, 5263 tests pass, `check:i18n` in parity (no new user-facing strings —
the dev warn is diagnostics). Root `bun run lint` clean; `fallow audit --base origin/main` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
