### PR TITLE
fix(tmp): gate the tmp guard per root, stop the test suite leaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,9 +481,12 @@ ceiling protects against any tmpfs consumer.
 
 Settings → Diagnose carries a **Temp filesystem inodes** row so this is visible before it bites:
 inode exhaustion otherwise reads as "disk full" while `df -h` shows plenty free (`df -i` is what
-shows it). It reports the worst of the roots the sweep visits, in whichever signal that root
-supports — so it cannot report a healthy tmpfs while the disk root agents actually write to is
-filling. On the percentage signal the row warns at `SHEPHERD_TMP_INODE_PCT` — the same threshold
+shows it). It reports the worst root in whichever signal that root supports — ranked by the state
+each would classify to, so a healthy tmpfs can never mask a disk root that is already past the band
+where the sweeper acts. It measures the roots a sweep can actually **reclaim** (the bare agent temp
+root and the tmpfs), deliberately not the session-scratch roots: those hold live sessions' scratch,
+which is reclaimed at archival and which the row's Fix cannot touch, so counting them would raise an
+alarm no action could clear. On the percentage signal the row warns at `SHEPHERD_TMP_INODE_PCT` — the same threshold
 that gates the sweep, so raising the knob moves both — and errors at 95%; on the entry-count signal
 it warns at `SHEPHERD_TMP_ENTRY_LIMIT` and errors at ten times that, with copy of its own (a
 filesystem with no inode table cannot meaningfully have "plenty of inodes free"). The row's

--- a/README.md
+++ b/README.md
@@ -462,9 +462,18 @@ shepherd`).
 
 Shepherd keeps spawned agents' Node compile cache **off** the `/tmp` tmpfs (it points
 `NODE_COMPILE_CACHE` at a disk dir) and runs an inode-guard sweep on **startup + daily** that, once
-`/tmp` inode use crosses a threshold, drops the compile cache and stale regenerable tool caches
-(bunx / fallow / agent-browser) — but never a live session's scratch, which is reclaimed on archival
-instead. So a long-lived host doesn't ENOSPC on inodes (with bytes to spare).
+a temp root crosses a pressure threshold, drops the compile cache and stale regenerable tool caches
+(bunx / fallow / agent-browser / leftover browser profiles) — but never a live session's scratch,
+which is reclaimed on archival instead. So a long-lived host doesn't ENOSPC on inodes (with bytes
+to spare).
+
+Pressure is measured **per temp root**, and by two different signals. Where the filesystem caps
+inodes (tmpfs, ext4) it is the inode use percentage. Where it allocates them on demand (btrfs, XFS,
+ZFS) there is no percentage to read, so Shepherd counts how many leftover top-level entries have
+piled up in that root instead and acts at `SHEPHERD_TMP_ENTRY_LIMIT`. Per-root matters because an
+entry count is specific to a directory: since agents were pointed at a disk-backed `TMPDIR`, the
+session-scratch root and the bare agent temp root beside it fill at completely different rates, and
+a single reading taken off one says nothing about the other.
 
 The in-app guard bounds Shepherd's _own_ churn; as a host-level belt, raise `/tmp`'s `nr_inodes` in
 `/etc/fstab` on long-uptime hosts (e.g. `tmpfs /tmp tmpfs nr_inodes=4194304 0 0`) so a higher inode
@@ -472,8 +481,13 @@ ceiling protects against any tmpfs consumer.
 
 Settings → Diagnose carries a **Temp filesystem inodes** row so this is visible before it bites:
 inode exhaustion otherwise reads as "disk full" while `df -h` shows plenty free (`df -i` is what
-shows it). The row warns at `SHEPHERD_TMP_INODE_PCT` — the same threshold that gates the sweep, so
-raising the knob moves both — and errors at 95%. The row's bands are kept ordered and in range: a
+shows it). It reports the worst of the roots the sweep visits, in whichever signal that root
+supports — so it cannot report a healthy tmpfs while the disk root agents actually write to is
+filling. On the percentage signal the row warns at `SHEPHERD_TMP_INODE_PCT` — the same threshold
+that gates the sweep, so raising the knob moves both — and errors at 95%; on the entry-count signal
+it warns at `SHEPHERD_TMP_ENTRY_LIMIT` and errors at ten times that, with copy of its own (a
+filesystem with no inode table cannot meaningfully have "plenty of inodes free"). The row's
+percentage bands are kept ordered and in range: a
 knob above 95 raises the error band with it (so the row never alarms below the line you set), and a
 value outside `(0, 100]` — including the legitimate `0` "always sweep" gate setting, which as a
 display band would mean "always warn" — falls back to 80 for the row only; the sweep itself still
@@ -484,8 +498,9 @@ in the temp filesystem (not reclaimed yet).
 
 Override env vars: `SHEPHERD_NODE_COMPILE_CACHE` (compile-cache dir), `SHEPHERD_TMP_INODE_PCT`
 (sweep threshold % **and** the Diagnose row's warning band, default `80`),
-`SHEPHERD_TMP_STALE_HOURS` (scratch staleness cutoff, default `24`), `SHEPHERD_TMP_SWEEP_DIR`
-(override the swept tmp root).
+`SHEPHERD_TMP_ENTRY_LIMIT` (the same pair for the entry-count signal, used where the filesystem has
+no inode ceiling, default `1000`), `SHEPHERD_TMP_STALE_HOURS` (scratch staleness cutoff, default
+`24`), `SHEPHERD_TMP_SWEEP_DIR` (override the swept tmp root).
 
 ### Live preview
 

--- a/docs-site/src/content/docs/operating.md
+++ b/docs-site/src/content/docs/operating.md
@@ -219,7 +219,13 @@ inodes on demand and report a total of zero. There the sweep and the row both fa
 to counting how many leftover top-level entries have accumulated in each temp root, warning at
 `SHEPHERD_TMP_ENTRY_LIMIT` and erroring at ten times it. Both signals are evaluated **per root**,
 and the row reports the worst — a quiet `/tmp` can sit beside a disk-backed agent temp root that is
-filling steadily, and one reading would hide the other.
+filling steadily, and one reading would hide the other. "Worst" is ranked by the state each root
+would report, not by a raw ratio, because the two signals reach their warning band at different
+fractions of their error band.
+
+The row measures only the roots a sweep can **reclaim**. Session-scratch roots are excluded: their
+contents belong to live sessions, are reclaimed at archival instead, and cannot be removed by the
+row's Fix — so counting them would pin the row at a warning that no action clears.
 This matters because inode exhaustion is easy to misdiagnose — writes start failing with
 "no space" errors while `df -h` still shows the volume mostly empty. `df -i` is what shows
 the real cause.

--- a/docs-site/src/content/docs/operating.md
+++ b/docs-site/src/content/docs/operating.md
@@ -206,13 +206,20 @@ tmpfs /tmp tmpfs nr_inodes=4194304 0 0
 ```
 
 The relevant override env vars (`SHEPHERD_NODE_COMPILE_CACHE`,
-`SHEPHERD_TMP_INODE_PCT`, `SHEPHERD_TMP_STALE_HOURS`, `SHEPHERD_TMP_SWEEP_DIR`) are
-listed in [Configuration](/reference/configuration/).
+`SHEPHERD_TMP_INODE_PCT`, `SHEPHERD_TMP_ENTRY_LIMIT`, `SHEPHERD_TMP_STALE_HOURS`,
+`SHEPHERD_TMP_SWEEP_DIR`) are listed in [Configuration](/reference/configuration/).
 
 The **Temp filesystem inodes** row in Settings → Diagnose surfaces this live: it warns
 at `SHEPHERD_TMP_INODE_PCT` (the same threshold that gates the sweep) and errors at 95% by
 default. The bands stay ordered: if you raise the knob above 95 the error band rises with it, so
 the row never alarms below the line you set.
+
+Not every filesystem has an inode ceiling to express as a percentage — btrfs, XFS and ZFS allocate
+inodes on demand and report a total of zero. There the sweep and the row both fall back
+to counting how many leftover top-level entries have accumulated in each temp root, warning at
+`SHEPHERD_TMP_ENTRY_LIMIT` and erroring at ten times it. Both signals are evaluated **per root**,
+and the row reports the worst — a quiet `/tmp` can sit beside a disk-backed agent temp root that is
+filling steadily, and one reading would hide the other.
 This matters because inode exhaustion is easy to misdiagnose — writes start failing with
 "no space" errors while `df -h` still shows the volume mostly empty. `df -i` is what shows
 the real cause.

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -71,6 +71,7 @@ Settings → Diagnose reports which case a host is in — see
 | --- | --- | --- |
 | `SHEPHERD_NODE_COMPILE_CACHE` | _(disk dir)_ | Node compile-cache dir (kept off the `/tmp` tmpfs) |
 | `SHEPHERD_TMP_INODE_PCT` | `80` | Inode-sweep threshold (% of `/tmp` inodes) — also the warning band of the **Temp filesystem inodes** Diagnose row (row bands stay ordered: >95 raises the error band too; outside `(0, 100]` the row falls back to 80, the sweep still honours it) |
+| `SHEPHERD_TMP_ENTRY_LIMIT` | `1000` | Entry-count sweep threshold, used where the filesystem allocates inodes on demand (btrfs/XFS/ZFS) and a percentage is meaningless — also the warning band of the **Temp filesystem inodes** row for that signal (error band: 10x) |
 | `SHEPHERD_TMP_STALE_HOURS` | `24` | Scratch staleness cutoff |
 | `SHEPHERD_TMP_SWEEP_DIR` | _(default tmp root)_ | Override the swept tmp root |
 

--- a/scripts/pre-push.ts
+++ b/scripts/pre-push.ts
@@ -357,6 +357,25 @@ export function plannedLaneCount(delta: boolean, changed: string[]): number {
   return n;
 }
 
