### PR TITLE
feat(ui): add thumb-reachable repo picker beside Next on mobile

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -4021,5 +4021,7 @@
   "feat_structured_tooltips_title": "Tooltips auf einen Blick",
   "feat_structured_tooltips_body": "Die Erklärungen zu kaltem Cache, Plan-Gate und Autopilot haben jetzt Überschriften und kurze Abschnitte. So findest du Kosten, Freigaben und Optionen schneller.",
   "feat_plan_gate_identity_title": "Plan Gate: sichere automatische Freigabe für beide CLIs",
-  "feat_plan_gate_identity_body": "Mit Autopilot können Claude und Codex genehmigte Pläne in isolierten Worktrees und geteilten Checkouts freigeben. Shepherd setzt für Review-Rückmeldungen und Ausführung genau die Unterhaltung der Aufgabe fort. Bei fehlender oder mehrdeutiger Zuordnung bleibt sie für dich angehalten; ältere Codex-Aufgaben ohne Startzuordnung brauchen einen Neustart."
+  "feat_plan_gate_identity_body": "Mit Autopilot können Claude und Codex genehmigte Pläne in isolierten Worktrees und geteilten Checkouts freigeben. Shepherd setzt für Review-Rückmeldungen und Ausführung genau die Unterhaltung der Aufgabe fort. Bei fehlender oder mehrdeutiger Zuordnung bleibt sie für dich angehalten; ältere Codex-Aufgaben ohne Startzuordnung brauchen einen Neustart.",
+  "feat_mobile_compose_repo_title": "Repo mit dem Daumen wechseln",
+  "feat_mobile_compose_repo_body": "Auf dem Smartphone öffnet ein Repo-Chip neben Weiter die Repo-Auswahl während des Schreibens. Suche oder wähle ein zuletzt verwendetes Repo und schreibe direkt weiter. Kopfzeile und Chip zeigen beide die aktuelle Auswahl."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -4021,5 +4021,7 @@
   "feat_structured_tooltips_title": "Tooltips you can scan",
   "feat_structured_tooltips_body": "Cold-cache, Plan gate and Autopilot explanations now use headings and short sections to make costs, approvals and choices easier to find.",
   "feat_plan_gate_identity_title": "Plan Gate: safe automatic release for both CLIs",
