### PR TITLE
fix(review): recognize merged PRs and retire their critic (#1790)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ import {
 } from "./push";
 import { ReadyNotifier } from "./ready-notify";
 import { Presence } from "./presence";
-import { ReviewService } from "./review";
+import { ReviewService, isTerminalPr } from "./review";
 import { StandalonePrCriticService } from "./standalone-critic";
 import { createIssueLogger } from "./issue-log";
 import { PlanGateService, shouldConsiderOnSettle, shouldCheckPlanDrift } from "./plan-gate";
@@ -1748,6 +1748,25 @@ const reKickReapedReview = (id: string) => {
     prPoller.pollSession(id);
   }
 };
+
+// #1790: the critic-retirement path hangs off consider(), which is driven by `session:git` — and
+// the poller emits that only when the state CHANGES. A PR that reached merged/closed while the
+// server was down (or before this retirement existed) is already in the poller's PERSISTED cache
+// at boot, so it will never emit again and its stranded REVIEW ERR / running critic would sit
+// there until archive. Walk the hydrated cache once so those settle at startup. In-memory only —
+// no `gh` calls — and per-session guarded so one bad row can't abort the reconcile chain.
+const settleTerminalPrs = async () => {
+  for (const s of store.list({ activeOnly: true })) {
+    const git = prPoller.get(s.id);
+    if (!git || !isTerminalPr(git)) continue;
+    try {
+      await reviewService.settleTerminalPr(s);
+    } catch (err) {
+      console.warn(`[review] terminal-PR settle failed for ${s.id}:`, err);
+    }
+  }
+};
+
 deferredStarts.push(() => {
   void planGate
     .adoptOrphans()
@@ -1756,6 +1775,9 @@ deferredStarts.push(() => {
     .then((ids) => {
       for (const id of ids) reKickReapedReview(id);
     })
+    // After the orphan reap (so a row it just closed isn't settled twice) and before the disk
+    // sweep (so anything this cancels is gone from `inflight` when protectedPaths is computed).
+    .then(() => settleTerminalPrs())
     .then(() => sweepStaleReviewWorktrees())
     // Last: fill token totals for completed Codex reviewer rows whose rollout hadn't resolved at
     // finalize (they book NULL = unknown). Runs after the reaps so rows just closed by them are

--- a/src/pr-poller.ts
+++ b/src/pr-poller.ts
@@ -60,7 +60,20 @@ export function guardStaleTerminal(
  *                 still holds for the cold-cache rebase/force-push case (same PR number, head moved).
  *                 A different-number terminal (reused branch name) falls through to the prev-cache check
  *                 rather than being blanket-trusted; or
- *   - `prev` already cached THIS PR (same number, non-"none" state) — a PR we already owned.
+ *   - `prev` already cached THIS PR (same number, non-"none" state) — a PR we already owned. Since
+ *                 #1929 that cache is PERSISTED (`session_git_cache`) and rehydrated at construction,
+ *                 so this identity survives a restart; or
+ *   - (#1790) the PR was opened no earlier than the session itself. This is the fallback for the one
+ *                 case the two proofs above can't cover: a PR the poller never observed as `open`
+ *                 (created and merged between sweeps, or a cache row that never landed), whose remote
+ *                 head a reviewer/rebase push has since moved out of the session's stale worktree —
+ *                 `ownsPr` then says false and a genuine merge would be downgraded to "none" forever.
+ *                 It is deliberately LAST and deliberately weakest: a cached identity, when there is
+ *                 one, is authoritative in BOTH directions (a different number rejects outright rather
+ *                 than falling through to here), and a payload without `createdAt` (an older cache
+ *                 entry, a forge that doesn't supply it) gets no proof at all. The reused-branch-name
+ *                 collision this whole function guards against is a PR created BEFORE the session, so
+ *                 it still fails here and still runs the ownership check.
  *  When this returns false, `raw` may be a reused-branch-name collision and must run through
  *  `guardStaleTerminal`. */
 export function trustsTerminal(
@@ -68,10 +81,15 @@ export function trustsTerminal(
   raw: GitState,
   marked: boolean,
   markedNumber: number | null,
+  /** `session.createdAt` (epoch ms), for the temporal fallback. Omitted ⇒ that proof is skipped. */
+  sessionCreatedAt: number | null = null,
 ): boolean {
   if (raw.state !== "merged" && raw.state !== "closed") return false; // guardStaleTerminal is a no-op off-terminal anyway
   if (marked && markedNumber != null && raw.number === markedNumber) return true;
-  return !!prev && prev.number != null && prev.number === raw.number && prev.state !== "none";
+  // A cached identity settles it either way — never fall through to the weaker temporal proof
+  // when we already know which PR this session owns.
+  if (prev && prev.number != null && prev.state !== "none") return prev.number === raw.number;
+  return sessionCreatedAt != null && raw.createdAt != null && raw.createdAt >= sessionCreatedAt;
 }
 
 /** Order-independent equality for two optional string lists. `runningChecks` is
@@ -415,7 +433,9 @@ export class PrPoller implements PrCache {
     const marked = s.mergingSince != null;
     const markedNumber = s.mergingPrNumber ?? null;
     const guard = (raw: GitState): GitState =>
-      trustsTerminal(prev, raw, marked, markedNumber) ? raw : this.rejectStaleTerminal(s, raw);
+      trustsTerminal(prev, raw, marked, markedNumber, s.createdAt)
+        ? raw
+        : this.rejectStaleTerminal(s, raw);
 
     const raw = batch
       ? await this.statusFromBatch(s, forge, batch, prev, marked, recheckNone, guard)

--- a/src/review.ts
+++ b/src/review.ts
@@ -324,7 +324,10 @@ export interface ReviewServiceDeps extends MembraneSeams {
   >;
   worktree: Pick<WorktreeMgr, "createDetached" | "remove" | "gitCommonDir">;
   resolveForge: (repoPath: string) => GitForge | null;
-  onChange: (id: string, verdict: ReviewVerdict) => void;
+  /** Broadcast a session's review state. `null` means the verdict row was DELETED (#1790: an
+   *  error verdict that a merged/closed PR made moot) — the client store treats a null review as
+   *  a removal, and every server-side `session:review` consumer re-reads the store from the id. */
+  onChange: (id: string, verdict: ReviewVerdict | null) => void;
   /** #1944: broadcast a spawn-notice change. Separate from `onChange`, which carries a verdict — a
    *  clamp or refusal must never synthesize one (it would wipe in-flight findings). */
   onSpawnNotice?: (id: string) => void;
@@ -414,6 +417,13 @@ export interface ReviewServiceDeps extends MembraneSeams {
   houseRulesBudgetChars?: () => number;
 }
 
+/** A PR no critic can act on any more: it merged, or it was closed unmerged. Either way the
+ *  code under review either landed or never will, so there is no review left to run and no
+ *  merge left to gate (#1790). */
+export function isTerminalPr(git: GitState): boolean {
+  return git.state === "merged" || git.state === "closed";
+}
+
 export class ReviewService {
   private inflight = new Map<string, InFlight>();
   // Session ids whose critic is mid-spawn but not yet in `inflight`. begin() awaits a
@@ -492,6 +502,13 @@ export class ReviewService {
     opts?: { force?: boolean },
   ): Promise<ReviewOutcome> {
     const force = opts?.force === true;
+    // #1790: a TERMINAL PR retires the critic instead of considering one. Routed BEFORE the
+    // open/green gate below so every consider() caller — the `session:git` subscription, the boot
+    // reconcile, forceReview — reaches the cleanup by this one path.
+    if (isTerminalPr(git)) {
+      await this.settleTerminalPr(session);
+      return "skipped";
+    }
     if (
       git.state !== "open" ||
       !checksCleared(git.checks, git.noCi ?? false) ||
@@ -554,6 +571,78 @@ export class ReviewService {
     // this return, so the non-force churn-skip "error" is irrelevant there; it's authoritative
     // only for the manual/force path.
     return this.inflight.has(session.id) ? "started" : "error";
+  }
+
+  /**
+   * Retire the PR critic for a session whose PR reached a TERMINAL state (merged or closed).
+   *
+   * `consider()` used to just return "skipped" off the open/green gate, which left three things
+   * behind: a critic mid-async-startup that still spawned after the merge, a running critic that
+   * kept burning tokens on code that had already landed (the reported `REVIEWING 8/8`), and a
+   * persisted verdict that only made sense while the PR was open (the reported sticky
+   * `REVIEW ERR 5/5`). Nothing else cleared them before `forget()` at archive, so a finished task
+   * could not read as complete.
+   *
+   * Idempotent — the boot reconcile and the live `session:git` edge both land here, and a second
+   * observation emits nothing.
+   */
+  async settleTerminalPr(session: Session): Promise<void> {
+    // 1. Clear a mid-spawn claim. A begin() suspended in one of its gh fetches re-checks
+    //    `starting` on resume and aborts at that tombstone — the same mechanism forget() uses —
+    //    so a merge observed mid-startup can't still be followed by a fresh critic.
+    this.starting.delete(session.id);
+
+    // 2. Cancel a live run, but NEVER steal one tick() already owns (`finalizing`): that single
+    //    owner completes its own teardown, and finalizeErrorVerdict() already suppresses the
+    //    now-moot error verdict it would otherwise persist. The claim + drop below are
+    //    SYNCHRONOUS, before any await, so an overlapping tick() cannot pass its own `finalizing`
+    //    guard and double-reap the same run.
+    const f = this.inflight.get(session.id);
+    if (f && !f.finalizing) {
+      f.finalizing = true;
+      this.dropInflight(session.id, f);
+      this.deps.onReviewing?.(session.id, false);
+      // Best-effort cost attribution — mirrors finalize(). It also closes the reviewer_spawns row;
+      // if the transcript is unreadable the row stays open and the boot sweep closes it with NULL
+      // totals, exactly as it does for a finalize that raced the same way.
+      await captureUsage(
+        (wt, id) => this.readUsage(wt, id, f.reviewerProvider, f.reviewerModel),
+        this.deps.store.completeReviewerSpawn.bind(this.deps.store),
+        f.worktreePath,
+        f.criticSessionId,
+        this.now(),
+        f.sessionId,
+      );
+      await reapRun(this.deps.herdr, this.deps.worktree, f.terminalId, f.worktreePath);
+    }
+
+    this.retireTerminalVerdict(session.id);
+  }
+
+  /** Verdict hygiene for a terminal PR.
+   *  - `error`: MOOT — there is no merge left to gate and no head left to re-review — so the row
+   *    is DELETED and `onChange` carries `null` (the client store reads a null review as a
+   *    removal). Without this a REVIEW ERR persisted while the PR was still open sticks until
+   *    archive; finalizeErrorVerdict() only covers a verdict written after the PR went terminal.
+   *  - `changes_requested`: real history, so it is KEPT — but marked `dismissed`, because
+   *    `criticReworkActive` (attention-core) has no PR-state gate and `verdictStale` only demotes
+   *    a verdict while the PR is OPEN. Left alone it would pin a merged session at Tier 1 forever.
+   *    `dismissed` is the established lever for exactly this (it also stops attachReviewPush
+   *    re-notifying); the decision, body, findings and round counters survive untouched.
+   *  - clean / `commented`: nothing to retire.
+   *  Both mutating branches are guarded, so re-entry is silent. */
+  private retireTerminalVerdict(sessionId: string): void {
+    const prior = this.deps.store.getReview(sessionId);
+    if (!prior) return;
+    if (prior.decision === "error") {
+      this.deps.store.dropReview(sessionId);
+      this.deps.onChange(sessionId, null);
+      return;
+    }
+    if (prior.decision !== "changes_requested" || prior.dismissed) return;
+    const dismissed = { ...prior, dismissed: true };
+    this.deps.store.putReview(dismissed);
+    this.deps.onChange(sessionId, dismissed);
   }
 
   /** Is the head we are about to review already superseded on the forge? One `prStatus` round-trip,

--- a/src/server.ts
+++ b/src/server.ts
@@ -4420,9 +4420,9 @@ async function dispatchForgeAction(
 
 // Compute the session's live, trust-guarded PR GitState — the same trust logic the
 // background poller uses (trustsTerminal): keep a genuinely-merged/closed PR when the
-// session is merge-train-flagged or the cache already owned this PR, else drop a
-// reused-branch-name collision to "none". Shared by the GET /git route and the
-// POST /review-pr route so both observe the identical value.
+// session is merge-train-flagged, the cache already owned this PR, or the PR was opened
+// no earlier than the session; else drop a reused-branch-name collision to "none". Shared
+// by the GET /git route and the POST /review-pr route so both observe the identical value.
 async function resolveGitState(
   forge: GitForge,
   session: Session,
@@ -4436,7 +4436,7 @@ async function resolveGitState(
   // merged/closed PR when merge-train-flagged or already-owned, else drop a reused
   // branch-name collision to "none".
   const guard = (raw: GitState): GitState =>
-    trustsTerminal(prev, raw, marked, markedNumber)
+    trustsTerminal(prev, raw, marked, markedNumber, session.createdAt)
       ? raw
       : guardStaleTerminal(raw, (headSha) => deps.ownsPr?.(session, headSha) ?? null);
 

--- a/test/pr-poller.test.ts
+++ b/test/pr-poller.test.ts
@@ -1168,7 +1168,155 @@ test("trustsTerminal: prev open #7, raw merged #8 (mismatched number), unmarked 
   ).toBe(false);
 });
 
+test("trustsTerminal: signal (c) no prev, terminal created at/after the session → true", () => {
+  expect(
+    trustsTerminal(
+      undefined,
+      {
+        kind: "github",
+        state: "merged",
+        number: 7,
+        checks: "success",
+        createdAt: 2_000,
+        deployConfigured: false,
+      },
+      false,
+      null,
+      2_000,
+    ),
+  ).toBe(true);
+});
+
+test("trustsTerminal: signal (c) no prev, terminal created BEFORE the session → false", () => {
+  expect(
+    trustsTerminal(
+      undefined,
+      {
+        kind: "github",
+        state: "merged",
+        number: 7,
+        checks: "success",
+        createdAt: 1_999,
+        deployConfigured: false,
+      },
+      false,
+      null,
+      2_000,
+    ),
+  ).toBe(false);
+});
+
+test("trustsTerminal: signal (c) needs a forge createdAt — absent → false (fail-closed)", () => {
+  expect(
+    trustsTerminal(
+      undefined,
+      { kind: "github", state: "merged", number: 7, checks: "success", deployConfigured: false },
+      false,
+      null,
+      2_000,
+    ),
+  ).toBe(false);
+});
+
+test("trustsTerminal: a cached identity outranks the temporal proof (mismatched number → false)", () => {
+  expect(
+    trustsTerminal(
+      { kind: "github", state: "open", number: 7, checks: "pending", deployConfigured: false },
+      {
+        kind: "github",
+        state: "merged",
+        number: 8,
+        checks: "success",
+        createdAt: 9_000,
+        deployConfigured: false,
+      },
+      false,
+      null,
+      2_000,
+    ),
+  ).toBe(false);
+});
+
+test("trustsTerminal: prev with no identity (state none) still reaches the temporal proof", () => {
+  expect(
+    trustsTerminal(
+      { kind: "github", state: "none", checks: "none", deployConfigured: false },
+      {
+        kind: "github",
+        state: "merged",
+        number: 7,
+        checks: "success",
+        createdAt: 9_000,
+        deployConfigured: false,
+      },
+      false,
+      null,
+      2_000,
+    ),
+  ).toBe(true);
+});
+
 // ── refresh integration tests ─────────────────────────────────────────────────
+test("refresh signal (c): cold cache + ownsPr=false, PR opened after the session → merged", async () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  const emitted: { state: string; number?: number }[] = [];
+  const poller = new PrPoller(
+    store,
+    () =>
+      forgeReturning(() => ({
+        state: "merged",
+        number: 7,
+        checks: "success",
+        headSha: "remote-final-head",
+        // The session was just created, so a PR opened "now" is at/after it.
+        createdAt: store.get(s.id)!.createdAt,
+        deployConfigured: false,
+      })),
+    (_id, git) => emitted.push({ state: git.state, number: git.number }),
+    120_000,
+    1000,
+    () => null,
+    15_000,
+    () => false, // ownsPr always false — the stale worktree can't reach the final head
+  );
+
+  await poller.tick();
+  expect(emitted).toHaveLength(1);
+  expect(emitted[0]!.state).toBe("merged"); // NOT "none"
+  expect(poller.snapshot()[s.id]?.state).toBe("merged");
+  expect(store.listSessionGitCache()[s.id]).toMatchObject({ state: "merged", number: 7 });
+});
+
+test("refresh signal (c): a terminal PR created BEFORE the session is still rejected to none", async () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  const emitted: { state: string; number?: number }[] = [];
+  const poller = new PrPoller(
+    store,
+    () =>
+      forgeReturning(() => ({
+        state: "merged",
+        number: 7,
+        checks: "success",
+        headSha: "old-head",
+        // A prior PR that merely reused this branch name.
+        createdAt: store.get(s.id)!.createdAt - 1,
+        deployConfigured: false,
+      })),
+    (_id, git) => emitted.push({ state: git.state, number: git.number }),
+    120_000,
+    1000,
+    () => null,
+    15_000,
+    () => false,
+  );
+
+  await poller.tick();
+  expect(emitted).toHaveLength(1);
+  expect(emitted[0]!.state).toBe("none");
+  expect(poller.snapshot()[s.id]?.state).toBe("none");
+});
 
 test("refresh signal (b): prior-owned PR transitions to merged, bypasses guard when ownsPr=false", async () => {
   const store = new SessionStore(":memory:");

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -4737,3 +4737,142 @@ test.skipIf(!onLinux1944)(
     expect(prompt).toContain("Run the security pass on every auth change."); // the policy did not
   },
 );
+
+// ── #1790: terminal-PR cleanup ────────────────────────────────────────────────
+// A merged/closed PR must retire the PR Critic for that session: cancel a run that is
+// starting or in flight, drop an obsolete REVIEW ERR, and stop a retained findings
+// verdict from reading as live operator-blocking rework.
+
+const MERGED: GitState = {
+  kind: "github",
+  state: "merged",
+  number: 7,
+  checks: "success",
+  headSha: "abc",
+  deployConfigured: false,
+};
+const CLOSED: GitState = { ...MERGED, state: "closed" };
+
+for (const [label, terminal] of [
+  ["merged", MERGED],
+  ["closed", CLOSED],
+] as const) {
+  test(`consider(${label}) cancels a non-finalizing in-flight critic`, async () => {
+    const events: { id: string; reviewing: boolean }[] = [];
+    const {
+      deps: d,
+      stopped,
+      removed,
+      completedSpawns,
+    } = makeDeps({
+      onReviewing: (id: string, reviewing: boolean) => events.push({ id, reviewing }),
+    });
+    const svc = new ReviewService(d as any);
+    await svc.consider(session(), OPEN_GREEN);
+    expect(svc.reviewingIds()).toEqual(["s1"]);
+
+    await svc.consider(session(), terminal);
+
+    expect(svc.reviewingIds()).toEqual([]); // no critic left in flight
+    expect(events.at(-1)).toEqual({ id: "s1", reviewing: false }); // badge cleared immediately
+    expect(stopped).toContain("rt"); // its terminal was reaped
+    expect(removed).toContain("/review-wt"); // its disposable worktree was removed
+    expect(completedSpawns).toHaveLength(1); // token cost still attributed
+  });
+
+  test(`consider(${label}) drops an obsolete error verdict and emits null`, async () => {
+    const changes: (ReviewVerdict | null)[] = [];
+    const { deps: d, reviews } = makeDeps({
+      onChange: (_id: string, v: ReviewVerdict | null) => changes.push(v),
+    });
+    reviews["s1"] = priorReview({ decision: "error", findings: [], errorRound: 2 });
+    const svc = new ReviewService(d as any);
+
+    await svc.consider(session(), terminal);
+
+    expect(reviews["s1"]).toBeUndefined();
+    expect(changes).toEqual([null]);
+  });
+}
+
+test("consider(merged) clears the starting claim so a suspended begin() never spawns", async () => {
+  // Same seam as the forget() race: park begin() inside getIssue, observe the merge while it
+  // is suspended, then let the fetch resolve. begin() must re-check `starting` and abort.
+  let release!: () => void;
+  const gate = new Promise<void>((r) => (release = r));
+  const {
+    deps: d,
+    started,
+    removed,
+  } = makeDeps({
+    resolveForge: () =>
+      ({
+        prStatus: async () => OPEN_GREEN,
+        getIssue: async () => {
+          await gate;
+          return { body: "ISSUE_BODY_XYZ" };
+        },
+      }) as any,
+  });
+  const svc = new ReviewService(d as any);
+  const p = svc.consider(session({ issueNumber: 99 }), OPEN_GREEN); // suspends mid getIssue
+  await Promise.resolve(); // let begin() advance into the parked await
+  await svc.consider(session({ issueNumber: 99 }), MERGED); // PR merges mid-spawn
+  release();
+  await p;
+
+  expect(started).toHaveLength(0); // no critic emerged from the suspended startup
+  expect(removed).toEqual(["/review-wt"]); // the probe worktree was reaped
+  expect(svc.reviewingIds()).toEqual([]);
+});
+
+test("consider(merged) leaves an already-finalizing run to its owner (no double reap)", async () => {
+  const { deps: d, stopped, removed } = makeDeps({});
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  // Simulate tick() having claimed the run: it owns the teardown and the verdict.
+  (svc as any).inflight.get("s1")!.finalizing = true;
+
+  await svc.consider(session(), MERGED);
+
+  expect(svc.reviewingIds()).toEqual(["s1"]); // still owned by the finalizer
+  expect(stopped).toEqual([]);
+  expect(removed).toEqual([]);
+});
+
+test("consider(merged) dismisses a retained changes_requested verdict, preserving its history", async () => {
+  const changes: (ReviewVerdict | null)[] = [];
+  const { deps: d, reviews } = makeDeps({
+    onChange: (_id: string, v: ReviewVerdict | null) => changes.push(v),
+  });
+  reviews["s1"] = priorReview({ addressRound: 3, streakReviews: 2 });
+  const svc = new ReviewService(d as any);
+
+  await svc.consider(session(), MERGED);
+
+  const after = reviews["s1"]!;
+  expect(after.dismissed).toBe(true); // no longer live rework → no Tier-1 critic-rework hold
+  expect(after.decision).toBe("changes_requested"); // history preserved
+  expect(after.findings).toEqual(["fix the race in worker.ts"]);
+  expect(after.addressRound).toBe(3);
+  expect(after.streakReviews).toBe(2);
+  expect(changes).toHaveLength(1);
+
+  await svc.consider(session(), MERGED); // idempotent: a second observation is silent
+  expect(changes).toHaveLength(1);
+});
+
+test("consider(merged) leaves a commented verdict untouched", async () => {
+  const changes: (ReviewVerdict | null)[] = [];
+  const { deps: d, reviews } = makeDeps({
+    onChange: (_id: string, v: ReviewVerdict | null) => changes.push(v),
+  });
+  reviews["s1"] = priorReview({ decision: "commented", findings: [] });
+  const svc = new ReviewService(d as any);
+
+  await svc.consider(session(), MERGED);
+
+  expect(reviews["s1"]?.decision).toBe("commented");
+  expect(reviews["s1"]?.dismissed).toBeUndefined();
+  expect(changes).toEqual([]);
+});

--- a/test/server-git.test.ts
+++ b/test/server-git.test.ts
@@ -659,6 +659,51 @@ test("GET git trusts a merged PR when session is merge-train-flagged, cold cache
   expect(body.number).toBe(344);
 });
 
+test("GET git trusts a cold-cache merged PR opened after the session (signal c)", async () => {
+  // #1790 parity: the on-demand route must reach the same verdict as the background poller
+  // for a PR the poller never observed as open, whose final head the stale worktree can't see.
+  const f = fakeForge({
+    prStatus: async () => ({
+      state: "merged",
+      number: 5,
+      headSha: "remote-final-head",
+      checks: "success",
+      createdAt: 2_000,
+      deployConfigured: true,
+    }),
+  });
+  const deps = Object.assign(makeDeps(f, { ...SESSION, createdAt: 1_000 }), {
+    ownsPr: () => false,
+  });
+  const app = makeApp(deps);
+  const res = await app.fetch(new Request("http://localhost/api/sessions/s1/git"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.state).toBe("merged");
+  expect(body.number).toBe(5);
+});
+
+test("GET git still drops a terminal PR opened BEFORE the session (reused branch name)", async () => {
+  const f = fakeForge({
+    prStatus: async () => ({
+      state: "merged",
+      number: 344,
+      headSha: "deadbee",
+      checks: "success",
+      createdAt: 999,
+      deployConfigured: true,
+    }),
+  });
+  const deps = Object.assign(makeDeps(f, { ...SESSION, createdAt: 1_000 }), {
+    ownsPr: () => false,
+  });
+  const app = makeApp(deps);
+  const res = await app.fetch(new Request("http://localhost/api/sessions/s1/git"));
+  const body = await res.json();
+  expect(body.state).toBe("none");
+  expect(body.number).toBeUndefined();
+});
+
 test("GET /api/activity returns the activity snapshot", async () => {
   const snap = { s1: { lastActivityTs: 123, summary: "edited poller.ts" } };
   const deps = Object.assign(makeDeps(fakeForge()), { activity: { snapshot: () => snap } });


### PR DESCRIPTION
Closes #1790.

A session whose PR had already merged could keep a PR Critic running (`REVIEWING 8/8`, TASK-706 / #1783) or keep a stale `REVIEW ERR 5/5` (TASK-711 / #1780), so finished work never read as complete and Commission couldn't proceed.

## What the issue's plan asked for, and what this does instead

The issue was filed 2026-07-15 and the tree has moved since, so two of its premises no longer hold:

- **Its proposed `Session.observedPrNumber` column is redundant — dropped.** PR #1929 (merged 2026-07-24) added `session_git_cache`; `PrPoller` hydrates its in-memory cache from SQLite at construction, so the `prev` that `trustsTerminal()` consults already survives a restart carrying the PR number. `test/pr-poller.test.ts` already has a passing test named *"restart hydrates prior PR identity and accepts its unreachable terminal transition"* — the issue's headline scenario. **This PR adds no column and no migration.**
- **Post-merge error suppression already exists** (`finalizeErrorVerdict()`, landed 2026-06-24, before both incidents). It only covers a verdict written *while* the PR is already terminal. TASK-711's error verdict was persisted while the PR was still open and only went moot on merge; nothing cleared that.

## Changes

**1. `trustsTerminal()` gains a fourth, weakest proof** (`src/pr-poller.ts`). For the one case the persisted cache can't cover — a PR the poller never observed as `open`, whose remote head a reviewer/rebase push moved out of the session's stale worktree, so `containsCommit()` correctly says `false` and a genuine merge is downgraded to `state: "none"` permanently — trust a terminal PR whose forge `createdAt` is at or after `session.createdAt`. `PrStatus.createdAt` is already populated by GitHub, Gitea and LocalForge, so there is no plumbing.

The persisted identity now settles it in **both** directions (a cached number that disagrees rejects outright rather than falling through to the weaker proof), and a payload without `createdAt` gets no proof at all. The reused-branch-name collision the whole function guards against is a PR created *before* the session, so it still fails here and still runs the ownership check. `WorktreeManager.containsCommit()` is not loosened. `src/server.ts` → `resolveGitState()` passes the same evidence, so the on-demand `GET /git` and the background poller can't disagree.

**2. `ReviewService.settleTerminalPr()`** (`src/review.ts`) — `consider()` used to return `"skipped"` for a non-open PR and touch nothing. It now routes merged/closed to a cleanup path that:
- clears a `starting` claim, so a `begin()` suspended in one of its gh fetches aborts at the tombstone instead of spawning a critic after the merge;
- cancels a non-finalizing in-flight run — the claim (`finalizing = true` + `dropInflight`) is synchronous before any await, so an overlapping `tick()` can't double-reap — emitting `reviewing: false`, capturing usage best-effort and reaping the terminal + worktree;
- never steals a run `tick()` already owns; that single owner finishes its own teardown.

**3. Verdict retirement.** A moot `error` verdict is deleted and `session:review` carries `null` (the client store already reads a null review as a removal). A `changes_requested` verdict is kept as history but marked `dismissed` — **this is beyond the issue's spec and is deliberate**: `criticReworkActive()` in `src/attention-core.ts` has no PR-state gate and `verdictStale()` only demotes a verdict while the PR is *open*, so a retained findings verdict would otherwise pin a merged session at **Tier 1** forever. `dismissed` is the established lever for exactly that (it also stops `attachReviewPush` re-notifying); decision, body, findings and round counters survive untouched. Clean and `commented` verdicts are untouched.

**4. Boot reconcile** (`src/index.ts`). Cleanup hangs off `consider()`, driven by `session:git` — which the poller emits only when the state *changes*. A session already cached as merged will never emit again, so the two reported sessions could never heal. A single in-memory walk of the hydrated cache at startup (no `gh` calls, per-session guarded) settles them.

## Scope

Server-only: 4 source files + 3 test files. **No DB schema change, no UI/i18n/feature-catalog change, no manual operator steps.** The critic badge is purely verdict-driven and `ui/src/lib/types.ts` already types the event payload as `ReviewVerdict | null`, so correcting the server state is sufficient and introduces no type drift. The plan-gate critic and the standalone repo-level critic are untouched.

## Accepted narrowings (on the record)

- A *different* PR opened on the same branch name *after* the session starts is now trusted without a commit-containment check. Shepherd branch names carry the task desig, so the collision is remote.
- A closed-then-**reopened** PR keeps its `dismissed` stamp; a fresh verdict on a new head, or `forceReview()` (which already resets `dismissed`), restores normal rework classification.

## Verification

`bun run lint`, `bun run typecheck`, `bun run test` (9844 pass / 0 fail), `git diff --check`, and `bunx fallow audit --base origin/main --fail-on-issues` all pass. The terminal check was extracted into `isTerminalPr()` so `consider()` stays under the cyclomatic bar rather than taking a cap override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