+/**
+ * A throwaway `SHEPHERD_REPO_ROOT` for the root-tests lane, removed when the orchestrator exits.
+ *
+ * Created HERE rather than by the test preload (`test/setup-test-env.ts`, which redirects TMPDIR
+ * for the run) because this is the PARENT process — it is not preloaded, so without its own
+ * cleanup this dir survives every push and accumulates (#1862).
+ */
+function makeRepoRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-reporoot-"));
+  process.on("exit", () => {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* best-effort: never fail a green push over cleanup */
+    }
+  });
+  return dir;
+}
+
 function buildLanes(
   repoRoot: string,
   opts: { delta: boolean; changed: string[]; maxWorkers: number; laneTimeoutOverride?: number },
@@ -543,10 +562,7 @@ function buildLanes(
         args: ["test", "./test"],
         cwd: repoRoot,
         // Point server.test.ts's throwaway repo at a unique temp dir (never the real root).
-        env: {
-          ...process.env,
-          SHEPHERD_REPO_ROOT: mkdtempSync(join(tmpdir(), "shepherd-reporoot-")),
-        },
+        env: { ...process.env, SHEPHERD_REPO_ROOT: makeRepoRoot() },
       },
     ],
   });

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -38,7 +38,13 @@ import {
 import { matchAgents, tabLabelMap, type IHerdrDriver } from "./herdr";
 import { formatResidueSize, verdictFor, type MiseClaudeState } from "./mise-claude";
 import { isShepherdHelperLabel } from "./tab-reaper";
-import { readTmpInodeUsePct, sweepClaudeTmp, tmpInodeBands } from "./tmp-sweep";
+import {
+  readTmpPressureSignal,
+  sweepClaudeTmp,
+  tmpEntryBands,
+  tmpInodeBands,
+  type TmpPressureSignal,
+} from "./tmp-sweep";
 import { SHELLS } from "./json-tolerant";
 import type { SessionStore } from "./store";
 import type { DiagnosticCheck, DiagnosticsSnapshot, DiagnosticState } from "./types";
@@ -934,16 +940,35 @@ export function classifyMembraneLaunch(f: MembraneLaunchFacts): DiagnosticCheck 
  *  strings, which are folder-trust copy. */
 const TMP_INODES_FIX_ACTION = "diagnostics_fix_action_tmp_inodes";
 
-/** Non-secret inode facts for the `tmp_inodes` check: use% of the temp filesystem, or `null` when
- *  it cannot be determined (no `statfs`; or a btrfs tmp reporting `files: 0`, since it allocates
- *  inodes dynamically and a percentage is meaningless there). Bands are passed in rather than read
- *  from env here so the classifier stays pure and testable. */
+/** Hint keys per pressure signal. Separate sets because the two readings describe different
+ *  things: a share of a fixed inode table vs. how much has accumulated where there is no table. */
+const TMP_INODE_HINTS = {
+  ok: "diagnostics_hint_tmp_inodes_ok",
+  high: "diagnostics_hint_tmp_inodes_high",
+  critical: "diagnostics_hint_tmp_inodes_critical",
+} as const;
+const TMP_ENTRY_HINTS = {
+  ok: "diagnostics_hint_tmp_entries_ok",
+  high: "diagnostics_hint_tmp_entries_high",
+  critical: "diagnostics_hint_tmp_entries_critical",
+} as const;
+
+/** Non-secret temp-filesystem pressure facts for the `tmp_inodes` check. The signal is whichever
+ *  reading the swept roots support — an inode percentage where the filesystem caps inodes, an
+ *  accumulated top-level entry count where it does not (btrfs/XFS/ZFS allocate them dynamically,
+ *  so a percentage is meaningless), or nothing at all. Bands are passed in rather than read from
+ *  env here so the classifier stays pure and testable. */
 export interface TmpInodeFacts {
-  usePct: number | null;
+  signal: TmpPressureSignal;
   /** Warning band — `SHEPHERD_TMP_INODE_PCT`, the SAME knob that gates the sweep. */
   warnPct: number;
   /** Error band — `TMP_INODE_ERROR_PCT`, raised to `warnPct` when the knob exceeds it. */
   errorPct: number;
+  /** Warning band for the entry-count signal — `SHEPHERD_TMP_ENTRY_LIMIT`, again the same knob
+   *  that gates the sweep on a filesystem with no inode ceiling. */
+  warnEntries: number;
+  /** Error band for the entry-count signal. */
+  errorEntries: number;
 }
 
 /** Map inode facts → check. `null` use% is `optional`/uninspectable (never degrades the health
@@ -956,31 +981,32 @@ export interface TmpInodeFacts {
  *  "always warn" here, which no fix could clear. */
 export function classifyTmpInodes(f: TmpInodeFacts): DiagnosticCheck {
   const id = "tmp_inodes";
-  if (f.usePct === null) {
+  if (f.signal.kind === "uninspectable") {
     return { id, state: "optional", hintKey: "diagnostics_hint_tmp_inodes_uninspectable" };
   }
-  if (f.usePct >= f.errorPct) {
-    return {
-      id,
-      state: "error",
-      hintKey: "diagnostics_hint_tmp_inodes_critical",
-      fixActionKey: TMP_INODES_FIX_ACTION,
-    };
+
+  // Each signal carries its own copy: "plenty of inodes free" is simply untrue of a filesystem
+  // that has no inode ceiling, where the honest statement is about what has piled up.
+  const [value, warn, error, keys] =
+    f.signal.kind === "inode-pct"
+      ? ([f.signal.usePct, f.warnPct, f.errorPct, TMP_INODE_HINTS] as const)
+      : ([f.signal.entries, f.warnEntries, f.errorEntries, TMP_ENTRY_HINTS] as const);
+
+  if (value >= error) {
+    return { id, state: "error", hintKey: keys.critical, fixActionKey: TMP_INODES_FIX_ACTION };
   }
-  if (f.usePct >= f.warnPct) {
-    return {
-      id,
-      state: "warning",
-      hintKey: "diagnostics_hint_tmp_inodes_high",
-      fixActionKey: TMP_INODES_FIX_ACTION,
-    };
+  if (value >= warn) {
+    return { id, state: "warning", hintKey: keys.high, fixActionKey: TMP_INODES_FIX_ACTION };
   }
-  return { id, state: "ok", hintKey: "diagnostics_hint_tmp_inodes_ok" };
+  return { id, state: "ok", hintKey: keys.ok };
 }
 
-/** Default `readTmpInodes`: statfs the temp filesystem and pair it with the live bands. */
+/** Default `readTmpInodes`: read the worst pressure across the roots the sweeper visits and pair
+ *  it with the live bands. Deliberately the SWEPT roots rather than a fixed `tmpdir()`: post-#1875
+ *  trusted agents write to a disk-backed root, so watching only the tmpfs reported a healthy
+ *  filesystem while the one filling up went unseen (#1862). */
 async function defaultReadTmpInodes(): Promise<TmpInodeFacts> {
-  return { usePct: await readTmpInodeUsePct(), ...tmpInodeBands() };
+  return { signal: await readTmpPressureSignal(), ...tmpInodeBands(), ...tmpEntryBands() };
 }
 
 /** Default `runTmpSweep`: the operator's forced sweep. `thresholdPct: 0` bypasses the inode gate

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -954,7 +954,7 @@ const TMP_ENTRY_HINTS = {
 } as const;
 
 /** Non-secret temp-filesystem pressure facts for the `tmp_inodes` check. The signal is whichever
- *  reading the swept roots support — an inode percentage where the filesystem caps inodes, an
+ *  reading the measured roots support — an inode percentage where the filesystem caps inodes, an
  *  accumulated top-level entry count where it does not (btrfs/XFS/ZFS allocate them dynamically,
  *  so a percentage is meaningless), or nothing at all. Bands are passed in rather than read from
  *  env here so the classifier stays pure and testable. */
@@ -1001,10 +1001,12 @@ export function classifyTmpInodes(f: TmpInodeFacts): DiagnosticCheck {
   return { id, state: "ok", hintKey: keys.ok };
 }
 
-/** Default `readTmpInodes`: read the worst pressure across the roots the sweeper visits and pair
- *  it with the live bands. Deliberately the SWEPT roots rather than a fixed `tmpdir()`: post-#1875
- *  trusted agents write to a disk-backed root, so watching only the tmpfs reported a healthy
- *  filesystem while the one filling up went unseen (#1862). */
+/** Default `readTmpInodes`: read the worst pressure across `diagnosedRoots()` — the temp roots a
+ *  sweep can actually RECLAIM — and pair it with the live bands. Deliberately more than a fixed
+ *  `tmpdir()`: post-#1875 trusted agents write to a disk-backed root, so watching only the tmpfs
+ *  reported a healthy filesystem while the one filling up went unseen (#1862). Deliberately less
+ *  than the swept set: it omits the session-scratch roots, whose contents the row's Fix cannot
+ *  remove (see `diagnosedRoots`). */
 async function defaultReadTmpInodes(): Promise<TmpInodeFacts> {
   return { signal: await readTmpPressureSignal(), ...tmpInodeBands(), ...tmpEntryBands() };
 }

--- a/src/tmp-sweep.ts
+++ b/src/tmp-sweep.ts
@@ -1,7 +1,7 @@
 import { promises as fsp, type Dirent } from "node:fs";
 import { execFile } from "node:child_process";
 import { homedir, tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 import {
   parseWorktrees,
@@ -228,6 +228,9 @@ interface FsOps {
   rm: typeof fsp.rm;
   unlink: typeof fsp.unlink;
   rmdir: typeof fsp.rmdir;
+  /** Optional so the many existing partial `fsOps` test fixtures stay valid; only the
+   *  entry-count pressure signal uses it, and it falls back to the real `fsp.opendir`. */
+  opendir?: OpenDirFn;
 }
 
 interface SweepOpts {
@@ -248,38 +251,185 @@ interface SweepCtx {
   log: (msg: string) => void;
 }
 
+/** What a `statfs` read says about a root's INODE CEILING. */
+type InodeCeiling =
+  /** A real ceiling exists and is readable — `usePct` of it is in use. */
+  | { kind: "pct"; usePct: number }
+  /** `statfs` succeeded but reports NO ceiling (`files: 0`): btrfs/XFS/ZFS allocate inodes
+   *  dynamically, so a percentage is meaningless. NOT a failure — see `tmpPressure`. */
+  | { kind: "none" }
+  /** Nothing could be read: no `statfs` function, an unusable count, or an absent root. */
+  | { kind: "unreadable"; why: "statfs-unavailable" | "root-missing" };
+
 /**
- * Resolves the fail-open inode gate. Returns the numeric inode use% when readable, or a
- * string skip-reason when the guard cannot read inode pressure:
- *  - `"statfs-unavailable"` — `statfs` is not a function, or reports non-finite `files`/`ffree`
- *    or `files <= 0` (an unusable count).
- *  - `"root-missing"` — `statfs(root)` throws (root absent / unstatfs-able).
+ * Read a root's inode ceiling. Deliberately distinguishes "there is no ceiling" from "the ceiling
+ * could not be read": conflating the two is what made every gate here fail open to DO NOTHING on
+ * a disk-backed tmp root (#1862) — `statfs` reports `files: 0` on btrfs, which is an answer, not
+ * an error.
  */
-async function inodeUsePct(
+async function readInodeCeiling(
   root: string,
-  statfs: FsOps["statfs"],
-  log: (msg: string) => void,
-): Promise<number | string> {
-  // Fail-open: without a usable statfs we cannot read inode pressure, so do nothing.
-  if (typeof statfs !== "function") {
-    log("[tmp-sweep] statfs unavailable — skipping inode guard");
-    return "statfs-unavailable";
-  }
+  // Accepts `undefined` on purpose: a caller injecting an absent `statfs` is saying "this
+  // filesystem cannot be read", and that must resolve to `unreadable`, not a type error.
+  statfs: FsOps["statfs"] | undefined,
+): Promise<InodeCeiling> {
+  if (typeof statfs !== "function") return { kind: "unreadable", why: "statfs-unavailable" };
 
   let stats: Awaited<ReturnType<typeof fsp.statfs>>;
   try {
     stats = await statfs(root);
   } catch {
     // Root absent / unstatfs-able — nothing to guard.
-    return "root-missing";
+    return { kind: "unreadable", why: "root-missing" };
   }
 
   const files = Number((stats as { files?: unknown }).files);
   const ffree = Number((stats as { ffree?: unknown }).ffree);
-  if (!Number.isFinite(files) || !Number.isFinite(ffree) || files <= 0) {
-    return "statfs-unavailable";
+  if (!Number.isFinite(files) || !Number.isFinite(ffree) || files < 0) {
+    return { kind: "unreadable", why: "statfs-unavailable" };
   }
-  return (1 - ffree / files) * 100;
+  if (files === 0) return { kind: "none" };
+  return { kind: "pct", usePct: (1 - ffree / files) * 100 };
+}
+
+/**
+ * Minimal shape of `fs.promises.opendir`'s result that the entry counter needs. Typed structurally
+ * (rather than as `Dir`) so a test can inject a plain async-iterable without constructing one.
+ */
+type OpenDirFn = (path: string) => Promise<AsyncIterable<{ name: string }>>;
+
+/** Ops `tmpPressure` needs. Injectable wholesale so no test touches a real filesystem. */
+export interface PressureOps {
+  statfs: FsOps["statfs"];
+  opendir: OpenDirFn;
+}
+
+/**
+ * Count a directory's top-level entries, stopping at `cap`. Returns `null` when the directory
+ * cannot be read at all (missing/unreadable ⇒ no signal, never "0 entries", which would read as
+ * a healthy root). Breaking out of the `for await` calls the iterator's `return()`, which is how
+ * `fs.Dir` closes its handle — so the early exit does not leak an fd.
+ */
+async function countEntriesUpTo(
+  dir: string,
+  cap: number,
+  opendir: OpenDirFn,
+): Promise<number | null> {
+  if (typeof opendir !== "function") return null;
+  let handle: AsyncIterable<{ name: string }>;
+  try {
+    handle = await opendir(dir);
+  } catch {
+    return null;
+  }
+  let n = 0;
+  try {
+    for await (const _ of handle) {
+      void _;
+      if (++n >= cap) break;
+    }
+  } catch {
+    return null;
+  }
+  return n;
+}
+
+/**
+ * How far above `entryLimit` the counter keeps counting. The gate only needs to know whether the
+ * limit was reached, but the `tmp_inodes` Diagnose row needs a number it can band, so the walk
+ * runs to the error band (10× the warning band) before giving up precision.
+ */
+const ENTRY_COUNT_CAP_FACTOR = 10;
+
+/** The pressure reading for ONE root. */
+export type TmpPressureSignal =
+  /** The root's filesystem caps inodes and `usePct` of them are in use. */
+  | { kind: "inode-pct"; usePct: number }
+  /** No inode ceiling — `entries` top-level entries counted (capped; see `atCap`). */
+  | { kind: "entry-count"; entries: number; limit: number; atCap: boolean }
+  /** Nothing could be measured. Never acts. */
+  | { kind: "uninspectable"; why: string };
+
+export interface TmpPressureResult {
+  /** True when this root is under enough pressure to justify acting on it. */
+  act: boolean;
+  signal: TmpPressureSignal;
+  /** Short log-ready summary of what was measured and decided. */
+  reason: string;
+}
+
+export interface TmpPressureOpts {
+  thresholdPct?: number;
+  entryLimit?: number;
+  ops?: Partial<PressureOps>;
+}
+
+/**
+ * Is this root under enough pressure to act on? Resolves one of three signals — never throws.
+ *
+ * Evaluated PER ROOT by every consumer, because unlike an inode percentage (a property of the
+ * filesystem) an entry count is a property of the PATH: `claudeTmpRoot()` is
+ * `<agentTmpDir()>/claude-$uid` and holds only session scratch, while the tool caches and
+ * agent-created worktrees this module reclaims accumulate in the BARE `agentTmpDir()` beside it.
+ * A single reading taken off one of them says nothing about the other.
+ *
+ * `uninspectable` never acts — the pre-existing fail-open, deliberately preserved: a guard that
+ * cannot see must not delete.
+ */
+export async function tmpPressure(
+  root: string,
+  opts: TmpPressureOpts = {},
+): Promise<TmpPressureResult> {
+  const thresholdPct =
+    opts.thresholdPct ?? envNum(process.env.SHEPHERD_TMP_INODE_PCT, DEFAULT_TMP_INODE_PCT);
+  const entryLimit =
+    opts.entryLimit ?? envNum(process.env.SHEPHERD_TMP_ENTRY_LIMIT, DEFAULT_TMP_ENTRY_LIMIT);
+  // `statfs` honours an EXPLICITLY-PRESENT key even when its value is undefined: "I cannot read
+  // this filesystem" is a meaningful injection, and `??`-ing the real `statfs` in its place would
+  // silently re-arm the gate a caller deliberately disarmed. `opendir` takes the opposite rule —
+  // it is optional on `FsOps`, so an ABSENT key means "not overridden".
+  const statfs = opts.ops && "statfs" in opts.ops ? opts.ops.statfs : fsp.statfs;
+  const opendir = opts.ops?.opendir ?? fsp.opendir;
+
+  const ceiling = await readInodeCeiling(root, statfs);
+
+  if (ceiling.kind === "unreadable") {
+    return { act: false, signal: { kind: "uninspectable", why: ceiling.why }, reason: ceiling.why };
+  }
+
+  if (ceiling.kind === "pct") {
+    const { usePct } = ceiling;
+    return {
+      act: usePct >= thresholdPct,
+      signal: { kind: "inode-pct", usePct },
+      reason:
+        usePct >= thresholdPct
+          ? `${usePct.toFixed(1)}% inode use`
+          : `below-threshold ${usePct.toFixed(1)}%`,
+    };
+  }
+
+  // No inode ceiling: fall back to how much has piled up in this root.
+  // Floor of 1 so a non-positive limit (the "always act" setting) still walks one entry rather
+  // than deriving a zero/negative cap that would make the counted number meaningless.
+  const cap = Math.max(entryLimit * ENTRY_COUNT_CAP_FACTOR, 1);
+  const entries = await countEntriesUpTo(root, cap, opendir);
+  if (entries === null) {
+    return {
+      act: false,
+      signal: { kind: "uninspectable", why: "entries-unreadable" },
+      reason: "entries-unreadable",
+    };
+  }
+  const atCap = entries >= cap;
+  const act = entries >= entryLimit;
+  return {
+    act,
+    signal: { kind: "entry-count", entries, limit: entryLimit, atCap },
+    reason: act
+      ? `${entries}${atCap ? "+" : ""} entries (limit ${entryLimit})`
+      : `below-entry-limit ${entries}/${entryLimit}`,
+  };
 }
 
 /**
@@ -296,6 +446,21 @@ export const TMP_INODE_ERROR_PCT = 95;
  * literals would let one drift and silently break that correspondence.
  */
 const DEFAULT_TMP_INODE_PCT = 80;
+
+/**
+ * The documented default of `SHEPHERD_TMP_ENTRY_LIMIT` — the top-level entry count at which a root
+ * whose filesystem has NO inode ceiling (btrfs/XFS/ZFS allocate inodes dynamically) counts as
+ * pressured. Also the `tmp_inodes` row's warning band for that signal, via `tmpEntryBands`.
+ *
+ * Deliberately far more eager than the inode-% analogue, because the two failure modes are not
+ * symmetric: 80% of a tmpfs means the host is near death, whereas crossing this only enables the
+ * EXISTING age-gated sweep of ALLOWLISTED names and arms reclaimers that are independently walled
+ * by their own refusals. Measured while diagnosing #1862: a healthy bare agent tmp root sits in the
+ * tens, a normal `claude-$uid` session-scratch root at ~2,900 — which is excluded from removal by
+ * name, so sitting permanently above this line changes nothing there — and the leaking root at
+ * 119,640.
+ */
+const DEFAULT_TMP_ENTRY_LIMIT = 1000;
 
 /**
  * Ordered display bands for the `tmp_inodes` diagnostics row.
@@ -325,35 +490,87 @@ export function tmpInodeBands(): { warnPct: number; errorPct: number } {
 }
 
 /**
- * Inode use% of the temp filesystem, or `null` when it cannot be determined.
+ * Display bands for the `entry-count` signal. The warning band IS `SHEPHERD_TMP_ENTRY_LIMIT`, so —
+ * exactly as `tmpInodeBands` does for the percentage signal — the row warns at the point the
+ * sweeper starts acting. A non-positive or non-finite knob has no coherent display band (it would
+ * mean "always warn", which no fix could clear), so it falls back to the default for the ROW while
+ * the gate still honours whatever was configured.
  *
- * Deliberately statfs's `tmpdir()` rather than `claudeTmpRoot()`: the latter is
- * `<tmpdir>/claude-$uid`, which does not exist on a freshly booted host, and `inodeUsePct`'s
- * `root-missing` branch would then report "uninspectable" on exactly the hosts that still have
- * headroom worth protecting. `tmpdir()` is the filesystem actually at risk and is always present.
- *
- * NOTE this is not necessarily `/tmp` — `os.tmpdir()` honours the SERVER process's own `TMPDIR`.
- * User-facing copy driven by this value must therefore say "the temporary filesystem", never a
- * hardcoded path. `null` covers both `inodeUsePct` skip-reasons, notably a btrfs tmp reporting
- * `files: 0` (it allocates inodes dynamically, so a percentage is meaningless there).
+ * Postcondition, relied on by the classifier: `0 < warnEntries < errorEntries`.
  */
-export async function readTmpInodeUsePct(
-  statfs: FsOps["statfs"] = fsp.statfs,
-): Promise<number | null> {
-  const pct = await inodeUsePct(tmpdir(), statfs, () => {});
-  return typeof pct === "number" ? pct : null;
+export function tmpEntryBands(): { warnEntries: number; errorEntries: number } {
+  const configured = envNum(process.env.SHEPHERD_TMP_ENTRY_LIMIT, DEFAULT_TMP_ENTRY_LIMIT);
+  const warnEntries = configured > 0 ? configured : DEFAULT_TMP_ENTRY_LIMIT;
+  return { warnEntries, errorEntries: warnEntries * ENTRY_COUNT_CAP_FACTOR };
+}
+
+/**
+ * The roots a default (production) sweep visits — the bare disk `agentTmpDir()`, the claude root
+ * and its nested `claude-$uid`, and the legacy tmpfs pair. Shared by `readTmpPressureSignal` and
+ * the worktree reaper so both act on exactly the set `sweepClaudeTmp` does, rather than on a
+ * filesystem the sweeper never touches.
+ */
+function sweptRoots(): string[] {
+  return resolveSweepRoots(claudeTmpRoot(), `claude-${uid()}`, false);
+}
+
+/** How bad a signal is, normalised against its own error band, for picking the worst root.
+ *  `uninspectable` sorts below every real reading so one unreadable root cannot mask a real one. */
+function severityRatio(
+  signal: TmpPressureSignal,
+  bands: { errorPct: number; errorEntries: number },
+): number {
+  if (signal.kind === "inode-pct") return signal.usePct / bands.errorPct;
+  if (signal.kind === "entry-count") return signal.entries / bands.errorEntries;
+  return -1;
+}
+
+/**
+ * The worst pressure signal across the roots the sweeper actually visits — the value behind the
+ * `tmp_inodes` Diagnose row.
+ *
+ * Post-#1875 no single path answers this. Trusted agents write to the disk `agentTmpDir()`, while
+ * the tmpfs `tmpdir()` is still real for sandboxed spawns and tools that hardcode `/tmp`; reading
+ * only one reports a healthy filesystem while the other fills. Roots that cannot be measured are
+ * skipped rather than allowed to mask a measurable one; `uninspectable` is returned only when NO
+ * root could be read.
+ *
+ * NOTE the roots are not necessarily under `/tmp` — user-facing copy driven by this must say "the
+ * temporary filesystem", never a hardcoded path, and no absolute path crosses the check payload.
+ */
+export async function readTmpPressureSignal(opts?: {
+  roots?: string[];
+  ops?: Partial<PressureOps>;
+}): Promise<TmpPressureSignal> {
+  const roots = opts?.roots ?? sweptRoots();
+  const bands = { ...tmpInodeBands(), ...tmpEntryBands() };
+  let worst: TmpPressureSignal = { kind: "uninspectable", why: "no-root-readable" };
+  let worstRatio = -Infinity;
+  for (const root of roots) {
+    const { signal } = await tmpPressure(root, { ops: opts?.ops });
+    const ratio = severityRatio(signal, bands);
+    if (ratio > worstRatio) {
+      worstRatio = ratio;
+      worst = signal;
+    }
+  }
+  return worst;
 }
 
 /**
  * Entry names this sweep is willing to age-gate-remove: regenerable tool caches that hold NO
- * live session working state (Bun's bunx cache, fallow's audit base cache, agent-browser's
- * Chrome profiles). Per-session scratch — the dashified `-home-…` worktree dirs and their
+ * live session working state — Bun's bunx cache, fallow's audit base cache, agent-browser's
+ * Chrome profiles, the browser-profile and artifact dirs Chromium/Playwright leave behind
+ * (4,963 observed on one host while diagnosing #1862), and the per-run root a crashed
+ * `bun test` leaves behind (`test/setup-test-env.ts` removes it on a clean exit).
+ * Per-session scratch — the dashified `-home-…` worktree dirs and their
  * session-id subdirs — is deliberately EXCLUDED: a still-running session leaves a stale
  * TOP-LEVEL mtime because it only writes into subdirs, so a coarse mtime check would let this
  * best-effort sweep `rm -rf` a live agent's scratch out from under it. Those dirs are reclaimed
  * precisely by `removeWorktreeScratch` on archival, when the session is known to be finished.
  */
-const REGENERABLE_CACHE = /^(bunx-|fallow-|agent-browser-)/;
+const REGENERABLE_CACHE =
+  /^(bunx-|fallow-|agent-browser-|shepherd-test-run-|\.?org\.chromium\.Chromium\.|playwright_|playwright-artifacts-)/;
 
 /**
  * Name prefix for fallow's audit-base worktree caches: `fallow-audit-base-cache-<srcHash>-<shaHash>`.
@@ -457,17 +674,45 @@ function resolveSweepRoots(root: string, nestedName: string, explicitRoot: boole
   ];
 }
 
+/** One pressure-gated pass over the sweep roots. `forced` skips the gate entirely (and measures
+ *  nothing). Returns what was removed plus the per-root reasons, split into roots that acted and
+ *  roots that declined, so the caller can report both without re-deriving them. */
+async function sweepGatedRoots(
+  sweepRoots: string[],
+  forced: boolean,
+  thresholdPct: number,
+  ctx: SweepCtx,
+): Promise<{ removed: number; acted: string[]; gated: string[] }> {
+  let removed = 0;
+  const acted: string[] = [];
+  const gated: string[] = [];
+  for (const dir of sweepRoots) {
+    if (!forced) {
+      const { act, reason } = await tmpPressure(dir, { thresholdPct, ops: ctx.ops });
+      (act ? acted : gated).push(reason);
+      if (!act) continue;
+    }
+    removed += await sweepDir(dir, ctx);
+  }
+  return { removed, acted, gated };
+}
+
 /**
  * Threshold-gated inode guard. TOTAL by contract: it NEVER throws or rejects — any
  * unexpected error resolves to `{ swept:false, reason:"error", removed:0 }` after logging,
  * so a caller can fire-and-forget it on a timer without a guard.
  *
- * `thresholdPct <= 0` FORCES a sweep: the gate is skipped entirely (no `statfs` call), so neither
- * `inodeUsePct` failure reason can silently suppress an explicitly-requested sweep. That path
+ * `thresholdPct <= 0` FORCES a sweep: the gate is skipped entirely (no `statfs` call), so no
+ * unreadable-pressure reason can silently suppress an explicitly-requested sweep. That path
  * reports `reason: "swept forced (gate bypassed)"` — there is no measured use% to quote.
  *
- * Otherwise only sweeps once inode use ≥ `thresholdPct`; below that it removes NOTHING. When it does
- * sweep, it walks `root` and the nested `root/claude-$uid`, removing `node-compile-cache`
+ * Otherwise the gate is evaluated PER ROOT (`tmpPressure`) and only the pressured roots are swept;
+ * an unpressured root in the same pass is left untouched. Gating once on `root` alone was wrong on
+ * any host with a disk-backed `TMPDIR` (#1862): in production `root` is
+ * `<agentTmpDir()>/claude-$uid`, holding only session scratch, while the caches this sweep exists
+ * to reclaim pile up in the BARE `agentTmpDir()` beside it — so the single reading reported a quiet
+ * root and the sweep never ran. When it does sweep, it walks `root` and the nested
+ * `root/claude-$uid`, removing `node-compile-cache`
  * wholesale (pure cache) and age-gating known regenerable tool caches (see `REGENERABLE_CACHE`),
  * while LEAVING per-session/unknown scratch in place, the nested scratch dir itself (its
  * children are swept when it is the sweep root), and every root dir itself. Age-gating is
@@ -490,44 +735,36 @@ export async function sweepClaudeTmp(opts?: SweepOpts): Promise<SweepResult> {
       rm: fsp.rm,
       unlink: fsp.unlink,
       rmdir: fsp.rmdir,
+      opendir: fsp.opendir,
     };
-
-    // FORCED sweep (#1862): `thresholdPct <= 0` means "sweep unconditionally" — the operator's
-    // one-click Doctor fix passes 0 for exactly that. Without this branch the gate below still
-    // bails on BOTH `inodeUsePct` failure reasons ("statfs-unavailable" — including a btrfs tmp
-    // reporting `files: 0` — and "root-missing" on a host whose claude root doesn't exist yet),
-    // because those return before the threshold is ever compared. The fix would silently do
-    // nothing on precisely those hosts. A 0% threshold has no other coherent meaning, so this
-    // makes the existing contract explicit; every threshold >= 1 keeps today's fail-open path
-    // byte-for-byte. `statfs` is not called at all here, so no use% exists to report — the reason
-    // string says so rather than formatting a figure that was never measured.
-    let gateReason = "swept forced (gate bypassed)";
-    if (thresholdPct > 0) {
-      const usePct = await inodeUsePct(root, ops.statfs, log);
-      if (typeof usePct === "string") {
-        return { swept: false, reason: usePct, removed: 0 };
-      }
-
-      if (usePct < thresholdPct) {
-        return {
-          swept: false,
-          reason: `below-threshold ${usePct.toFixed(1)}%`,
-          removed: 0,
-        };
-      }
-      gateReason = `swept ${usePct.toFixed(1)}% inode use`;
-    }
 
     const nestedName = `claude-${uid()}`;
     const ctx: SweepCtx = { ops, now, staleMs, nestedName, log };
     const sweepRoots = resolveSweepRoots(root, nestedName, opts?.root !== undefined);
 
-    let removed = 0;
-    for (const dir of sweepRoots) removed += await sweepDir(dir, ctx);
+    // FORCED sweep (#1862): `thresholdPct <= 0` means "sweep unconditionally" — the operator's
+    // one-click Doctor fix passes 0 for exactly that. Without this branch an unreadable gate
+    // ("statfs-unavailable", or "root-missing" on a host whose claude root doesn't exist yet)
+    // would silently suppress an explicitly-requested sweep. A 0% threshold has no other coherent
+    // meaning. No pressure is measured at all here, so the reason string says so rather than
+    // formatting a figure that was never taken.
+    const forced = thresholdPct <= 0;
+    const { removed, acted, gated } = await sweepGatedRoots(sweepRoots, forced, thresholdPct, ctx);
+
+    // Every root declined ⇒ nothing was swept. Report the roots' own reasons rather than a single
+    // invented one: on a mixed host they differ (a below-threshold tmpfs beside an unreadable
+    // disk root), and collapsing them hides which reading actually held the sweep back.
+    if (!forced && gated.length === sweepRoots.length) {
+      return { swept: false, reason: [...new Set(gated)].join("; "), removed: 0 };
+    }
 
     return {
       swept: true,
-      reason: gateReason,
+      // Keep the MEASUREMENT in the line, not just a root tally: "swept 1/2 root(s)" alone would
+      // drop the one fact an operator reading the log needs — what the pressure actually was.
+      reason: forced
+        ? "swept forced (gate bypassed)"
+        : `swept ${acted.length}/${sweepRoots.length} root(s): ${[...new Set(acted)].join("; ")}`,
       removed,
     };
   } catch (err) {
@@ -582,26 +819,57 @@ interface ReapFallowCtx {
   log: (msg: string) => void;
 }
 
+/** Sidecar files fallow writes beside each audit-base cache dir. Removed WITH their dir, and —
+ *  when the dir is already gone — age-gate-removed on their own (see `reapOrphanSidecar`). */
+const FALLOW_SIDECARS = [".lock", ".last-used", ".sha"];
+
 /**
- * Handles ONE fallow-cache directory entry. Skips sidecar files (`.lock`/`.last-used` —
- * cleaned up alongside their parent) and any name not starting with `FALLOW_CACHE_PREFIX`.
- * For eligible entries: stats the path, age-gates via `removeIfStale`, and on removal
- * best-effort removes `${p}.lock` and `${p}.last-used`. Per-entry try/catch — never
- * aborts the pass, never rejects. Returns 1 if the dir was removed, 0 otherwise.
+ * Age-gate-remove a sidecar whose cache dir NO LONGER EXISTS. A sidecar with a live dir is left
+ * alone — it is removed alongside that dir. Without this an interrupted/externally-removed cache
+ * leaves its sidecars behind permanently: they never match the dir path the reaper stats (157 such
+ * orphans observed while diagnosing #1862). Fail-closed: any stat error counts as 0.
+ */
+async function reapOrphanSidecar(
+  sidecar: string,
+  dir: string,
+  ctx: ReapFallowCtx,
+): Promise<number> {
+  try {
+    await ctx.ops.stat(dir);
+    return 0; // dir still there — the dir pass owns this sidecar
+  } catch {
+    /* dir gone ⇒ orphan */
+  }
+  try {
+    return await removeIfStale(sidecar, await ctx.ops.stat(sidecar), ctx);
+  } catch (err) {
+    ctx.log(`[tmp-sweep] fallow sidecar reap failed for ${sidecar}: ${String(err)}`);
+    return 0;
+  }
+}
+
+/**
+ * Handles ONE fallow-cache entry. A sidecar file is reaped only when orphaned; any name not
+ * starting with `FALLOW_CACHE_PREFIX` is skipped. For a cache dir: stats the path, age-gates via
+ * `removeIfStale`, and on removal best-effort removes each `FALLOW_SIDECARS` file beside it.
+ * Per-entry try/catch — never aborts the pass, never rejects. Returns the number of entries
+ * removed (the dir counts as 1; its sidecars are not counted separately).
  */
 async function reapFallowEntry(root: string, ent: Dirent, ctx: ReapFallowCtx): Promise<number> {
-  // Skip sidecar files (.lock / .last-used) — cleaned up with their parent dir.
   if (!ent.name.startsWith(FALLOW_CACHE_PREFIX)) return 0;
-  if (ent.name.endsWith(".lock") || ent.name.endsWith(".last-used")) return 0;
 
   const p = join(root, ent.name);
+  const suffix = FALLOW_SIDECARS.find((s) => ent.name.endsWith(s));
+  if (suffix) return reapOrphanSidecar(p, p.slice(0, -suffix.length), ctx);
+
   try {
     const st = await ctx.ops.stat(p);
     const wasRemoved = await removeIfStale(p, st, ctx);
     if (wasRemoved) {
       // Best-effort removal of sidecars; ignore individual failures.
-      await ctx.ops.rm(`${p}.lock`, { recursive: false, force: true }).catch(() => {});
-      await ctx.ops.rm(`${p}.last-used`, { recursive: false, force: true }).catch(() => {});
+      for (const s of FALLOW_SIDECARS) {
+        await ctx.ops.rm(`${p}${s}`, { recursive: false, force: true }).catch(() => {});
+      }
       return 1;
     }
     return 0;
@@ -634,10 +902,10 @@ async function reapFallowRoot(root: string, ctx: ReapFallowCtx): Promise<number>
  *
  * Scans the deduped set of roots `[claudeTmpRoot(), join(claudeTmpRoot(), "claude-"+uid()),
  * tmpdir()]` (the third catches caches whose `TMPDIR` was the bare system `/tmp`). Only considers
- * entries whose name starts with `FALLOW_CACHE_PREFIX`; ignores `.lock`/`.last-used` sidecar
- * files (they are cleaned up alongside their parent dir). For each stale cache dir it removes the
- * dir AND `${dir}.lock` AND `${dir}.last-used`. Per-entry try/catch — never aborts the pass,
- * never rejects. Returns `{ removed }`.
+ * entries whose name starts with `FALLOW_CACHE_PREFIX`. For each stale cache dir it removes the
+ * dir and every `FALLOW_SIDECARS` file beside it; a sidecar whose dir is already gone is
+ * age-gate-removed on its own. Per-entry try/catch — never aborts the pass, never rejects.
+ * Returns `{ removed }` — entries removed, dirs and orphaned sidecars alike.
  */
 export async function reapFallowCaches(opts?: ReapFallowOpts): Promise<ReapFallowResult> {
   const log = opts?.log ?? console.warn;
@@ -701,7 +969,9 @@ export interface ReapWorktreesOpts {
   /** A RESOLVED snapshot of same-uid process cwds (from `liveProcCwds()`), taken by the
    *  caller so the synchronous `/proc` scan stays out of this async module. */
   liveCwds?: string[];
-  /** Tmp roots a candidate must live under to be eligible. Default `[claudeTmpRoot(), tmpdir()]`. */
+  /** Tmp roots a candidate must live under to be eligible. Default: the roots the sweep visits
+   *  (`sweptRoots()`) plus the bare `tmpdir()`. Must include the BARE `agentTmpDir()`, not just
+   *  `claudeTmpRoot()`: post-#1875 an agent's `git worktree add "$TMPDIR/x"` lands there (#1862). */
   tmpRoots?: string[];
   thresholdPct?: number;
   staleMs?: number;
@@ -710,7 +980,7 @@ export interface ReapWorktreesOpts {
   execGit?: ExecGit;
   realpath?: (p: string) => Promise<string>;
   statfs?: FsOps["statfs"];
-  fsOps?: Pick<FsOps, "readdir" | "stat">;
+  fsOps?: Pick<FsOps, "readdir" | "stat" | "opendir">;
   /** Injectable removal (default `git worktree remove`, no `--force` — cleanliness proven). */
   removeWorktree?: (repo: string, worktreePath: string) => Promise<void>;
 }
@@ -726,6 +996,7 @@ interface WorktreeCandidate {
   repo: string;
   path: string; // git-registered path
   real: string; // realpath-resolved (implies on-disk: realpath threw ⇒ not a candidate)
+  root: string; // the MOST SPECIFIC tmp root it lives under — whose pressure gates its removal
   locked: boolean;
   bare: boolean;
   prunable: boolean;
@@ -909,12 +1180,19 @@ async function discoverTmpWorktreeCandidates(ctx: {
       } catch {
         continue;
       }
-      if (!ctx.tmpRoots.some((r) => isUnder(real, r)) || seen.has(real)) continue;
+      // Most specific (longest) containing root wins: the roots nest
+      // (`<agentTmpDir()>/claude-$uid` inside `agentTmpDir()`), and a candidate's removal should be
+      // justified by the pressure of the directory it is actually piling up in, not its parent's.
+      const root = ctx.tmpRoots
+        .filter((r) => isUnder(real, r))
+        .sort((a, b) => b.length - a.length)[0];
+      if (root === undefined || seen.has(real)) continue;
       seen.add(real);
       candidates.push({
         repo,
         path: e.path,
         real,
+        root,
         locked: e.locked,
         bare: e.bare,
         prunable: e.prunable,
@@ -925,10 +1203,10 @@ async function discoverTmpWorktreeCandidates(ctx: {
 }
 
 /** Apply refusals to each candidate and reap those with a live justification. Returns the count
- *  removed. `canRemove` folds the git-floor + inode-pressure gate: false ⇒ discover-only. */
+ *  removed. `canRemove` folds the git-floor + PER-ROOT pressure gate: false ⇒ discover-only. */
 async function reapCandidates(
   candidates: WorktreeCandidate[],
-  canRemove: boolean,
+  canRemove: (c: WorktreeCandidate) => boolean,
   refusalCtx: Parameters<typeof worktreeRefusal>[1],
   removeWorktree: (repo: string, worktreePath: string) => Promise<void>,
   log: (msg: string) => void,
@@ -940,7 +1218,7 @@ async function reapCandidates(
       log(`[tmp-sweep] keep worktree ${c.real}: ${reason}`);
       continue;
     }
-    if (!canRemove) continue; // reapable but no live justification to act
+    if (!canRemove(c)) continue; // reapable but no live justification to act
     try {
       await removeWorktree(c.repo, c.path);
       reaped += 1;
@@ -950,6 +1228,23 @@ async function reapCandidates(
     }
   }
   return reaped;
+}
+
+/** Resolve each root's pressure once, logging the ones that decline. Keyed by the SAME resolved
+ *  root strings a candidate is attributed to, so the lookup cannot silently miss. */
+async function pressureByRoot(
+  roots: string[],
+  thresholdPct: number,
+  ops: Partial<PressureOps>,
+  log: (msg: string) => void,
+): Promise<Map<string, boolean>> {
+  const pressured = new Map<string, boolean>();
+  for (const root of roots) {
+    const { act, reason } = await tmpPressure(root, { thresholdPct, ops });
+    pressured.set(root, act);
+    if (!act) log(`[tmp-sweep] worktree reap: no pressure under ${root} (${reason})`);
+  }
+  return pressured;
 }
 
 /**
@@ -981,7 +1276,7 @@ export async function reapAbandonedWorktrees(
       ((repo: string, wt: string) => execGit(repo, ["worktree", "remove", wt]).then(() => {}));
 
     const [tmpRoots, liveWorktreePaths, liveCwds] = await Promise.all([
-      resolveAllRealpaths(opts.tmpRoots ?? [claudeTmpRoot(), tmpdir()], realpath),
+      resolveAllRealpaths(opts.tmpRoots ?? [...sweptRoots(), tmpdir()], realpath),
       resolveAllRealpaths(opts.liveWorktreePaths ?? [], realpath),
       resolveAllRealpaths(opts.liveCwds ?? [], realpath),
     ]);
@@ -991,8 +1286,15 @@ export async function reapAbandonedWorktrees(
     // discover (so `retained` reflects reality and the store skips) but never remove.
     const gitOk = await gitMeetsFloor(execGit, firstRepo);
     if (!gitOk) log("[tmp-sweep] worktree reap: git < 2.38 or unreadable — discovering only");
-    const usePct = await inodeUsePct(tmpdir(), statfs, log);
-    const pressureOk = typeof usePct === "number" && usePct >= thresholdPct;
+
+    // PER-ROOT pressure (#1862): reading it once off `tmpdir()` let a quiet tmpfs veto reclaim on
+    // a pressured disk root — and post-#1875 the disk root is where agents actually write.
+    const pressured = await pressureByRoot(
+      tmpRoots,
+      thresholdPct,
+      { statfs, opendir: opts.fsOps?.opendir },
+      log,
+    );
 
     const candidates = await discoverTmpWorktreeCandidates({
       repoPaths: opts.repoPaths,
@@ -1005,7 +1307,7 @@ export async function reapAbandonedWorktrees(
     const refusalCtx = { liveWorktreePaths, liveCwds, cutoff, execGit, readdir, stat };
     const reaped = await reapCandidates(
       candidates,
-      gitOk && pressureOk,
+      (c) => gitOk && (pressured.get(c.root) ?? false),
       refusalCtx,
       removeWorktree,
       log,
@@ -1158,15 +1460,26 @@ async function reclaimContentDir(
 }
 
 export interface ReclaimStoreOpts {
-  /** The forked store root. Default `<tmpdir>/.pnpm-store` — the only name allowed to reach
-   *  bare `tmpdir()`. A wrong mount root just yields a missing dir → safe skip. */
-  storeRoot?: string;
+  /** The forked store roots. Default: `.pnpm-store` under each of `tmpdir()` and (when enabled)
+   *  the bare `agentTmpDir()` — the only names allowed to reach those bare roots. pnpm forks its
+   *  store beside the install to stay same-filesystem, so post-#1875 a trusted agent's install
+   *  forks it on DISK, which the tmpfs-only default never reclaimed (#1862). A wrong root just
+   *  yields a missing dir → safe skip. */
+  storeRoots?: string[];
   thresholdPct?: number;
   staleMs?: number;
   now?: number;
   statfs?: FsOps["statfs"];
-  fsOps?: Pick<FsOps, "readdir" | "stat" | "unlink" | "rmdir">;
+  fsOps?: Pick<FsOps, "readdir" | "stat" | "unlink" | "rmdir" | "opendir">;
   log?: (msg: string) => void;
+}
+
+/** Default store roots: `.pnpm-store` under the tmpfs and the disk agent tmp root, deduped. */
+function defaultStoreRoots(): string[] {
+  const agentTmp = agentTmpDir();
+  return [...new Set([tmpdir(), ...(agentTmp ? [agentTmp] : [])])].map((r) =>
+    join(r, ".pnpm-store"),
+  );
 }
 
 export interface ReclaimStoreResult {
@@ -1174,8 +1487,9 @@ export interface ReclaimStoreResult {
   freedFiles: number;
   /** Bucket dirs pruned after emptying out. */
   freedDirs: number;
-  /** A whole-store skip reason (`below-threshold …`, `no-store`, `sibling-fresh …`, …), or
-   *  `reclaimed` when the per-file pass ran (freed counts carry the detail). */
+  /** The per-store-root outcomes, deduped and joined: a skip reason (`below-threshold …`,
+   *  `no-store`, `sibling-fresh …`, …) for each root that was skipped, and `reclaimed` for each
+   *  root whose per-file pass ran (the freed counts carry the detail). */
   reason: string;
 }
 
@@ -1237,40 +1551,56 @@ export async function reclaimForkedPnpmStore(opts: ReclaimStoreOpts): Promise<Re
   const log = opts.log ?? console.warn;
   const c: ReclaimCounters = { freedFiles: 0, freedDirs: 0 };
   try {
-    const storeRoot = opts.storeRoot ?? join(tmpdir(), ".pnpm-store");
+    const storeRoots = opts.storeRoots ?? defaultStoreRoots();
     const { cutoff, thresholdPct } = resolveTmpGate(opts);
-    const readdir = opts.fsOps?.readdir ?? fsp.readdir;
-    const stat = opts.fsOps?.stat ?? fsp.stat;
-    const unlink = opts.fsOps?.unlink ?? fsp.unlink;
-    const rmdir = opts.fsOps?.rmdir ?? fsp.rmdir;
-    const statfs = opts.statfs ?? fsp.statfs;
+    const ops: ContentOps = {
+      readdir: opts.fsOps?.readdir ?? fsp.readdir,
+      stat: opts.fsOps?.stat ?? fsp.stat,
+      unlink: opts.fsOps?.unlink ?? fsp.unlink,
+      rmdir: opts.fsOps?.rmdir ?? fsp.rmdir,
+    };
+    const pressureOps = { statfs: opts.statfs ?? fsp.statfs, opendir: opts.fsOps?.opendir };
 
-    const usePct = await inodeUsePct(tmpdir(), statfs, log);
-    if (typeof usePct === "string") return { ...c, reason: usePct };
-    if (usePct < thresholdPct) {
-      return { ...c, reason: `below-threshold ${usePct.toFixed(1)}%` };
+    const reasons: string[] = [];
+    for (const storeRoot of storeRoots) {
+      // Gate on the pressure of the store's OWN parent, not a fixed `tmpdir()`: a quiet tmpfs must
+      // not veto reclaiming a store that forked onto a pressured disk root, or vice versa (#1862).
+      const { act, reason } = await tmpPressure(dirname(storeRoot), {
+        thresholdPct,
+        ops: pressureOps,
+      });
+      reasons.push(act ? await reclaimOneStore(storeRoot, cutoff, ops, c, log) : reason);
     }
-
-    let rootEntries: Dirent[];
-    try {
-      rootEntries = (await readdir(storeRoot, { withFileTypes: true })) as Dirent[];
-    } catch {
-      return { ...c, reason: "no-store" };
-    }
-
-    const versionDirs = resolveStoreVersionDirs(rootEntries);
-    if (versionDirs.length === 0) return { ...c, reason: "no-version-dir" };
-
-    const sibling = await siblingBlocker(rootEntries, storeRoot, cutoff, stat);
-    if (sibling) return { ...c, reason: sibling };
-
-    const contentOps: ContentOps = { readdir, stat, unlink, rmdir };
-    await reclaimIdleVersionDirs(storeRoot, versionDirs, cutoff, contentOps, c, log);
-    return { ...c, reason: "reclaimed" };
+    return { ...c, reason: [...new Set(reasons)].join("; ") || "no-store-root" };
   } catch (err) {
     log(`[tmp-sweep] store reclaim unexpected error: ${String(err)}`);
     return { ...c, reason: "error" };
   }
+}
+
+/** Partial-reclaim ONE forked store root, accumulating into `c`. Returns its skip/act reason. */
+async function reclaimOneStore(
+  storeRoot: string,
+  cutoff: number,
+  ops: ContentOps,
+  c: ReclaimCounters,
+  log: (msg: string) => void,
+): Promise<string> {
+  let rootEntries: Dirent[];
+  try {
+    rootEntries = (await ops.readdir(storeRoot, { withFileTypes: true })) as Dirent[];
+  } catch {
+    return "no-store";
+  }
+
+  const versionDirs = resolveStoreVersionDirs(rootEntries);
+  if (versionDirs.length === 0) return "no-version-dir";
+
+  const sibling = await siblingBlocker(rootEntries, storeRoot, cutoff, ops.stat);
+  if (sibling) return sibling;
+
+  await reclaimIdleVersionDirs(storeRoot, versionDirs, cutoff, ops, c, log);
+  return "reclaimed";
 }
 
 interface PruneOpts {

--- a/src/tmp-sweep.ts
+++ b/src/tmp-sweep.ts
@@ -507,9 +507,12 @@ export function tmpEntryBands(): { warnEntries: number; errorEntries: number } {
 
 /**
  * The roots a default (production) sweep visits — the bare disk `agentTmpDir()`, the claude root
- * and its nested `claude-$uid`, and the legacy tmpfs pair. Shared by `readTmpPressureSignal` and
- * the worktree reaper so both act on exactly the set `sweepClaudeTmp` does, rather than on a
- * filesystem the sweeper never touches.
+ * and its nested `claude-$uid`, and the legacy tmpfs pair. The worktree reaper's default root set,
+ * so it reclaims across exactly what `sweepClaudeTmp` walks rather than a filesystem the sweeper
+ * never touches.
+ *
+ * NOT what the `tmp_inodes` Diagnose row reads — that is the narrower `diagnosedRoots()`, which
+ * excludes the session-scratch roots a sweep cannot reclaim. See its doc for why the two differ.
  */
 function sweptRoots(): string[] {
   return resolveSweepRoots(claudeTmpRoot(), `claude-${uid()}`, false);
@@ -583,12 +586,13 @@ function severityOf(
 }
 
 /**
- * The worst pressure signal across the roots the sweeper actually visits — the value behind the
- * `tmp_inodes` Diagnose row.
+ * The worst pressure signal across `diagnosedRoots()` — the value behind the `tmp_inodes` Diagnose
+ * row.
  *
  * Post-#1875 no single path answers this. Trusted agents write to the disk `agentTmpDir()`, while
  * the tmpfs `tmpdir()` is still real for sandboxed spawns and tools that hardcode `/tmp`; reading
- * only one reports a healthy filesystem while the other fills. Roots that cannot be measured are
+ * only one reports a healthy filesystem while the other fills. "Worst" is ranked by the STATE each
+ * reading classifies to (see `severityOf`), never by a raw ratio. Roots that cannot be measured are
  * skipped rather than allowed to mask a measurable one; `uninspectable` is returned only when NO
  * root could be read.
  *

--- a/src/tmp-sweep.ts
+++ b/src/tmp-sweep.ts
@@ -456,9 +456,10 @@ const DEFAULT_TMP_INODE_PCT = 80;
  * symmetric: 80% of a tmpfs means the host is near death, whereas crossing this only enables the
  * EXISTING age-gated sweep of ALLOWLISTED names and arms reclaimers that are independently walled
  * by their own refusals. Measured while diagnosing #1862: a healthy bare agent tmp root sits in the
- * tens, a normal `claude-$uid` session-scratch root at ~2,900 — which is excluded from removal by
- * name, so sitting permanently above this line changes nothing there — and the leaking root at
- * 119,640.
+ * tens, a normal `claude-$uid` session-scratch root at ~2,900, and the leaking root at 119,640. The
+ * scratch root sitting permanently above this line is inert: its contents match nothing the sweep
+ * will remove, and `diagnosedRoots()` keeps it out of the Diagnose row so it cannot raise an alarm
+ * no Fix could clear.
  */
 const DEFAULT_TMP_ENTRY_LIMIT = 1000;
 
@@ -514,15 +515,71 @@ function sweptRoots(): string[] {
   return resolveSweepRoots(claudeTmpRoot(), `claude-${uid()}`, false);
 }
 
-/** How bad a signal is, normalised against its own error band, for picking the worst root.
- *  `uninspectable` sorts below every real reading so one unreadable root cannot mask a real one. */
-function severityRatio(
+/**
+ * The roots the `tmp_inodes` Diagnose row measures. Deliberately NOT `sweptRoots()`.
+ *
+ * A swept root also includes the SESSION-SCRATCH roots — `claudeTmpRoot()` and its nested
+ * `claude-$uid`, plus the legacy pair. Their contents are the dashified per-worktree dirs, which
+ * match nothing in `REGENERABLE_CACHE` by design (a live long-running session leaves a stale
+ * top-level mtime, so a coarse age check would delete a running agent's scratch) and are reclaimed
+ * only by `removeWorktreeScratch` at archival. Counting them would put the row permanently at
+ * `warning` on a healthy host — 2,902 such dirs were measured on one while diagnosing #1862 — with
+ * a Fix button whose forced sweep cannot remove a single one of them. An alarm no action can clear
+ * is exactly the trap `tmpInodeBands` already documents for the percentage knob.
+ *
+ * So the row watches the two roots whose pressure a sweep CAN act on:
+ *  - the bare disk `agentTmpDir()` — where the regenerable tool caches accumulate; and
+ *  - `tmpdir()` — the tmpfs, still real for sandboxed spawns and tools that hardcode `/tmp`.
+ *
+ * Nothing is lost by dropping the nested roots: each sits on the same filesystem as a root that
+ * remains, so the inode percentage is identical, and `tmpdir()` is always present (unlike
+ * `<tmpdir>/claude-$uid` on a freshly booted host — the #1876 rationale, restored).
+ *
+ * Session-scratch accumulation is a real signal, but it needs a different remedy and different
+ * copy than this row offers; it is tracked separately in #2304.
+ */
+function diagnosedRoots(): string[] {
+  const agentTmp = agentTmpDir();
+  return [...new Set([...(agentTmp ? [agentTmp] : []), tmpdir()])];
+}
+
+/** Bands for both signals, as `classifyTmpInodes` applies them. */
+interface PressureBands {
+  warnPct: number;
+  errorPct: number;
+  warnEntries: number;
+  errorEntries: number;
+}
+
+/**
+ * How bad a signal is, for picking the worst root. Ordered by the STATE it will classify to
+ * FIRST, and only then by how deep into that state it sits.
+ *
+ * Ranking on a normalised ratio alone is wrong ACROSS KINDS, because warn sits at a different
+ * fraction of error in each: 80/95 = 0.84 for the percentage, 1000/10000 = 0.10 for the entry
+ * count. A quiet `/tmp` at 70% (`ok`, ratio 0.74) would then outrank an agent tmp root at 1,500
+ * entries (`warning`, ratio 0.15) and the row would report the healthy one — the exact masking
+ * this function exists to prevent. `ratio` is kept only to break ties WITHIN a state, where both
+ * candidates classify the same and it is a meaningful "how far in".
+ *
+ * `uninspectable` sorts below every real reading, so one unreadable root cannot mask a real one.
+ */
+function severityOf(
   signal: TmpPressureSignal,
-  bands: { errorPct: number; errorEntries: number },
-): number {
-  if (signal.kind === "inode-pct") return signal.usePct / bands.errorPct;
-  if (signal.kind === "entry-count") return signal.entries / bands.errorEntries;
-  return -1;
+  bands: PressureBands,
+): { rank: number; ratio: number } {
+  const [value, warn, error] =
+    signal.kind === "inode-pct"
+      ? [signal.usePct, bands.warnPct, bands.errorPct]
+      : signal.kind === "entry-count"
+        ? [signal.entries, bands.warnEntries, bands.errorEntries]
+        : [null, 0, 0];
+
+  if (value === null) return { rank: -1, ratio: 0 };
+  // Thresholds are `>=`, matching `classifyTmpInodes` exactly: a rank that disagreed with the
+  // classifier would reintroduce the same masking by a different route.
+  const rank = value >= error ? 2 : value >= warn ? 1 : 0;
+  return { rank, ratio: value / error };
 }
 
 /**
@@ -542,14 +599,16 @@ export async function readTmpPressureSignal(opts?: {
   roots?: string[];
   ops?: Partial<PressureOps>;
 }): Promise<TmpPressureSignal> {
-  const roots = opts?.roots ?? sweptRoots();
+  const roots = opts?.roots ?? diagnosedRoots();
   const bands = { ...tmpInodeBands(), ...tmpEntryBands() };
   let worst: TmpPressureSignal = { kind: "uninspectable", why: "no-root-readable" };
+  let worstRank = -Infinity;
   let worstRatio = -Infinity;
   for (const root of roots) {
     const { signal } = await tmpPressure(root, { ops: opts?.ops });
-    const ratio = severityRatio(signal, bands);
-    if (ratio > worstRatio) {
+    const { rank, ratio } = severityOf(signal, bands);
+    if (rank > worstRank || (rank === worstRank && ratio > worstRatio)) {
+      worstRank = rank;
       worstRatio = ratio;
       worst = signal;
     }

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -119,7 +119,13 @@ function healthyDeps(): DiagnosticsDeps {
     // tmp_inodes (#1862): a roomy temp filesystem → ok. Injected because the default statfs's the
     // REAL tmpdir(), whose inode use varies by host — without pinning it, every all-ok/overall
     // assertion here would flip on a machine whose /tmp happens to be under pressure.
-    readTmpInodes: async () => ({ usePct: 12, warnPct: 80, errorPct: 95 }),
+    readTmpInodes: async () => ({
+      signal: { kind: "inode-pct" as const, usePct: 12 },
+      warnPct: 80,
+      errorPct: 95,
+      warnEntries: 1000,
+      errorEntries: 10000,
+    }),
     // preview_probes (#1912): backend healthy + cell fresh → ok. Pinned so the row is
     // deterministic regardless of the test host's real /proc/lsof state.
     runPreviewProbe: async () => "ok",
@@ -2197,11 +2203,21 @@ describe("codex_model_auth advisory", () => {
 describe("classifyTmpInodes", () => {
   // Bands are PASSED, never read from env here — that is the whole point of the parameterisation:
   // the row must warn at exactly the point `SHEPHERD_TMP_INODE_PCT` makes the sweeper act.
-  const facts = (usePct: number | null, warnPct = 80, errorPct = 95) => ({
-    usePct,
+  const bands = { warnPct: 80, errorPct: 95, warnEntries: 1000, errorEntries: 10000 };
+  const facts = (usePct: number, warnPct = 80, errorPct = 95) => ({
+    ...bands,
+    signal: { kind: "inode-pct" as const, usePct },
     warnPct,
     errorPct,
   });
+  /** The entry-count signal, used where a filesystem allocates inodes dynamically (#1862). */
+  const entryFacts = (entries: number, warnEntries = 1000, errorEntries = 10000) => ({
+    ...bands,
+    signal: { kind: "entry-count" as const, entries, limit: warnEntries, atCap: false },
+    warnEntries,
+    errorEntries,
+  });
+  const unreadable = { ...bands, signal: { kind: "uninspectable" as const, why: "root-missing" } };
 
   it("below the warning band → ok", () => {
     const c = classifyTmpInodes(facts(46));
@@ -2232,10 +2248,10 @@ describe("classifyTmpInodes", () => {
     expect(classifyTmpInodes(facts(92, 90)).state).toBe("warning");
   });
 
-  it("null use% → optional/uninspectable, never a pip degrade and never a fix", () => {
-    // Covers BOTH read failures: statfs absent (non-Linux), and a btrfs tmp reporting files: 0
-    // (it allocates inodes dynamically, so a percentage would be meaningless).
-    const c = classifyTmpInodes(facts(null));
+  it("an unmeasurable root → optional/uninspectable, never a pip degrade and never a fix", () => {
+    // statfs absent (non-Linux), an absent root, or an unreadable directory: nothing to report.
+    // A btrfs tmp reporting `files: 0` is NOT this case any more — it yields an entry count.
+    const c = classifyTmpInodes(unreadable);
     expect(c).toEqual({
       id: "tmp_inodes",
       state: "optional",
@@ -2243,13 +2259,52 @@ describe("classifyTmpInodes", () => {
     });
     expect(c.fixActionKey).toBeUndefined();
   });
+
+  // #1862: on btrfs/XFS/ZFS there is no inode ceiling, so the row bands an accumulated ENTRY
+  // COUNT instead — and says so in its own copy, since "plenty of inodes free" is not a true
+  // statement about a filesystem that has no inode table to be free of.
+  it("entry-count signal bands on the entry limit, with its own hint copy", () => {
+    expect(classifyTmpInodes(entryFacts(12))).toEqual({
+      id: "tmp_inodes",
+      state: "ok",
+      hintKey: "diagnostics_hint_tmp_entries_ok",
+    });
+
+    const warn = classifyTmpInodes(entryFacts(1000));
+    expect(warn.state).toBe("warning");
+    expect(warn.hintKey).toBe("diagnostics_hint_tmp_entries_high");
+    expect(warn.fixActionKey).toBe("diagnostics_fix_action_tmp_inodes");
+
+    const err = classifyTmpInodes(entryFacts(24158));
+    expect(err.state).toBe("error");
+    expect(err.hintKey).toBe("diagnostics_hint_tmp_entries_critical");
+    expect(err.fixActionKey).toBe("diagnostics_fix_action_tmp_inodes");
+  });
+
+  it("a raised SHEPHERD_TMP_ENTRY_LIMIT moves the entry-count warning boundary", () => {
+    expect(classifyTmpInodes(entryFacts(1500, 1000)).state).toBe("warning");
+    expect(classifyTmpInodes(entryFacts(1500, 2000, 20000)).state).toBe("ok");
+  });
+
+  it("the two signals never borrow each other's bands", () => {
+    // 90 entries is healthy; 90% inode use is a warning. Same number, opposite verdicts — a
+    // regression here would mean one signal is being classified against the other's thresholds.
+    expect(classifyTmpInodes(entryFacts(90)).state).toBe("ok");
+    expect(classifyTmpInodes(facts(90)).state).toBe("warning");
+  });
 });
 
 describe("tmp_inodes probe + fix dispatch", () => {
   it("surfaces the row from injected facts", async () => {
     const svc = new DiagnosticsService({
       ...healthyDeps(),
-      readTmpInodes: async () => ({ usePct: 99, warnPct: 80, errorPct: 95 }),
+      readTmpInodes: async () => ({
+        signal: { kind: "inode-pct" as const, usePct: 99 },
+        warnPct: 80,
+        errorPct: 95,
+        warnEntries: 1000,
+        errorEntries: 10000,
+      }),
     });
     const checks = (await svc.check(0)).checks;
     expect(checks.find((c) => c.id === "tmp_inodes")?.state).toBe("error");
@@ -2274,7 +2329,13 @@ describe("tmp_inodes probe + fix dispatch", () => {
     let swept = 0;
     const svc = new DiagnosticsService({
       ...healthyDeps(),
-      readTmpInodes: async () => ({ usePct: 99, warnPct: 80, errorPct: 95 }),
+      readTmpInodes: async () => ({
+        signal: { kind: "inode-pct" as const, usePct: 99 },
+        warnPct: 80,
+        errorPct: 95,
+        warnEntries: 1000,
+        errorEntries: 10000,
+      }),
       runTmpSweep: async () => {
         swept += 1;
       },

--- a/test/setup-test-env.test.ts
+++ b/test/setup-test-env.test.ts
@@ -1,0 +1,29 @@
+import { test, expect, describe } from "bun:test";
+import { mkdtempSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+
+// #1862: 144 files under `test/` mkdtemp into `tmpdir()` and most never clean up, which leaked
+// ~2.0M inodes into the shared temp root. The preload (`test/setup-test-env.ts`, wired via
+// bunfig.toml) redirects the whole run into one throwaway dir it drops on exit. These assert the
+// harness itself — if the redirect silently stops working, the leak comes back unnoticed.
+describe("per-run TMPDIR", () => {
+  test("the run is redirected into its own throwaway root", () => {
+    expect(process.env.TMPDIR).toBeDefined();
+    expect(basename(process.env.TMPDIR as string)).toStartWith("shepherd-test-run-");
+    expect(existsSync(process.env.TMPDIR as string)).toBe(true);
+  });
+
+  test("os.tmpdir() follows it, so every existing mkdtemp call site relocates", () => {
+    // The load-bearing premise: `os.tmpdir()` re-reads TMPDIR per call rather than caching it at
+    // startup. Without this, redirecting the env would move nothing.
+    expect(tmpdir()).toBe(process.env.TMPDIR as string);
+    const d = mkdtempSync(join(tmpdir(), "preload-probe-"));
+    expect(d).toStartWith(process.env.TMPDIR as string);
+  });
+
+  test("TMP and TEMP agree, for tools that read those instead", () => {
+    expect(process.env.TMP).toBe(process.env.TMPDIR as string);
+    expect(process.env.TEMP).toBe(process.env.TMPDIR as string);
+  });
+});

--- a/test/setup-test-env.ts
+++ b/test/setup-test-env.ts
@@ -1,3 +1,8 @@
+import { afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 // Preloaded before any test module (bunfig.toml → [test] preload), which means it runs
 // BEFORE `src/config.ts` is first imported. That ordering is the whole point: `config` is a
 // single object literal that snapshots ~100 `SHEPHERD_*` env vars at import and never re-reads
@@ -40,3 +45,37 @@ for (const key of Object.keys(process.env)) {
 // that set `config.hooksIngest` / `config.hooksSignals` directly (service.test.ts, poller*.test.ts).
 process.env.SHEPHERD_HOOKS_INGEST = "0";
 process.env.SHEPHERD_HOOKS_SIGNALS = "0";
+
+// ── Per-run TMPDIR (#1862) ───────────────────────────────────────────────────
+//
+// 144 files under `test/` call `mkdtempSync(join(tmpdir(), …))` and most never clean up, so every
+// run leaked hundreds of dirs into the shared temp root — 119,640 entries / ~2.0M inodes had
+// accumulated on one host in 53 days, and nothing reclaimed them: the sweep's REGENERABLE_CACHE
+// allowlist matches none of those names. Before #1875 pointed agents at a disk-backed TMPDIR that
+// output went straight to the `/tmp` tmpfs, whose INODE table it is easily large enough to exhaust
+// (ENOSPC with bytes to spare — the failure #1862 reports).
+//
+// Fix the class, not the instances: point the whole run at one throwaway root and drop it at the
+// end. `os.tmpdir()` re-reads `process.env.TMPDIR` on every call, so all 518 existing call sites
+// relocate with no per-test change, and spawned child processes inherit it. TMP/TEMP are set too
+// for tools that read those instead.
+//
+// `mkdtempSync` deliberately runs BEFORE the reassignment, so the run root is created in the
+// INHERITED temp dir rather than inside itself.
+//
+// Cleanup runs from a preload-level `afterAll`, which Bun fires ONCE after the whole run. It is
+// deliberately NOT `process.on("exit")` / `"beforeExit"`: verified empirically, Bun's test runner
+// fires NEITHER from a preload, so an exit handler here is dead code that silently leaks every
+// run. A run KILLED mid-flight still leaves its root behind — `shepherd-test-run-` is in
+// `REGENERABLE_CACHE`, so the age-gated sweep reclaims those.
+const runTmpRoot = mkdtempSync(join(tmpdir(), "shepherd-test-run-"));
+process.env.TMPDIR = runTmpRoot;
+process.env.TMP = runTmpRoot;
+process.env.TEMP = runTmpRoot;
+afterAll(() => {
+  try {
+    rmSync(runTmpRoot, { recursive: true, force: true });
+  } catch {
+    /* best-effort: never fail a green run over cleanup */
+  }
+});

--- a/test/tmp-sweep.test.ts
+++ b/test/tmp-sweep.test.ts
@@ -601,6 +601,76 @@ describe("readTmpPressureSignal", () => {
     expect((signal as { usePct: number }).usePct).toBeCloseTo(99.9);
   });
 
+  // The critic's finding on #2305: ranking by a ratio normalised to each signal's ERROR band
+  // alone does not preserve STATE order across kinds, because warn sits at a different fraction
+  // of error in each (80/95 = 0.84 vs 1000/10000 = 0.10).
+  test("a warning root outranks a healthier root of the other kind", async () => {
+    // /tmp at 70% classifies `ok` but scored 0.737; the agent root at 1,500 entries classifies
+    // `warning` — 50% past the band where the sweeper acts — but scored only 0.15. The row used
+    // to report the healthy one.
+    const signal = await readTmpPressureSignal({
+      roots: ["/tmpfs", "/agent"],
+      ops: {
+        statfs: (async (p: string) =>
+          p === "/tmpfs" ? { files: 1000, ffree: 300 } : { files: 0, ffree: 0 }) as never,
+        opendir: opendirOf(1500),
+      },
+    });
+    expect(signal).toMatchObject({ kind: "entry-count", entries: 1500 });
+  });
+
+  test("within one state, the deeper reading still wins", async () => {
+    const signal = await readTmpPressureSignal({
+      roots: ["/a", "/b"],
+      ops: {
+        statfs: (async (p: string) =>
+          p === "/a" ? { files: 1000, ffree: 150 } : { files: 1000, ffree: 120 }) as never,
+        opendir: opendirOf(0),
+      },
+    });
+    // Both are `warning` (85% and 88%); the ratio breaks the tie toward the worse one.
+    expect((signal as { usePct: number }).usePct).toBeCloseTo(88);
+  });
+
+  test("an ok root of one kind still wins over an ok root of the other", async () => {
+    // Nothing is in a warning state, so the tie-break ratio decides and the row reports a real
+    // reading rather than falling through to uninspectable.
+    const signal = await readTmpPressureSignal({
+      roots: ["/tmpfs", "/agent"],
+      ops: {
+        statfs: (async (p: string) =>
+          p === "/tmpfs" ? { files: 1000, ffree: 300 } : { files: 0, ffree: 0 }) as never,
+        opendir: opendirOf(10),
+      },
+    });
+    expect(signal).toMatchObject({ kind: "inode-pct" });
+  });
+
+  // The row's Fix runs a forced sweep, which only removes ALLOWLISTED names. Session scratch
+  // matches none of them by design, so counting those roots would pin the row at `warning` on a
+  // healthy host with a button that cannot clear it.
+  test("the default roots exclude session scratch, whose contents no Fix can reclaim", async () => {
+    setEnv("SHEPHERD_AGENT_TMPDIR", "/fake/agent");
+    setEnv("SHEPHERD_TMP_SWEEP_DIR", "/fake/agent/claude-9999");
+
+    const seen: string[] = [];
+    await readTmpPressureSignal({
+      ops: {
+        statfs: (async (p: string) => {
+          seen.push(p);
+          return { files: 1000, ffree: 900 };
+        }) as never,
+        opendir: opendirOf(0),
+      },
+    });
+
+    expect(seen).toContain("/fake/agent");
+    expect(seen).toContain(tmpdir());
+    // The scratch roots the SWEEP visits must not be measured by the ROW.
+    expect(seen).not.toContain("/fake/agent/claude-9999");
+    expect(seen.some((p) => p.includes("claude-9999"))).toBe(false);
+  });
+
   test("an unreadable root never masks a measurable one", async () => {
     const signal = await readTmpPressureSignal({
       roots: ["/gone", "/real"],

--- a/test/tmp-sweep.test.ts
+++ b/test/tmp-sweep.test.ts
@@ -14,7 +14,9 @@ import {
   reapAbandonedWorktrees,
   reclaimForkedPnpmStore,
   resolveStoreVersionDirs,
-  readTmpInodeUsePct,
+  readTmpPressureSignal,
+  tmpEntryBands,
+  tmpPressure,
   tmpInodeBands,
   TMP_INODE_ERROR_PCT,
   FALLOW_CACHE_PREFIX,
@@ -329,6 +331,76 @@ describe("sweepClaudeTmp", () => {
     });
   });
 
+  // #1862 REGRESSION. The gate used to be read ONCE, off `claudeTmpRoot()`. In production that is
+  // `<agentTmpDir()>/claude-$uid` — session scratch only — while the caches this sweep reclaims
+  // pile up in the BARE `agentTmpDir()` beside it. On a filesystem with no inode ceiling the entry
+  // count is path-specific, so the single reading said "quiet" and the sweep never ran at all.
+  test("per-root gate: a root over the entry limit is swept, a quiet sibling is not", async () => {
+    setEnv("SHEPHERD_TMP_ENTRY_LIMIT", "2");
+    const root = mkTmp();
+    const nestedDir = join(root, nested);
+    mkdirSync(nestedDir);
+
+    // Stale regenerable caches in BOTH roots; only the over-limit one may be swept.
+    const loud = join(root, "bunx-1000-loud");
+    const quiet = join(nestedDir, "bunx-1000-quiet");
+    mkdirSync(loud);
+    mkdirSync(quiet);
+    const now = Date.now();
+    const old = new Date(now - 48 * 3600_000);
+    utimesSync(loud, old, old);
+    utimesSync(quiet, old, old);
+
+    const fsp = await import("node:fs/promises");
+    const res = await sweepClaudeTmp({
+      root,
+      now,
+      // files: 0 ⇒ no inode ceiling ⇒ the entry-count fallback, which is the path-specific one.
+      fsOps: {
+        statfs: fakeStatfs(0, 0),
+        readdir: fsp.readdir,
+        stat: fsp.stat,
+        rm: fsp.rm,
+        // `root` holds 2 entries (the cache + the nested dir); the nested dir holds 1.
+        opendir: fsp.opendir,
+      } as never,
+      log: () => {},
+    });
+
+    expect(res.swept).toBe(true);
+    expect(existsSync(loud)).toBe(false); // over the limit → swept
+    expect(existsSync(quiet)).toBe(true); // under it → untouched
+    expect(res.reason).toContain("1/2 root(s)");
+  });
+
+  test("every root quiet → nothing swept, and the reason names the readings", async () => {
+    setEnv("SHEPHERD_TMP_ENTRY_LIMIT", "50");
+    const root = mkTmp();
+    const stale = join(root, "bunx-1000-x");
+    mkdirSync(stale);
+    const now = Date.now();
+    const old = new Date(now - 48 * 3600_000);
+    utimesSync(stale, old, old);
+
+    const fsp = await import("node:fs/promises");
+    const res = await sweepClaudeTmp({
+      root,
+      now,
+      fsOps: {
+        statfs: fakeStatfs(0, 0),
+        readdir: fsp.readdir,
+        stat: fsp.stat,
+        rm: fsp.rm,
+        opendir: fsp.opendir,
+      } as never,
+      log: () => {},
+    });
+
+    expect(res).toMatchObject({ swept: false, removed: 0 });
+    expect(res.reason).toContain("below-entry-limit");
+    expect(existsSync(stale)).toBe(true);
+  });
+
   // Forced sweep (#1862). The Doctor row's one-click fix passes `thresholdPct: 0` to mean "sweep
   // unconditionally". Both `inodeUsePct` failure reasons return BEFORE the threshold is compared,
   // so without the bypass the fix would silently do nothing on exactly the hosts that hit them —
@@ -423,40 +495,157 @@ describe("sweepClaudeTmp", () => {
       log: () => {},
     });
     expect(swept.swept).toBe(true);
-    expect(swept.reason).toBe("swept 90.0% inode use");
+    // Per-root gating (#1862) added the root tally; the MEASUREMENT this test exists for must
+    // still be in the line, otherwise the operator log loses the only fact worth reading.
+    expect(swept.reason).toContain("90.0% inode use");
   });
 });
 
-// readTmpInodeUsePct (#1862) — the value behind the tmp_inodes Diagnose row.
-describe("readTmpInodeUsePct", () => {
-  test("statfs's tmpdir(), NOT claudeTmpRoot()", async () => {
-    // claudeTmpRoot() is <tmpdir>/claude-$uid, which does not exist on a freshly booted host — the
-    // root-missing branch would then report "uninspectable" on exactly the hosts with headroom
-    // left to protect. tmpdir() is the filesystem actually at risk and is always present.
-    const seen: string[] = [];
-    await readTmpInodeUsePct((async (p: string) => {
-      seen.push(p);
-      return { files: 1000, ffree: 100 };
-    }) as never);
-    expect(seen).toEqual([tmpdir()]);
+// ── tmpPressure (#1862) ─────────────────────────────────────────────────────────
+// The gate every consumer here reads. Its whole reason to exist is that `statfs` reporting
+// `files: 0` is an ANSWER (btrfs/XFS/ZFS allocate inodes dynamically), not a read failure — the
+// old code conflated the two and every gate fell through to "do nothing" on a disk-backed root.
+describe("tmpPressure", () => {
+  const statfsOf = (files: number, ffree: number) => (async () => ({ files, ffree })) as never;
+  /** An opendir stub yielding `n` entries, counting how many were actually consumed. */
+  const opendirOf = (n: number, consumed?: { count: number }) =>
+    (async () => ({
+      async *[Symbol.asyncIterator]() {
+        for (let i = 0; i < n; i++) {
+          if (consumed) consumed.count++;
+          yield { name: `e${i}` };
+        }
+      },
+    })) as never;
+
+  test("a real inode ceiling bands on the percentage", async () => {
+    const ops = { statfs: statfsOf(1000, 100), opendir: opendirOf(0) };
+    expect(await tmpPressure("/r", { thresholdPct: 80, ops })).toMatchObject({
+      act: true,
+      signal: { kind: "inode-pct", usePct: 90 },
+    });
+    expect(await tmpPressure("/r", { thresholdPct: 95, ops })).toMatchObject({
+      act: false,
+      signal: { kind: "inode-pct" },
+    });
   });
 
-  test("reports the use percentage", async () => {
-    const pct = await readTmpInodeUsePct((async () => ({ files: 1000, ffree: 100 })) as never);
-    expect(pct).toBeCloseTo(90);
+  test("files: 0 falls back to an entry count instead of giving up", async () => {
+    const ops = { statfs: statfsOf(0, 0), opendir: opendirOf(1500) };
+    const r = await tmpPressure("/r", { entryLimit: 1000, ops });
+    expect(r.act).toBe(true);
+    expect(r.signal).toMatchObject({ kind: "entry-count", entries: 1500, limit: 1000 });
   });
 
-  test("btrfs-style files: 0 → null, never a bogus percentage", async () => {
-    // btrfs allocates inodes dynamically and reports zero total, so a percentage is meaningless.
-    expect(await readTmpInodeUsePct((async () => ({ files: 0, ffree: 0 })) as never)).toBeNull();
+  test("below the entry limit does not act", async () => {
+    const ops = { statfs: statfsOf(0, 0), opendir: opendirOf(12) };
+    const r = await tmpPressure("/r", { entryLimit: 1000, ops });
+    expect(r.act).toBe(false);
+    expect(r.reason).toContain("below-entry-limit");
   });
 
-  test("an unreadable filesystem → null", async () => {
-    expect(
-      await readTmpInodeUsePct((async () => {
-        throw new Error("ENOENT");
-      }) as never),
-    ).toBeNull();
+  test("the entry walk stops at the cap rather than counting a 100k-entry root", async () => {
+    const consumed = { count: 0 };
+    const ops = { statfs: statfsOf(0, 0), opendir: opendirOf(1_000_000, consumed) };
+    const r = await tmpPressure("/r", { entryLimit: 10, ops });
+    expect(r.act).toBe(true);
+    expect(r.signal).toMatchObject({ kind: "entry-count", atCap: true });
+    // 10 * ENTRY_COUNT_CAP_FACTOR — bounded work, never the whole directory.
+    expect(consumed.count).toBe(100);
+  });
+
+  test("an unreadable root never acts", async () => {
+    for (const ops of [
+      { statfs: undefined as never, opendir: opendirOf(0) },
+      {
+        statfs: (async () => {
+          throw new Error("ENOENT");
+        }) as never,
+        opendir: opendirOf(0),
+      },
+      {
+        statfs: statfsOf(0, 0),
+        opendir: (async () => {
+          throw new Error("EACCES");
+        }) as never,
+      },
+    ]) {
+      const r = await tmpPressure("/r", { ops });
+      expect(r.act).toBe(false);
+      expect(r.signal.kind).toBe("uninspectable");
+    }
+  });
+});
+
+// readTmpPressureSignal (#1862) — the value behind the tmp_inodes Diagnose row.
+describe("readTmpPressureSignal", () => {
+  const opendirOf = (n: number) =>
+    (async () => ({
+      async *[Symbol.asyncIterator]() {
+        for (let i = 0; i < n; i++) yield { name: `e${i}` };
+      },
+    })) as never;
+
+  test("reports the WORST root, not the first", async () => {
+    // The whole point post-#1875: the tmpfs can be quiet while the disk root agents actually
+    // write to is filling. Reading only one of them reports a healthy filesystem.
+    const signal = await readTmpPressureSignal({
+      roots: ["/quiet", "/loud"],
+      ops: {
+        statfs: (async (p: string) =>
+          p === "/quiet" ? { files: 1000, ffree: 900 } : { files: 1000, ffree: 1 }) as never,
+        opendir: opendirOf(0),
+      },
+    });
+    expect(signal).toMatchObject({ kind: "inode-pct" });
+    expect((signal as { usePct: number }).usePct).toBeCloseTo(99.9);
+  });
+
+  test("an unreadable root never masks a measurable one", async () => {
+    const signal = await readTmpPressureSignal({
+      roots: ["/gone", "/real"],
+      ops: {
+        statfs: (async (p: string) => {
+          if (p === "/gone") throw new Error("ENOENT");
+          return { files: 1000, ffree: 100 };
+        }) as never,
+        opendir: opendirOf(0),
+      },
+    });
+    expect(signal).toMatchObject({ kind: "inode-pct" });
+  });
+
+  test("all roots unreadable → uninspectable", async () => {
+    const signal = await readTmpPressureSignal({
+      roots: ["/a", "/b"],
+      ops: {
+        statfs: (async () => {
+          throw new Error("ENOENT");
+        }) as never,
+        opendir: opendirOf(0),
+      },
+    });
+    expect(signal.kind).toBe("uninspectable");
+  });
+});
+
+// tmpEntryBands (#1862) — the display bands for the entry-count signal.
+describe("tmpEntryBands", () => {
+  test("default: warns at the entry limit, errors an order of magnitude above", () => {
+    expect(tmpEntryBands()).toEqual({ warnEntries: 1000, errorEntries: 10000 });
+  });
+
+  test("a non-positive knob falls back rather than warning forever", () => {
+    const prev = process.env.SHEPHERD_TMP_ENTRY_LIMIT;
+    try {
+      process.env.SHEPHERD_TMP_ENTRY_LIMIT = "0";
+      expect(tmpEntryBands()).toEqual({ warnEntries: 1000, errorEntries: 10000 });
+      process.env.SHEPHERD_TMP_ENTRY_LIMIT = "250";
+      expect(tmpEntryBands()).toEqual({ warnEntries: 250, errorEntries: 2500 });
+    } finally {
+      if (prev === undefined) delete process.env.SHEPHERD_TMP_ENTRY_LIMIT;
+      else process.env.SHEPHERD_TMP_ENTRY_LIMIT = prev;
+    }
   });
 });
 
@@ -708,6 +897,60 @@ describe("agent tmp dir geometry (#1875)", () => {
 });
 
 describe("reapFallowCaches", () => {
+  // #1862: 157 orphaned sidecars were found on one host. The reaper only ever removed sidecars
+  // ALONGSIDE a surviving dir, so once the dir went (interrupted run, external cleanup) its
+  // sidecars became permanently unreachable — they never match the dir path the pass stats.
+  test("an orphaned sidecar (its cache dir already gone) is age-gate-removed on its own", async () => {
+    const root = mkTmp();
+    const now = Date.now();
+    const old = new Date(now - 48 * 3600_000);
+
+    const orphan = join(root, `${FALLOW_CACHE_PREFIX}deadbeef.lock`);
+    const orphanSha = join(root, `${FALLOW_CACHE_PREFIX}deadbeef.sha`);
+    writeFileSync(orphan, "");
+    writeFileSync(orphanSha, "");
+    utimesSync(orphan, old, old);
+    utimesSync(orphanSha, old, old);
+
+    // A sidecar whose dir is STILL THERE must be left to the dir pass, not reaped here.
+    const liveDir = join(root, `${FALLOW_CACHE_PREFIX}cafe`);
+    mkdirSync(liveDir); // fresh mtime → the dir itself is kept
+    const liveLock = `${liveDir}.lock`;
+    writeFileSync(liveLock, "");
+    utimesSync(liveLock, old, old);
+
+    const res = await reapFallowCaches({
+      now,
+      staleMs: 24 * 3600_000,
+      fsOps: fsp,
+      log: () => {},
+      roots: [root],
+    });
+
+    expect(existsSync(orphan)).toBe(false);
+    expect(existsSync(orphanSha)).toBe(false);
+    expect(existsSync(liveLock)).toBe(true);
+    expect(existsSync(liveDir)).toBe(true);
+    expect(res.removed).toBe(2);
+  });
+
+  test("a FRESH orphaned sidecar is kept — the age gate still applies", async () => {
+    const root = mkTmp();
+    const orphan = join(root, `${FALLOW_CACHE_PREFIX}fresh.lock`);
+    writeFileSync(orphan, "");
+
+    const res = await reapFallowCaches({
+      now: Date.now(),
+      staleMs: 24 * 3600_000,
+      fsOps: fsp,
+      log: () => {},
+      roots: [root],
+    });
+
+    expect(existsSync(orphan)).toBe(true);
+    expect(res.removed).toBe(0);
+  });
+
   test("removes a stale fallow dir and its .lock / .last-used sidecars", async () => {
     const root = mkTmp();
     setEnv("SHEPHERD_TMP_SWEEP_DIR", root);
@@ -1006,6 +1249,46 @@ describe("reapAbandonedWorktrees", () => {
     expect(removed).toEqual(["/tmp/wt-a"]);
   });
 
+  // #1862: pressure used to be read once off `tmpdir()`, so a quiet tmpfs vetoed reclaim on the
+  // disk root agents actually write to post-#1875 (and vice versa). It is now per root.
+  test("per-root pressure: only the candidate under the pressured root is reaped", async () => {
+    const { opts, removed } = reaperOpts({
+      tmpRoots: ["/quiet", "/loud"],
+      statfs: (async (p: string) =>
+        p === "/quiet" ? { files: 1000, ffree: 900 } : { files: 1000, ffree: 100 }) as never,
+      execGit: async (_c: string, args: string[]) => {
+        if (args[0] === "--version") return "git version 2.54.0";
+        if (args[0] === "worktree" && args[1] === "list")
+          return porc("/quiet/wt-a") + porc("/loud/wt-b");
+        if (args[0] === "status") return "";
+        return "";
+      },
+    });
+    const r = await reapAbandonedWorktrees(opts as never);
+    expect(removed).toEqual(["/loud/wt-b"]);
+    expect(r).toEqual({ reaped: 1, retained: 1 });
+  });
+
+  test("a candidate is gated by its MOST SPECIFIC root, not its parent", async () => {
+    // The roots nest. A worktree inside the quiet nested root must not inherit the loud parent's
+    // justification — the pressure that licenses a destructive removal has to be the directory
+    // the worktree is actually piling up in.
+    const { opts, removed } = reaperOpts({
+      tmpRoots: ["/t", "/t/nested"],
+      statfs: (async (p: string) =>
+        p === "/t/nested" ? { files: 1000, ffree: 900 } : { files: 1000, ffree: 100 }) as never,
+      execGit: async (_c: string, args: string[]) => {
+        if (args[0] === "--version") return "git version 2.54.0";
+        if (args[0] === "worktree" && args[1] === "list") return porc("/t/nested/wt-a");
+        if (args[0] === "status") return "";
+        return "";
+      },
+    });
+    const r = await reapAbandonedWorktrees(opts as never);
+    expect(removed).toEqual([]);
+    expect(r).toEqual({ reaped: 0, retained: 1 });
+  });
+
   test("dirty (git status non-empty) → kept, retained 1", async () => {
     const { opts, removed } = reaperOpts({
       execGit: async (_c: string, args: string[]) => {
@@ -1174,7 +1457,7 @@ describe("reclaimForkedPnpmStore", () => {
     const rmdirs: string[] = [];
     const unlinkErrors = new Set<string>();
     const opts = {
-      storeRoot: ROOT,
+      storeRoots: [ROOT],
       now: NOW,
       statfs: fakeStatfs(1000, 100), // 90% ≥ 80
       fsOps: {
@@ -1212,6 +1495,47 @@ describe("reclaimForkedPnpmStore", () => {
     // index/ metadata and the files/ dir itself are never touched.
     expect(unlinked).not.toContain(`${ROOT}/v10/index/meta`);
     expect(rmdirs).not.toContain(`${ROOT}/v10/files`);
+  });
+
+  // #1862: pnpm forks its store BESIDE the install to stay same-filesystem, so post-#1875 a
+  // trusted agent's install forks it on disk. Defaulting to `<tmpdir>/.pnpm-store` alone meant
+  // that store was never reclaimed by anything.
+  test("reclaims a store under every configured root, gated on that root's own pressure", async () => {
+    const { opts, R, unlinked } = storeHarness();
+    const DISK = "/disk/.pnpm-store";
+    R[DISK] = [dirent("v10", true)];
+    R[`${DISK}/v10`] = [dirent("files", true), dirent("index", true)];
+    R[`${DISK}/v10/files`] = [dirent("aa", true)];
+    R[`${DISK}/v10/files/aa`] = [dirent("blob", false)];
+    R[`${DISK}/v10/index`] = [dirent("meta", false)];
+
+    const r = await reclaimForkedPnpmStore({
+      ...opts,
+      storeRoots: [ROOT, DISK],
+    } as never);
+
+    expect(r.freedFiles).toBe(2);
+    expect(unlinked).toContain(`${DISK}/v10/files/aa/blob`);
+  });
+
+  test("a quiet root's store is skipped without vetoing a pressured root's", async () => {
+    const { opts, R, unlinked } = storeHarness();
+    const QUIET = "/quiet/.pnpm-store";
+    R[QUIET] = [dirent("v10", true)];
+    R[`${QUIET}/v10`] = [dirent("files", true)];
+    R[`${QUIET}/v10/files`] = [dirent("aa", true)];
+    R[`${QUIET}/v10/files/aa`] = [dirent("blob", false)];
+
+    const r = await reclaimForkedPnpmStore({
+      ...opts,
+      storeRoots: [ROOT, QUIET],
+      // Gate reads the store's PARENT dir, so key on that.
+      statfs: (async (p: string) =>
+        p === "/quiet" ? { files: 1000, ffree: 900 } : { files: 1000, ffree: 100 }) as never,
+    } as never);
+
+    expect(unlinked).toEqual([`${ROOT}/v10/files/9f/abc`]);
+    expect(r.reason).toContain("below-threshold");
   });
 
   test("retained worktrees no longer gate: the pass still frees the unlinked fraction", async () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -4024,5 +4024,8 @@
   "feat_structured_tooltips_body": "Die Erklärungen zu kaltem Cache, Plan-Gate und Autopilot haben jetzt Überschriften und kurze Abschnitte. So findest du Kosten, Freigaben und Optionen schneller.",
   "feat_plan_gate_identity_title": "Plan Gate: sichere automatische Freigabe für beide CLIs",
   "feat_plan_gate_identity_body": "Mit Autopilot können Claude und Codex genehmigte Pläne in isolierten Worktrees und geteilten Checkouts freigeben. Shepherd setzt für Review-Rückmeldungen und Ausführung genau die Unterhaltung der Aufgabe fort. Bei fehlender oder mehrdeutiger Zuordnung bleibt sie für dich angehalten; ältere Codex-Aufgaben ohne Startzuordnung brauchen einen Neustart.",
-  "done_recap_archive_stale": "Nach 7 Tagen Stillstand automatisch dekommissioniert"
+  "done_recap_archive_stale": "Nach 7 Tagen Stillstand automatisch dekommissioniert",
+  "diagnostics_hint_tmp_entries_ok": "Das temporäre Dateisystem vergibt [[inode|Inodes]] dynamisch — eine Auslastung in Prozent gibt es dort nicht. Shepherd beobachtet stattdessen, wie viele Überbleibsel sich ansammeln. Aktuell unbedenklich wenige.",
+  "diagnostics_hint_tmp_entries_high": "Im temporären Dateisystem sammeln sich Überbleibsel an. Es vergibt [[inode|Inodes]] dynamisch, deshalb beobachtet Shepherd die Anzahl statt einer Auslastung in Prozent. Unbeachtet verlangsamt das jeden Verzeichnis-Scan und kann die [[inode|Inodes]] trotzdem aufbrauchen. „Beheben“ räumt die Caches auf, die Shepherd freigeben kann.",
+  "diagnostics_hint_tmp_entries_critical": "Das temporäre Dateisystem ist stark mit Überbleibseln zugesetzt — weit jenseits der Schwelle, ab der Shepherd aufräumt. Verzeichnis-Scans werden langsam, und die [[inode|Inodes]] können ausgehen, obwohl Speicherplatz frei aussieht. „Beheben“ räumt die Caches auf, die Shepherd freigeben kann."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -4024,5 +4024,8 @@
   "feat_structured_tooltips_body": "Cold-cache, Plan gate and Autopilot explanations now use headings and short sections to make costs, approvals and choices easier to find.",
   "feat_plan_gate_identity_title": "Plan Gate: safe automatic release for both CLIs",
   "feat_plan_gate_identity_body": "With Autopilot on, Claude and Codex can release approved plans in isolated worktrees and shared checkouts. Shepherd resumes the exact task conversation for review feedback and execution. Missing or ambiguous identity keeps the task stopped for you; older Codex tasks without launch attribution need a relaunch.",
-  "done_recap_archive_stale": "Decommissioned automatically after 7 days settled"
+  "done_recap_archive_stale": "Decommissioned automatically after 7 days settled",
+  "diagnostics_hint_tmp_entries_ok": "The temporary filesystem allocates [[inode|inodes]] on demand, so there is no usage percentage to read — Shepherd watches how many leftover entries pile up instead. Few enough to be healthy.",
+  "diagnostics_hint_tmp_entries_high": "Leftover entries are piling up in the temporary filesystem. It allocates [[inode|inodes]] on demand, so Shepherd watches the count rather than a usage percentage. Left alone this slows every scan of those directories and can still exhaust the filesystem's [[inode|inodes]]. Fix sweeps the caches Shepherd can reclaim.",
+  "diagnostics_hint_tmp_entries_critical": "The temporary filesystem is badly cluttered with leftover entries — far past the point where Shepherd starts sweeping. Directory scans get slow and the filesystem can run out of [[inode|inodes]] while disk space still looks free. Fix sweeps the caches Shepherd can reclaim."
 }


### PR DESCRIPTION
`Refs #1862.` Its four suggested directions all shipped (#1876, #1881, #1882) — but the guard they built **has been inert since #1882 merged**, and the failure it was built to stop was still running. This makes it work, and stops the thing that was actually producing the litter.

## Defect 1 — the pressure gate was dead on btrfs/XFS/ZFS

`inodeUsePct` read `statfs`'s `files: 0` as a read *failure*. It is an *answer*: those filesystems allocate inodes on demand, so there is no ceiling to express as a percentage. Every gate then failed open to **do nothing**. #1882 moved `claudeTmpRoot()` onto btrfs `/home`, so `sweepClaudeTmp()` returned `{swept:false}` on every boot and every daily run for 53 days.

```
statfs(~/.cache/shepherd/tmp) → files: 0,       ffree: 0        (btrfs /home)
statfs(/tmp)                  → files: 1048576, ffree: 1027312  (tmpfs)
```

`tmpPressure()` now resolves three signals — `inode-pct`, `entry-count` (where there is no ceiling), and `uninspectable` (never acts, preserving the fail-open). The entry walk uses `opendir` with an early exit, so it never materialises a 100k-entry array on the single event loop.

## Defect 2 — it was also gating on the wrong *directory*

Caught in plan review, and the more interesting half. Unlike a percentage, **an entry count is path-specific**. `sweepClaudeTmp` read the gate once off `claudeTmpRoot()` — in production `<agentTmpDir()>/claude-$uid`, which holds only session scratch — while the caches it exists to reclaim pile up in the **bare** `agentTmpDir()` beside it. The signal would have reported "quiet" on precisely the host it targets. Pressure is now evaluated **per root**.

Same root-blindness in the reclaimers, which landed before #1882: `reapAbandonedWorktrees` omitted the bare agent `$TMPDIR` (where a nested agent's `git worktree add "$TMPDIR/x"` now lands), `reclaimForkedPnpmStore` still defaulted to `<tmpdir>/.pnpm-store`, and both read pressure off `tmpdir()` — so a quiet tmpfs vetoed reclaim on a pressured disk root. Each candidate is now gated by its **most specific** containing root: a worktree inside a quiet nested root must not inherit a loud parent's justification for a destructive removal.

Live, on this host — every disk root previously read `statfs-unavailable`:

```
~/.cache/shepherd/tmp            -> act=true  | 10000+ entries (limit 1000)
~/.cache/shepherd/tmp/claude-1000-> act=true  | 2904 entries (limit 1000)
/tmp                             -> act=false | below-threshold 2.0%
```

## What was actually filling the disk: our own test suite

Not the forked pnpm store #1862 blames. `~/.cache/shepherd/tmp` held **119,640 entries / 2,015,613 inodes**, all accumulated since #1882 merged. 144 files under `test/` `mkdtemp` into `tmpdir()` and most never clean up — ~12,000 dirs/day — and `REGENERABLE_CACHE` matched none of those names, so even a *forced* sweep reclaimed zero.

```
14166 shep-plugins-*   8635 rollup-test-*   7850 shepherd-update-test-*   7834 codex-update-*
```

Before #1875 that output went straight to the `/tmp` tmpfs. At the observed rate it exhausts a 1,048,576-inode table on its own — so this is plausibly a co-cause of the original ENOSPC report, independent of pnpm.

**The fix touches none of those 144 files.** `os.tmpdir()` re-reads `process.env.TMPDIR` per call (verified), so the existing `bunfig.toml` preload points the whole run at one throwaway root; all 518 call sites relocate and child processes inherit it.

One trap worth recording: cleanup is a preload-level **`afterAll`**, not `process.on("exit")`. Bun's test runner fires *neither* `exit` nor `beforeExit` from a preload — I shipped the exit handler first, measured a still-leaking run, and probed it. An exit handler there is silent dead code. A run killed mid-flight still leaves its root, which is why `shepherd-test-run-` is in the allowlist.

## Also

- `reapFallowCaches` reaps **orphaned** sidecars (`.lock`/`.last-used`/`.sha` whose cache dir is gone — 157 observed). They previously could never be removed: the pass only ever deleted sidecars alongside a surviving dir.
- The allowlist covers leftover Chromium/Playwright profile dirs (4,963 observed), still behind the 24h staleness gate — a live profile's mtime is fresh by definition.
- The **Temp filesystem inodes** Diagnose row reports the worst root in whichever signal each supports, ranked by the state each reading classifies to so a healthy tmpfs cannot mask a disk root already past the sweeper's band. It was watching `tmpdir()` only, so it showed a healthy 3% while the root agents write to held 119,640 unreaped entries — the exact misdiagnosis #1862 is about. It measures only roots a sweep can **reclaim**, excluding session scratch (reclaimed at archival, untouchable by the row's Fix) so it cannot raise an alarm no action clears. The entry-count bands get their own EN/DE copy, because "plenty of inodes free" is not a true statement about a filesystem with no inode table.

## Verification

- `bun run lint`, `bunx tsc --noEmit`, root `bun run test` (9,847 pass), `cd ui && bun run test` (5,263 pass), and pre-push (7 lanes, fallow audit clean) all green.
- **Leak-freedom measured end-to-end, not assumed:** entries in the tmp root before and after a full suite run — **delta 0**, and no run root survives.
- New tests: all three pressure signals incl. the bounded walk; per-root gating in *both* consumers (the sweep case is the regression guard against gating on `claudeTmpRoot()` alone); most-specific-root attribution; multi-root store reclaim; orphan-sidecar reaping with its age gate; and the preload harness asserting its own redirect.
- Fixed mid-review: my first `tmpPressure` used `?? fsp.statfs`, which silently re-armed the gate for a caller that had explicitly injected `undefined` to disarm it. It now honours an explicitly-present key.

## Out of scope

- The one-click Fix still runs only `sweepClaudeTmp({thresholdPct: 0})`, never the destructive reclaimers.
- Session scratch under `claude-$uid` (2,902 dirs / 372,469 inodes here) is excluded from the sweep by design and reclaimed at archival. Its accumulation suggests `removeWorktreeScratch()` is not keeping up — filed as **#2304** with the measurements rather than folded in here.
- `*.node-gyp` dirs, which package managers create and Shepherd does not own.

## Host note

The one-time cleanup of pre-existing litter was already performed on the dev host (119,640 → 24,158 entries). No manual step is owed at merge: the survivors are inside the age gate and the fixed sweeper reclaims them on its next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