-  "feat_plan_gate_identity_body": "With Autopilot on, Claude and Codex can release approved plans in isolated worktrees and shared checkouts. Shepherd resumes the exact task conversation for review feedback and execution. Missing or ambiguous identity keeps the task stopped for you; older Codex tasks without launch attribution need a relaunch."
+  "feat_plan_gate_identity_body": "With Autopilot on, Claude and Codex can release approved plans in isolated worktrees and shared checkouts. Shepherd resumes the exact task conversation for review feedback and execution. Missing or ambiguous identity keeps the task stopped for you; older Codex tasks without launch attribution need a relaunch.",
+  "feat_mobile_compose_repo_title": "Switch repos within thumb reach",
+  "feat_mobile_compose_repo_body": "On phones, a repo chip beside Next opens the repo picker while you type. Search or choose a recent repo, then continue writing. The header and chip both show your current selection."
 }

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -4474,7 +4474,7 @@ describe("NewTask 7A keyboard-compose state", () => {
       expect(displayOf(".cfoot")).toBe("none");
       expect(displayOf(".toolbar")).toBe("none");
       // …the pinned action row and the in-field meta line appear…
-      expect(document.querySelectorAll(".compose-actions button").length).toBe(3);
+      expect(document.querySelectorAll(".compose-actions button").length).toBe(4);
       expect(displayOf(".compose-meta")).not.toBe("none");
       // …and the header compresses to the read-only context line.
       expect(document.querySelector(".ctx-line")).toBeTruthy();
@@ -4739,11 +4739,34 @@ describe("NewTask 7A keyboard-compose state", () => {
     }
   });
 
+  it.each([320, 390])("keeps a long repo chip beside Next within a %ipx phone", async (width) => {
+    overwriteGetLocale(() => "de");
+    const longRepo = { ...composeRepo, name: "a-repository-with-a-very-long-name" };
+    const { fake, restore } = await mountMobile({}, true, [longRepo]);
+    try {
+      await page.viewport(width, 844);
+      await enterCompose(fake);
+      const chip = document.querySelector<HTMLButtonElement>(".ca-repo")!;
+      await expect.poll(() => chip.textContent).toContain(longRepo.name);
+      const rect = chip.getBoundingClientRect();
+      const nextRect = nextButton().getBoundingClientRect();
+      expectMinPx(rect.height, 44, "repo chip tap-target height");
+      expectMinPx(rect.width, 44, "repo chip tap-target width");
+      expect(rect.right).toBeLessThan(nextRect.left);
+      expect(rect.top).toBe(nextRect.top);
+      expect(nextRect.right).toBeLessThanOrEqual(width);
+      expect(nextRect.bottom).toBeLessThanOrEqual(fake.height);
+      expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(width);
+    } finally {
+      restore();
+    }
+  });
+
   // Switching repo mid-compose used to cost five taps and drop the soft keyboard twice:
   // the context line was inert (tap 1 only blurred), a pick left the sheet open (tap 4
   // dismissed it) and the prompt unfocused (tap 5). These pin the two-tap replacement.
-  describe("compose-state repo switching", () => {
-    const repoSeg = () => document.querySelector<HTMLButtonElement>(".ctx-seg-repo")!;
+  describe.each([".ctx-seg-repo", ".ca-repo"])("compose repo switch via %s", (selector) => {
+    const repoSeg = () => document.querySelector<HTMLButtonElement>(selector)!;
     const engineSeg = () => document.querySelector<HTMLButtonElement>(".ctx-seg-engine")!;
 
     async function mountTwoRepos() {
@@ -4796,6 +4819,11 @@ describe("NewTask 7A keyboard-compose state", () => {
         expect(document.querySelector(".ctx-sheet")).toBeNull();
         expect(document.activeElement).toBe(promptField());
         expect(promptField().selectionStart).toBe("half a thought".length);
+        await expect
+          .poll(() => document.querySelector(".ctx-seg-repo")?.textContent)
+          .toContain("other-repo");
+        expect(document.querySelector(".ca-repo")?.textContent).toContain("other-repo");
+        expect(promptField().value).toBe("half a thought");
       } finally {
         restore();
       }

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -526,7 +526,7 @@
   // ── 7A keyboard-compose state (touch only) ────────────────────────────────
   // While the soft keyboard is up, the modal collapses to the visible viewport:
   // everything already confirmed (mode, engine, footer CTA) folds away and a
-  // pinned action row (attach · hide keyboard · Next →) rides above the keys.
+  // pinned action row (attach · hide keyboard · repo · Next →) rides above the keys.
   // Gated on the keyboard being REALLY open (visualViewport occlusion, computed
   // in syncViewport) — focus alone must not fold controls: the programmatic
   // focus() on open raises no keyboard on iOS, and hardware-keyboard tablets
@@ -2440,6 +2440,22 @@
           </button>
           <button
             type="button"
+            class="ca-btn ca-repo"
+            aria-haspopup="dialog"
+            aria-expanded={activeSheet === "context"}
+            aria-label={m.newtask_context_chip_aria({
+              repo: selectedRepoName || m.reposelect_placeholder(),
+              branch: baseBranch,
+            })}
+            onpointerdown={(e) => e.preventDefault()}
+            onclick={openRepoPicker}
+          >
+            <span aria-hidden="true">{projectIcons.iconFor(repoPath) ?? "▣"}</span>
+            <b>{selectedRepoName || m.reposelect_placeholder()}</b>
+            <span class="chev" aria-hidden="true">▾</span>
+          </button>
+          <button
+            type="button"
             class="ca-next"
             onpointerdown={(e) => {
               e.preventDefault();
@@ -3897,7 +3913,7 @@
     .compose-meta .cm-hint {
       margin-left: auto;
     }
-    /* Pinned action row: attach · hide keyboard · Next →. */
+    /* Pinned action row: attach · hide keyboard · repo · Next →. */
     .compose-actions {
       flex-shrink: 0;
       display: flex;
@@ -3923,8 +3939,37 @@
     .ca-btn:disabled {
       opacity: 0.6;
     }
-    .ca-next {
+    .ca-repo {
+      flex: 0 1 auto;
+      min-width: 44px;
+      width: auto;
       margin-left: auto;
+      gap: 4px;
+      padding: 0 8px;
+      font-size: var(--fs-meta);
+    }
+    .ca-repo b {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .ca-repo > span {
+      flex-shrink: 0;
+    }
+    .ca-repo .chev {
+      color: var(--color-muted);
+      font-size: var(--fs-micro);
+    }
+    .ca-repo:hover {
+      background: var(--color-hover);
+      border-color: var(--color-line-bright);
+    }
+    .ca-repo:focus-visible {
+      outline: 1px solid var(--color-amber);
+      outline-offset: 2px;
+    }
+    .ca-next {
+      flex-shrink: 0;
       min-height: 44px;
       display: flex;
       align-items: center;

--- a/ui/src/lib/feature-announcements/entries/v1.48.0-mobile-compose-repo.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.48.0-mobile-compose-repo.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "mobile-compose-repo",
+  sinceVersion: "1.48.0",
+  titleKey: "feat_mobile_compose_repo_title",
+  bodyKey: "feat_mobile_compose_repo_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
## Summary

On phones, switching the repo while writing a new task required reaching the header above the prompt. Add a repo chip immediately left of Next in the action row above the keyboard. It shows the current repo and opens the existing searchable picker with recent repos.

Both entry points share the same selection and focus handling, preserving the draft and returning the caret to the prompt after a pick. Long repo names truncate so Next stays visible on narrow screens. Includes an EN/DE What's-New entry.

## Validation

- UI: `bun run check`, `CI=true bun run test` (320 files, 5,243 tests), and `bun run check:i18n` passed.
- Changed files: ESLint, Prettier, and `git diff --check` passed.
- Browser coverage exercises both repo entry points, real pointer activation, synchronized labels, and draft/caret preservation. Layout assertions cover 320px and 390px widths with German labels and long repo names; screenshots at both widths were visually reviewed.
- The mandatory pre-push gate also passed root tests/typechecking, UI and extension checks/tests/builds, branch/catalog gates, and the fallow audit.
