### PR TITLE
fix(buildqueue): distinguish Shepherd controls from the terminal

### DIFF
--- a/ui/src/lib/components/BuildQueuePanel.svelte
+++ b/ui/src/lib/components/BuildQueuePanel.svelte
@@ -517,12 +517,13 @@
 
 <style>
   .bqp {
+    --bqp-surface: color-mix(in oklab, var(--color-muted) 6%, var(--color-panel));
     display: flex;
     flex-direction: column;
     flex: none;
     min-width: 0;
-    background: var(--color-panel);
-    border-top: 1px solid var(--color-line);
+    background: var(--bqp-surface);
+    border: 1px solid var(--color-line-bright);
     font-family: var(--font-mono);
     font-size: var(--fs-meta);
   }
@@ -534,7 +535,7 @@
      (DESIGN.md: calm by default, alarm when earned). The action's own amber outline
      and inset glow do the pointing. */
   .is-awaiting {
-    background: color-mix(in oklab, var(--color-amber) 4%, var(--color-panel));
+    background: color-mix(in oklab, var(--color-amber) 4%, var(--bqp-surface));
     border-top: 1px solid var(--color-amber);
   }
 


### PR DESCRIPTION
## Summary

The build queue above the terminal blended into terminal output after the recent layout update. Give the entire plan and approval area a continuous 1px neutral border and a subtle theme-aware background tint so it reads as Shepherd controls in both light and dark mode. Approval/start actions retain their amber emphasis.

## Validation

- `cd ui && bun run check`: 0 errors, 0 warnings.
- `cd ui && CI=true bun run test`: 320 files, 5,235 tests passed.
- `cd ui && bun run check:i18n`: both catalogs in parity.
- Chromium visual checks at 390px and 1280px in both themes, covering running, approval and collapsed states; no horizontal overflow.
- Self-reviewed the CSS-only diff; `git diff --check` passed.

## Checklist

- [x] Conventional-commit title; linear branch from current `origin/main`.
- [x] Relevant UI checks and tests pass.
- [x] Existing semantic design tokens reused.
- [x] No new copy, feature capability, public API or configuration requiring catalog or documentation updates.
